### PR TITLE
[java] Minor updates for Java

### DIFF
--- a/products/java.md
+++ b/products/java.md
@@ -58,7 +58,7 @@ releases:
     release: 2014-03-18
     support: 2022-03-31
     eol: 2025-03-31
-    latest: "8u302"
+    latest: "8u301"
   - releaseCycle: "7"
     release: 2011-07-07
     support: 2019-07-31

--- a/products/java.md
+++ b/products/java.md
@@ -16,7 +16,7 @@ releases:
     release: 2021-03-16
     support: 2021-09-30
     eol: 2021-09-30
-    latest: "16.0.0"
+    latest: "16.0.2"
   - releaseCycle: "15"
     release: 2020-09-16
     support: 2021-03-31
@@ -42,7 +42,7 @@ releases:
     release: 2018-09-25
     support: 2023-09-30
     eol: 2026-09-30
-    latest: "11.0.10"
+    latest: "11.0.12"
   - releaseCycle: "10"
     release: 2018-03-20
     support: 2018-09-25
@@ -58,11 +58,11 @@ releases:
     release: 2014-03-18
     support: 2022-03-31
     eol: 2025-03-31
-    latest: "8u281"
+    latest: "8u302"
   - releaseCycle: "7"
     release: 2011-07-07
     support: 2019-07-31
-    eol: 2022-07-31
+    eol: 2019-07-01
     latest: "7u221"
   - releaseCycle: "6"
     release: 2006-12-11


### PR DESCRIPTION
The only weird change here is the Java SE 7's EOL date of 2019. There's differing levels of support for this from different vendors. 

[RedHat offered support till June 2020](https://access.redhat.com/articles/1299013)

[AdoptOpenJDK](https://adoptopenjdk.net) doesn't list JDK 7.

[jdk.java.net](https://jdk.java.net/java-se-ri/7) explicitly calls it out as an unsupported release:

>These binaries are provided primarily for use by implementors of the Java SE 7 Platform Specification and are recommended for reference purposes only. The Reference Implementations have been approved by the JCP and will receive no further updates, not even for security issues. Binaries for development and production use will be available from Oracle and in most popular Linux distributions.

Oracle's own [Java at a glance page](https://www.oracle.com/java/technologies/java-se-glance.html) which we link to, only mentions 8,11, and 16.

However, [Oracle's release notes for Java 7](https://www.oracle.com/java/technologies/javase/7-support-relnotes.html) mention JDK 7u311 as the latest release (July 20, 2021)

[Oracle's support roadmap](https://www.oracle.com/java/technologies/java-se-support-roadmap.html) page lists 2 dates:

- July 2019 for premier support
- July 2022 for extended support

with this disclaimer:

>The Extended Support uplift fee will be waived for the period June 2019 - July 2022 for Java SE 7. The Extended Support uplift fee will be waived for the period March 2022 - December 2030 for Java SE 8. During this period, you will receive Extended Support as described in the Oracle Technical Support Level sections of the Technical Support Policies.

Even with this, I couldn't find a way to install JDK 7u311 without contacting Oracle Sales. Unsure of what to do here. A note in the text perhaps?

https://www.oracle.com/java/technologies/java-se-support-roadmap.html

Aside: https://javadl-esd-secure.oracle.com/update/baseline.version is also a good resource