### PR TITLE
Add page for Fedora releases

### DIFF
--- a/fedora.md
+++ b/fedora.md
@@ -1,0 +1,27 @@
+---
+permalink: /fedora
+title: Fedora Linux
+layout: post
+link: https://fedoraproject.org/wiki/End_of_life
+activeSupportColumn: false
+command: lsb_release -d
+releases:
+  "30":
+    release: 2019-05-07
+    latest: 30
+    eol: 2020-05-07
+  "29":
+    release: 2018-10-30
+    latest: 29
+    eol: 2019-10-30
+  "28":
+    release: 2018-05-01
+    latest: 28
+    eol: 2019-05-31
+  "27":
+    release: 2017-11-14
+    latest: 27
+    eol: 2018-11-30
+---
+
+Fedora end of life dates are not typically known far in advance with to-the-day accuracy, but are supported for approximately 13 months.  Fedora tries to release twice a year (about every 6 months) and supports the current (n) and previous (n-1) version.  See [this link](https://fedoraproject.org/wiki/Releases) for a list of all releases, and [this link](https://fedoraproject.org/wiki/Fedora_Release_Life_Cycle) for more information about the Fedora Release Cycle.    A list of all EOL releases can be found [here](https://fedoraproject.org/wiki/End_of_life).


### PR DESCRIPTION
Fedora is particularly painful to find EOL information for, so this will
be very nice to have.