### PR TITLE
Added .NET Core 2.2 EOL

### DIFF
--- a/tools/dotnetcore.md
+++ b/tools/dotnetcore.md
@@ -29,7 +29,7 @@ releases:
   - releaseCycle: 2.2
     release: 2018-12-04
     latest: 2.2.5
-    eol: false
+    eol: 2019-12-23
   - releaseCycle: 3.0
     release: 2019-09-23
     latest: 3.0.0

--- a/tools/dotnetcore.md
+++ b/tools/dotnetcore.md
@@ -24,11 +24,11 @@ releases:
   - releaseCycle: 2.1
     lts: true
     release: 2018-05-30
-    latest: 2.1.11
+    latest: 2.1.13
     eol: 2021-10-21
   - releaseCycle: 2.2
     release: 2018-12-04
-    latest: 2.2.5
+    latest: 2.2.7
     eol: 2019-12-23
   - releaseCycle: 3.0
     release: 2019-09-23


### PR DESCRIPTION
According to https://dotnet.microsoft.com/platform/support/policy/dotnet-core:

> Current releases are supported for three months after a subsequent Current or LTS release.

This means that, since .NET Core 3.0 was released on `2019-09-23`, 2.2 will be EOL on `2019-12-23` 😄 