### PR TITLE
Fix ROS melodic release date

### DIFF
--- a/tools/ros.md
+++ b/tools/ros.md
@@ -16,7 +16,7 @@ releases:
     release: 2020-05-23
   - releaseCycle: 'Melodic Morenia'
     eol: 2023-04-01
-    release: 2011-01-05
+    release: 2018-05-23
   - releaseCycle: 'Lunar Loggerhead'
     eol: 2019-05-01
     release: 2017-05-23


### PR DESCRIPTION
ROS melodic was released on May 23rd, 2018, not Jan 15th, 2011: http://wiki.ros.org/melodic

The page should probably also mention that Noetic was the last release of ROS1 and all future development will be with ROS2, but that is a separate issue.