### PR TITLE
Add changelog link for MariaDB

### DIFF
--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -103,7 +103,7 @@ layout: default
   <td>
     {% if diff > 0 or r.eol == false %}
       {% if page.changelogTemplate %}
-      <a href="{{page.changelogTemplate | replace: '__RELEASE_CYCLE__',r.releaseCycle  | replace: '__LATEST__',r.latest}}">
+      <a href="{{page.changelogTemplate | replace: '__RELEASE_CYCLE__',r.releaseCycle  | replace: '__LATEST__',r.latest | replace: '__LATEST_SHORT_HAND__',r.latestShortHand }}">
         {{r.latest}}
       </a>
       {%else%}

--- a/tools/mariadb.md
+++ b/tools/mariadb.md
@@ -3,6 +3,7 @@ title: MariaDB
 layout: post
 permalink: /mariadb
 link: https://mariadb.org/about/maintenance-policy/
+changelogTemplate: https://mariadb.com/kb/en/mariadb-__LATEST_SHORT_HAND__-changelog/
 activeSupportColumn: false
 releaseDateColumn: true
 command: mysqld --version
@@ -13,23 +14,28 @@ releases:
     release: 2012-04-11
     eol: 2020-04-11
     latest: 5.5.64
+    latestShortHand: 5564
     lts: true
   - releaseCycle: 10.0
     release: 2014-03-31
     eol: 2019-03-31
+    latestShortHand: 10038
     latest: 10.0.38
   - releaseCycle: 10.1
     release: 2015-10-17
     eol: 2020-10-17
+    latestShortHand: 10140
     latest: 10.1.40
   - releaseCycle: 10.2
     release: 2017-05-23
     eol: 2022-05-23
     latest: 10.2.24
+    latestShortHand: 10224
   - releaseCycle: 10.3
     release: 2018-05-25
     eol: 2023-05-25
     latest: 10.3.15
+    latestShortHand: 10315
 ---
 
 > [MariaDB](https://mariadb.org/about/) is a community-developed, commercially supported fork of the MySQL relational database management system (RDBMS).


### PR DESCRIPTION
MariaDB's changelog link for all version releases is  `https://mariadb.com/kb/en/library/mariadb-5564-changelog/` for version `5.5.64` and other versions.

I had to add a new field in releases named `latestShortHand` (for lack of better name hehe). Thoughts?