### PR TITLE
Correcting Windows Server 2016 EOL date

### DIFF
--- a/tools/windowsServer.md
+++ b/tools/windowsServer.md
@@ -46,7 +46,7 @@ releases:
   - releaseCycle: "Windows Server 2016 (Datacenter, Essentials, Standard)"
     release: 2016-10-15
     support: 2022-01-11
-    eol: 2023-10-10
+    eol: 2027-01-12
   - releaseCycle: "Windows Storage Server 2016"
     release: 2016-10-15
     support: 2022-01-11


### PR DESCRIPTION
The current EOL date shown is for Server 2012 and not for 2016 as seen here
https://docs.microsoft.com/en-us/lifecycle/products/windows-server-2016