### PR TITLE
Fix site title not linking to site root

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -3,6 +3,7 @@ description: >- # this means to ignore newlines until "baseurl:"
   Check End of Life of php, python, ubuntu, alpine, laravel, debian, centos, django, .NET,
   fedora, iphone, redhat, postgres, ruby, windows, Node.js, mariadb, laravel, java etc at one place.
   Verify whether your application needs an update, or if you need to upgrade your device.
+baseurl: /
 markdown: kramdown
 plugins:
   - jekyll-feed


### PR DESCRIPTION
Since the Jekyll `baseurl` was unset, the site title had an empty `href` attribute on every page. This meant that even though a user is on a page `https://endoflife.date/debian`, the site title's anchor tag is:
```
<a href="" class="site-title fs-6 lh-tight">endoflife.date</a>
```

Here's the behavior pre-fix:
![broken-title](https://user-images.githubusercontent.com/9140811/68772275-337a3580-0632-11ea-8f89-f90b13bb34f5.gif)


And post-fix:
![title-fixed](https://user-images.githubusercontent.com/9140811/68772282-370dbc80-0632-11ea-8185-1ca64bac69dd.gif)
