### PR TITLE
[ci] Fail build if releases are not strings

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,7 +21,7 @@ changelogTemplate: "https://link/of/the/__RELEASE_CYCLE__/and/__LATEST__/version
 # A list of releases, supported or not
 # Newer releases go on top of the list, in order
 releases:
-    # Release range (usually major.minor), put in quotes if a string.
+    # Release range (usually major.minor), always put in quotes
   - releaseCycle: "1.2"
     # End of Security Support for the product. Alternatively, set to true|false if EOL is not pre-decided
     eol: 2019-01-01
@@ -33,7 +33,8 @@ releases:
     release: 2017-03-12
     # Current latest release
     # remove is releaseColumn is false
-    latest: 1.2.3
+    # always put in quotes
+    latest: "1.2.3"
 # A few extra fields define overall page behaviour
 
 # URL for the page

--- a/_plugins/validate-releases.rb
+++ b/_plugins/validate-releases.rb
@@ -1,0 +1,24 @@
+require 'fileutils'
+require 'json'
+require 'yaml'
+
+STRING_KEYS = ['latest', 'releaseCycle']
+
+failure = false
+
+def process_file(markdown_file)
+  hash = YAML.load_file(markdown_file)
+  hash['releases'].each do |r|
+    STRING_KEYS.each do |k|
+      if r.key? k
+        if r[k].class != String
+          puts "#{markdown_file} has non-string value #{r[k]} in #{k}. Please wrap it in quotes"
+          failure = true
+        end
+      end
+    end
+  end
+end
+
+Dir['tools/*.md'].each { |file| process_file(file) }
+exit(1) if failure

--- a/_plugins/validate-releases.rb
+++ b/_plugins/validate-releases.rb
@@ -2,23 +2,28 @@ require 'fileutils'
 require 'json'
 require 'yaml'
 
+# These are fields we expect to be strings, but YAML
+# picks up version numbers (like 3.10) as numbers and would
+# format them to 3.1 instead. So we ensure these are always
+# read as strings instead.
 STRING_KEYS = ['latest', 'releaseCycle']
 
-failure = false
-
-def process_file(markdown_file)
-  hash = YAML.load_file(markdown_file)
-  hash['releases'].each do |r|
-    STRING_KEYS.each do |k|
-      if r.key? k
-        if r[k].class != String
-          puts "#{markdown_file} has non-string value #{r[k]} in #{k}. Please wrap it in quotes"
-          failure = true
+def process_files
+  success = true
+  Dir['tools/*.md'].each do |markdown_file|
+    hash = YAML.load_file(markdown_file)
+    hash['releases'].each do |r|
+      STRING_KEYS.each do |k|
+        if r.key? k
+          if r[k].class != String
+            puts "#{markdown_file} has non-string value #{r[k]} in #{k}. Please wrap it in quotes"
+            success = true
+          end
         end
       end
     end
   end
+  success
 end
 
-Dir['tools/*.md'].each { |file| process_file(file) }
-exit(1) if failure
+exit(1) unless process_files

--- a/tools/amazon-linux.md
+++ b/tools/amazon-linux.md
@@ -10,13 +10,13 @@ releaseDateColumn: true
 sortReleasesBy: 'release'
 releases:
   - releaseCycle: 'Amazon Linux AMI'
-    release: 2010-09-14
+    release: "2010-09-14"
     eol: 2020-12-31
-    latest: 2018.03
+    latest: "2018.03"
   - releaseCycle: 'Amazon Linux 2'
     release: 2017-12-19
     eol: 2023-06-30
-    latest: 2.0.20210617.0
+    latest: "2.0.20210617.0"
     link: https://aws.amazon.com/amazon-linux-2/release-notes/
 ---
 

--- a/tools/android.md
+++ b/tools/android.md
@@ -12,10 +12,10 @@ releaseDateColumn: true
 eolColumn: Security Support
 sortReleasesBy: 'release'
 releases:
-  - releaseCycle: 1.0
+  - releaseCycle: "1.0"
     release: 2008-09-23
     eol: true
-  - releaseCycle: 1.1
+  - releaseCycle: "1.1"
     release: 2009-02-09
     eol: true
   - releaseCycle: Cupcake (1.5)

--- a/tools/django.md
+++ b/tools/django.md
@@ -10,38 +10,38 @@ command: python -c "import django; print(django.get_version())"
 releaseDateColumn: false
 sortReleasesBy: 'releaseCycle'
 releases:
-  - releaseCycle: 3.2
+  - releaseCycle: "3.2"
     support: 2021-12-01
     eol: 2024-04-01
-    latest: 3.2
+    latest: "3.2"
     lts: true
-  - releaseCycle: 3.1
+  - releaseCycle: "3.1"
     support: 2021-04-05
     eol: 2021-12-01
-    latest: 3.1.8
-  - releaseCycle: 3.0
+    latest: "3.1.8"
+  - releaseCycle: "3.0"
     support: 2020-08-01
     eol: 2021-04-01
-    latest: 3.0.14
-  - releaseCycle: 2.2
+    latest: "3.0.14"
+  - releaseCycle: "2.2"
     lts: true
     support: 2019-12-01
     eol: 2022-04-01
-    latest: 2.2.19
-  - releaseCycle: 2.1
+    latest: "2.2.19"
+  - releaseCycle: "2.1"
     support: 2019-04-01
     eol: 2019-12-01
-    latest: 2.1.15
-  - releaseCycle: 2.0
+    latest: "2.1.15"
+  - releaseCycle: "2.0"
     support: 2018-08-01
     eol: 2019-04-01
-    latest: 2.0.13
+    latest: "2.0.13"
     lts: false
-  - releaseCycle: 1.11
+  - releaseCycle: "1.11"
     lts: true
     support: 2017-12-02
     eol: 2020-04-01
