### PR TITLE
Microsoft delayed the scheduled end of several products

### DIFF
--- a/tools/windows.md
+++ b/tools/windows.md
@@ -28,15 +28,15 @@ releases:
     eol: 2021-05-11
   - releaseCycle: "Windows 10, v1809 (W)"
     release: 2018-11-13
-    support: 2020-05-11
-    eol: 2020-05-11
+    support: 2020-11-10
+    eol: 2020-11-10
   - releaseCycle: "Windows 10, v1803 (E)(W)"
     release: 2018-04-30
     support: 2020-05-11
     eol: 2020-05-11
   - releaseCycle: "Windows 10, v1709 (E)"
     release: 2017-10-17
-    support: 2020-04-14
+    support: 2020-10-13
     eol: 2020-10-13
   - releaseCycle: "Windows 10, v1709 (W)"
     release: 2017-10-17

--- a/tools/windowsServer.md
+++ b/tools/windowsServer.md
@@ -20,8 +20,8 @@ releases:
     eol: 2020-12-08
   - releaseCycle: "Windows Server, version 1809 (Datacenter, Standard)"
     release: 2018-11-13
-    support: 2020-05-12
-    eol: 2020-05-12
+    support: 2020-11-10
+    eol: 2020-11-10
   - releaseCycle: "Windows Server 2019 (Datacenter, Essentials, Standard)"
     release: 2018-11-13
     support: 2024-01-09


### PR DESCRIPTION
[Microsoft Annoucement: Lifecycle changes to end of support and servicing dates](https://support.microsoft.com/en-us/help/4557164/lifecycle-changes-to-end-of-support-and-servicing-dates)

> Published: April 14, 2020
> 
> Microsoft has been deeply engaged with customers around the world who are impacted by the current public health situation. As a member of the global community, we want to contribute to reducing the stress our customers face right now. To that end, we have delayed the scheduled end of support and servicing dates for the following products to help people and organizations focus their attention on retaining business continuity:
> 
> Windows 10, version 1709 (Enterprise, Education, IoT Enterprise). The final security update for this version will be released on October 13, 2020, instead of April 14, 2020. See the Microsoft Tech Community Blog for more information.
> 
> Windows 10, version 1809 (Home, Pro, Pro Education, Pro for Workstations, IoT Core). The final security update for this version will be released on November 10, 2020, instead of May 12, 2020. In addition, we are temporarily pausing Microsoft initiated feature updates for Home and Pro editions running on version 1809. The rollout process restart for Microsoft-initiated feature updates for devices running on Windows 10, version 1809 will be dramatically slowed and closely monitored in advance of the delayed November 10, 2020 end of service date to provide adequate time for a smooth update process. See Windows Message Center for more information. 
> 
> Windows Server, version 1809 (Datacenter, Standard). The final security update for this version will be released on November 10, 2020, instead of May 12, 2020.  
> 
> Configuration Manager (current branch), version 1810. The end of support date for version 1810 has been delayed from May 27, 2020, to December 1, 2020. See the Microsoft Tech Community Blog for more information.
> 
> SharePoint Server 2010, SharePoint Foundation 2010, and Project Server 2010. The end of support date for these products has been delayed from October 13, 2020, to April 13, 2021. See the SharePoint Tech Community blog for more information.
> 
> Dynamics 365 cloud services. The deprecation date of the Microsoft Dynamics 365 Customer Engagement legacy web client has been delayed by two months to December 2020. Additionally, we are enabling a simplified process for Dynamics 365 Finance, Supply Chain Management, and Commerce customers to pause updates for an extended period. See the Business Applications blog for more information.
> 
> Basic Authentication. Microsoft has postponed the disablement of Basic Authentication in Exchange Online for those tenants still actively using it until the second half of 2021. Go here for the latest information.
> 
> These changes do not impact or delay the end of support date of other versions not mentioned here. The end of support date for Exchange Server 2010, Office 2010, Project 2010, Office 2016 for Mac, and Office 2013 connectivity to the Office 365 services remains the same. See Microsoft Office 2010 End of Support blog and the Project 2010 end of support roadmap for additional resources and options.
> 
> We recognize this is an evolving situation. We will continue to listen to our customers and keep this announcement up to date as needed.
> 
> The information on this page is subject to the Microsoft Policy Disclaimer and Change Notice. Return to this site periodically to review any such changes.