### PR TITLE
Add openSUSE Linux

### DIFF
--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -157,17 +157,13 @@ END DEBUG COMMENT
 
   {%if page.releaseColumn != false %}
   <td>
-    {% if diff > 0 %}
-      {%if r.link %}
-        <a href="{{r.link}}" title="Release Notes / Changelog">{{r.latest}}</a>
-      {%elsif page.changelogTemplate %}
-      <a title = "Release Notes / Changelog" href="{{page.changelogTemplate | replace: '__RELEASE_CYCLE__',r.releaseCycle  | replace: '__LATEST__',r.latest | replace: '__LATEST_SHORT_HAND__',r.latestShortHand | replace: '__CYCLE_SHORT_HAND__',r.cycleShortHand}}">
-        {{r.latest}}
-      </a>
-      {%else %}
-        {{r.latest}}
-      {%endif%}
-    {%else%}NA{%endif%}
+    {% if releaseLink!="" and diff > 0 %}
+      <a href="{{releaseLink}}" title="Release Notes / Changelog">{{r.latest}}</a>
+    {%elsif diff > 0 %}
+      {{r.latest}}
+    {%else%}
+      NA
+    {%endif%}
   </td>
   {%endif%}
 </tr>

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -23,13 +23,56 @@ layout: default
 {% for r in sorted_releases %}
 {% assign support =r.support | date: '%s' | plus:0 %}
 {% assign securityFixes = r.eol | date: '%s' | plus:0 %}
-{% assign diff = r.eol | date: '%s' | plus:0|minus:now %}
+
+
+{% comment %}
+diff is the number of days towards EoL. Positive is in the future. Negative is in the past.
+In case we don't have an exact date, we use boolean values (true/false) instead. In such
+cases diff is set to -1 for true (EoL has been reached)
+or +1 (EoL is in the future)
+{% endcomment %}
+{% if r.eol == true %}
+{% assign diff = -1 %}
+{% elsif r.eol == false %}
+{% assign diff = 1 %}
+{% else %}
+{% assign diff = r.eol | date: '%s' | plus:0| minus:now %}
+{% endif %}
+
+
 {% assign diffSupport = support|minus:now %}
 {% assign diffSecurity6  = diff | minus:10651938 %}
 {% assign diffSupport6  = diffSupport | minus:10651938 %}
+{% capture releaseCycleText %}{{r.releaseCycle}}{%if r.lts%} (LTS){%endif%}{%endcapture%}
+{% capture releaseLink %}
+{%if r.link and diff > 0 %}
+{{r.link}}
+{%elsif page.changelogTemplate and diff > 0%}
+{{page.changelogTemplate | replace: '__RELEASE_CYCLE__',r.releaseCycle  | replace: '__LATEST__',r.latest | replace: '__LATEST_SHORT_HAND__',r.latestShortHand | replace: '__CYCLE_SHORT_HAND__',r.cycleShortHand}}
+{%endif%}
+{%endcapture%}
+{% assign releaseLink = releaseLink | strip %}
+<!-- START DEBUG COMMENT
+diffSupport: {{diffSupport}}
+diffSupport6: {{diffSupport6}}
+diff: {{diff}}
+eol: {{r.eol}}
+
+
+: {{releaseLink}}
+
+END DEBUG COMMENT
+-->
+
+<!-- Main Row starts here -->
 <tr>
   <td>
-    {{r.releaseCycle}}{%if r.lts%} (LTS){%endif%}
+    {% comment %}Only put a link in the version column if the release column is not shown{% endcomment %}
+    {%if releaseLink!="" and page.releaseColumn == false %}
+      <a href="{{releaseLink}}" title="Release Notes / Changelog">{{releaseCycleText}}</a>
+    {%else %}
+      {{releaseCycleText}}
+    {%endif%}
   </td>
 
   {%if page.releaseDateColumn%}
@@ -81,7 +124,7 @@ layout: default
 
   <td class=
     {% if securityFixes > 5 %}
-      {% if diff < 0 and r.eol !=false %}
+      {% if diff < 0 %}
       "bg-red-000"
       {% elsif diffSecurity6 > 0 %}
       "bg-green-000"
@@ -114,7 +157,7 @@ layout: default
 
   {%if page.releaseColumn != false %}
   <td>
-    {% if diff > 0 or r.eol == false %}
+    {% if diff > 0 %}
       {%if r.link %}
         <a href="{{r.link}}" title="Release Notes / Changelog">{{r.latest}}</a>
       {%elsif page.changelogTemplate %}

