### PR TITLE
[RHEL] Correct RHEL 4 and 5 EOL dates, correct RHEL 8 latest release mistake

### DIFF
--- a/tools/redhat.md
+++ b/tools/redhat.md
@@ -35,7 +35,7 @@ releases:
     release: 2019-05-01
     support: 2024-05-31
     eol: 2029-05-31
-    latest: "8.10"
+    latest: "8.4"
 ---
 
 > Red Hat Enterprise Linux is a Linux distribution developed by Red Hat for the commercial market.

--- a/tools/redhat.md
+++ b/tools/redhat.md
@@ -16,11 +16,11 @@ releases:
   - releaseCycle: "RHEL 4"
     release: 2005-02-14
     support: 2009-03-31
-    eol: 2017-03-31
+    eol: 2012-02-29
   - releaseCycle: "RHEL 5"
     release: 2007-03-15
     support: 2013-01-08
-    eol: 2020-11-30
+    eol: 2017-03-31
   - releaseCycle: "RHEL 6"
     release: 2010-11-10
     support: 2016-05-10


### PR DESCRIPTION
As previously argued in https://github.com/endoflife-date/endoflife.date/pull/343 , ELS should not be considered the end of security date. Changing the EOL dates of RHEL 4 and 5 to correct this, as per RHEL documentation: https://access.redhat.com/support/policy/updates/errata