### PR TITLE
Add API endpoint to list all tools

### DIFF
--- a/_plugins/create-json-files.rb
+++ b/_plugins/create-json-files.rb
@@ -39,10 +39,7 @@ def json_filename(output_dir, name)
   File.join(output_dir, filename)
 end
 
-# file is something like 'tools/foo.md'
-def process_file(markdown_file)
-  tool = Tool.new(markdown_file)
-
+def process_tool(tool)
   output_dir = File.join(API_DIR, tool.permalink)
   FileUtils.mkdir_p(output_dir) unless FileTest.directory?(output_dir)
 
@@ -56,6 +53,18 @@ def process_file(markdown_file)
   File.open(output_file, 'w') { |f| f.puts all_cycles.to_json }
 end
 
+# each file is something like 'tools/foo.md'
+def process_all_files()
+  all_tools = []
+  Dir['tools/*.md'].each do |file|
+    tool = Tool.new(file)
+    tool_cycles = process_tool(tool)
+    all_tools.append(tool.permalink)
+  end
+  output_file = json_filename(API_DIR, 'all-tools')
+  File.open(output_file, 'w') { |f| f.puts all_tools.sort.to_json }
+end
+
 ############################################################
 
-Dir['tools/*.md'].each { |file| process_file(file) }
+process_all_files()

--- a/_plugins/create-json-files.rb
+++ b/_plugins/create-json-files.rb
@@ -61,7 +61,7 @@ def process_all_files()
     tool_cycles = process_tool(tool)
     all_tools.append(tool.permalink)
   end
-  output_file = json_filename(API_DIR, 'all-tools')
+  output_file = json_filename(API_DIR, 'all')
   File.open(output_file, 'w') { |f| f.puts all_tools.sort.to_json }
 end
 


### PR DESCRIPTION
I've created a CLI to access the API!

https://github.com/hugovk/norwegianblue

For example:

![image](https://user-images.githubusercontent.com/1324225/122570941-e69fe180-d054-11eb-94dd-1ecf259883a8.png)

It would be useful to have an endpoint to list all the tool names, currently:

```console
$ cat api/all-tools.json
["alpine","amazon-linux","android","bootstrap","centos","debian","django","dotnet","dotnetcore","dotnetfx","drupal","elasticsearch","elixir","fedora","filemaker","freebsd","go","godot","iphone","java","kindle","kubernetes","laravel","macos","magento","mariadb","mongodb","mssqlserver","mysql","nodejs","office","perl","php","pixel","postgresql","powershell","python","rabbitmq","rails","redis","rhel","ros","ruby","spring-framework","surface","symfony","ubuntu","wagtail","windows","windowsembedded","windowsserver"]
```

https://deploy-preview-273--endoflife-date.netlify.app/api/all-tools.json

Naming things is hard; I wasn't sure about the address `api/all-tools.json`.

What do you think?

Could also be worth thinking if the regular API should be something like `/api/v1/tool/python/3.9.json` and `/api/v1/tool/python.json`?