### PR TITLE
EoL of .NET Core 3.1 is final

### DIFF
--- a/tools/dotnetcore.md
+++ b/tools/dotnetcore.md
@@ -44,5 +44,3 @@ releases:
 > [.NET](https://dotnet.microsoft.com/) is a free, cross-platform, open source developer platform for building many different types of applications.
 
 Microsoft publishes new major releases of .NET Core on a regular cadence, enabling developers, the community and businesses to plan their roadmaps. Beginning with .NET Core 3.1, these releases will happen every November and every other release will be LTS. LTS releases are supported for three years after the initial release.
-
-The EoL date for 3.1 given above is approximate.


### PR DESCRIPTION
Removed the note. I don't think is true (anymore)

>LTS releases get free support and patches for 3 years.

https://dotnet.microsoft.com/platform/support/policy/dotnet-core