### PR TITLE
Fix Alpinelinux release

### DIFF
--- a/tools/alpinelinux.md
+++ b/tools/alpinelinux.md
@@ -17,7 +17,7 @@ releases:
     release: 2019-06-19
     latest: 3.10.5
     eol: 2021-05-01
-  - releaseCycle: "v3.5"
+  - releaseCycle: "v3.9"
     release: 2019-01-29
     latest: 3.9.6
     eol: 2021-01-01


### PR DESCRIPTION
There was typo in https://github.com/endoflife-date/endoflife.date/commit/4339f96f4e5b6bec058ee78c11645cf546569751