--- a/tools/opensuse.md
+++ b/tools/opensuse.md
@@ -85,34 +85,6 @@ releases:
     release: 2008-06-19
     support: 2010-07-26
     eol: 2010-07-26
-  - releaseCycle: "openSUSE 10.3"
-    release: 2007-10-04
-    support: 2009-10-31
-    eol: 2009-10-31
-  - releaseCycle: "openSUSE 10.2"
-    release: 2006-12-07
-    support: 2008-11-30
-    eol: 2008-11-30
-  - releaseCycle: "SUSE Linux 10.1"
-    release: 2006-03-11
-    support: 2008-05-31
-    eol: 2008-05-31
-  - releaseCycle: "SUSE Linux 10.0"
-    release: 2005-10-06
-    support: 2007-11-30
-    eol: 2007-11-30
-  - releaseCycle: "SUSE Linux 9.3"
-    release: 2005-04-15
-    support: 2007-04-30
-    eol: 2007-04-30
-  - releaseCycle: "SUSE Linux 9.2"
-    release: 2004-10-25
-    support: 2006-10-31
-    eol: 2006-10-31
-  - releaseCycle: "SUSE Linux 9.1"
-    release: 2004-04-21
-    support: 2006-06-30
-    eol: 2006-06-30
 
 # A slug for https://simpleicons.org/
 # If the icon is not available on simpleicons, set it to "NA"

--- a/tools/opensuse.md
+++ b/tools/opensuse.md
@@ -10,106 +10,82 @@ category: os
 # which must be present in the releases underneath
 sortReleasesBy: "release"
 
-# Template to be used to generate a link for the release
-# __RELEASE_CYCLE__ will be replaced by the value of releaseCycle
-# __LATEST__ will be replaced by the value of latest
+changelogTemplate: https://doc.opensuse.org/release-notes/x86_64/openSUSE/Leap/__CYCLE_SHORT_HAND__/
 
-# A list of releases, supported or not
-# Newer releases go on top of the list, in order
 releases:
   - releaseCycle: "openSUSE Leap 15.3"
     release: 2021-06-02
     support: 2022-12-1
     eol: 2022-12-1
-    latest: "openSUSE Leap 15.3"
+    cycleShortHand: 15.3
   - releaseCycle: "openSUSE Leap 15.2"
     release: 2020-07-02
     support: 2021-12-1
     eol: 2021-12-1
-    latest: "openSUSE Leap 15.2"
+    cycleShortHand: 15.2
   - releaseCycle: "openSUSE Leap 15.1"
     release: 2019-05-22
     support: 2021-02-02
     eol: 2021-02-02
-    latest: "openSUSE Leap 15.1"
   - releaseCycle: "openSUSE Leap 15.0"
     release: 2018-05-25
     support: 2019-12-03
     eol: 2019-12-03
-    latest: "openSUSE 15.0"
   - releaseCycle: "openSUSE Leap 42.3"
     release: 2017-07-26
     support: 2019-07-01
     eol: 2019-07-01
-    latest: "openSUSE 42.3"
   - releaseCycle: "openSUSE Leap 42.2"
     release: 2016-11-16
     support: 2018-01-26
     eol: 2018-01-26
-    latest: "openSUSE 42.2"
   - releaseCycle: "openSUSE Leap 42.1"
     release: 2015-11-4
     support: 2017-05-17
     eol: 2017-05-17
-    latest: "openSUSE 42.1"
   - releaseCycle: "openSUSE 13.2"
     release: 2015-12-14
     support: 2017-01-17
     eol: 2017-01-17
-    latest: "openSUSE 13.2"
   - releaseCycle: "openSUSE 13.1"
     release: 2014-01-08
     support: 2016-02-03
     eol: 2016-02-03
-    latest: "openSUSE 13.1"
   - releaseCycle: "openSUSE 12.3"
     release: 2013-03-13
     support: 2015-01-29
     eol: 2015-01-29
-    latest: "openSUSE 12.3"
   - releaseCycle: "openSUSE 12.2"
     release: 2012-09-05
     support: 2014-01-15
     eol: 2014-01-15
-    latest: "openSUSE 12.2"
   - releaseCycle: "openSUSE 12.1"
     release: 2011-11-16
     support: 2013-05-15
     eol: 2013-05-15
-    latest: "openSUSE 12.1"
   - releaseCycle: "openSUSE 11.4"
     release: 2011-03-10
     support: 2012-11-05
     eol: 2012-11-05
