### PR TITLE
Add alpine 3.12 release

### DIFF
--- a/tools/alpinelinux.md
+++ b/tools/alpinelinux.md
@@ -9,6 +9,10 @@ command: cat /etc/alpine-release
 releaseDateColumn: true
 sortReleasesBy: 'release'
 releases:
+  - releaseCycle: "v3.12"
+    release: 2020-05-29
+    latest: 3.12.0
+    eol: 2022-05-01
   - releaseCycle: "v3.11"
     release: 2019-12-19
     latest: 3.11.6


### PR DESCRIPTION
Adds the recently released [Alpine 3.12](https://alpinelinux.org/posts/Alpine-3.12.0-released.html)