### PR TITLE
Update Buster EOL in debian.md 

### DIFF
--- a/tools/debian.md
+++ b/tools/debian.md
@@ -56,6 +56,6 @@ releases:
 
 At any given time, there is one stable release of Debian, which has the support of the Debian security team. When a new stable version is released, the security team will usually cover the previous version for a year or so, while they also cover the new/current version. Only stable is recommended for production use.
 
-[Debian Long Term Support (LTS)](https://wiki.debian.org/LTS) is a project to extend the lifetime of all Debian stable releases to (at least) 5 years. Debian LTS will not be handled by the Debian security team, but by a separate group of volunteers and companies interested in making it a success.
+[Debian Long Term Support (LTS)](https://wiki.debian.org/LTS) is a project to extend the lifetime of all Debian stable releases to (at least) 5 years. Debian LTS will not be handled by the Debian security team, but by a separate group of volunteers and companies interested in making it a success. Not all packages of the Debian archive are supported by LTS, the (debian-security-support)[https://wiki.debian.org/LTS/Using#Check_for_unsupported_packages] package can check for unsupported packages.
 
-A commercial offering for [Extended Long Term Support](https://wiki.debian.org/LTS/Extended) is available.
+A commercial offering for [Extended Long Term Support](https://wiki.debian.org/LTS/Extended) is available

--- a/tools/debian.md
+++ b/tools/debian.md
@@ -11,7 +11,7 @@ sortReleasesBy: 'release'
 releases:
   - releaseCycle: 'Debian 10 "Buster"'
     release: 2019-07-06
-    eol: 2022-01-01
+    eol: 2024-06-01
     latest: 10.9
     link: https://lists.debian.org/debian-announce/2021/msg00001.html
   - releaseCycle: 'Debian 9 "Stretch" (LTS)'
@@ -56,6 +56,6 @@ releases:
 
 At any given time, there is one stable release of Debian, which has the support of the Debian security team. When a new stable version is released, the security team will usually cover the previous version for a year or so, while they also cover the new/current version. Only stable is recommended for production use.
 
-Debian <abbr title="Long Term Support">LTS</abbr> is a project to extend the lifetime of all Debian stable releases to (at least) 5 years. Debian LTS will not be handled by the Debian security team, but by a separate group of volunteers and companies interested in making it a success.
+[Debian Long Term Support (LTS)](https://wiki.debian.org/LTS) is a project to extend the lifetime of all Debian stable releases to (at least) 5 years. Debian LTS will not be handled by the Debian security team, but by a separate group of volunteers and companies interested in making it a success.
 
 A commercial offering for [Extended Long Term Support](https://wiki.debian.org/LTS/Extended) is available.


### PR DESCRIPTION
Use the scheduled support date for Buster LTS in 2024. It seems misleading to show the current EOL as 2022.

Source: https://wiki.debian.org/LTS