### PR TITLE
[freebsd] Add older freebsd releases

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ api/
 .idea/
 .jekyll-cache
 _data/gke.json
+.bundle/

--- a/products/freebsd.md
+++ b/products/freebsd.md
@@ -39,6 +39,136 @@ releases:
     cycleShortHand: 11.4
     release: 2020-06-16
     eol: 2021-09-30
+  - releaseCycle: "releng/10.4"
+    cycleShortHand: 10.4
+    release: 2017-10-03
+    eol: 2018-10-31
+  - releaseCycle: "releng/10.3"
+    cycleShortHand: 10.3
+    release: 2016-04-04
+    eol: 2018-04-30
+  - releaseCycle: "releng/10.2"
+    cycleShortHand: 10.2
+    release: 2015-08-13
+    eol: 2016-12-31
+  - releaseCycle: "releng/10.1"
+    cycleShortHand: 10.1
+    release: 2014-11-14
+    eol: 2016-12-31
+  - releaseCycle: "releng/10.0"
+    cycleShortHand: 10.0
+    release: 2014-01-20
+    eol: 2016-02-28
+  - releaseCycle: "releng/9.3"
+    cycleShortHand: 9.3
+    release: 2014-07-16
+    eol: 2016-12-31
+  - releaseCycle: "releng/9.2"
+    cycleShortHand: 9.2
+    release: 2013-09-30
+    eol: 2014-12-31
+  - releaseCycle: "releng/9.1"
+    cycleShortHand: 9.1
+    release: 2012-12-30
+    eol: 2014-12-31
+  - releaseCycle: "releng/9.0"
+    cycleShortHand: 9.0
+    release: 2012-01-10
+    eol: 2013-03-31
+  - releaseCycle: "stable/9"
+    cycleShortHand: 9.x
+    eol: 2016-12-31
+  - releaseCycle: "releng/8.4"
+    cycleShortHand: 8.4
+    release: 2013-06-09
+    eol: 2015-08-01
+  - releaseCycle: "releng/8.3"
+    cycleShortHand: 8.3
+    release: 2012-04-18
+    eol: 2014-04-30
+  - releaseCycle: "releng/8.2"
+    cycleShortHand: 8.2
+    release: 2011-02-24
+    eol: 2012-07-31
+  - releaseCycle: "releng/8.1"
+    cycleShortHand: 8.1
+    release: 2010-07-23
+    eol: 2012-07-31
+  - releaseCycle: "releng/8.0"
+    cycleShortHand: 8.0
+    release: 2009-11-25
+    eol: 2010-11-30
+  - releaseCycle: "stable/8"
+    cycleShortHand: 8.x
+    eol: 2015-08-01
+  - releaseCycle: "releng/7.4"
+    cycleShortHand: 7.4
+    release: 2011-02-24
+    eol: 2013-02-28
+  - releaseCycle: "releng/7.3"
+    cycleShortHand: 7.3
+    release: 2010-03-23
+    eol: 2012-03-31
+  - releaseCycle: "releng/7.2"
+    cycleShortHand: 7.2
+    release: 2009-03-04
+    eol: 2010-06-30
+  - releaseCycle: "releng/7.1"
+    cycleShortHand: 7.1
+    release: 2009-01-04
+    eol: 2011-02-28
+  - releaseCycle: "releng/7.0"
+    cycleShortHand: 7.0
+    release: 2008-02-27
+    eol: 2009-04-30
+  - releaseCycle: "stable/7"
+    cycleShortHand: 7.x
+    eol: 2013-02-28
+  - releaseCycle: "releng/6.4"
+    cycleShortHand: 6.4
+    release: 2008-11-28
+    eol: 2010-11-30
+  - releaseCycle: "releng/6.3"
+    cycleShortHand: 6.3
+    release: 2008-01-18
+    eol: 2010-01-31
+  - releaseCycle: "releng/6.2"
+    cycleShortHand: 6.2
+    release: 2007-01-15
+    eol: 2008-05-31
+  - releaseCycle: "releng/6.1"
+    cycleShortHand: 6.1
+    release: 2006-05-09
+    eol: 2008-05-31
+  - releaseCycle: "releng/6.0"
+    cycleShortHand: 6.0
+    release: 2005-11-04
+    eol: 2007-01-31
+  - releaseCycle: "stable/6"
+    cycleShortHand: 6.x
+    eol: 2010-11-30
+  - releaseCycle: "releng/5.5"
+    cycleShortHand: 5.5
+    release: 2006-05-25
+    eol: 2008-05-31
+  - releaseCycle: "releng/5.4"
+    cycleShortHand: 5.4
+    release: 2005-05-09
+    eol: 2006-10-31
+  - releaseCycle: "releng/5.3"
+    cycleShortHand: 5.3
+    release: 2004-11-06
+    eol: 2005-10-31
+  - releaseCycle: "stable/5"
+    cycleShortHand: 5.x
+    eol: 2008-05-31
+  - releaseCycle: "releng/4.11"
+    release: 2005-01-25
+    eol: 2007-01-31
+  - releaseCycle: "stable/4"
+    cycleShortHand: 4.x
+    eol: 2007-01-31
+
 ---
 
 > [FreeBSD](https://www.freebsd.org) is an operating system used to power modern servers, desktops, and embedded platforms.
@@ -47,7 +177,7 @@ Each release is supported by the Security Officer for a limited time only. Under
 
 The Expected EoL (end-of-life) column indicates the earliest date on which support for that branch or release will end. Please note that these dates may be pushed back if circumstances warrant it.
 
-The FreeBSD Security Officer provides security advisories for `-STABLE` Branches and the Security Branches. (Advisories are not issued for the `-CURRENT` Branch, which is primarily oriented towards FreeBSD developers.)
+The FreeBSD Security Officer provides security advisories for `-STABLE` Branches and the Security Branches. Advisories are not issued for the `-CURRENT` Branch, which is primarily oriented towards FreeBSD developers.
 
 The -STABLE branch tags have names like `stable/10`. The corresponding builds have names like `FreeBSD 10.1-STABLE`.
 

--- a/products/freebsd.md
+++ b/products/freebsd.md
@@ -58,7 +58,7 @@ releases:
   - releaseCycle: "releng/10.0"
     cycleShortHand: "10.0"
     release: 2014-01-20
-    eol: 2016-02-28
+    eol: 2015-02-28
   - releaseCycle: "releng/9.3"
     cycleShortHand: "9.3"
     release: 2014-07-16
@@ -158,7 +158,7 @@ releases:
   - releaseCycle: "releng/5.3"
     cycleShortHand: "5.3"
     release: 2004-11-06
-    eol: 2005-10-31
+    eol: 2006-10-31
   - releaseCycle: "stable/5"
     cycleShortHand: "5"
     eol: 2008-05-31

--- a/products/freebsd.md
+++ b/products/freebsd.md
@@ -11,162 +11,162 @@ sortReleasesBy: cycleShortHand
 command: freebsd-version
 releases:
   - releaseCycle: "stable/13"
-    cycleShortHand: 13.x
+    cycleShortHand: "13"
     eol: 2026-01-31
   - releaseCycle: "releng/13.0"
-    cycleShortHand: 13.x
+    cycleShortHand: "13.0"
     # 13.1-RELEASE + 3 months
     eol: false
     release: 2021-04-13
   - releaseCycle: "stable/12"
-    cycleShortHand: 12.x
+    cycleShortHand: "12"
     eol: 2024-06-30
   - releaseCycle: "releng/12.2"
-    cycleShortHand: 12.2
+    cycleShortHand: "12.2"
     release: 2020-10-27
     release: NA
     # 12.3-RELEASE + 3 months
     eol: false
   - releaseCycle: "releng/12.1"
-    cycleShortHand: 12.1
+    cycleShortHand: "12.1"
     release: 2019-11-04
     release: NA
     eol: 2021-01-31
   - releaseCycle: "stable/11"
-    cycleShortHand: 11.x
+    cycleShortHand: "11.0"
     eol: 2021-09-30
   - releaseCycle: "releng/11.4"
-    cycleShortHand: 11.4
+    cycleShortHand: "11.4"
     release: 2020-06-16
     eol: 2021-09-30
   - releaseCycle: "releng/10.4"
-    cycleShortHand: 10.4
+    cycleShortHand: "10.4"
     release: 2017-10-03
     eol: 2018-10-31
   - releaseCycle: "releng/10.3"
-    cycleShortHand: 10.3
+    cycleShortHand: "10.3"
     release: 2016-04-04
     eol: 2018-04-30
   - releaseCycle: "releng/10.2"
-    cycleShortHand: 10.2
+    cycleShortHand: "10.2"
     release: 2015-08-13
     eol: 2016-12-31
   - releaseCycle: "releng/10.1"
-    cycleShortHand: 10.1
+    cycleShortHand: "10.1"
     release: 2014-11-14
     eol: 2016-12-31
   - releaseCycle: "releng/10.0"
-    cycleShortHand: 10.0
+    cycleShortHand: "10.0"
     release: 2014-01-20
     eol: 2016-02-28
   - releaseCycle: "releng/9.3"
-    cycleShortHand: 9.3
+    cycleShortHand: "9.3"
     release: 2014-07-16
     eol: 2016-12-31
   - releaseCycle: "releng/9.2"
-    cycleShortHand: 9.2
+    cycleShortHand: "9.2"
     release: 2013-09-30
     eol: 2014-12-31
   - releaseCycle: "releng/9.1"
-    cycleShortHand: 9.1
+    cycleShortHand: "9.1"
     release: 2012-12-30
     eol: 2014-12-31
   - releaseCycle: "releng/9.0"
-    cycleShortHand: 9.0
+    cycleShortHand: "9.0"
     release: 2012-01-10
     eol: 2013-03-31
   - releaseCycle: "stable/9"
-    cycleShortHand: 9.x
+    cycleShortHand: "9"
     eol: 2016-12-31
   - releaseCycle: "releng/8.4"
-    cycleShortHand: 8.4
+    cycleShortHand: "8.4"
     release: 2013-06-09
     eol: 2015-08-01
   - releaseCycle: "releng/8.3"
-    cycleShortHand: 8.3
+    cycleShortHand: "8.3"
     release: 2012-04-18
     eol: 2014-04-30
   - releaseCycle: "releng/8.2"
-    cycleShortHand: 8.2
+    cycleShortHand: "8.2"
     release: 2011-02-24
     eol: 2012-07-31
   - releaseCycle: "releng/8.1"
-    cycleShortHand: 8.1
+    cycleShortHand: "8.1"
     release: 2010-07-23
     eol: 2012-07-31
   - releaseCycle: "releng/8.0"
-    cycleShortHand: 8.0
+    cycleShortHand: "8.0"
     release: 2009-11-25
     eol: 2010-11-30
   - releaseCycle: "stable/8"
-    cycleShortHand: 8.x
+    cycleShortHand: "8"
     eol: 2015-08-01
   - releaseCycle: "releng/7.4"
-    cycleShortHand: 7.4
+    cycleShortHand: "7.4"
     release: 2011-02-24
     eol: 2013-02-28
   - releaseCycle: "releng/7.3"
-    cycleShortHand: 7.3
+    cycleShortHand: "7.3"
     release: 2010-03-23
     eol: 2012-03-31
   - releaseCycle: "releng/7.2"
-    cycleShortHand: 7.2
+    cycleShortHand: "7.2"
     release: 2009-03-04
     eol: 2010-06-30
   - releaseCycle: "releng/7.1"
-    cycleShortHand: 7.1
+    cycleShortHand: "7.1"
     release: 2009-01-04
     eol: 2011-02-28
   - releaseCycle: "releng/7.0"
-    cycleShortHand: 7.0
+    cycleShortHand: "7.0"
     release: 2008-02-27
     eol: 2009-04-30
   - releaseCycle: "stable/7"
-    cycleShortHand: 7.x
+    cycleShortHand: "7"
     eol: 2013-02-28
   - releaseCycle: "releng/6.4"
-    cycleShortHand: 6.4
+    cycleShortHand: "6.4"
     release: 2008-11-28
     eol: 2010-11-30
   - releaseCycle: "releng/6.3"
-    cycleShortHand: 6.3
+    cycleShortHand: "6.3"
     release: 2008-01-18
     eol: 2010-01-31
   - releaseCycle: "releng/6.2"
-    cycleShortHand: 6.2
+    cycleShortHand: "6.2"
     release: 2007-01-15
     eol: 2008-05-31
   - releaseCycle: "releng/6.1"
-    cycleShortHand: 6.1
+    cycleShortHand: "6.1"
     release: 2006-05-09
     eol: 2008-05-31
   - releaseCycle: "releng/6.0"
-    cycleShortHand: 6.0
+    cycleShortHand: "6.0"
     release: 2005-11-04
     eol: 2007-01-31
   - releaseCycle: "stable/6"
-    cycleShortHand: 6.x
+    cycleShortHand: "6"
     eol: 2010-11-30
   - releaseCycle: "releng/5.5"
-    cycleShortHand: 5.5
+    cycleShortHand: "5.5"
     release: 2006-05-25
     eol: 2008-05-31
   - releaseCycle: "releng/5.4"
-    cycleShortHand: 5.4
+    cycleShortHand: "5.4"
     release: 2005-05-09
     eol: 2006-10-31
   - releaseCycle: "releng/5.3"
-    cycleShortHand: 5.3
+    cycleShortHand: "5.3"
     release: 2004-11-06
     eol: 2005-10-31
   - releaseCycle: "stable/5"
-    cycleShortHand: 5.x
+    cycleShortHand: "5"
     eol: 2008-05-31
   - releaseCycle: "releng/4.11"
     release: 2005-01-25
     eol: 2007-01-31
   - releaseCycle: "stable/4"
-    cycleShortHand: 4.x
+    cycleShortHand: "4"
     eol: 2007-01-31
 
 ---


### PR DESCRIPTION
I've modified the text for freebsd.md slightly, and added all the historical unsupported releases.
I know the API isn't stable but I've an interest in having as many versions as possible available via API, if this is acceptable I'll go through some other OS/distributions.

This pull req will also add a modification to .gitignore for .bundle/, I can separate that out if you like.