### PR TITLE
Adds Code of Conduct

### DIFF
--- a/CODE-OF-CONDUCT.md
+++ b/CODE-OF-CONDUCT.md
@@ -1,0 +1,128 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, religion, or sexual identity
+and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the
+  overall community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or
+  advances of any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email
+  address, without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for moderation
+decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+Examples of representing our community include using an official e-mail address,
+posting via an official social media account, or acting as an appointed
+representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the community leaders responsible for enforcement at
+endoflife.date-coc@captnemo.in.
+All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series
+of actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external channels
+like social media. Violating these terms may lead to a temporary or
+permanent ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited interaction
+with those enforcing the Code of Conduct, is allowed during this period.
+Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior,  harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within
+the community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.0, available at
+https://www.contributor-covenant.org/version/2/0/code_of_conduct.html.
+
+Community Impact Guidelines were inspired by [Mozilla's code of conduct
+enforcement ladder](https://github.com/mozilla/diversity).
+
+[homepage]: https://www.contributor-covenant.org
+
+For answers to common questions about this code of conduct, see the FAQ at
+https://www.contributor-covenant.org/faq. Translations are available at
+https://www.contributor-covenant.org/translations.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -66,3 +66,7 @@ Time-turners are no longer released, and the last known stable release was in HP
 File a Pull Request with this file created, and Netlify will provide a preview URL for the same. Once merged, it goes live on the website.
 
 You can visit <https://github.com/endoflife-date/endoflife.date/new/master/tools> to directly create your file.
+
+## Code of Conduct
+
+Please note that this project is released with a [Contributor Code of Conduct](CODE-OF-CONDUCT.md). By participating in this project you agree to abide by its terms.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -63,9 +63,13 @@ releaseImage: https://jkrowling.com/timeturner-releases.png
 Time-turners are no longer released, and the last known stable release was in HP.5 release.
 ```
 
-File a Pull Request with this file created, and Netlify will provide a preview URL for the same. Once merged, it goes live on the website.
+File a Pull Request with this file created, and Netlify will provide a preview URL for the same. Once the pull request is merged, the changes are automatically deployed on the website.
 
 You can visit <https://github.com/endoflife-date/endoflife.date/new/master/tools> to directly create your file.
+
+## Hacking
+
+If you'd like to work on the site internals, see [HACKING.md](https://github.com/endoflife-date/endoflife.date/blob/master/HACKING.md).
 
 ## Code of Conduct
 

--- a/README.md
+++ b/README.md
@@ -1,28 +1,17 @@
-# endoflife.date [![Netlify Status](https://api.netlify.com/api/v1/badges/a4c194ea-370a-436d-b58f-b1b7eadd88a3/deploy-status)](https://app.netlify.com/sites/endoflife/deploys) [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg?style=flat-square)](http://makeapullrequest.com) ![powered by Jekyll](https://img.shields.io/badge/powered_by-Jekyll-blue.svg) [![Website shields.io](https://img.shields.io/website-up-down-green-red/https/endoflife.date.svg)](https://endoflife.date/) [![made-with-Markdown](https://img.shields.io/badge/Made%20with-Markdown-1f425f.svg)](http://commonmark.org) [![Contributor Covenant](https://img.shields.io/badge/Contributor%20Covenant-2.0-4baaaa.svg)](CODE-OF-CONDUCT.md)
+# endoflife.date
 
-Keep track of various EOL dates as they are approaching. Visit <https://endoflife.date> for a list of supported tools.
+[![Netlify Status](https://api.netlify.com/api/v1/badges/a4c194ea-370a-436d-b58f-b1b7eadd88a3/deploy-status)](https://app.netlify.com/sites/endoflife/deploys) [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg?style=flat-square)](http://makeapullrequest.com) ![powered by Jekyll](https://img.shields.io/badge/powered_by-Jekyll-blue.svg) [![Website shields.io](https://img.shields.io/website-up-down-green-red/https/endoflife.date.svg)](https://endoflife.date/) [![made-with-Markdown](https://img.shields.io/badge/Made%20with-Markdown-1f425f.svg)](http://commonmark.org) [![Contributor Covenant](https://img.shields.io/badge/Contributor%20Covenant-2.0-4baaaa.svg)](CODE-OF-CONDUCT.md)
 
-Add more by filing a PR on GitHub.
-
-Inspired by my [rant on twitter](https://twitter.com/captn3m0/status/1110504412064239617) on how various languages get this wrong.
-
-## Suggestion
-
-The reason this site exists is because this information is very often hidden away. If you're releasing something on a regular basis:
-
-1. List only supported releases.
-2. Give EoL dates/policy if possible.
-3. Hide unsupported releases behind a few extra clicks.
-4. Mention security/active release difference if needed.
+Keep track of various End of Life dates as they are approaching. Visit <https://endoflife.date> for a list of supported tools. A [lot of languages and tools get this wrong](https://twitter.com/captn3m0/status/1110504412064239617). endoflife.date collates this data and presents it in an easily accessible format, with URLs that are easy to guess and remember.
 
 ## Contributing
 
 Please see [CONTRIBUTING.md](CONTRIBUTING.md) for details. Please note that this project is released with a [Contributor Code of Conduct](CODE-OF-CONDUCT.md). By participating in this project you agree to abide by its terms.
 
-## HACKING
+## Working on the Code
 
 If you'd like to hack on how the site gets built, see [HACKING.md](HACKING.md).
 
 ## License
 
-Licensed under the [MIT License](https://nemo.mit-license.org/). See LICENSE file for details.
+Licensed under the [MIT License](LICENSE).

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# endoflife.date [![Netlify Status](https://api.netlify.com/api/v1/badges/a4c194ea-370a-436d-b58f-b1b7eadd88a3/deploy-status)](https://app.netlify.com/sites/endoflife/deploys) [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg?style=flat-square)](http://makeapullrequest.com) ![powered by Jekyll](https://img.shields.io/badge/powered_by-Jekyll-blue.svg) [![Website shields.io](https://img.shields.io/website-up-down-green-red/https/endoflife.date.svg)](https://endoflife.date/) [![made-with-Markdown](https://img.shields.io/badge/Made%20with-Markdown-1f425f.svg)](http://commonmark.org)
+# endoflife.date [![Netlify Status](https://api.netlify.com/api/v1/badges/a4c194ea-370a-436d-b58f-b1b7eadd88a3/deploy-status)](https://app.netlify.com/sites/endoflife/deploys) [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg?style=flat-square)](http://makeapullrequest.com) ![powered by Jekyll](https://img.shields.io/badge/powered_by-Jekyll-blue.svg) [![Website shields.io](https://img.shields.io/website-up-down-green-red/https/endoflife.date.svg)](https://endoflife.date/) [![made-with-Markdown](https://img.shields.io/badge/Made%20with-Markdown-1f425f.svg)](http://commonmark.org) [![Contributor Covenant](https://img.shields.io/badge/Contributor%20Covenant-2.0-4baaaa.svg)](CODE-OF-CONDUCT.md)
 
 Keep track of various EOL dates as they are approaching. Visit <https://endoflife.date> for a list of supported tools.
 
@@ -17,7 +17,7 @@ The reason this site exists is because this information is very often hidden awa
 
 ## Contributing
 
-Please see [CONTRIBUTING.md](CONTRIBUTING.md) for details.
+Please see [CONTRIBUTING.md](CONTRIBUTING.md) for details. Please note that this project is released with a [Contributor Code of Conduct](CODE-OF-CONDUCT.md). By participating in this project you agree to abide by its terms.
 
 ## HACKING
 


### PR DESCRIPTION
Nice to have, and a pre-requisite for https://github.com/endoflife-date/endoflife.date/discussions/224.

Using https://www.contributor-covenant.org as-is. They have a important note on adapting this:

>It’s important to understand that simply adopting Contributor Covenant will not prevent conflict or toxicity in your community.
>As a leader you are responsible for the safe, fair, and transparent enforcement of your community’s code of conduct. A code of conduct without such enforcement sends a false signal that a community is welcoming and inclusive, which can have a disastrous impact on marginalized or otherwise vulnerable people.
>Before you decide to adopt Contributor Covenant, take the time to discuss enforcement with other trusted members of your community. Thoroughly read the Enforcement Guidelines section of the document. If the suggested actions and consequences don’t suit the context of your community, consider moving this section to another document (such as an FAQ or ‘How to Report’ page) and adapting it to your needs.

Since the CoC email comes to me, it isn't perfect - but we can start with this?