### PR TITLE
Remove old Python 2.7 info

### DIFF
--- a/tools/python.md
+++ b/tools/python.md
@@ -51,6 +51,4 @@ releases:
 
 > [Python](https://www.python.org/) is an interpreted, high-level, general-purpose programming language.
 
-By default, the end-of-life is scheduled 5 years after the first release, but can be adjusted by the release manager of each branch. The support for Python 2.7 was extended to 2020-01-01. Versions older than 2.7 have reached end-of-life.
-
-Many projects have [pledged to drop support for Python 2.7](https://python3statement.org/) no later than 2020, coinciding with the Python development team’s timeline for dropping support for Python 2.7.
+By default, the end-of-life is scheduled 5 years after the first release, but can be adjusted by the release manager of each branch.


### PR DESCRIPTION
Python 2.7 is now just another EOL version, time to remove this special case info?