### PR TITLE
Add redirects for various pages

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -11,6 +11,3 @@ trim_trailing_whitespace = true
 indent_style = space
 indent_size = 2
 insert_final_newline = true
-
-[_redirects]
-indent_style = tab

--- a/.editorconfig
+++ b/.editorconfig
@@ -11,3 +11,6 @@ trim_trailing_whitespace = true
 indent_style = space
 indent_size = 2
 insert_final_newline = true
+
+[_redirects]
+indent_style = tab

--- a/_config.yml
+++ b/_config.yml
@@ -18,6 +18,8 @@ exclude:
   - vendor/
   - README.md
   - LICENSE
+include:
+  - _redirects
 # Theme Documentation: https://pmarsceill.github.io/just-the-docs/
 theme: just-the-docs
 nav_sort: case_insensitive

--- a/_redirects
+++ b/_redirects
@@ -17,15 +17,15 @@ Jekyll doesn't copy it to _site directory, where Netlify expects it.
 {% endcomment %}
 {% for page in site.pages %}
 
-	{% if page.alternate_urls %}
+  {% if page.alternate_urls %}
 
 # Redirects for {{page.path}}
-		{% for url in page.alternate_urls %}
+    {% for url in page.alternate_urls %}
 
-{{page.permalink}}					{{url}}
+{{page.permalink}}          {{url}}
 
-		{% endfor %}
+    {% endfor %}
 
-	{% endif %}
+  {% endif %}
 
 {% endfor %}

--- a/_redirects
+++ b/_redirects
@@ -14,6 +14,9 @@ To create a new redirect, add a alternate_urls array in the page front-matter.
 The _redirects file is included in _config.yml/include key otherwise
 Jekyll doesn't copy it to _site directory, where Netlify expects it.
 
+The Redirect syntax is
+/redirect-this /to-that
+
 {% endcomment %}
 {% for page in site.pages %}
 
@@ -21,8 +24,7 @@ Jekyll doesn't copy it to _site directory, where Netlify expects it.
 
 # Redirects for {{page.path}}
     {% for url in page.alternate_urls %}
-
-{{page.permalink}}          {{url}}
+{{url}}       {{page.permalink}}
 
     {% endfor %}
 

--- a/_redirects
+++ b/_redirects
@@ -1,0 +1,31 @@
+---
+# Setting a layout forces Jekyll to render this file
+layout: null
+---
+{% comment %}
+
+The following loop creates a _redirects file as per
+Netlify's syntax: https://docs.netlify.com/routing/redirects/
+
+This also creates a lot of whitespace in the resulting file.
+
+To create a new redirect, add a alternate_urls array in the page front-matter.
+
+The _redirects file is included in _config.yml/include key otherwise
+Jekyll doesn't copy it to _site directory, where Netlify expects it.
+
+{% endcomment %}
+{% for page in site.pages %}
+
+	{% if page.alternate_urls %}
+
+# Redirects for {{page.path}}
+		{% for url in page.alternate_urls %}
+
+{{page.permalink}}					{{url}}
+
+		{% endfor %}
+
+	{% endif %}
+
+{% endfor %}

--- a/tools/alpinelinux.md
+++ b/tools/alpinelinux.md
@@ -1,5 +1,7 @@
 ---
 permalink: /alpine
+alternate_urls:
+  - /alpinelinux
 title: Alpine Linux
 layout: post
 link: https://wiki.alpinelinux.org/wiki/Alpine_Linux:Releases

--- a/tools/android.md
+++ b/tools/android.md
@@ -1,5 +1,7 @@
 ---
 title: Android OS
+alternate_urls:
+  - /aosp
 layout: post
 permalink: /android
 link: https://developer.android.com/about/versions/11

--- a/tools/dotnet.md
+++ b/tools/dotnet.md
@@ -1,5 +1,7 @@
 ---
 permalink: /dotnet
+alternate_urls:
+  - /.net
 layout: post
 title: .NET
 command: dotnet --version

--- a/tools/dotnetcore.md
+++ b/tools/dotnetcore.md
@@ -1,5 +1,7 @@
 ---
 permalink: /dotnetcore
+alternate_urls:
+  - /.netcore
 layout: post
 title: .NET Core
 command: dotnet --version

--- a/tools/dotnetfx.md
+++ b/tools/dotnetfx.md
@@ -1,6 +1,8 @@
 ---
 permalink: /dotnetfx
 layout: post
+alternative_urls:
+  - /.netfx
 title: .NET Framework
 command: reg query "HKLM\SOFTWARE\Microsoft\Net Framework Setup\NDP" /s
 link: https://dotnet.microsoft.com/download/dotnet-framework

--- a/tools/go.md
+++ b/tools/go.md
@@ -1,6 +1,8 @@
 ---
 title: Go
 permalink: /go
+alternate_urls:
+  - /golang
 layout: post
 link: https://golang.org/doc/devel/release.html#policy
 changelogTemplate: https://github.com/golang/go/issues?q=milestone%3AGo__LATEST__

--- a/tools/godot.md
+++ b/tools/godot.md
@@ -1,6 +1,8 @@
 ---
 title: Godot
 permalink: /godot
+alternate_urls:
+  - /godotengine
 layout: post
 link: https://docs.godotengine.org/en/latest/about/release_policy.html
 eolColumn: Critical, Security and Platform support

--- a/tools/iphone.md
+++ b/tools/iphone.md
@@ -1,6 +1,8 @@
 ---
 layout: post
 permalink: /iphone
