### PR TITLE
[SEO] Configurable description for every page.

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,8 +1,4 @@
 title: endoflife.date
-description: >- # this means to ignore newlines until "baseurl:"
-  Check End of Life of php, python, ubuntu, alpine, laravel, debian, centos, django, .NET,
-  fedora, iphone, redhat, postgres, ruby, windows, Node.js, mariadb, java etc at one place.
-  Verify whether your application needs an update, or if you need to upgrade your device.
 baseurl: /
 markdown: kramdown
 plugins:

--- a/_includes/head_custom.html
+++ b/_includes/head_custom.html
@@ -1,9 +1,8 @@
 {% capture d %}
 {% if page.layout == 'post' %}
-Check End of Life for {{page.title}} at one place. Verify whether your application needs an update, or if you need to upgrade your device. {%if page.alternate_urls %}endoflife.date/{{page.alternate_urls[0]}}{%endif%}. {{page.title}} release policy and release schedule.
+Check End of Life, Support Schedule, and release timelines for {{page.title}}. {%if page.alternate_urls %}endoflife.date{{page.alternate_urls[0]}}{%endif%}. {{page.title}} release policy. {{page.title}} release schedule. {{page.title}} end of life.
 {% else %}
-{% for page in site.pages %}{{page.title}},{% endfor %} etc at one place.
-  Verify whether your application needs an update, or if you need to upgrade your device.
+Check End of Life, Support Schedule, and release timelines for  {% for page in site.pages%}{%if page.releases%}{{page.title}}, {%endif%}{% endfor %} etc at one place.
 {% endif %}
 {% endcapture %}
 <meta name="description" content="{{ d | strip }}" />

--- a/_includes/head_custom.html
+++ b/_includes/head_custom.html
@@ -1,0 +1,10 @@
+{% capture d %}
+{% if page.layout == 'post' %}
+Check End of Life for {{page.title}} at one place. Verify whether your application needs an update, or if you need to upgrade your device. {%if page.alternate_urls %}endoflife.date/{{page.alternate_urls[0]}}{%endif%}. {{page.title}} release policy and release schedule.
+{% else %}
+{% for page in site.pages %}{{page.title}},{% endfor %} etc at one place.
+  Verify whether your application needs an update, or if you need to upgrade your device.
+{% endif %}
+{% endcapture %}
+<meta name="description" content="{{ d | strip }}" />
+<meta property="og:description" content="{{ d | strip }}" />


### PR DESCRIPTION
This gives every product page its own description.

## Earlier:

[**Common Description**](https://endoflife.date/)

>Check End of Life of php, python, ubuntu, alpine, laravel, debian, centos, django, .NET, fedora, iphone, redhat, postgres, ruby, windows, Node.js, mariadb, java etc at one place. Verify whether your application needs an update, or if you need to upgrade your device.

[**Specific Description**](https://endoflife.date/iphone)

>Check End of Life of php, python, ubuntu, alpine, laravel, debian, centos, django, .NET, fedora, iphone, redhat, postgres, ruby, windows, Node.js, mariadb, java etc at one place. Verify whether your application needs an update, or if you need to upgrade your device.

## After this PR

[**Common Description**](https://deploy-preview-315--endoflife-date.netlify.app/)

>Check End of Life, Support Schedule, and release timelines for  Alpine Linux, Amazon Linux, Android OS, Bootstrap, CentOS, Debian, Django, .NET, .NET Core, .NET Framework, Drupal, Elasticsearch, Elixir, Fedora Linux, FileMaker, FreeBSD, Go, Godot, iPhone, Java/OpenJDK, Amazon Kindle, Kubernetes, Laravel, macOS, Magento, MariaDB, MongoDB Server, Microsoft SQL Server, MySQL, Node.js, Microsoft Office, openSUSE, Perl, PHP, Google Pixel, PostgreSQL, PowerShell, Python, Qt, RabbitMQ, Red Hat Enterprise Linux, Redis, ROS, Ruby on Rails, Ruby, SUSE Linux Enterprise Server, Spring Framework, Microsoft Surface, Symfony, Ubuntu, Wagtail, Windows, Windows Embedded, Windows Server,  etc at one place.

[**Specific Description**](https://deploy-preview-315--endoflife-date.netlify.app/iphone)

>Check End of Life, Support Schedule, and release timelines for iPhone. endoflife.date/ios. iPhone release policy. iPhone release schedule. iPhone end of life.