### PR TITLE
Update .NET Core to latest dates and releases

### DIFF
--- a/tools/dotnetcore.md
+++ b/tools/dotnetcore.md
@@ -24,7 +24,7 @@ releases:
   - releaseCycle: 2.1
     lts: true
     release: 2018-05-30
-    latest: 2.1.15
+    latest: 2.1.16
     eol: 2021-08-30
   - releaseCycle: 2.2
     release: 2018-12-04
@@ -32,12 +32,12 @@ releases:
     eol: 2019-12-23
   - releaseCycle: 3.0
     release: 2019-09-23
-    latest: 3.0.2
-    eol: 2020-03-23
+    latest: 3.0.3
+    eol: 2020-03-03
   - releaseCycle: 3.1
     lts: true
     release: 2019-12-03
-    latest: 3.1.1
+    latest: 3.1.2
     eol: 2022-12-03
 ---
 


### PR DESCRIPTION
.NET Core 3.0 had the wrong EoL date according to https://devblogs.microsoft.com/dotnet/net-core-3-0-end-of-life/.