### PR TITLE
[Android] Added 8.1 and set 8.0 to EOL

### DIFF
--- a/products/android.md
+++ b/products/android.md
@@ -55,9 +55,14 @@ releases:
   - releaseCycle: Nougat (7.x)
     release: 2016-08-22
     eol: true
-  - releaseCycle: Oreo (8.x)
+  - releaseCycle: Oreo (8.0.x)
     release: 2017-08-21
+    eol: true
+    
+  - releaseCycle: Oreo (8.1.x)
+    release: 2017-12-05
     eol: false
+
   - releaseCycle: Pie (9.x)
     release: 2018-08-06
     eol: false


### PR DESCRIPTION
Android 8.0 and 8.1 are separate trees, 8.0 is no longer receiving security updates, 8.1 is. This can be seen in the latest bulletins: https://source.android.com/security/bulletin/2021-08-01