### PR TITLE
[iphone] Add note about recent security fix to old apple devices

### DIFF
--- a/tools/iphone.md
+++ b/tools/iphone.md
@@ -72,6 +72,6 @@ releases:
     eol: false
 ---
 
-Most likely, new iPhone models will come out in September every year (with a few possible exceptions). iPhone support (supported devices gets the latest iOS updates) is quite long.
+Most likely, new iPhone models will come out in September every year (with a few possible exceptions). iPhone support (supported devices gets the latest iOS updates) is quite long. Apple ocassionaly releases security updates for much older devices, such as [this security fix in iOS 12.5.2](https://support.apple.com/en-us/HT212257) which was pushed to iPhone 6 and iPhone 5S.
 
 Apple maintains a list of Supported iPhone models at <https://support.apple.com/en-in/guide/iphone/iphe3fa5df43/ios>.


### PR DESCRIPTION
>The company also released a patch update to iOS 12, version 12.5.2, so that iPhone 6, iPhone 5s, third-generation iPad mini, first-generation iPad Air and the sixth-generation iPod touch users can also benefit from the security fixes.

> Available for: iPhone 5s, iPhone 6, iPhone 6 Plus, iPad Air, iPad mini 2, iPad mini 3, and iPod touch (6th generation)

Ref: https://9to5mac.com/2021/03/26/apple-releases-ios-14-4-2-and-ios-12-5-2-with-security-bug-fixes/, https://support.apple.com/en-us/HT212257

Don't think we should mark these devices as supported, but thought having a note might be relevant. Thoughts?