### PR TITLE
Update powershell.md for 7.0.0 release

### DIFF
--- a/tools/powershell.md
+++ b/tools/powershell.md
@@ -19,8 +19,12 @@ releases:
     latest: 6.1.5
   - releaseCycle: 6.2
     release: 2019-03-28
+    eol: 2020-09-04
+    latest: 6.2.4
+  - releaseCycle: 7.0
+    release: 2020-03-04
     eol: false
-    latest: 6.2.3
+    latest: 7.0.0
 ---
 
 > [PowerShell Core](https://aka.ms/powershell)  is a cross-platform (Windows, Linux, and macOS) automation and configuration tool/framework that works well with your existing tools and is optimized for dealing with structured data (e.g. JSON, CSV, XML, etc.), REST APIs, and object models. It includes a command-line shell, an associated scripting language and a framework for processing cmdlets.

--- a/tools/powershell.md
+++ b/tools/powershell.md
@@ -25,6 +25,7 @@ releases:
     release: 2020-03-04
     eol: false
     latest: 7.0.0
+    lts: true
 ---
 
 > [PowerShell Core](https://aka.ms/powershell)  is a cross-platform (Windows, Linux, and macOS) automation and configuration tool/framework that works well with your existing tools and is optimized for dealing with structured data (e.g. JSON, CSV, XML, etc.), REST APIs, and object models. It includes a command-line shell, an associated scripting language and a framework for processing cmdlets.

--- a/tools/powershell.md
+++ b/tools/powershell.md
@@ -4,7 +4,7 @@ layout: post
 title: PowerShell
 command: pwsh -v
 link: https://docs.microsoft.com/powershell/scripting/powershell-support-lifecycle
-changelogTemplate: https://github.com/PowerShell/PowerShell/blob/master/CHANGELOG.md
+changelogTemplate: https://github.com/PowerShell/PowerShell/blob/master/CHANGELOG/__RELEASE_CYCLE__.md
 releaseDateColumn: true
 sortReleasesBy: "releaseCycle"
 eolColumn: Support Status

--- a/tools/powershell.md
+++ b/tools/powershell.md
@@ -1,7 +1,7 @@
 ---
 permalink: /powershell
 layout: post
-title: PowerShell Core
+title: PowerShell
 command: pwsh -v
 link: https://docs.microsoft.com/powershell/scripting/powershell-support-lifecycle
 changelogTemplate: https://github.com/PowerShell/PowerShell/blob/master/CHANGELOG.md


### PR DESCRIPTION
Update the EOL of 6.2 and make entry for 7.0

Change the name from `PowerShell Core` to `PowerShell` as per the change since 7.0

/cc @TravisEz13 