### PR TITLE
Adds support for tool icons

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,20 +10,29 @@ To add a new page to the website, [create a new markdown file with YAML frontmat
 
 ```yaml
 ---
-title: timeturner
+title: Timeturner
 layout: post
 # Possible values are os,db,tool,lang,framework
 # If you add a new value, please mention it on the PR Description
 category: os
-# The hash of the `releases` object to be used for sortin in descending order
+
+# What should be used to sort releases. Set to one of:
+# releaseCycle/eol/support/release/cycleShortHand
+# which must be present in the releases underneath
 sortReleasesBy: "releaseCycle"
+
+# Template to be used to generate a link for the release
+# __RELEASE_CYCLE__ will be replaced by the value of releaseCycle
+# __LATEST__ will be replaced by the value of latest
 changelogTemplate: "https://link/of/the/__RELEASE_CYCLE__/and/__LATEST__/version"
+
 # A list of releases, supported or not
 # Newer releases go on top of the list, in order
 releases:
     # Release range (usually major.minor), always put in quotes
   - releaseCycle: "1.2"
     # End of Security Support for the product. Alternatively, set to true|false if EOL is not pre-decided
+    # In case there is extended/commercial support available, pick the date most
     eol: 2019-01-01
     # End of Active Support for the product. This is where bugfixes usually stop coming in. (remove if activeSupportColumn=false)
     # Alternatively, set to true|false if it is not pre-decided
@@ -32,20 +41,26 @@ releases:
     # remove if releaseDateColumn is false
     release: 2017-03-12
     # Current latest release
-    # remove is releaseColumn is false
+    # remove if releaseColumn is false
     # always put in quotes
     latest: "1.2.3"
+
+# A slug for https://simpleicons.org/
+# If the icon is not available on simpleicons, set it to "NA"
+icon_slug: ministryofmagic
+
 # A few extra fields define overall page behaviour
 
 # URL for the page
 permalink: /timeturner
-# More information link
+# More information link. This link should contain
+# information about the release policy and schedule
 link: https://jkrowling.com/timeturner-releases
 # Whether to hide the "Active Support" column (optional, default true)
 activeSupportColumn: false
 # Whether to hide/show the latest release column. If the product doesn't have patch releases, set this to false. (optional, default true)
 releaseColumn: true
-# Whether to increase the release date column
+# Whether to show the release date column
 # optional, default false
 releaseDateColumn: true
 # What to call the End of Life  (Security Support) column. (optional)
@@ -53,11 +68,13 @@ eolColumn: Service Status
 # Command that can be used to check the current version. (optional)
 command: swish and flick
 # An image that shows a graphical representation of the releases.
+# This is not the product logo
 releaseImage: https://jkrowling.com/timeturner-releases.png
 
 # In the markdown section, ensure that the following are present:
-# 1. A one line statement about what the tool is, with a link to the primary website
+# 1. A one line statement about what the tool is, with a link to the primary website (in a quote)
 # 2. A short summary of the release policy, pointing out the EoL policy as well, if available.
+# 3. Any additional information that may be of interest
 ---
 > [Time Turner](https://jkrowling.com/time-turner) is device that powers short-term time travel.
 

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -131,6 +131,26 @@ layout: default
 {% endfor %}
 </table>
 
+<style>
+.maincontent>blockquote {
+  margin-left: 60px;
+}
+.productlogo {
+  float: left;
+}
+.maincontent>p:nth-of-type(1) {
+  clear:  both;
+}
+</style>
+
+{% if page.icon_slug and page.icon_slug != "NA" %}
+<img class=productlogo width=50 height=50 src="https://simpleicons.org/icons/{{page.icon_slug}}.svg" >
+{% elsif page.icon_slug!="NA" %}
+<img class=productlogo width=50 height=50 src="https://simpleicons.org/icons{{page.permalink}}.svg" >
+{% endif %}
+
+
+
 <div class="maincontent">{{content}}</div>
 
 <p>More information is available on the <a href="{{page.link}}">{{page.title}} website</a>. </p>

--- a/tools/alpinelinux.md
+++ b/tools/alpinelinux.md
@@ -5,6 +5,7 @@ alternate_urls:
 title: Alpine Linux
 layout: post
 link: https://alpinelinux.org/releases/
+icon_slug: alpinelinux
 changelogTemplate: https://alpinelinux.org/posts/Alpine-__LATEST__-released.html
 activeSupportColumn: false
 command: cat /etc/alpine-release

--- a/tools/amazon-linux.md
+++ b/tools/amazon-linux.md
@@ -1,6 +1,7 @@
 ---
 permalink: /amazon-linux
 title: Amazon Linux
+icon_slug: amazonaws
 layout: post
 link: https://aws.amazon.com/amazon-linux-2/release-notes/
 activeSupportColumn: false

--- a/tools/android.md
+++ b/tools/android.md
@@ -68,9 +68,6 @@ releases:
     eol: false
 ---
 
+>Android is a mobile operating system based on a modified version of the Linux kernel and other open source software, designed primarily for touchscreen mobile devices such as smartphones and tablets.
 
-[Android OS Version History](https://en.wikipedia.org/wiki/Android_version_history)
-
-The development of Android started in 2003 by Android, Inc., which was purchased by Google in 2005.
-
-Major versions of Android are released once a year now, prior to the launch of their Pixel phones.
+Major versions of Android are released once a year now, prior to the launch of their Pixel phones. See [Android OS Version History](https://en.wikipedia.org/wiki/Android_version_history) as well.

--- a/tools/dotnetcore.md
+++ b/tools/dotnetcore.md
@@ -3,6 +3,7 @@ permalink: /dotnetcore
 alternate_urls:
   - /.netcore
 layout: post
+icon_slug: dotnet
 title: .NET Core
 command: dotnet --version
 link: https://dotnet.microsoft.com/platform/support/policy/dotnet-core

--- a/tools/dotnetfx.md
+++ b/tools/dotnetfx.md
@@ -3,6 +3,7 @@ permalink: /dotnetfx
 layout: post
 alternative_urls:
   - /.netfx
+icon_slug: dotnet
 title: .NET Framework
 command: reg query "HKLM\SOFTWARE\Microsoft\Net Framework Setup\NDP" /s
 link: https://dotnet.microsoft.com/download/dotnet-framework
@@ -42,4 +43,4 @@ releases:
     eol: 2016-01-12
 ---
 
-> [.NET Framework](https://dotnet.microsoft.com/) is a software framework developed by Microsoft that runs primarily on Microsoft Windows. It includes a large class library called Framework Class Library (FCL) and provides language interoperability (each language can use code written in other languages) across several programming languages.
+> [.NET Framework](https://dotnet.microsoft.com/) is a software framework developed by Microsoft that runs primarily on Microsoft Windows. It includes a large class library called Framework Class Library (FCL) and provides language interoperability across several programming languages.

--- a/tools/elasticsearch.md
+++ b/tools/elasticsearch.md
@@ -112,6 +112,8 @@ releases:
 
 ---
 
+> Elasticsearch is a search engine that provides a distributed, multitenant-capable full-text search engine with an HTTP web interface and schema-free JSON documents.
+
 Each major release of all Elastic products is supported for 18 months from the General Availability date. The last minor release of the two most recent major branches of Elasticsearch (and compatible releases of Kibana, Beats, and Logstash) is maintained.
 
 Major versions, such as 1.0.0, 2.0.0, 5.0.0, 6.0.0, and 7.0.0 will introduce features and break backwards compatibility. Minor versions, such as 7.1.0 and 7.2.0, will only introduce features. Maintenance releases, such as 7.1.1 and 7.1.2, will fix bugs only. Maintenance activity occurs on all releases, but we focus on the minor release stream (e.g., 7.1.x) to define how long we maintain a particular code line. Active maintenance of a minor release implies that we are fixing bugs and backporting some number of fixes into that code branch.

--- a/tools/filemaker.md
+++ b/tools/filemaker.md
@@ -3,6 +3,7 @@ title: FileMaker
 layout: post
 permalink: /filemaker
 link: https://www.filemaker.com/support/product-availability.html
+icon_slug: "NA"
 activeSupportColumn: false
 releaseColumn: false
 eolColumn: Support Status

--- a/tools/go.md
+++ b/tools/go.md
@@ -41,6 +41,6 @@ releases:
     latest: 1.10.8
 ---
 
-[Go](https://golang.org/) is an open source programming language that makes it easy to build simple, reliable, and efficient software.
+> [Go](https://golang.org/) is an open source programming language that makes it easy to build simple, reliable, and efficient software.
 
 Each major Go release is supported until there are two newer major releases. For example, Go 1.5 was supported until the Go 1.7 release, and Go 1.6 was supported until the Go 1.8 release. It fixes critical problems, including critical security problems, in supported releases as needed by issuing minor revisions (for example, Go 1.6.1, Go 1.6.2, and so on). The security policy can be found at <https://golang.org/security>.

--- a/tools/godot.md
+++ b/tools/godot.md
@@ -4,6 +4,7 @@ permalink: /godot
 alternate_urls:
   - /godotengine
 layout: post
+icon_slug: godotengine
 link: https://docs.godotengine.org/en/latest/about/release_policy.html
 eolColumn: Critical, Security and Platform support
 activeSupportColumn: true

--- a/tools/iphone.md
+++ b/tools/iphone.md
@@ -4,6 +4,7 @@ permalink: /iphone
 alternate_urls:
   - /ios
 title: iPhone
+icon_slug: apple
 link: https://en.wikipedia.org/wiki/List_of_iOS_devices#In_production_and_supported
 discontinuedColumn: true
 activeSupportColumn: false
@@ -73,6 +74,8 @@ releases:
     discontinued: false
     eol: false
 ---
+
+> The iPhone is a line of smartphones designed and marketed by Apple Inc. that use Apple's iOS mobile operating system.
 
 Most likely, new iPhone models will come out in September every year (with a few possible exceptions). iPhone support (supported devices gets the latest iOS updates) is quite long. Apple ocassionaly releases security updates for much older devices, such as [this security fix in iOS 12.5.2](https://support.apple.com/en-us/HT212257) which was pushed to iPhone 6 and iPhone 5S.
 

--- a/tools/java.md
+++ b/tools/java.md
@@ -70,6 +70,8 @@ releases:
     latest: "6u211"
 ---
 
+> [Java](https://oracle.com/java/) is a high-level, class-based, object-oriented programming language that is designed to have as few implementation dependencies as possible. Java applications are typically compiled to bytecode that can run on any Java virtual machine (JVM) regardless of the underlying computer architecture.
+
 Java as developed by the [OpenJDK Project](https://openjdk.java.net/), owned and primarily employed by Oracle, has been on a 6-month rapid-release cycle since the release of Java 10, and starting with Java 11, has new LTS releases every six releases, or three years. Java 8 is the last release on the old cycle methodology still in active support. Non-LTS releases are supported for 6 months. The latest supported release in each release cycle can be found at <https://www.oracle.com/java/technologies/java-se-glance.html>.
 
 Official builds and support from Oracle come in two varieties: open source under the GNU GPL, and a proprietary license that must be purchased. Only the very latest Java release is available pre-built with the open source license, one must purchase support to get builds from Oracle for 8 or 11. Other projects such as [AdoptOpenJDK](https://adoptopenjdk.net/) or Linux distributions may provide builds external of Oracle and are governed under the open source license.

--- a/tools/kindle.md
+++ b/tools/kindle.md
@@ -2,6 +2,7 @@
 title: Amazon Kindle
 layout: post
 category: os
+icon_slug: amazon
 sortReleasesBy: "release"
 releases:
   - releaseCycle: "Kindle Oasis 3 (10th Generation)"
@@ -52,9 +53,8 @@ releaseColumn: true
 releaseDateColumn: true
 eolColumn: Service Status
 ---
-[Amazon Kindle](https://en.wikipedia.org/wiki/Amazon_Kindle) is a series of e-readers designed by Amazon.
-There is no official data of the release cycle. Based on [Wikipedia](https://en.wikipedia.org/wiki/Amazon_Kindle#Specifications) and [INFORMER](https://theinformr.com/ereaders/amazon-kindle-10th-gen/), Amazon Kindle usually releases every year.
+> [Amazon Kindle](https://en.wikipedia.org/wiki/Amazon_Kindle) is a series of e-readers designed by Amazon.
 
-Also, there is no official information about the end of life date. However, according to the software release notes at [Kindle E-Reader Software Updates](https://www.amazon.com/gp/help/customer/display.html?nodeId=GKMQC26VQQMM8XSW), the software update usually lasts about five years.
+There is no official information about the end of life date. However, according to the software release notes at [Kindle E-Reader Software Updates](https://www.amazon.com/gp/help/customer/display.html?nodeId=GKMQC26VQQMM8XSW), the software update usually lasts about five years.
 
-Please be noted that the older version of release notes are not available on the Amazon website. The update information can be got from  Kindle -> Menu ->Settings -> Device Info -> What's New
+The older version of release notes are not available on the Amazon website. The changelog is still available in the device by following the `Settings -> Device Info -> What's New` menu.

--- a/tools/magento.md
+++ b/tools/magento.md
@@ -3,7 +3,6 @@ title: Magento
 permalink: /magento
 layout: post
 link: https://magento.com/tech-resources/download
-releaseImage: https://static.magento.com/sites/all/themes/magento/logo.svg
 changelogTemplate: https://devdocs.magento.com/guides/v__RELEASE_CYCLE__/release-notes/ReleaseNotes__LATEST__OpenSource.html
 activeSupportColumn: true
 command: php bin/magento --version

--- a/tools/mongodb.md
+++ b/tools/mongodb.md
@@ -8,7 +8,6 @@ changelogTemplate: https://docs.mongodb.com/manual/release-notes/__RELEASE_CYCLE
 activeSupportColumn: false
 releaseDateColumn: true
 command: mongod --version
-releaseImage: https://webassets.mongodb.com/_com_assets/cms/MongoDB_Logo_FullColorBlack_RGB-4td3yuxzjs.png
 releases:
   - releaseCycle: "4.4"
     eol: false

--- a/tools/mssqlserver.md
+++ b/tools/mssqlserver.md
@@ -2,6 +2,7 @@
 title: Microsoft SQL Server
 permalink: /mssqlserver
 layout: post
+icon_slug: microsoftsqlserver
 category: db
 link: https://support.microsoft.com/en-us/lifecycle/search?terms=SQL%20Server
 activeSupportColumn: true
@@ -41,7 +42,7 @@ releases:
     latest: 10.50.6560.0 SP3 GDR
 ---
 
->[SQLServer](https://www.microsoft.com/en-us/sql-server/): Microsoft SQL Server is a relational database management system developed by Microsoft. As a database server, it is a software product with the primary function of storing and retrieving data as requested by other software applications—which may run either on the same computer or on another computer across a network
+>[SQLServer](https://www.microsoft.com/en-us/sql-server/): Microsoft SQL Server is a relational database management system developed by Microsoft.
 
 [Latest updates for Microsoft SQL Server](https://docs.microsoft.com/en-us/sql/database-engine/install-windows/latest-updates-for-microsoft-sql-server)
 

--- a/tools/nodejs.md
+++ b/tools/nodejs.md
@@ -5,6 +5,7 @@ alternate_urls:
   - /node.js
 layout: post
 title: Node.js
+icon_slug: nodedotjs
 link: https://nodejs.org/en/about/releases/
 releaseImage: https://raw.githubusercontent.com/nodejs/Release/master/schedule.svg?sanitize=true
 changelogTemplate: https://github.com/nodejs/node/blob/master/doc/changelogs/CHANGELOG_V__RELEASE_CYCLE__.md#__LATEST__

--- a/tools/office.md
+++ b/tools/office.md
@@ -4,6 +4,7 @@ permalink: /office
 alternate_urls:
   - /msoffice
 layout: post
+icon_slug: microsoftoffice
 link: https://support.microsoft.com/en-us/lifecycle/search?terms=Office
 activeSupportColumn: true
 releaseColumn: false
@@ -39,3 +40,7 @@ releases:
     support: 2012-10-09
     eol: 2017-10-10
 ---
+
+> Microsoft Office, or simply Office, is a family of client software, server software, and services developed by Microsoft.
+
+Note that Microsoft Office 2019 for Mac is [only supported until 2023-10-10](https://docs.microsoft.com/en-us/lifecycle/products/microsoft-office-2019-for-mac).

--- a/tools/php.md
+++ b/tools/php.md
@@ -3,7 +3,6 @@ title: PHP
 permalink: /php
 layout: post
 link: https://www.php.net/supported-versions.php
-releaseImage: https://www.php.net/images/logos/php-logo.png
 changelogTemplate: https://www.php.net/ChangeLog-__CYCLE_SHORT_HAND__.php#__LATEST__
 activeSupportColumn: true
 command: php --version

--- a/tools/pixel.md
+++ b/tools/pixel.md
@@ -2,6 +2,7 @@
 layout: post
 permalink: /pixel
 title: Google Pixel
+icon_slug: google
 link: https://support.google.com/nexus/answer/4457705?hl=en
 discontinuedColumn: true
 activeSupportColumn: false
@@ -52,6 +53,8 @@ releases:
     eol: 2018-10-31
     support: 2015-11-19
 ---
+
+> Google Pixel is Google's current line of Android Phones and other consumer electronics.
 
 The Pixel phones come out around the first or second week of October every year (the A series being unpredicatable). Pixels support their devices for about three years with guaranteed software/security updates. That is only the guaranteed date, however Google may provide additional year(s) of updates, but is not bound to.
 

--- a/tools/powershell.md
+++ b/tools/powershell.md
@@ -37,6 +37,6 @@ releases:
     latest:  "6.0.5"
 ---
 
-> [PowerShell](https://aka.ms/powershell)  is a cross-platform (Windows, Linux, and macOS) automation and configuration tool/framework that works well with your existing tools and is optimized for dealing with structured data (e.g. JSON, CSV, XML, etc.), REST APIs, and object models. It includes a command-line shell, an associated scripting language and a framework for processing cmdlets.
+> [PowerShell](https://aka.ms/powershell)  is a cross-platform automation and configuration tool/framework that is optimized for dealing with structured data (e.g. JSON, CSV, XML, etc.), REST APIs, and object models. It includes a command-line shell, an associated scripting language and a framework for processing cmdlets.
 
 PowerShell follows the [Modern Lifecycle Policy](https://docs.microsoft.com/powershell/scripting/powershell-support-lifecycle).

--- a/tools/rabbitmq.md
+++ b/tools/rabbitmq.md
@@ -8,12 +8,11 @@ changelogTemplate: https://github.com/rabbitmq/rabbitmq-server/releases/tag/v__L
 activeSupportColumn: false
 releaseDateColumn: true
 command: rabbitmqctl --version
-releaseImage: https://www.rabbitmq.com/img/rabbitmq_logo_strap.png
 releases:
   - releaseCycle: "3.8"
     eol: false
     release: 2019-10-01
-    latest: "3.8.14"
+    latest: "3.8.19"
   - releaseCycle: "3.7"
     eol: 2020-09-30
     release: 2017-11-28

--- a/tools/redhat.md
+++ b/tools/redhat.md
@@ -3,6 +3,7 @@ releaseImage: https://access.redhat.com/sites/default/files/images/rhel_8_life_c
 title: Red Hat Enterprise Linux
 layout: post
 permalink: /rhel
+icon_slug: redhat
 alternate_urls:
   - /redhat
   - /redhatlinux
@@ -36,6 +37,8 @@ releases:
     latest: "8.0"
 ---
 
-Red Hat Enterprise Linux versions 5, 6, and 7 each deliver ten years of support (unless otherwise noted below under Exceptions) in Full Support, Maintenance Support 1 and Maintenance Support 2 Phases followed by an Extended Life Phase. In addition, for Red Hat Enterprise Linux 5 and 6, customers may purchase annual Add-on subscriptions called Extended Life-cycle Support (ELS) to extend limited subscription services beyond the Maintenance Support 2 Phase.
+> Red Hat Enterprise Linux is a Linux distribution developed by Red Hat for the commercial market.
+
+Red Hat Enterprise Linux versions 5, 6, and 7 each deliver ten years of support in Full Support, Maintenance Support 1 and Maintenance Support 2 Phases followed by an Extended Life Phase. In addition, for Red Hat Enterprise Linux 5 and 6, customers may purchase annual Add-on subscriptions called Extended Life-cycle Support (ELS) to extend limited subscription services beyond the Maintenance Support 2 Phase.
 
 With the introduction of Red Hat Enterprise Linux version 8, Red Hat is simplifying the RHEL product phases from four to three: Full Support, Maintenance Support, and Extended Life Phase.

--- a/tools/redis.md
+++ b/tools/redis.md
@@ -20,7 +20,12 @@ releases:
     latest: '5.0.12'
 ---
 
-> [Redis](https://redis.io/) is an open source (BSD licensed), in-memory data structure store, used as a database, cache and message broker. It supports data structures such as strings, hashes, lists, sets, sorted sets with range queries, bitmaps, hyperloglogs, geospatial indexes with radius queries and streams. Redis has built-in replication, Lua scripting, LRU eviction, transactions and different levels of on-disk persistence, and provides high availability via Redis Sentinel and automatic partitioning with Redis Cluster. 
+> [Redis](https://redis.io/) is an open source (BSD licensed), in-memory data structure store, used as a database, cache and message broker. It supports data structures such as strings, hashes, lists, sets, sorted sets with range queries, bitmaps, hyperloglogs, geospatial indexes with radius queries and streams. Redis has built-in replication, Lua scripting, LRU eviction, transactions and different levels of on-disk persistence, and provides high availability via [Redis Sentinel](https://redis.io/topics/sentinel) and automatic partitioning with [Redis Cluster](https://docs.redislabs.com/latest/rc/concepts/clustering/).
 
 
+A new major version is planned for release once a year. Generally, every major release is followed by a minor version after six months. The latest stable release is always fully supported and maintained.
 
+Two additional versions receive maintenance only, meaning that only fixes for critical bugs and major security issues are committed and released as patches:
+
+- The previous minor version of the latest stable release.
+- The previous stable major release.

--- a/tools/ruby-on-rails.md
+++ b/tools/ruby-on-rails.md
@@ -5,6 +5,7 @@ alternate_urls:
   - /ruby-on-rails
   - /roro
 layout: post
+icon_slug: rubyonrails
 title: Ruby on Rails
 link: https://guides.rubyonrails.org/maintenance_policy.html
 changelogTemplate: https://github.com/rails/rails/releases/tag/v__LATEST__

--- a/tools/surface.md
+++ b/tools/surface.md
@@ -1,6 +1,7 @@
 ---
 layout: post
 permalink: /surface
+icon_slug: windows
 title: Microsoft Surface
 link: https://docs.microsoft.com/surface/surface-driver-firmware-lifecycle-support
 activeSupportColumn: false
@@ -75,4 +76,4 @@ releases:
     eol: 2017-04-11
 ---
 
-Microsoft Surface is a series of touchscreen-based personal computers and interactive whiteboards designed and developed by Microsoft, running the Microsoft Windows operating system.
+> Microsoft Surface is a series of touchscreen-based personal computers and interactive whiteboards designed and developed by Microsoft, running the Microsoft Windows operating system.

--- a/tools/windowsEmbedded.md
+++ b/tools/windowsEmbedded.md
@@ -2,6 +2,7 @@
 title: Windows Embedded
 layout: post
 permalink: /windowsembedded
+icon_slug: windows
 link: https://support.microsoft.com/en-us/lifecycle/search?terms=Windows%20Embedded
 category: os
 activeSupportColumn: true

--- a/tools/windowsServer.md
+++ b/tools/windowsServer.md
@@ -1,6 +1,7 @@
 ---
 title: Windows Server
 permalink: /windowsserver
+icon_slug: windows
 layout: post
 link: https://support.microsoft.com/en-us/lifecycle/search?terms=Windows%20Server
 category: os


### PR DESCRIPTION
For #283.

This doesn't put icons on the left sidebar, because that needs theme-modding, but this is a good start, since we get a clear icon url for (almost) everything this way.

All products have a image next to their description now, except for Filemaker.