### PR TITLE
Create a JSON page per tool

### DIFF
--- a/_plugins/create-json-files.rb
+++ b/_plugins/create-json-files.rb
@@ -50,12 +50,7 @@ def process_file(markdown_file)
   tool.release_cycles.each do |cycle|
     output_file = json_filename(output_dir, cycle.fetch('name'))
     File.open(output_file, 'w') { |f| f.puts cycle.fetch('data').to_json }
-    all_cycles.append(
-      {
-        cycle: cycle.fetch('name'),
-        data: cycle.fetch('data')
-      }
-    )
+    all_cycles.append({'cycle' => cycle.fetch('name')}.merge(cycle.fetch('data')))
   end
   output_file = json_filename(API_DIR, tool.permalink)
   File.open(output_file, 'w') { |f| f.puts all_cycles.to_json }

--- a/_plugins/create-json-files.rb
+++ b/_plugins/create-json-files.rb
@@ -46,10 +46,19 @@ def process_file(markdown_file)
   output_dir = File.join(API_DIR, tool.permalink)
   FileUtils.mkdir_p(output_dir) unless FileTest.directory?(output_dir)
 
+  all_cycles = []
   tool.release_cycles.each do |cycle|
     output_file = json_filename(output_dir, cycle.fetch('name'))
     File.open(output_file, 'w') { |f| f.puts cycle.fetch('data').to_json }
+    all_cycles.append(
+      {
+        cycle: cycle.fetch('name'),
+        data: cycle.fetch('data')
+      }
+    )
   end
+  output_file = json_filename(API_DIR, tool.permalink)
+  File.open(output_file, 'w') { |f| f.puts all_cycles.to_json }
 end
 
 ############################################################


### PR DESCRIPTION
Fixes https://github.com/endoflife-date/endoflife.date/issues/90.

Creates a JSON page per tool.

```console
$ ruby _plugins/create-json-files.rb
$ cat api/python/3.9.json # existing file
{"release":"2020-10-05","eol":"2025-10-05","latest":"3.9.5","link":"https://www.python.org/downloads/release/python-395/"}
$ cat api/python.json # new file
[{"cycle":3.9,"data":{"release":"2020-10-05","eol":"2025-10-05","latest":"3.9.5","link":"https://www.python.org/downloads/release/python-395/"}},{"cycle":3.8,"data":{"release":"2019-10-14","eol":"2024-10-14","latest":"3.8.10","link":"https://www.python.org/downloads/release/python-3810/"}},{"cycle":3.7,"data":{"release":"2018-06-27","eol":"2023-06-27","latest":"3.7.10","link":"https://www.python.org/downloads/release/python-3710/"}},{"cycle":3.6,"data":{"release":"2016-12-23","eol":"2021-12-23","latest":"3.6.13","link":"https://www.python.org/downloads/release/python-3613/"}},{"cycle":3.5,"data":{"release":"2015-09-30","eol":"2020-09-13","latest":"3.5.10","link":"https://www.python.org/downloads/release/python-3510/"}},{"cycle":3.4,"data":{"release":"2014-03-16","eol":"2019-03-18","latest":"3.4.10","link":"https://www.python.org/downloads/release/python-3410/"}},{"cycle":3.3,"data":{"release":"2012-09-29","eol":"2017-09-29","latest":"3.3.7","link":"https://www.python.org/downloads/release/python-337/"}},{"cycle":2.7,"data":{"release":"2010-07-03","eol":"2020-01-01","latest":"2.7.18","link":"https://github.com/python/cpython/blob/2.7/Misc/NEWS.d/2.7.18rc1.rst"}}]
```

Prettified the JSON looks like this, is this the right sort of format?

```json
[
  {
    "cycle": 3.9,
    "data": {
      "release": "2020-10-05",
      "eol": "2025-10-05",
      "latest": "3.9.5",
      "link": "https://www.python.org/downloads/release/python-395/"
    }
  },
  {
    "cycle": 3.8,
    "data": {
      "release": "2019-10-14",
      "eol": "2024-10-14",
      "latest": "3.8.10",
      "link": "https://www.python.org/downloads/release/python-3810/"
    }
  },
  {
    "cycle": 3.7,
    "data": {
      "release": "2018-06-27",
      "eol": "2023-06-27",
      "latest": "3.7.10",
      "link": "https://www.python.org/downloads/release/python-3710/"
    }
  },
  {
    "cycle": 3.6,
    "data": {
      "release": "2016-12-23",
      "eol": "2021-12-23",
      "latest": "3.6.13",
      "link": "https://www.python.org/downloads/release/python-3613/"
    }
  },
  {
    "cycle": 3.5,
    "data": {
      "release": "2015-09-30",
      "eol": "2020-09-13",
      "latest": "3.5.10",
      "link": "https://www.python.org/downloads/release/python-3510/"
    }
  },
  {
    "cycle": 3.4,
    "data": {
      "release": "2014-03-16",
      "eol": "2019-03-18",
      "latest": "3.4.10",
      "link": "https://www.python.org/downloads/release/python-3410/"
    }
  },
  {
    "cycle": 3.3,
    "data": {
      "release": "2012-09-29",
      "eol": "2017-09-29",
      "latest": "3.3.7",
      "link": "https://www.python.org/downloads/release/python-337/"
    }
  },
  {
    "cycle": 2.7,
    "data": {
      "release": "2010-07-03",
      "eol": "2020-01-01",
      "latest": "2.7.18",
      "link": "https://github.com/python/cpython/blob/2.7/Misc/NEWS.d/2.7.18rc1.rst"
    }
  }
]
```