### PR TITLE
Update Go 1.15.9 and 1.16.1

### DIFF
--- a/tools/go.md
+++ b/tools/go.md
@@ -12,12 +12,12 @@ releases:
   - releaseCycle: "1.16"
     release: 2021-02-16
     eol: false
-    latest: 1.16.0
+    latest: 1.16.1
     link: https://golang.org/doc/go1.16
   - releaseCycle: "1.15"
     release: 2020-08-11
     eol: false
-    latest: 1.15.8
+    latest: 1.15.9
   - releaseCycle: "1.14"
     release: 2020-02-25
     eol: true


### PR DESCRIPTION
Go version update to 1.15.9 and 1.16.1, no EOL with this update.