-    latest: "openSUSE 11.4"
   - releaseCycle: "openSUSE 11.3"
     release: 2010-07-15
     support: 2012-01-20
     eol: 2012-01-20
-    latest: "openSUSE 11.3"
   - releaseCycle: "openSUSE 11.2"
     release: 2009-11-12
     support: 2011-05-12
     eol: 2011-05-12
-    latest: "openSUSE 11.2"
   - releaseCycle: "openSUSE 11.1"
     release: 2008-12-18
     support: 2011-01-14
     eol: 2011-01-14
-    latest: "openSUSE 11.1"
   - releaseCycle: "openSUSE 11.0"
     release: 2008-06-19
     support: 2010-07-26
     eol: 2010-07-26
-    latest: "openSUSE 11.0"
 
-# A slug for https://simpleicons.org/
-# If the icon is not available on simpleicons, set it to "NA"
 icon_slug: opensuse
 
-# A few extra fields define overall page behaviour
-
-# URL for the page
 permalink: /opensuse
 alternate_urls:
   - /opensuseleap
@@ -124,19 +100,16 @@ releaseColumn: false
 # optional, default false
 releaseDateColumn: true
 # What to call the End of Life  (Security Support) column. (optional)
-eolColumn: End of life
+eolColumn: End of Life
 # Command that can be used to check the current version. (optional)
 command: cat /usr/lib/os-release
-# An image that shows a graphical representation of the releases.
-# This is not the product logo
-#releaseImage: https://jkrowling.com/timeturner-releases.png
 
-# In the markdown section, ensure that the following are present:
-# 1. A one line statement about what the tool is, with a link to the primary website (in a quote)
-# 2. A short summary of the release policy, pointing out the EoL policy as well, if available.
-# 3. Any additional information that may be of interest
 ---
