### PR TITLE
Add Amazon Kindle

### DIFF
--- a/tools/kindle.md
+++ b/tools/kindle.md
@@ -1,0 +1,57 @@
+---
+title: Amazon Kindle
+layout: post
+category: os
+sortReleasesBy: "release"
+releases:
+  - releaseCycle: "Kindle Oasis 3 (10th Generation)"
+    release: 2019-07-24
+    eol: false
+    latest: 5.13.5
+  - releaseCycle: "Kindle 10 (10th Generation)"
+    release: 2019-04-10
+    eol: false
+    latest: 5.13.5
+  - releaseCycle: "Kindle Paperwhite 4 (10th Generation)"
+    release: 2018-11-07
+    eol: false
+    latest: 5.13.5
+  - releaseCycle: "Kindle Oasis 2 (9th Generation)"
+    release: 2017-10-31
+    eol: false
+    latest: 5.13.5
+  - releaseCycle: "Kindle 8 (8th Generation)"
+    release: 2016-06-22
+    eol: false
+    latest: 5.13.5
+  - releaseCycle: "Kindle Oasis (8th Generation)"
+    release: 2016-04-27
+    eol: false
+    latest: 5.13.5
+  - releaseCycle: "Kindle Voyage (7th Generation)"
+    release: 2014-11-04
+    eol: false
+    latest: 5.13.5
+  - releaseCycle: "Kindle Paperwhite 3 (7th Generation)"
+    release: 2015-06-30
+    eol: 2020-12-01
+    latest: 5.13.4
+  - releaseCycle: "Kindle 7 (7th Generation)"
+    release: 2014-10-02
+    eol: 2019-10-01
+    latest: 5.12.2.1
+  - releaseCycle: "Kindle Paperwhite 2 (6th Generation)"
+    release: 2013-09-30
+    eol: 2019-10-01
+    latest: 5.12.2.1
+# URL for the page
+permalink: /kindle
+link: https://www.amazon.com/gp/help/customer/display.html?nodeId=GKMQC26VQQMM8XSW
+activeSupportColumn: false
+releaseColumn: true
+releaseDateColumn: true
+eolColumn: Service Status
+---
+[Amazon Kindle](https://en.wikipedia.org/wiki/Amazon_Kindle) is a series of e-readers designed by Amazon.
+
+Amazon Kindle usually releases every year while maintains for about five years.

--- a/tools/kindle.md
+++ b/tools/kindle.md
@@ -53,5 +53,8 @@ releaseDateColumn: true
 eolColumn: Service Status
 ---
 [Amazon Kindle](https://en.wikipedia.org/wiki/Amazon_Kindle) is a series of e-readers designed by Amazon.
+There is no official data of the release cycle. Based on [Wikipedia](https://en.wikipedia.org/wiki/Amazon_Kindle#Specifications) and [INFORMER](https://theinformr.com/ereaders/amazon-kindle-10th-gen/), Amazon Kindle usually releases every year.
 
-Amazon Kindle usually releases every year while maintains for about five years.
+Also, there is no official information about the end of life date. However, according to the software release notes at [Kindle E-Reader Software Updates](https://www.amazon.com/gp/help/customer/display.html?nodeId=GKMQC26VQQMM8XSW), the software update usually lasts about five years.
+
+Please be noted that the older version of release notes are not available on the Amazon website. The update information can be got from  Kindle -> Menu ->Settings -> Device Info -> What's New

--- a/tools/macos.md
+++ b/tools/macos.md
@@ -5,28 +5,28 @@ category: os
 sortReleasesBy: "release"
 changelogTemplate: "https://link/of/the/__RELEASE_CYCLE__/and/__LATEST__/version"
 releases:
-  - releaseCycle: "Big Sur"
+  - releaseCycle: "macOS 11 (Big Sur)"
     release: 2020-11-12
     eol: false
-  - releaseCycle: "Catalina"
+  - releaseCycle: "macOS 10.15 (Catalina)"
     release: 2019-10-07
     eol: false
-  - releaseCycle: "Mojave"
+  - releaseCycle: "macOS 10.14 (Mojave)"
     release: 2018-09-24
     eol: false
-  - releaseCycle: "High Sierra"
+  - releaseCycle: "macOS 10.13 (High Sierra)"
     release: 2017-09-25
     eol: 2020-12-01
-  - releaseCycle: "Sierra"
+  - releaseCycle: "macOS 10.12 (Sierra)"
     release: 2016-09-20
     eol: 2019-10-01
-  - releaseCycle: "El Capitan"
+  - releaseCycle: "OS X 10.11 (El Capitan)"
     release: 2015-09-30
     eol: 2018-12-01
-  - releaseCycle: "Yosemite"
+  - releaseCycle: "OS X 10.10 (Yosemite)"
     release: 2014-10-16
     eol: 2017-08-01
-  - releaseCycle: "Mavericks"
+  - releaseCycle: "OS X 10.9 (Mavericks)"
     release: 2013-10-22
     eol: 2016-12-01
 # URL for the page
@@ -39,6 +39,6 @@ eolColumn: Service Status
 command: sw_vers
 
 ---
-[macOS](https://en.wikipedia.org/wiki/MacOS) is the primary operating system for Apple's Mac computers
+[macOS](https://en.wikipedia.org/wiki/MacOS) (aka OS X, Mac OS X) is the primary operating system for Apple's Mac computers.
 
 Major versions of macOS are released once a year now, usually maitained for three years.

--- a/tools/macos.md
+++ b/tools/macos.md
@@ -1,0 +1,44 @@
+---
+title: macOS
+layout: post
+category: os
+sortReleasesBy: "release"
+changelogTemplate: "https://link/of/the/__RELEASE_CYCLE__/and/__LATEST__/version"
+releases:
+  - releaseCycle: "Big Sur"
+    release: 2020-11-12
+    eol: false
+  - releaseCycle: "Catalina"
+    release: 2019-10-07
+    eol: false
+  - releaseCycle: "Mojave"
+    release: 2018-09-24
+    eol: false
+  - releaseCycle: "High Sierra"
+    release: 2017-09-25
+    eol: 2020-12-01
+  - releaseCycle: "Sierra"
+    release: 2016-09-20
+    eol: 2019-10-01
+  - releaseCycle: "El Capitan"
+    release: 2015-09-30
+    eol: 2018-12-01
+  - releaseCycle: "Yosemite"
+    release: 2014-10-16
+    eol: 2017-08-01
+  - releaseCycle: "Mavericks"
+    release: 2013-10-22
+    eol: 2016-12-01
+# URL for the page
+permalink: /macOS
+link: https://developer.apple.com/documentation/macos-release-notes
+activeSupportColumn: false
+releaseColumn: false
+releaseDateColumn: true
+eolColumn: Service Status
+command: sw_vers
+
+---
+[macOS](https://en.wikipedia.org/wiki/MacOS) is the primary operating system for Apple's Mac computers
+
+Major versions of macOS are released once a year now, usually maitained for three years.


### PR DESCRIPTION
date source
- software support info comes from https://www.amazon.com/gp/help/customer/display.html?nodeId=GKMQC26VQQMM8XSW
- The first source of release date is https://en.wikipedia.org/wiki/Amazon_Kindle#Specifications
- The second source of release date  is https://theinformr.com/ereaders/amazon-kindle-10th-gen/#specs