-    latest: 1.11.29
+    latest: "1.11.29"
 ---
 
 > [Django](https://www.djangoproject.com/) is a high-level Python Web framework that encourages rapid development and clean, pragmatic design.

--- a/tools/dotnet.md
+++ b/tools/dotnet.md
@@ -11,11 +11,11 @@ releaseDateColumn: true
 sortReleasesBy: "releaseCycle"
 eolColumn: Support Status
 releases:
-  - releaseCycle: 5.0
+  - releaseCycle: "5.0"
     lts: false
     release: 2020-11-10
     eol: 2022-02-28
-    latest: 5.0.7
+    latest: "5.0.7"
 ---
 
 > [.NET](https://dotnet.microsoft.com/) is a free, cross-platform, open source developer platform for building many different types of applications.

--- a/tools/dotnetcore.md
+++ b/tools/dotnetcore.md
@@ -11,36 +11,36 @@ releaseDateColumn: true
 sortReleasesBy: "releaseCycle"
 eolColumn: Support Status
 releases:
-  - releaseCycle: 3.1
+  - releaseCycle: "3.1"
     lts: true
     release: 2019-12-03
-    latest: 3.1.16
+    latest: "3.1.16"
     eol: 2022-12-03
-  - releaseCycle: 3.0
+  - releaseCycle: "3.0"
     release: 2019-09-23
-    latest: 3.0.3
+    latest: "3.0.3"
     eol: 2020-03-03
-  - releaseCycle: 2.2
+  - releaseCycle: "2.2"
     release: 2018-12-04
-    latest: 2.2.8
+    latest: "2.2.8"
     eol: 2019-12-23
-  - releaseCycle: 2.1
+  - releaseCycle: "2.1"
     lts: true
     release: 2018-05-30
-    latest: 2.1.27
+    latest: "2.1.27"
     eol: 2021-08-21
-  - releaseCycle: 2.0
+  - releaseCycle: "2.0"
     release: 2017-08-14
     eol: 2018-10-01
-    latest: 2.0.9
-  - releaseCycle: 1.1
+    latest: "2.0.9"
+  - releaseCycle: "1.1"
     release: 2016-11-16
     eol: 2019-06-27
-    latest: 1.1.13
-  - releaseCycle: 1.0
+    latest: "1.1.13"
+  - releaseCycle: "1.0"
     release: 2016-06-27
     eol: 2019-06-27
-    latest: 1.0.16
+    latest: "1.0.16"
 ---
 
 > [.NET](https://dotnet.microsoft.com/) is a free, cross-platform, open source developer platform for building many different types of applications.

--- a/tools/dotnetfx.md
+++ b/tools/dotnetfx.md
@@ -10,34 +10,34 @@ releaseDateColumn: true
 sortReleasesBy: "releaseCycle"
 eolColumn: Support Status
 releases:
-  - releaseCycle: 4.8
+  - releaseCycle: "4.8"
     release: 2019-04-18
     eol: false
-  - releaseCycle: 4.7.2
+  - releaseCycle: "4.7.2"
     release: 2018-04-30
     eol: false
-  - releaseCycle: 4.7.1
+  - releaseCycle: "4.7.1"
     release: 2017-10-17
     eol: false
-  - releaseCycle: 4.7
+  - releaseCycle: "4.7"
     release: 2017-04-05
     eol: false
-  - releaseCycle: 4.6.2
+  - releaseCycle: "4.6.2"
     release: 2016-08-02
     eol: false
-  - releaseCycle: 4.6.1
+  - releaseCycle: "4.6.1"
     release: 2015-11-30
     eol: 2022-04-26
-  - releaseCycle: 4.6
+  - releaseCycle: "4.6"
     release: 2015-07-20
     eol: 2022-04-26
-  - releaseCycle: 4.5.2
+  - releaseCycle: "4.5.2"
     release: 2014-05-05
     eol: 2022-04-26
-  - releaseCycle: 4.5.1
+  - releaseCycle: "4.5.1"
     release: 2014-05-05
     eol: 2016-01-12
-  - releaseCycle: 4.5
+  - releaseCycle: "4.5"
     release: 2012-08-15
     eol: 2016-01-12
 ---

--- a/tools/drupal.md
+++ b/tools/drupal.md
@@ -11,37 +11,37 @@ command: drush status
 releaseImage: https://www.drupal.org/files/2019_minor_release_schedule.png
 sortReleasesBy: 'releaseCycle'
 releases:
-  - releaseCycle: 9.2
+  - releaseCycle: "9.2"
     release: 2021-06-16
     support: 2021-12-08
     eol:     2022-06-01
-    latest:  9.2.0
-  - releaseCycle: 9.1
+    latest:  "9.2.0"
+  - releaseCycle: "9.1"
     release: 2020-12-02
     support: 2021-06-16
     eol:     2021-12-08
-    latest:  9.1.10
-  - releaseCycle: 9.0
+    latest:  "9.1.10"
+  - releaseCycle: "9.0"
     release: 2020-06-03
     support: 2020-12-02
     eol:     2021-06-16
-    latest:  9.0.12
-  - releaseCycle: 8.9
+    latest:  "9.0.12"
+  - releaseCycle: "8.9"
     release: 2020-06-03
     support: 2020-12-01
     eol:     2021-11-01
-    latest:  8.9.14
+    latest:  "8.9.14"
     lts: true
-  - releaseCycle: 8.8
+  - releaseCycle: "8.8"
     release: 2019-12-04
     support: 2020-06-03
     eol:     2020-12-01
-    latest:  8.8.12
-  - releaseCycle: 7
+    latest:  "8.8.12"
+  - releaseCycle: "7"
     release: 2011-01-05
     support: 2015-11-19
     eol:     2022-11-28
-    latest:  7.80
+    latest:  "7.80"
 ---
 
 > [Drupal](https://www.drupal.org/) is a free and open-source content management framework written in PHP and distributed under the GNU General Public License.

--- a/tools/fedora.md
+++ b/tools/fedora.md
@@ -12,35 +12,35 @@ releases:
   # feature release 35 expected on 2021-10-27 -> calculate EoL of 33
   #- releaseCycle: "35"
   #  release: 2021-10-27
-  #  latest: 34
+  #  latest: "34"
   #  eol: false
   - releaseCycle: "34"
     release: 2021-04-27
-    latest: 34
+    latest: "34"
     eol: false
   - releaseCycle: "33"
     release: 2020-10-27
-    latest: 33
+    latest: "33"
     eol: false
   - releaseCycle: "32"
     release: 2020-04-28
-    latest: 32
+    latest: "32"
     eol: 2021-05-25
   - releaseCycle: "31"
     release: 2019-10-29
-    latest: 31
+    latest: "31"
     eol: 2020-11-30
   - releaseCycle: "30"
     release: 2019-05-07
-    latest: 30
+    latest: "30"
     eol: 2020-05-26
   - releaseCycle: "29"
     release: 2018-10-30
-    latest: 29
+    latest: "29"
     eol: 2019-11-26
   - releaseCycle: "28"
     release: 2018-05-01
-    latest: 28
+    latest: "28"
     eol: 2019-05-28
 ---
 

--- a/tools/godot.md
+++ b/tools/godot.md
@@ -14,44 +14,44 @@ releases:
     release: 2014-12-01
     eol: true
     support: false
-    latest: 1.1
+    latest: "1.1"
   - releaseCycle: "2.0"
     release: 2016-02-01
     eol: true
     support: false
-    latest: 2.0.4.1
+    latest: "2.0.4.1"
     lts: false
     link: https://godotengine.org/article/maintenance-release-godot-2-0-4
   - releaseCycle: "2.1"
     release: 2016-07-01
     eol: false
     support: false
-    latest: 2.1.6
+    latest: "2.1.6"
     lts: true
     link: https://godotengine.org/article/maintenance-release-godot-2-1-6
   - releaseCycle: "3.0"
     release: 2018-01-01
     support: false
     eol: true
-    latest: 3.0.6
+    latest: "3.0.6"
     link: https://godotengine.org/article/maintenance-release-godot-3-0-6
   - releaseCycle: "3.1"
     release: 2019-03-01
     support: false
     eol: false
-    latest: 3.1.2
+    latest: "3.1.2"
     link: https://godotengine.org/article/maintenance-release-godot-3-1-2
   - releaseCycle: "3.2"
     release: 2020-01-01
     support: false
     eol: true
-    latest: 3.2.3
+    latest: "3.2.3"
     link: https://godotengine.org/article/maintenance-release-godot-3-2-3
   - releaseCycle: "3.3"
     release: 2021-04-22
     support: true
     eol: false
-    latest: 3.3
+    latest: "3.3"
     link: https://godotengine.org/article/godot-3-3-has-arrived
 ---
 >[Godot Engine](https://godotengine.org/) is a feature-packed, cross-platform game engine to create 2D and 3D games from a unified interface released under the MIT License. It provides a comprehensive set of common tools, so users can focus on making games without having to reinvent the wheel. Games can be exported in one click to a [number of platforms](https://docs.godotengine.org/en/latest/tutorials/export/exporting_basics.html#exporting-by-platform).

--- a/tools/java.md
+++ b/tools/java.md
@@ -11,63 +11,63 @@ link: https://www.oracle.com/technetwork/java/java-se-support-roadmap.html
 releaseDateColumn: true
 sortReleasesBy: 'releaseCycle'
 releases:
-  - releaseCycle: 16
+  - releaseCycle: "16"
     release: 2021-03-16
     support: 2021-09-30
     eol: 2021-09-30
-    latest: 16.0.0
-  - releaseCycle: 15
+    latest: "16.0.0"
+  - releaseCycle: "15"
     release: 2020-09-16
     support: 2021-03-31
     eol: 2021-03-31
-    latest: 15.0.2
-  - releaseCycle: 14
+    latest: "15.0.2"
+  - releaseCycle: "14"
     release: 2020-03-17
     support: 2020-09-30
     eol: 2020-09-30
-    latest: 14.0.2
-  - releaseCycle: 13
+    latest: "14.0.2"
+  - releaseCycle: "13"
     release: 2019-09-17
     support: 2020-03-31
     eol: 2020-03-31
-    latest: 13.0.2
-  - releaseCycle: 12
+    latest: "13.0.2"
+  - releaseCycle: "12"
     release: 2019-03-19
     support: 2019-09-30
     eol: 2019-09-30
-    latest: 12.0.2
-  - releaseCycle: 11
+    latest: "12.0.2"
+  - releaseCycle: "11"
     lts: true
     release: 2018-09-25
     support: 2023-09-30
     eol: 2026-09-30
-    latest: 11.0.10
-  - releaseCycle: 10
+    latest: "11.0.10"
+  - releaseCycle: "10"
     release: 2018-03-20
     support: 2018-09-25
     eol: 2018-09-25
-    latest: 10.0.2
-  - releaseCycle: 9
+    latest: "10.0.2"
+  - releaseCycle: "9"
     release: 2017-09-21
     support: 2018-03-20
     eol: 2018-03-20
-    latest: 9.0.4
-  - releaseCycle: 8
+    latest: "9.0.4"
+  - releaseCycle: "8"
     lts: true
     release: 2014-03-18
     support: 2022-03-31
     eol: 2025-03-31
-    latest: 8u281
-  - releaseCycle: 7
+    latest: "8u281"
+  - releaseCycle: "7"
     release: 2011-07-07
     support: 2019-07-31
     eol: 2022-07-31
-    latest: 7u221
-  - releaseCycle: 6
+    latest: "7u221"
+  - releaseCycle: "6"
     release: 2006-12-11
     support: 2015-12-31
     eol: 2018-12-31
-    latest: 6u211
+    latest: "6u211"
 ---
 
 Java as developed by the [OpenJDK Project](https://openjdk.java.net/), owned and primarily employed by Oracle, has been on a 6-month rapid-release cycle since the release of Java 10, and starting with Java 11, has new LTS releases every six releases, or three years. Java 8 is the last release on the old cycle methodology still in active support. Non-LTS releases are supported for 6 months. The latest supported release in each release cycle can be found at <https://www.oracle.com/java/technologies/java-se-glance.html>.

--- a/tools/magento.md
+++ b/tools/magento.md
@@ -10,96 +10,96 @@ command: php bin/magento --version
 releaseDateColumn: true
 sortReleasesBy: 'releaseCycle'
 releases:
-  - releaseCycle: 2.4
+  - releaseCycle: "2.4"
     cycleShortHand: 2
     release: 2020-07-28
     eol: false
     support: true
-    latest: 2.4.0
-  - releaseCycle: 2.3
+    latest: "2.4.0"
+  - releaseCycle: "2.3"
     cycleShortHand: 2
     release: 2018-11-28
     eol: 2021-05-28
     support: 2022-01-28
-    latest: 2.3.5
-  - releaseCycle: 2.2
+    latest: "2.3.5"
+  - releaseCycle: "2.2"
     cycleShortHand: 2
     release: 2017-09-01
     eol: 2019-12-01
     support: 2019-12-01
-    latest: 2.2.11
-  - releaseCycle: 2.1
+    latest: "2.2.11"
+  - releaseCycle: "2.1"
     cycleShortHand: 2
     release: 2016-06-01
     eol: 2019-06-01
     support: 2019-06-01
-    latest: 2.1.18
-  - releaseCycle: 2.0
+    latest: "2.1.18"
+  - releaseCycle: "2.0"
     cycleShortHand: 2
     release: 2015-11-01
     eol: 2018-03-01
     support: 2018-03-01
-    latest: 2.0.18
-  - releaseCycle: 1.9
+    latest: "2.0.18"
+  - releaseCycle: "1.9"
     cycleShortHand: 1
     release: 2014-05-01
     eol: 2020-06-01
     support: 2020-06-01
-    latest: 1.9.4.3
-  - releaseCycle: 1.8
+    latest: "1.9.4.3"
+  - releaseCycle: "1.8"
     cycleShortHand: 1
     release: 2013-09-01
     eol: 2020-06-01
     support: 2014-09-01
-    latest: 1.8.1.0
-  - releaseCycle: 1.7
+    latest: "1.8.1.0"
+  - releaseCycle: "1.7"
     cycleShortHand: 1
     release: 2012-04-01
     eol: 2020-06-01
     support: 2013-04-01
-    latest: 1.7.0.2
-  - releaseCycle: 1.6
+    latest: "1.7.0.2"
+  - releaseCycle: "1.6"
     cycleShortHand: 1
     release: 2011-08-01
     eol: 2020-06-01
     support: 2012-08-01
-    latest: 1.6.2.0
-  - releaseCycle: 1.5
+    latest: "1.6.2.0"
+  - releaseCycle: "1.5"
     cycleShortHand: 1
     release: 2011-02-01
     eol: 2020-06-01
     support: 2012-02-01
-    latest: 1.5.1.0
-  - releaseCycle: 1.4
+    latest: "1.5.1.0"
+  - releaseCycle: "1.4"
     cycleShortHand: 1
     release: 2010-02-01
     eol: 2012-02-01
     support: 2011-02-01
-    latest: 1.4.2.0
-  - releaseCycle: 1.3
+    latest: "1.4.2.0"
+  - releaseCycle: "1.3"
     cycleShortHand: 1
     release: 2009-03-01
     eol: 2011-03-01
     support: 2010-03-01
-    latest: 1.3.3.0
-  - releaseCycle: 1.2
+    latest: "1.3.3.0"
+  - releaseCycle: "1.2"
     cycleShortHand: 1
     release: 2008-12-01
     eol: 2010-12-01
     support: 2009-12-01
-    latest: 1.2.1.2
-  - releaseCycle: 1.1
+    latest: "1.2.1.2"
+  - releaseCycle: "1.1"
     cycleShortHand: 1
     release: 2008-07-01
     eol: 2010-07-01
     support: 2009-07-01
-    latest: 1.1.8
-  - releaseCycle: 1.0
+    latest: "1.1.8"
+  - releaseCycle: "1.0"
     cycleShortHand: 1
     release: 2008-03-01
     eol: 2010-03-01
     support: 2009-03-01
-    latest: 1.0.0
+    latest: "1.0.0"
 ---
 
 > [Magento](https://magento.com/): Magento is an open-source e-commerce platform written in PHP.

--- a/tools/mariadb.md
+++ b/tools/mariadb.md
@@ -10,42 +10,42 @@ command: mysqld --version
 eolColumn: Support Status
 sortReleasesBy: 'releaseCycle'
 releases:
-  - releaseCycle: 5.5
+  - releaseCycle: "5.5"
     release: 2012-04-11
     eol: 2020-04-11
-    latest: 5.5.65
-    latestShortHand: 5565
+    latest: "5.5.65"
+    latestShortHand: "5565"
     lts: true
-  - releaseCycle: 10.0
+  - releaseCycle: "10.0"
     release: 2014-03-31
     eol: 2019-03-31
-    latestShortHand: 10038
-    latest: 10.0.38
-  - releaseCycle: 10.1
+    latestShortHand: "10038"
+    latest: "10.0.38"
+  - releaseCycle: "10.1"
     release: 2015-10-17
     eol: 2020-10-17
-    latest: 10.1.46
-    latestShortHand: 10146
-  - releaseCycle: 10.2
+    latest: "10.1.46"
+    latestShortHand: "10146"
+  - releaseCycle: "10.2"
     release: 2017-05-23
     eol: 2022-05-23
-    latest: 10.2.36
-    latestShortHand: 10236
-  - releaseCycle: 10.3
+    latest: "10.2.36"
+    latestShortHand: "10236"
+  - releaseCycle: "10.3"
     release: 2018-05-25
     eol: 2023-05-25
-    latest: 10.3.27
-    latestShortHand: 10327
-  - releaseCycle: 10.4
+    latest: "10.3.27"
+    latestShortHand: "10327"
+  - releaseCycle: "10.4"
     release: 2019-06-18
     eol: 2024-06-18
-    latest: 10.4.17
-    latestShortHand: 10417
-  - releaseCycle: 10.5
+    latest: "10.4.17"
+    latestShortHand: "10417"
+  - releaseCycle: "10.5"
     release: 2020-06-24
     eol: 2025-06-24
-    latest: 10.5.8
-    latestShortHand: 1058
+    latest: "10.5.8"
+    latestShortHand: "1058"
 ---
 
 > [MariaDB](https://mariadb.org/about/) is a community-developed, commercially supported fork of the MySQL relational database management system (RDBMS).

--- a/tools/mongodb.md
+++ b/tools/mongodb.md
@@ -10,61 +10,61 @@ releaseDateColumn: true
 command: mongod --version
 releaseImage: https://webassets.mongodb.com/_com_assets/cms/MongoDB_Logo_FullColorBlack_RGB-4td3yuxzjs.png
 releases:
-  - releaseCycle: 4.4
+  - releaseCycle: "4.4"
     eol: false
     release: 2020-07-30
-    latest: 4.4.5
-  - releaseCycle: 4.2
+    latest: "4.4.5"
+  - releaseCycle: "4.2"
     eol: false
     release: 2019-08-31
-    latest: 4.2.13
-  - releaseCycle: 4.0
+    latest: "4.2.13"
+  - releaseCycle: "4.0"
     eol: 2022-01-31
     release: 2018-06-30
-    latest: 4.0.24
-  - releaseCycle: 3.6
+    latest: "4.0.24"
+  - releaseCycle: "3.6"
     eol: 2021-04-30
     release: 2017-11-30
-    latest: 3.6.23
-  - releaseCycle: 3.4
+    latest: "3.6.23"
+  - releaseCycle: "3.4"
     eol: 2020-01-31
     release: 2016-11-30
-    latest: 3.4.24
-  - releaseCycle: 3.2
+    latest: "3.4.24"
+  - releaseCycle: "3.2"
     eol: 2018-07-31
     release: 2015-12-31
-    latest: 3.2.22
-  - releaseCycle: 3.0
+    latest: "3.2.22"
+  - releaseCycle: "3.0"
     eol: 2018-02-28
     release: 2015-03-31
-    latest: 3.0.15
-  - releaseCycle: 2.6
+    latest: "3.0.15"
+  - releaseCycle: "2.6"
     eol: 2016-10-31
     release: 2014-04-30
-    latest: 2.6.12
-  - releaseCycle: 2.4
+    latest: "2.6.12"
+  - releaseCycle: "2.4"
     eol: 2013-03-31
     release: 2016-03-31
-    latest: 2.4.14
-  - releaseCycle: 2.2
+    latest: "2.4.14"
+  - releaseCycle: "2.2"
     eol: 2014-02-28
     release: 2012-08-31
-  - releaseCycle: 2.0
+  - releaseCycle: "2.0"
     eol: 2013-03-31
     release: 2011-09-30
-  - releaseCycle: 1.8
+  - releaseCycle: "1.8"
     eol: 2012-09-30
     release: 2011-03-31
-  - releaseCycle: 1.6
+  - releaseCycle: "1.6"
     eol: 2012-02-28
     release: 2010-08-31
-  - releaseCycle: 1.4
+  - releaseCycle: "1.4"
     eol: 2012-09-30
     release: 2010-03-31
-  - releaseCycle: 1.2
+  - releaseCycle: "1.2"
     eol: 2011-06-30
     release: 2009-12-31
-  - releaseCycle: 1.0
+  - releaseCycle: "1.0"
     eol: 2010-08-31
     release: 2009-02-28
 ---

--- a/tools/mssqlserver.md
+++ b/tools/mssqlserver.md
@@ -9,12 +9,12 @@ command: select @@version
 releaseDateColumn: true
 sortReleasesBy: 'latest'
 releases:
-  - releaseCycle: 2019
+  - releaseCycle: "2019"
     release: 2019-11-04
     support: 2025-01-07
     eol: 2030-01-08
     latest: 15.0.2070.41 GDR 15.0.4123.1 CU10
-  - releaseCycle: 2017
+  - releaseCycle: "2017"
     release: 2017-09-29
     support: 2022-10-11
     eol: 2027-10-12

--- a/tools/nodejs.md
+++ b/tools/nodejs.md
@@ -13,37 +13,37 @@ command: node --version
 releaseDateColumn: true
 sortReleasesBy: 'releaseCycle'
 releases:
-  - releaseCycle: 16
+  - releaseCycle: "16"
     release: 2021-04-20
     lts: false
     # enters lts: true on 2021-10-26
     support: 2022-10-18
     eol: 2024-04-30
-    latest: 16.4.1
-  - releaseCycle: 15
+    latest: "16.4.1"
+  - releaseCycle: "15"
     release: 2020-10-20
     lts: false
     support: 2021-04-01
     eol: 2021-06-01
-    latest: 15.14.0
-  - releaseCycle: 14
+    latest: "15.14.0"
+  - releaseCycle: "14"
     release: 2020-04-21
     lts: true
     support: 2021-10-19
     eol: 2023-04-30
-    latest: 14.17.2
-  - releaseCycle: 12
+    latest: "14.17.2"
+  - releaseCycle: "12"
     release: 2019-04-23
     lts: true
     support: 2020-10-20
     eol: 2022-04-30
-    latest: 12.22.2
-  - releaseCycle: 10
+    latest: "12.22.2"
+  - releaseCycle: "10"
     release: 2018-04-24
     lts: true
     support: 2020-05-19
     eol: 2021-04-30
-    latest: 10.24.1
+    latest: "10.24.1"
 ---
 
 > [Node.js](https://nodejs.org/) is an open-source, cross-platform JavaScript run-time environment built on Chrome's V8 JavaScript engine that executes JavaScript code outside of a browser.

--- a/tools/php.md
+++ b/tools/php.md
@@ -10,84 +10,84 @@ command: php --version
 releaseDateColumn: true
 sortReleasesBy: 'releaseCycle'
 releases:
-  - releaseCycle: 8.0
-    cycleShortHand: 8
+  - releaseCycle: "8.0"
+    cycleShortHand: "8"
     release: 2020-11-26
     support: 2022-11-26
     eol:     2023-11-26
-    latest:  8.0.0
-  - releaseCycle: 7.4
-    cycleShortHand: 7
+    latest:  "8.0.0"
+  - releaseCycle: "7.4"
+    cycleShortHand: "7"
     release: 2019-11-28
     support: 2021-11-28
     eol:     2022-11-28
-    latest:  7.4.13
-  - releaseCycle: 7.3
-    cycleShortHand: 7
+    latest:  "7.4.13"
+  - releaseCycle: "7.3"
+    cycleShortHand: "7"
     release: 2018-12-06
     support: 2020-12-06
     eol:     2021-12-06
-    latest:  7.3.25
-  - releaseCycle: 7.2
-    cycleShortHand: 7
+    latest:  "7.3.25"
+  - releaseCycle: "7.2"
+    cycleShortHand: "7"
     release: 2017-11-30
     support: 2019-11-30
     eol:     2020-11-30
-    latest:  7.2.34
-  - releaseCycle: 7.1
-    cycleShortHand: 7
+    latest:  "7.2.34"
+  - releaseCycle: "7.1"
+    cycleShortHand: "7"
     release: 2016-12-01
     support: 2018-12-01
     eol:     2019-12-01
-    latest:  7.1.33
-  - releaseCycle: 7.0
-    cycleShortHand: 7
+    latest:  "7.1.33"
+  - releaseCycle: "7.0"
+    cycleShortHand: "7"
     release: 2015-12-03
     support: 2018-12-12
     eol:     2019-01-01
-    latest:  7.0.33
-  - releaseCycle: 5.6
-    cycleShortHand: 5
+    latest:  "7.0.33"
+  - releaseCycle: "5.6"
+    cycleShortHand: "5"
     release: 2014-08-28
     support: 2017-01-19
     eol:     2018-12-31
-    latest:  5.6.40
-  - releaseCycle: 5.5
-    cycleShortHand: 7
+    latest:  "5.6.40"
+  - releaseCycle: "5.5"
+    cycleShortHand: "7"
     release: 2013-06-20
     support: 2015-07-10
     eol:     2016-07-10
-    latest:  5.5.27
-  - releaseCycle: 5.4
-    cycleShortHand: 5
+    latest:  "5.5.27"
+  - releaseCycle: "5.4"
+    cycleShortHand: "5"
     release: 2012-03-01
     support: 2014-09-14
     eol:     2015-09-14
-    latest:  5.4.45
-  - releaseCycle: 5.3
-    cycleShortHand: 5
+    latest:  "5.4.45"
+  - releaseCycle: "5.3"
+    cycleShortHand: "5"
     release: 2009-06-30
     support: 2011-06-30
     eol:     2014-08-14
-    latest:  5.3.29
-  - releaseCycle: 5.2
-    cycleShortHand: 5
+    latest:  "5.3.29"
+  - releaseCycle: "5.2"
+    cycleShortHand: "5"
     release: 2006-11-02
     support: 2008-11-02
     eol:     2011-01-06
-    latest:  5.2.17
-  - releaseCycle: 5.1
-    cycleShortHand: 5
+    latest:  "5.2.17"
+  - releaseCycle: "5.1"
+    cycleShortHand: "5"
     release: 2005-11-24
     support: 2006-08-24
     eol:     2006-08-24
-    latest:  5.1.6
-  - releaseCycle: 5.0
-    cycleShortHand: 5
+    latest:  "5.1.6"
+  - releaseCycle: "5.0"
+    cycleShortHand: "5"
     release: 2004-07-13
     support: 2005-09-05
     eol:     2005-09-05
-    latest:  5.0.5
+    latest:  "5.0.5"
 ---
 
 > [PHP](https://www.php.net/): Hypertext Preprocessor (or simply PHP) is a general-purpose programming language originally designed for web development.

--- a/tools/postgresql.md
+++ b/tools/postgresql.md
@@ -13,70 +13,70 @@ command: psql -c "SELECT version();"
 releaseDateColumn: true
 sortReleasesBy: 'releaseCycle'
 releases:
-  - releaseCycle: 13
+  - releaseCycle: "13"
     release: 2020-09-24
     eol: 2025-11-13
-    latest: 13.3
-  - releaseCycle: 12
+    latest: "13.3"
+  - releaseCycle: "12"
     release: 2019-10-03
     eol: 2024-11-14
-    latest: 12.7
-  - releaseCycle: 11
+    latest: "12.7"
+  - releaseCycle: "11"
     release: 2018-10-18
     eol: 2023-11-09
-    latest: 11.12
-  - releaseCycle: 10
+    latest: "11.12"
+  - releaseCycle: "10"
     release: 2017-10-05
     eol: 2022-11-10
-    latest: 10.17
-  - releaseCycle: 9.6
+    latest: "10.17"
+  - releaseCycle: "9.6"
     release: 2016-09-29
     eol: 2021-11-11
-    latest: 9.6.22
-  - releaseCycle: 9.5
+    latest: "9.6.22"
+  - releaseCycle: "9.5"
     release: 2016-01-07
     eol: 2021-02-11
-    latest: 9.5.25
-  - releaseCycle: 9.4
+    latest: "9.5.25"
+  - releaseCycle: "9.4"
     release: 2014-12-08
     eol: 2020-02-13
-    latest: 9.4.26
-  - releaseCycle: 9.3
+    latest: "9.4.26"
+  - releaseCycle: "9.3"
     release: 2013-09-09
     eol: 2018-11-08
-    latest: 9.3.25
-  - releaseCycle: 9.2
+    latest: "9.3.25"
+  - releaseCycle: "9.2"
     release: 2012-09-10
     eol: 2018-11-09
-    latest: 9.2.24
-  - releaseCycle: 9.1
+    latest: "9.2.24"
+  - releaseCycle: "9.1"
     release: 2011-09-12
     eol: 2016-10-27
-    latest: 9.1.24
-  - releaseCycle: 9.0
+    latest: "9.1.24"
+  - releaseCycle: "9.0"
     release: 2010-09-20
     eol: 2015-10-08
-    latest: 9.0.23
-  - releaseCycle: 8.4
+    latest: "9.0.23"
+  - releaseCycle: "8.4"
     release: 2009-07-01
     eol: 2014-07-24
-    latest: 8.4.22
-  - releaseCycle: 8.3
+    latest: "8.4.22"
+  - releaseCycle: "8.3"
     release: 2008-02-04
     eol: 2013-02-07
-    latest: 8.3.23
-  - releaseCycle: 8.2
+    latest: "8.3.23"
+  - releaseCycle: "8.2"
     release: 2006-12-05
     eol: 2011-12-05
-    latest: 8.2.23
-  - releaseCycle: 8.1
+    latest: "8.2.23"
+  - releaseCycle: "8.1"
     release: 2005-11-08
     eol: 2010-11-08
-    latest: 8.1.23
-  - releaseCycle: 8.0
+    latest: "8.1.23"
+  - releaseCycle: "8.0"
     release: 2005-01-19
     eol: 2010-10-01
-    latest: 8.0.26
+    latest: "8.0.26"
 ---
 
 > [PostgreSQL](https://www.postgresql.org/), also known as Postgres, is a free and open-source relational database management system (RDBMS) emphasizing extensibility and technical standards compliance.

--- a/tools/powershell.md
+++ b/tools/powershell.md
@@ -9,32 +9,32 @@ releaseDateColumn: true
 sortReleasesBy: "release"
 eolColumn: Support Status
 releases:
-  - releaseCycle: 7.1
+  - releaseCycle: "7.1"
     cycleShortHand: 7.1
     release: 2020-11-11
     eol:     2022-02-15
-    latest:  7.1.3
-  - releaseCycle: 7.0
+    latest:  "7.1.3"
+  - releaseCycle: "7.0"
     cycleShortHand: 7.0
     lts: true
     release: 2020-03-04
     eol:     2022-12-03
-    latest:  7.0.6
-  - releaseCycle: 6.2
+    latest:  "7.0.6"
+  - releaseCycle: "6.2"
     cycleShortHand: 6.2
     release: 2019-03-28
     eol:     2020-09-04
-    latest:  6.2.7
-  - releaseCycle: 6.1
+    latest:  "6.2.7"
+  - releaseCycle: "6.1"
     cycleShortHand: 6.1
     release: 2018-09-13
     eol:     2019-09-28
-    latest:  6.1.5
-  - releaseCycle: 6.x
+    latest:  "6.1.5"
+  - releaseCycle: "6.x"
     cycleShortHand: 6.0
     release: 2018-01-10
     eol:     2019-02-13
-    latest:  6.0.5
+    latest:  "6.0.5"
 ---
 
 > [PowerShell](https://aka.ms/powershell)  is a cross-platform (Windows, Linux, and macOS) automation and configuration tool/framework that works well with your existing tools and is optimized for dealing with structured data (e.g. JSON, CSV, XML, etc.), REST APIs, and object models. It includes a command-line shell, an associated scripting language and a framework for processing cmdlets.

--- a/tools/rabbitmq.md
+++ b/tools/rabbitmq.md
@@ -10,41 +10,41 @@ releaseDateColumn: true
 command: rabbitmqctl --version
 releaseImage: https://www.rabbitmq.com/img/rabbitmq_logo_strap.png
 releases:
-  - releaseCycle: 3.8
+  - releaseCycle: "3.8"
     eol: false
     release: 2019-10-01
-    latest: 3.8.14
-  - releaseCycle: 3.7
+    latest: "3.8.14"
+  - releaseCycle: "3.7"
     eol: 2020-09-30
     release: 2017-11-28
-    latest: 3.7.28
-  - releaseCycle: 3.6
+    latest: "3.7.28"
+  - releaseCycle: "3.6"
     eol: 2018-05-31
     release: 2015-12-22
-    latest: 3.6.16
-  - releaseCycle: 3.5
+    latest: "3.6.16"
+  - releaseCycle: "3.5"
     eol: 2016-10-31
     release: 2015-03-11
-    latest: 3.5.8
-  - releaseCycle: 3.4
+    latest: "3.5.8"
+  - releaseCycle: "3.4"
     eol: 2015-10-31
     release: 2014-10-21
-    latest: 3.4.4
-  - releaseCycle: 3.3
+    latest: "3.4.4"
+  - releaseCycle: "3.3"
     eol: 2015-03-31
     release: 2014-04-02
-    latest: 3.3.5
-  - releaseCycle: 3.2
+    latest: "3.3.5"
+  - releaseCycle: "3.2"
     eol: 2014-10-31
     release: 2013-10-23
-    latest: 3.2.4
-  - releaseCycle: 3.1
+    latest: "3.2.4"
+  - releaseCycle: "3.1"
     eol: 2014-04-30
     release: 2013-05-01
-    latest: 3.1.5
-  - releaseCycle: 3.0
+    latest: "3.1.5"
+  - releaseCycle: "3.0"
     eol: 2013-11-30
     release: 2012-11-19
-    latest: 3.0.4
+    latest: "3.0.4"
 ---
 > [RabbitMQ](https://www.rabbitmq.com/) is an open source message broker.

--- a/tools/redhat.md
+++ b/tools/redhat.md
@@ -28,12 +28,12 @@ releases:
     release: 2014-06-10
     support: 2019-12-31
     eol: false
-    latest: 7.6
+    latest: "7.6"
   - releaseCycle: "RHEL 8"
     release: 2019-05-01
     support: 2024-05-31
     eol: false
-    latest: 8.0
+    latest: "8.0"
 ---
 
 Red Hat Enterprise Linux versions 5, 6, and 7 each deliver ten years of support (unless otherwise noted below under Exceptions) in Full Support, Maintenance Support 1 and Maintenance Support 2 Phases followed by an Extended Life Phase. In addition, for Red Hat Enterprise Linux 5 and 6, customers may purchase annual Add-on subscriptions called Extended Life-cycle Support (ELS) to extend limited subscription services beyond the Maintenance Support 2 Phase.

--- a/tools/redis.md
+++ b/tools/redis.md
@@ -9,13 +9,13 @@ command: $ redis-server --version
 releaseDateColumn: false
 sortReleasesBy: 'releaseCycle'
 releases:
-  - releaseCycle: 6.2
+  - releaseCycle: "6.2"
     eol: false
     latest: '6.2.1'
-  - releaseCycle: 6.0
+  - releaseCycle: "6.0"
     eol: false
     latest: '6.0.12'
-  - releaseCycle: 5.0
+  - releaseCycle: "5.0"
     eol: false
     latest: '5.0.12'
 ---

--- a/tools/ruby-on-rails.md
+++ b/tools/ruby-on-rails.md
@@ -12,33 +12,33 @@ releaseDateColumn: true
 category: framework
 sortReleasesBy: release
 releases:
-  - releaseCycle: 6.1
+  - releaseCycle: "6.1"
     release: 2020-12-09
     eol: false
-    latest: 6.1.4
-  - releaseCycle: 6.0
+    latest: "6.1.4"
+  - releaseCycle: "6.0"
     release: 2019-08-16
     eol: false
-    latest: 6.0.4
-  - releaseCycle: 5.2
+    latest: "6.0.4"
+  - releaseCycle: "5.2"
     release: 2018-04-09
     eol: false
-    latest: 5.2.6
-  - releaseCycle: 5.1
+    latest: "5.2.6"
+  - releaseCycle: "5.1"
     release: 2017-04-27
     eol: 2019-08-25
     support: 2018-04-09
-    latest: 5.1.7
-  - releaseCycle: 5.0
+    latest: "5.1.7"
+  - releaseCycle: "5.0"
     release: 2016-06-30
     eol: 2018-04-09
     support: 2018-04-09
-    latest: 5.0.7.2
-  - releaseCycle: 4.2
+    latest: "5.0.7.2"
+  - releaseCycle: "4.2"
     release: 2014-12-20
     eol: 2017-04-27
     support: 2016-06-30
-    latest: 4.2.11.1
+    latest: "4.2.11.1"
 ---
 
 >[Ruby on Rails](https://rubyonrails.org/), or Rails, is a server-side web application framework written in Ruby.

--- a/tools/ruby.md
+++ b/tools/ruby.md
@@ -11,51 +11,51 @@ releases:
   - releaseCycle: "3.0"
     release: 2020-12-25
     eol: 2024-03-31
-    latest: 3.0.1
+    latest: "3.0.1"
     link: https://www.ruby-lang.org/en/news/2021/04/05/ruby-3-0-1-released/
   - releaseCycle: "2.7"
     release: 2019-12-25
     eol: 2023-03-31
-    latest: 2.7.3
+    latest: "2.7.3"
     link: https://www.ruby-lang.org/en/news/2021/04/05/ruby-2-7-3-released/
   - releaseCycle: "2.6"
     release: 2018-12-25
     eol: 2022-03-31
-    latest: 2.6.7
+    latest: "2.6.7"
     link: https://www.ruby-lang.org/en/news/2021/04/05/ruby-2-6-7-released/
   - releaseCycle: "2.5"
     release: 2017-12-25
     eol: 2021-03-31
-    latest: 2.5.9
+    latest: "2.5.9"
     link: https://www.ruby-lang.org/en/news/2021/04/05/ruby-2-5-9-released/
   - releaseCycle: "2.4"
     release: 2016-12-25
     eol: 2020-03-31
-    latest: 2.4.10
+    latest: "2.4.10"
     link: https://www.ruby-lang.org/en/news/2019/04/01/ruby-2-4-6-released/
   - releaseCycle: "2.3"
     release: 2015-12-25
     eol: 2019-03-31
-    latest: 2.3.8
+    latest: "2.3.8"
     link: https://www.ruby-lang.org/en/news/2018/10/17/ruby-2-3-8-released/
   - releaseCycle: "2.2"
     release: 2014-12-25
     eol: 2018-03-31
-    latest: 2.2.10
+    latest: "2.2.10"
     link: https://www.ruby-lang.org/en/news/2018/03/28/ruby-2-2-10-released/
   - releaseCycle: "2.1"
     release: 2013-12-25
     eol: 2017-03-31
-    latest: 2.1.10
+    latest: "2.1.10"
     link: https://www.ruby-lang.org/en/news/2016/04/01/ruby-2-1-10-released/
   - releaseCycle: "2.0.0"
     release: 2013-02-24
     eol: 2016-02-24
-    latest: 2.0.0-p648
+    latest: "2.0.0-p648"
   - releaseCycle: "1.9.3"
     release: 2011-10-31
     eol: 2015-02-23
-    latest: 1.9.3-p551
+    latest: "1.9.3-p551"
 ---
 
 > [Ruby](https://www.ruby-lang.org/) is a dynamic, open source programming language with a focus on simplicity and productivity. It has an elegant syntax that is natural to read and easy to write.

--- a/tools/symfony.md
+++ b/tools/symfony.md
@@ -8,119 +8,119 @@ command: composer show symfony/symfony | grep versions
 releaseDateColumn: true
 sortReleasesBy: 'releaseCycle'
 releases:
-  - releaseCycle: 5.3
+  - releaseCycle: "5.3"
     release: 2021-05-31
     support: 2022-01-01
     eol: 2022-01-01
-    latest: 5.3.1
+    latest: "5.3.1"
     lts: false
     link: https://symfony.com/blog/symfony-5-3-1-released
-  - releaseCycle: 5.2
+  - releaseCycle: "5.2"
     release: 2020-11-30
     support: 2021-07-21
     eol: 2021-07-21
-    latest: 5.2.10
+    latest: "5.2.10"
     lts: false
     link: https://symfony.com/blog/symfony-5-2-10-released
-  - releaseCycle: 5.1
+  - releaseCycle: "5.1"
     release: 2020-05-31
     support: 2021-01-21
     eol: 2021-01-21
-    latest: 5.1.11
+    latest: "5.1.11"
     lts: false
     link: https://symfony.com/blog/symfony-5-1-11-released
-  - releaseCycle: 5.0
+  - releaseCycle: "5.0"
     release: 2019-11-21
     support: 2020-07-21
     eol: 2020-07-21
-    latest: 5.0.11
+    latest: "5.0.11"
     lts: false
     link: https://symfony.com/blog/symfony-5-0-11-released
-  - releaseCycle: 4.4
+  - releaseCycle: "4.4"
     release: 2019-11-21
     support: 2022-11-21
     eol: 2023-11-21
-    latest: 4.4.25
+    latest: "4.4.25"
     lts: true
     link: https://symfony.com/blog/symfony-4-4-25-released
-  - releaseCycle: 4.3
+  - releaseCycle: "4.3"
     release: 2019-05-01
     support: 2020-01-01
     eol: 2020-07-01
-    latest: 4.3.11
+    latest: "4.3.11"
     lts: false
     link: https://symfony.com/blog/symfony-4-3-11-released
-  - releaseCycle: 4.2
+  - releaseCycle: "4.2"
     release: 2018-11-01
     support: 2019-07-01
     eol: 2020-01-01
-    latest: 4.2.9
+    latest: "4.2.9"
     lts: false
     link: https://symfony.com/blog/symfony-4-2-9-released
-  - releaseCycle: 4.1
+  - releaseCycle: "4.1"
     release: 2018-05-01
     support: 2019-01-01
     eol: 2019-07-01
-    latest: 4.1.12
+    latest: "4.1.12"
     lts: false
     link: https://symfony.com/blog/symfony-4-1-12-released
-  - releaseCycle: 4.0
+  - releaseCycle: "4.0"
     release: 2017-11-01
     support: 2018-07-01
     eol: 2019-01-01
-    latest: 4.0.15
+    latest: "4.0.15"
     lts: false
     link: https://symfony.com/blog/symfony-4-0-15-released
-  - releaseCycle: 3.4
+  - releaseCycle: "3.4"
     release: 2017-11-01
     support: 2020-11-01
     eol: 2021-11-01
-    latest: 3.4.49
+    latest: "3.4.49"
     lts: true
     link: https://symfony.com/blog/symfony-3-4-49-released
-  - releaseCycle: 3.3
+  - releaseCycle: "3.3"
     release: 2017-05-01
     support: 2018-01-01
     eol: 2018-07-01
-    latest: 3.3.13
+    latest: "3.3.13"
     lts: false
     link: https://symfony.com/blog/symfony-3-3-13-released
-  - releaseCycle: 3.2
+  - releaseCycle: "3.2"
     release: 2016-11-01
     support: 2017-07-01
     eol: 2018-01-01
-    latest: 3.2.14
+    latest: "3.2.14"
     lts: false
-  - releaseCycle: 3.1
+  - releaseCycle: "3.1"
     release: 2016-05-01
     support: 2017-01-01
     eol: 2017-07-01
-    latest: 3.1.10
+    latest: "3.1.10"
     lts: false
-  - releaseCycle: 3.0
+  - releaseCycle: "3.0"
     release: 2015-11-01
     support: 2016-07-01
     eol: 2017-01-01
-    latest: 3.0.9
+    latest: "3.0.9"
     lts: false
-  - releaseCycle: 2.8
+  - releaseCycle: "2.8"
     release: 2015-11-01
     support: 2018-11-01
     eol: 2019-11-01
-    latest: 2.8.52
+    latest: "2.8.52"
     lts: true
     link: https://symfony.com/blog/symfony-2-8-52-released
-  - releaseCycle: 2.7
+  - releaseCycle: "2.7"
     release: 2015-05-01
     support: 2018-05-01
     eol: 2019-05-01
-    latest: 2.7.51
+    latest: "2.7.51"
     lts: true
-  - releaseCycle: 2.3
+  - releaseCycle: "2.3"
     release: 2013-05-01
     support: 2016-05-01
     eol: 2017-05-01
-    latest: 2.3.42
+    latest: "2.3.42"
     lts: true
 
 ---

--- a/tools/wagtail.md
+++ b/tools/wagtail.md
@@ -14,7 +14,7 @@ releases:
     support: 2021-08-01
     release: 2021-05-12
     lts: false
-    latest: 2.13
+    latest: "2.13"
   - releaseCycle: "2.12"
     eol: 2021-08-01
     support: 2021-05-01


### PR DESCRIPTION
Enforced a type-check for `release` and `latest` fields for every release via a Jekyll plugin.

This should catch future errors by breaking the build and informing the user what broke exactly. Also update the CONTRIBUTING guidelines to enforce the quote usage on both fields.

See #266, #277 and https://dev.to/hugovk/the-python-3-1-problem-85g for why this is needed.

Thanks to @hugovk for spotting this!