+alternate_urls:
+  - /ios
 title: iPhone
 link: https://en.wikipedia.org/wiki/List_of_iOS_devices#In_production_and_supported
 discontinuedColumn: true

--- a/tools/java.md
+++ b/tools/java.md
@@ -1,5 +1,8 @@
 ---
 permalink: /java
+alternate_urls:
+  - /openjdk
+  - /jdk
 layout: post
 title: Java/OpenJDK
 command: java --version

--- a/tools/kubernetes.md
+++ b/tools/kubernetes.md
@@ -9,6 +9,8 @@ releaseDateColumn: true
 sortReleasesBy: "release"
 activeSupportColumn: true
 eolColumn: Maintenance Support
+alternate_urls:
+  - /k8s
 # The release date for "N" should match the eol date for N-3 release.
 releases:
   - releaseCycle: "1.16"

--- a/tools/macos.md
+++ b/tools/macos.md
@@ -40,6 +40,6 @@ eolColumn: Service Status
 command: sw_vers
 
 ---
-[macOS](https://en.wikipedia.org/wiki/MacOS) (aka OS X, Mac OS X) is the primary operating system for Apple's Mac computers.
+>[macOS](https://en.wikipedia.org/wiki/MacOS) (aka OS X, Mac OS X) is the primary operating system for Apple's Mac computers.
 
 Major versions of macOS are released once a year now, usually maitained for three years.

--- a/tools/macos.md
+++ b/tools/macos.md
@@ -1,5 +1,7 @@
 ---
 title: macOS
+alternate_urls:
+  - /mac
 layout: post
 category: os
 sortReleasesBy: "release"
@@ -29,8 +31,7 @@ releases:
   - releaseCycle: "OS X 10.9 (Mavericks)"
     release: 2013-10-22
     eol: 2016-12-01
-# URL for the page
-permalink: /macOS
+permalink: /macos
 link: https://developer.apple.com/documentation/macos-release-notes
 activeSupportColumn: false
 releaseColumn: false

--- a/tools/nodejs.md
+++ b/tools/nodejs.md
@@ -1,5 +1,8 @@
 ---
 permalink: /nodejs
+alternate_urls:
+  - /node
+  - /node.js
 layout: post
 title: Node.js
 link: https://nodejs.org/en/about/releases/

--- a/tools/office.md
+++ b/tools/office.md
@@ -1,6 +1,8 @@
 ---
 title: Microsoft Office
 permalink: /office
+alternate_urls:
+  - /msoffice
 layout: post
 link: https://support.microsoft.com/en-us/lifecycle/search?terms=Office
 activeSupportColumn: true

--- a/tools/postgresql.md
+++ b/tools/postgresql.md
@@ -2,6 +2,9 @@
 title: PostgreSQL
 layout: post
 permalink: /postgresql
+alternate_urls:
+  - /postgres
+  - /pg
 link: https://www.postgresql.org/support/versioning/
 changelogTemplate: https://www.postgresql.org/docs/release/__LATEST__/
 activeSupportColumn: false

--- a/tools/redhat.md
+++ b/tools/redhat.md
@@ -3,6 +3,9 @@ releaseImage: https://access.redhat.com/sites/default/files/images/rhel_8_life_c
 title: Red Hat Enterprise Linux
 layout: post
 permalink: /rhel
+alternate_urls:
+  - /redhat
+  - /redhatlinux
 link: https://access.redhat.com/support/policy/updates/errata
 activeSupportColumn: true
 releaseDateColumn: true

--- a/tools/ruby-on-rails.md
+++ b/tools/ruby-on-rails.md
@@ -1,5 +1,9 @@
 ---
 permalink: /rails
+alternate_urls:
+  - /rubyonrails
+  - /ruby-on-rails
+  - /roro
 layout: post
 title: Ruby on Rails
 link: https://guides.rubyonrails.org/maintenance_policy.html

--- a/tools/spring-framework.md
+++ b/tools/spring-framework.md
@@ -1,5 +1,7 @@
 ---
 title: Spring Framework
+alternate_urls:
+  - /spring
 layout: post
 category: framework
 sortReleasesBy: "releaseCycle"

--- a/tools/windowsEmbedded.md
+++ b/tools/windowsEmbedded.md
@@ -1,7 +1,7 @@
 ---
 title: Windows Embedded
 layout: post
-permalink: /windowsEmbedded
+permalink: /windowsembedded
 link: https://support.microsoft.com/en-us/lifecycle/search?terms=Windows%20Embedded
 category: os
 activeSupportColumn: true

--- a/tools/windowsServer.md
+++ b/tools/windowsServer.md
@@ -1,6 +1,6 @@
 ---
 title: Windows Server
-permalink: /windowsServer
+permalink: /windowsserver
 layout: post
 link: https://support.microsoft.com/en-us/lifecycle/search?terms=Windows%20Server
 category: os


### PR DESCRIPTION
### Why

- Much easier to remember, type, and still uses canonical pages (so we have a single URL)
- Lets people make mistakes, and we can still redirect to the best possible page (/go or /golang for eg)

### How

The `_redirects` file is as per [Netlify Configuration](https://docs.netlify.com/routing/redirects/#syntax-for-the-redirects-file). The file is ignored by Jekyll, so it is added to the `_config.yml/include` section, and has a `layout: null` for force-rendering the same.

Each page has a `alternate_urls` key, which gets used to generate the entries in the `_redirects` file (which also gets comments).