### PR TITLE
[RHEL] Clarified EOL dates.

### DIFF
--- a/tools/redhat.md
+++ b/tools/redhat.md
@@ -24,17 +24,18 @@ releases:
   - releaseCycle: "RHEL 6"
     release: 2010-11-10
     support: 2016-05-10
-    eol: 2024-06-30
+    eol: 2020-11-30
+    
   - releaseCycle: "RHEL 7"
     release: 2014-06-10
     support: 2019-12-31
-    eol: false
-    latest: "7.6"
+    eol: 2024-06-30
+    latest: "7.9"
   - releaseCycle: "RHEL 8"
     release: 2019-05-01
     support: 2024-05-31
-    eol: false
-    latest: "8.0"
+    eol: 2029-05-31
+    latest: "8.10"
 ---
 
 > Red Hat Enterprise Linux is a Linux distribution developed by Red Hat for the commercial market.

--- a/tools/redhat.md
+++ b/tools/redhat.md
@@ -1,5 +1,5 @@
 ---
-releaseImage: https://access.redhat.com/sites/default/files/images/rhel_8_life_cycle_8_0519_releases.png
+releaseImage: https://access.redhat.com/sites/default/files/images/rhel_8_life_cycle_8_0620_planning_0.png
 title: Red Hat Enterprise Linux
 layout: post
 permalink: /rhel


### PR DESCRIPTION
Changes to RHEL 6:

Changed end of security support to November 30, 2020*

Changes to RHEL 7:

Updated RHEL 7 latest release to 7.9

Added end of security support date of June 30, 2024*

Changes to RHEL 8:

Updated RHEL 8 latest release to 8.10

Added end of security period of May 31, 2029*

*Reasoning behind these changes is because previously the "End of life" date was defined by the ELS timeline of RHEL, but as stated by official RHEL documentation, this does not provide security updates: https://www.redhat.com/en/resources/els-datasheet

> Extended Life Phase. During the Extended Life Phase, a Red Hat Enterprise Linux subscription provides continued access to previously released content on the Red Hat Customer Portal, as well as other content such as documentation and the Red Hat knowledgebase. **By default no bug fixes, security fixes, hardware enablement, or root-cause analysis is available during this phase.**

While it it technically not end of life yet until it reaches this date, on the website the end of life date is stated as security support, which is inaccurate here. Under the ELS, RHEL is not receiving security updates even if it is not yet EOL. 