-> [openSUSE](https://www.opensuse.org/) is a linux distribution claiming its
-"The makers' choice for sysadmins, developers and desktop users".
+> [openSUSE](https://www.opensuse.org/) is a linux distribution developed by the community-supported openSUSE Project and aimed at sysadmins, developers and desktop users.
 
-As of today, openSUSE Leap is actively maintained and developed. The current version is *openSuse Leap 15.3*.
+openSUSE Leap is the name for openSUSE's regular releases, which were previously known as just 'openSUSE' for versions 13.2 and earlier. A Leap Minor Release (42.1, 42.2, 15.1, 15.2, etc.) is expected to be released annually. Users are expected to upgrade to the latest minor release within 6 months of its availability, leading to a _maintenance life cycle of 18 months_. Support is defined as:
+
+- security updates for all included packages
+- critical bugfix updates
+
+A Leap major release (15.x) is supported until the next major release. Leap 15's lifecycle fully aligns with SUSE Linux Enterprise. There is a projection as of March 2021 that Leap 15 will extend to Leap 15.5. The previous major version of Leap, 42, was supported more than 36 months, while the current major version of Leap, 15, now stands well beyond 36 months of security and maintenance support as stated above.

--- a/tools/opensuse.md
+++ b/tools/opensuse.md
@@ -8,7 +8,7 @@ category: os
 # What should be used to sort releases. Set to one of:
 # releaseCycle/eol/support/release/cycleShortHand
 # which must be present in the releases underneath
-sortReleasesBy: "release"
+sortReleasesBy: "releaseCycle"
 
 # Template to be used to generate a link for the release
 # __RELEASE_CYCLE__ will be replaced by the value of releaseCycle
@@ -21,17 +21,17 @@ releases:
     release: 2021-06-02
     support: 2022-12-1
     eol: 2022-12-1
-    latest: "openSUSE 15.3"
+    latest: "openSUSE Leap 15.3"
   - releaseCycle: "openSUSE Leap 15.2"
     release: 2020-07-02
     support: 2021-12-1
     eol: 2021-12-1
-    latest: "openSUSE 15.2"
+    latest: "openSUSE Leap 15.2"
   - releaseCycle: "openSUSE Leap 15.1"
     release: 2019-05-22
     support: 2021-02-02
     eol: 2021-02-02
-    latest: "openSUSE 15.1"
+    latest: "openSUSE Leap 15.1"
   - releaseCycle: "openSUSE Leap 15.0"
     release: 2018-05-25
     support: 2019-12-03

--- a/tools/opensuse.md
+++ b/tools/opensuse.md
@@ -22,12 +22,12 @@ sortReleasesBy: "release"
 releases:
   - releaseCycle: "openSUSE Leap 15.3"
     release: 2021-06-02
-    support: 2022-12-0
-    eol: 2022-12-0
+    support: 2022-12-1
+    eol: 2022-12-1
   - releaseCycle: "openSUSE Leap 15.2"
     release: 2020-07-02
-    support: 2021-12-0
-    eol: 2021-12-0
+    support: 2021-12-1
+    eol: 2021-12-1
   - releaseCycle: "openSUSE Leap 15.1"
     release: 2019-05-22
     support: 2021-02-02

--- a/tools/opensuse.md
+++ b/tools/opensuse.md
@@ -14,9 +14,6 @@ sortReleasesBy: "release"
 # __RELEASE_CYCLE__ will be replaced by the value of releaseCycle
 # __LATEST__ will be replaced by the value of latest
 
-# What is this for??
-#changelogTemplate: "https://link/of/the/__RELEASE_CYCLE__/and/__LATEST__/version"
-
 # A list of releases, supported or not
 # Newer releases go on top of the list, in order
 releases:
@@ -119,7 +116,7 @@ releases:
 
 # A slug for https://simpleicons.org/
 # If the icon is not available on simpleicons, set it to "NA"
-icon_slug: openSUSE # Right??
+icon_slug: opensuse
 
 # A few extra fields define overall page behaviour
 
@@ -136,11 +133,11 @@ activeSupportColumn: false
 releaseColumn: true
 # Whether to show the release date column
 # optional, default false
-releaseDateColumn: true
+releaseDateColumn: false
 # What to call the End of Life  (Security Support) column. (optional)
 eolColumn: End of life
 # Command that can be used to check the current version. (optional)
-command: swish and flick
+command: cat /usr/lib/os-release
 # An image that shows a graphical representation of the releases.
 # This is not the product logo
 #releaseImage: https://jkrowling.com/timeturner-releases.png

--- a/tools/opensuse.md
+++ b/tools/opensuse.md
@@ -8,7 +8,7 @@ category: os
 # What should be used to sort releases. Set to one of:
 # releaseCycle/eol/support/release/cycleShortHand
 # which must be present in the releases underneath
-sortReleasesBy: "releaseCycle"
+sortReleasesBy: "release"
 
 # Template to be used to generate a link for the release
 # __RELEASE_CYCLE__ will be replaced by the value of releaseCycle

--- a/tools/opensuse.md
+++ b/tools/opensuse.md
@@ -115,7 +115,7 @@ alternate_urls:
   - /opensuseleap
 # More information link. This link should contain
 # information about the release policy and schedule
-link: https://en.opensuse.org/Lifetimetps
+link: https://en.opensuse.org/Lifetime
 # Whether to hide the "Active Support" column (optional, default true)
 activeSupportColumn: false
 # Whether to hide/show the latest release column. If the product doesn't have patch releases, set this to false. (optional, default true)

--- a/tools/opensuse.md
+++ b/tools/opensuse.md
@@ -21,70 +21,87 @@ releases:
     release: 2021-06-02
     support: 2022-12-1
     eol: 2022-12-1
+    latest: "openSUSE 15.3"
   - releaseCycle: "openSUSE Leap 15.2"
     release: 2020-07-02
     support: 2021-12-1
     eol: 2021-12-1
+    latest: "openSUSE 15.2"
   - releaseCycle: "openSUSE Leap 15.1"
     release: 2019-05-22
     support: 2021-02-02
     eol: 2021-02-02
+    latest: "openSUSE 15.1"
   - releaseCycle: "openSUSE Leap 15.0"
     release: 2018-05-25
     support: 2019-12-03
     eol: 2019-12-03
+    latest: "openSUSE 15.0"
   - releaseCycle: "openSUSE Leap 42.3"
     release: 2017-07-26
     support: 2019-07-01
     eol: 2019-07-01
+    latest: "openSUSE 42.3"
   - releaseCycle: "openSUSE Leap 42.2"
     release: 2016-11-16
     support: 2018-01-26
     eol: 2018-01-26
+    latest: "openSUSE 42.2"
   - releaseCycle: "openSUSE Leap 42.1"
     release: 2015-11-4
     support: 2017-05-17
     eol: 2017-05-17
+    latest: "openSUSE 42.1"
   - releaseCycle: "openSUSE 13.2"
     release: 2015-12-14
     support: 2017-01-17
     eol: 2017-01-17
+    latest: "openSUSE 13.2"
   - releaseCycle: "openSUSE 13.1"
     release: 2014-01-08
     support: 2016-02-03
     eol: 2016-02-03
+    latest: "openSUSE 13.1"
   - releaseCycle: "openSUSE 12.3"
     release: 2013-03-13
     support: 2015-01-29
     eol: 2015-01-29
+    latest: "openSUSE 12.3"
   - releaseCycle: "openSUSE 12.2"
     release: 2012-09-05
     support: 2014-01-15
     eol: 2014-01-15
+    latest: "openSUSE 12.2"
   - releaseCycle: "openSUSE 12.1"
     release: 2011-11-16
     support: 2013-05-15
     eol: 2013-05-15
+    latest: "openSUSE 12.1"
   - releaseCycle: "openSUSE 11.4"
     release: 2011-03-10
     support: 2012-11-05
     eol: 2012-11-05
+    latest: "openSUSE 11.4"
   - releaseCycle: "openSUSE 11.3"
     release: 2010-07-15
     support: 2012-01-20
     eol: 2012-01-20
+    latest: "openSUSE 11.3"
   - releaseCycle: "openSUSE 11.2"
     release: 2009-11-12
     support: 2011-05-12
     eol: 2011-05-12
+    latest: "openSUSE 11.2"
   - releaseCycle: "openSUSE 11.1"
     release: 2008-12-18
     support: 2011-01-14
     eol: 2011-01-14
+    latest: "openSUSE 11.1"
   - releaseCycle: "openSUSE 11.0"
     release: 2008-06-19
     support: 2010-07-26
     eol: 2010-07-26
+    latest: "openSUSE 11.0"
 
 # A slug for https://simpleicons.org/
 # If the icon is not available on simpleicons, set it to "NA"

--- a/tools/opensuse.md
+++ b/tools/opensuse.md
@@ -1,0 +1,156 @@
+---
+title: openSUSE
+layout: post
+# Possible values are os,db,tool,lang,framework
+# If you add a new value, please mention it on the PR Description
+category: os
+
+# What should be used to sort releases. Set to one of:
+# releaseCycle/eol/support/release/cycleShortHand
+# which must be present in the releases underneath
+sortReleasesBy: "release"
+
+# Template to be used to generate a link for the release
+# __RELEASE_CYCLE__ will be replaced by the value of releaseCycle
+# __LATEST__ will be replaced by the value of latest
+
+# What is this for??
+#changelogTemplate: "https://link/of/the/__RELEASE_CYCLE__/and/__LATEST__/version"
+
+# A list of releases, supported or not
+# Newer releases go on top of the list, in order
+releases:
+  - releaseCycle: "openSUSE Leap 15.3"
+    release: 2021-06-02
+    support: 2022-12-0
+    eol: 2022-12-0
+  - releaseCycle: "openSUSE Leap 15.2"
+    release: 2020-07-02
+    support: 2021-12-0
+    eol: 2021-12-0
+  - releaseCycle: "openSUSE Leap 15.1"
+    release: 2019-05-22
+    support: 2021-02-02
+    eol: 2021-02-02
+  - releaseCycle: "openSUSE Leap 15.0"
+    release: 2018-05-25
+    support: 2019-12-03
+    eol: 2019-12-03
+  - releaseCycle: "openSUSE Leap 42.3"
+    release: 2017-07-26
+    support: 2019-07-01
+    eol: 2019-07-01
+  - releaseCycle: "openSUSE Leap 42.2"
+    release: 2016-11-16
+    support: 2018-01-26
+    eol: 2018-01-26
+  - releaseCycle: "openSUSE Leap 42.1"
+    release: 2015-11-4
+    support: 2017-05-17
+    eol: 2017-05-17
+  - releaseCycle: "openSUSE 13.2"
+    release: 2015-12-14
+    support: 2017-01-17
+    eol: 2017-01-17
+  - releaseCycle: "openSUSE 13.1"
+    release: 2014-01-08
+    support: 2016-02-03
+    eol: 2016-02-03
+  - releaseCycle: "openSUSE 12.3"
+    release: 2013-03-13
+    support: 2015-01-29
+    eol: 2015-01-29
+  - releaseCycle: "openSUSE 12.2"
+    release: 2012-09-05
+    support: 2014-01-15
+    eol: 2014-01-15
+  - releaseCycle: "openSUSE 12.1"
+    release: 2011-11-16
+    support: 2013-05-15
+    eol: 2013-05-15
+  - releaseCycle: "openSUSE 11.4"
+    release: 2011-03-10
+    support: 2012-11-05
+    eol: 2012-11-05
+  - releaseCycle: "openSUSE 11.3"
+    release: 2010-07-15
+    support: 2012-01-20
+    eol: 2012-01-20
+  - releaseCycle: "openSUSE 11.2"
+    release: 2009-11-12
+    support: 2011-05-12
+    eol: 2011-05-12
+  - releaseCycle: "openSUSE 11.1"
+    release: 2008-12-18
+    support: 2011-01-14
+    eol: 2011-01-14
+  - releaseCycle: "openSUSE 11.0"
+    release: 2008-06-19
+    support: 2010-07-26
+    eol: 2010-07-26
+  - releaseCycle: "openSUSE 10.3"
+    release: 2007-10-04
+    support: 2009-10-31
+    eol: 2009-10-31
+  - releaseCycle: "openSUSE 10.2"
+    release: 2006-12-07
+    support: 2008-11-30
+    eol: 2008-11-30
+  - releaseCycle: "SUSE Linux 10.1"
+    release: 2006-03-11
+    support: 2008-05-31
+    eol: 2008-05-31
+  - releaseCycle: "SUSE Linux 10.0"
+    release: 2005-10-06
+    support: 2007-11-30
+    eol: 2007-11-30
+  - releaseCycle: "SUSE Linux 9.3"
+    release: 2005-04-15
+    support: 2007-04-30
+    eol: 2007-04-30
+  - releaseCycle: "SUSE Linux 9.2"
+    release: 2004-10-25
+    support: 2006-10-31
+    eol: 2006-10-31
+  - releaseCycle: "SUSE Linux 9.1"
+    release: 2004-04-21
+    support: 2006-06-30
+    eol: 2006-06-30
+
+# A slug for https://simpleicons.org/
+# If the icon is not available on simpleicons, set it to "NA"
+icon_slug: openSUSE # Right??
+
+# A few extra fields define overall page behaviour
+
+# URL for the page
+permalink: /opensuse
+alternate_urls:
+  - /opensuseleap
+# More information link. This link should contain
+# information about the release policy and schedule
+link: https://en.opensuse.org/Lifetimetps
+# Whether to hide the "Active Support" column (optional, default true)
+activeSupportColumn: false
+# Whether to hide/show the latest release column. If the product doesn't have patch releases, set this to false. (optional, default true)
+releaseColumn: true
+# Whether to show the release date column
+# optional, default false
+releaseDateColumn: true
+# What to call the End of Life  (Security Support) column. (optional)
+eolColumn: End of life
+# Command that can be used to check the current version. (optional)
+command: swish and flick
+# An image that shows a graphical representation of the releases.
+# This is not the product logo
+#releaseImage: https://jkrowling.com/timeturner-releases.png
+
+# In the markdown section, ensure that the following are present:
+# 1. A one line statement about what the tool is, with a link to the primary website (in a quote)
+# 2. A short summary of the release policy, pointing out the EoL policy as well, if available.
+# 3. Any additional information that may be of interest
+---
+> [openSUSE](https://www.opensuse.org/) is a linux distribution claiming its
+"The makers' choice for sysadmins, developers and desktop users".
+
+As of today, openSUSE Leap is actively maintained and developed. The current version is *openSuse Leap 15.3*.

--- a/tools/opensuse.md
+++ b/tools/opensuse.md
@@ -119,10 +119,10 @@ link: https://en.opensuse.org/Lifetime
 # Whether to hide the "Active Support" column (optional, default true)
 activeSupportColumn: false
 # Whether to hide/show the latest release column. If the product doesn't have patch releases, set this to false. (optional, default true)
-releaseColumn: true
+releaseColumn: false
 # Whether to show the release date column
 # optional, default false
-releaseDateColumn: false
+releaseDateColumn: true
 # What to call the End of Life  (Security Support) column. (optional)
 eolColumn: End of life
 # Command that can be used to check the current version. (optional)


### PR DESCRIPTION
#294 Adding openSUSE. Please review, especially:
- what should the fields `eol` and `support` look like if the EOL-date (currently) only consists of month and year - they haven't specified a day yet
- what is changelolTemplate for?
- what is iconSlug for?
- for longer articles, my English sucks. Please review the markdown section and add additional information if needed.

The dates come from:
- https://en.opensuse.org/Lifetime
- https://de.wikipedia.org/wiki/OpenSUSE#Versionen