### PR TITLE
Add NVIDIA-GPUs

### DIFF
--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -13,8 +13,8 @@ layout: default
     <tr>
       <th>Version</th>
       {% if page.releaseDateColumn%}<th>Released</th>{% endif %}
-      {% if page.activeSupportColumn%}<th>Active Support</th>{% endif %}
       {% if page.discontinuedColumn%}<th>Discontinued</th>{% endif %}
+      {% if page.activeSupportColumn%}<th>Active Support</th>{% endif %}
       <th>{{ page.eolColumn | default: "Security Support" }}</th>
       {% if page.releaseColumn != false %}<th>Release</th>{% endif %}
     </tr>
@@ -71,6 +71,20 @@ or +1 (EoL is in the future)
   </td>
   {% endif %}
 
+  {% if page.discontinuedColumn %}
+  <td class="{% unless r.discontinued %}bg-green-000{% endunless %}">
+    {% if r.discontinued %}
+      {% if r.discontinued == true%}
+        Discontinued
+      {% else %}
+        {{r.discontinued | timeago}} <div>({{r.discontinued | date_to_string}})</div>
+      {% endif %}
+    {% else %}
+      In Production
+    {% endif %}
+  </td>
+  {% endif %}
+
   {% if page.activeSupportColumn %}
     <td class=
     {% if support > 5 %}
@@ -104,20 +118,6 @@ or +1 (EoL is in the future)
       {% endif %}
     {% endif %}
     </td>
-  {% endif %}
-
-  {% if page.discontinuedColumn %}
-  <td class="{% unless r.discontinued %}bg-green-000{% endunless %}">
-    {% if r.discontinued %}
-      {% if r.discontinued == true%}
-        Discontinued
-      {% else %}
-        {{r.discontinued | timeago}} <div>({{r.discontinued | date_to_string}})</div>
-      {% endif %}
-    {% else %}
-      In Production
-    {% endif %}
-  </td>
   {% endif %}
 
   <td class=
@@ -169,6 +169,7 @@ or +1 (EoL is in the future)
 </table>
 
 <style>
+/* TODO:  Move these styles to proper SCSS */
 .maincontent>blockquote {
   margin-left: 60px;
 }
@@ -208,8 +209,6 @@ or +1 (EoL is in the future)
 <img class=productlogo width=50 height=50 src="https://simpleicons.org/icons{{page.permalink}}.svg" >
 {% endif %}
 
-
-
 <div class="maincontent">{{content}}</div>
 
 <p>More information is available on the <a href="{{page.link}}">{{page.title}} website</a>. </p>
@@ -217,7 +216,6 @@ or +1 (EoL is in the future)
 {% if page.releaseColumn != false %}<p>You should be running one of the supported release numbers listed above in the rightmost column.</p>{% endif %}
 
 {% if page.command %}<div id="version-command" class="card card-body bg-light">You can check the version that you are currently using by running: <pre>{{page.command}}</pre></div>{% endif %}
-
 
 <hr>
 

--- a/products/nvidia-products.md
+++ b/products/nvidia-products.md
@@ -1,0 +1,189 @@
+---
+title: NVIDIA products
+layout: post
+permalink: /nvidia-products
+category: app
+iconSlug: nvidia
+link: https://www.nvidia.com/en-us/geforce/graphics-cards/
+activeSupportColumn: true
+releaseDateColumn: true
+discontinuedColumn: true
+sortReleasesBy: 'release'
+releases:
+  - releaseCycle: "Consumer Fermi (GF1xx)*"
+    release: 2010-03-26
+    support: 2018-03-10
+    eol: 2018-03-10
+    discontinued: true
+  - releaseCycle: "Professional Fermi (GF1xx)"
+    release: 2010-07-23
+    support: 2018-07-31
+    eol: 2022-12-31
+    discontinued: true
+
+
+
+  - releaseCycle: "Consumer Kepler (GKxxx)"
+    release: 2012-03-22
+    support: true
+    eol: 2024-07-01
+    discontinued: true
+
+    
+  - releaseCycle: "Professional Kepler (GKxxx)"
+    release: 2013-03-01
+    support: true
+    eol: 2024-07-01
+    discontinued: true
+
+
+  - releaseCycle: "Mobile Professional Kepler (GKxxx)" # Verify release date.
+    release: 2012-03-22
+    support: 2019-04-23
+    eol: 2020-04-30
+    discontinued: true
+
+
+  - releaseCycle: "Mobile Consumer Kepler (GKxxx)" 
+    release: 2012-03-22
+    support: 2019-03-11
+    eol: 2019-04-11
+    discontinued: true
+
+
+
+  - releaseCycle: "Consumer Maxwell (GMxxx)"
+    release: 2014-09-19
+    support: true
+    eol: false
+    discontinued: true
+    
+  - releaseCycle: "Professional Maxwell (GMxxx)"
+    release: 2015-06-29
+    support: true
+    eol: false
+    discontinued: true
+
+
+  - releaseCycle: "Mobile Professional Maxwell (GMxxx)" 
+    release: 2015-08-18
+    support: true
+    eol: false
+    discontinued: true
+
+
+  - releaseCycle: "Mobile Consumer Maxwell (GMxxx)" 
+    release: 2014-10-07
+    support: true
+    eol: false
+    discontinued: true
+
+
+  - releaseCycle: "Consumer Pascal (GP10x)"
+    release: 2016-05-27
+    support: true
+    eol: false
+    discontinued: true
+   
+  - releaseCycle: "Professional Pascal (GP10x)"
+    release: 2016-04-05
+    support: true
+    eol: false
+    discontinued: true
+
+
+  - releaseCycle: "Mobile Professional Pascal (GP10x)"
+    release: 2017-02-06
+    support: true
+    eol: false
+    discontinued: true
+
+
+  - releaseCycle: "Mobile Consumer Pascal (GP10x)" 
+    release: 2016-08-15
+    support: true
+    eol: false
+    discontinued: true
+
+
+  - releaseCycle: "Professional Volta (GV100)" 
+    release: 2017-12-07
+    support: true
+    eol: false
+    discontinued: false
+
+
+  - releaseCycle: "Consumer Turing (TU1xX)"
+    release: 2018-09-20
+    support: true
+    eol: false
+    discontinued: true
+
+  - releaseCycle: "Professional Turing (TU1xX)"
+    release: 2018-08-13
+    support: true
+    eol: false
+    discontinued: true
+
+
+  - releaseCycle: "Mobile Professional Turing (TU1xX)"
+    release: 2019-05-27
+    support: true
+    eol: false
+    discontinued: true
+
+
+  - releaseCycle: "Mobile Consumer Turing (TU1xX)" 
+    release: 2019-01-29
+    support: true
+    eol: false
+    discontinued: true
+
+
+  - releaseCycle: "Consumer Ampere (GA10x)"
+    release: 2020-09-01
+    support: true
+    eol: false
+    discontinued: false
+    
+  - releaseCycle: "Professional Ampere (GA10x)"
+    release: 2020-10-05
+    support: true
+    eol: false
+    discontinued: false
+
+
+  - releaseCycle: "Mobile Professional Ampere (GA10x)"
+    release: 2021-04-12
+    support: true
+    eol: false
+    discontinued: false
+
+
+  - releaseCycle: "Mobile Consumer Ampere (GA10x)" 
+    release: 2021-01-12
+    support: true
+    eol: false
+    discontinued: false
+
+---
+
+> Nvidia designs graphics processing units (GPUs) for the gaming and professional markets, as well as system on a chip units (SoCs) for the mobile computing and automotive market. This page tracks Nvidia drivers, which provide support for their various GPU lineups and are [available for Windows, Linux, Solaris, and FreeBSD](https://www.nvidia.com/Download/index.aspx?lang=en-us).
+
+## Common misconceptions
+
+There are multiple GPUs with the same name but part of a different architecture (therefore different support status length), and there are also cases where a card is rebranded across series, for example:
+
+- GT 730: Has a GF108 (Fermi) and a GK208 (Kepler) varient.
+- GT 625: Has a GF108 (Fermi) and a GK107/GK208 (Kepler) varient. 
+- GT 640: Has a GF116 (Fermi) and a GK107/GK208 (Kepler) varient. 
+- GT 645 is a Fermi card, even though all other 600 series are Kepler varients (with the exception of the above)
+- GT 705 has a GF119 (Fermi) and a GK208 (Kepler) varient.
+
+
+Due to this confusing naming scheme, one should not look at just the model name when seeing their support status, but instead their architecture. Easiest way to check this is to [download and run GPU-Z](https://www.techpowerup.com/gpuz/), it'll show you your GPU architecture there, which you can cross reference to see its support status.
+
+
+
+*Consumer GF1xx ("Fermi") GPUs are supported on Linux via the `R390` [legacy driver series](https://nvidia.custhelp.com/app/answers/detail/a_id/3142/~/support-timeframes-for-unix-legacy-gpu-releases) till the end of 2022.
+

--- a/products/nvidiaproducts.md
+++ b/products/nvidiaproducts.md
@@ -172,6 +172,12 @@ releases:
 
 > Nvidia designs graphics processing units (GPUs) for the gaming and professional markets, as well as system on a chip units (SoCs) for the mobile computing and automotive market. This page tracks Nvidia drivers, which provide support for their various GPU lineups and are [available for Windows, Linux, Solaris, and FreeBSD](https://www.nvidia.com/Download/index.aspx?lang=en-us).
 
+## Naming scheme
+
+- Professional cards include cards under their `NVS`, `Quadro`, `Quadro RTX`, `GRID`, and `Tesla`.
+- Consumer cards include their `GeForce` and `Titan` lineups. 
+
+
 ## Common misconceptions
 
 There are multiple GPUs with the same name but part of a different architecture (therefore different support status length), and there are also cases where a card is rebranded across series, for example:
@@ -185,7 +191,7 @@ There are multiple GPUs with the same name but part of a different architecture 
 
 Due to this confusing naming scheme, one should not look at just the model name when seeing their support status, but instead their architecture. Easiest way to check this is to [download and run GPU-Z](https://www.techpowerup.com/gpuz/), it'll show you your GPU architecture there, which you can cross reference to see its support status.
 
-
+In addition to different architectures being used on the same branded cards, all-in-one **desktops** are known to feature Mobile GPUs, which would make them fall under a different (and often shorter) support cycle. 
 
 *Consumer GF1xx ("Fermi") GPUs are supported on Linux via the `R390` [legacy driver series](https://nvidia.custhelp.com/app/answers/detail/a_id/3142/~/support-timeframes-for-unix-legacy-gpu-releases) till the end of 2022.
 

--- a/products/nvidiaproducts.md
+++ b/products/nvidiaproducts.md
@@ -42,7 +42,7 @@ releases:
   - releaseCycle: "Mobile Professional Kepler (GKxxx)" # Verify release date.
     release: 2012-03-22
     support: 2019-04-23
-    eol: 2024-07-01
+    eol: 2022-03-01
     discontinued: 2021-09-01
 
 

--- a/products/nvidiaproducts.md
+++ b/products/nvidiaproducts.md
@@ -104,7 +104,7 @@ releases:
     release: 2016-08-15
     support: true
     eol: false
-    discontinued: -1
+    discontinued: 2021-09-01
 
 
   - releaseCycle: "Professional Volta (GV100)" 

--- a/products/nvidiaproducts.md
+++ b/products/nvidiaproducts.md
@@ -170,7 +170,7 @@ releases:
 
 ---
 
-> Nvidia designs graphics processing units (GPUs) for the gaming and professional markets, as well as system on a chip units (SoCs) for the mobile computing and automotive market. This page tracks Nvidia drivers, which provide support for their various GPU lineups and are [available for Windows, Linux, Solaris, and FreeBSD](https://www.nvidia.com/Download/index.aspx?lang=en-us).
+> Nvidia designs graphics processing units (GPUs) for the gaming and professional markets, as well as system on a chip units (SoCs) for the mobile computing and automotive market. This page tracks Nvidia GPUs, which provide support for their various GPU lineups and are [available for Windows, Linux, Solaris, and FreeBSD](https://www.nvidia.com/Download/index.aspx?lang=en-us).
 
 ## Naming scheme
 
@@ -207,9 +207,12 @@ Due to this confusing naming scheme, one should not look at just the model name 
 2. First identify if you have a consumer or a frofessional card. If you see `GeForce` or `Titan` in the Name, you have a consumer card. If you see `NVS`, `Quadro`, `Quadro RTX`, `GRID`, or `Tesla` in the name, you have a professional card.
 3. Next identify the card architecture. This will be the GPU textbox. You can cross reference this with the support table at the top of this page. 
 
+
 This GPU Code follows a similar pattern for most cards, for example we have `GA102`:
 
+
 `G`: This means generation
+
 `A`: This means it belongs to the **Ampere** generation.
 
 Most GPU codes follow this same pattern, with the exceptions of `TUxxx` which means Turing architecture. 

--- a/products/nvidiaproducts.md
+++ b/products/nvidiaproducts.md
@@ -1,7 +1,10 @@
 ---
 title: NVIDIA products
 layout: post
-permalink: /nvidiaproducts
+permalink: /nvidia-products
+alternate_urls:
+  - /nvidia-gpu
+  - /nvidia-gpus
 category: device
 iconSlug: nvidia
 link: https://www.nvidia.com/en-us/geforce/graphics-cards/

--- a/products/nvidiaproducts.md
+++ b/products/nvidiaproducts.md
@@ -174,7 +174,7 @@ releases:
 
 ## Naming scheme
 
-- Professional cards include cards under their `NVS`, `Quadro`, `Quadro RTX`, `GRID`, and `Tesla`.
+- Professional cards include cards under their `NVS`, `Quadro`, `Quadro RTX`, `GRID`, and `Tesla` lineups.
 - Consumer cards include their `GeForce` and `Titan` lineups. 
 
 
@@ -190,6 +190,8 @@ There are multiple GPUs with the same name but part of a different architecture 
 
 
 Due to this confusing naming scheme, one should not look at just the model name when seeing their support status, but instead their architecture. Easiest way to check this is to [download and run GPU-Z](https://www.techpowerup.com/gpuz/), it'll show you your GPU architecture there, which you can cross reference to see its support status.
+
+
 
 In addition to different architectures being used on the same branded cards, all-in-one **desktops** are known to feature Mobile GPUs, which would make them fall under a different (and often shorter) support cycle. 
 

--- a/products/nvidiaproducts.md
+++ b/products/nvidiaproducts.md
@@ -42,7 +42,7 @@ releases:
   - releaseCycle: "Mobile Professional Kepler (GKxxx)" # Verify release date.
     release: 2012-03-22
     support: 2019-04-23
-    eol: 2020-04-30
+    eol: 2024-07-01
     discontinued: 2021-09-01
 
 

--- a/products/nvidiaproducts.md
+++ b/products/nvidiaproducts.md
@@ -182,11 +182,22 @@ releases:
 
 There are multiple GPUs with the same name but part of a different architecture (therefore different support status length), and there are also cases where a card is rebranded across series, for example:
 
+### Desktop:
+
 - GT 730: Has a GF108 (Fermi) and a GK208 (Kepler) varient.
 - GT 625: Has a GF108 (Fermi) and a GK107/GK208 (Kepler) varient. 
 - GT 640: Has a GF116 (Fermi) and a GK107/GK208 (Kepler) varient. 
-- GT 645 is a Fermi card, even though all other 600 series are Kepler varients (with the exception of the above)
+- GT 645/620 is a Fermi card, even though all other 600 series are Kepler varients (with the exception of the above)
 - GT 705 has a GF119 (Fermi) and a GK208 (Kepler) varient.
+- GTX 745, 750 and 750 Ti are Maxwell, even though all other 700 series are Kepler varients (with the exception of the above)
+
+### Laptop:
+
+- GT 810M/820M are Fermi cards.
+- GT 825M/870M/880M are Kepler cards.
+- GTX 870M: Has a GM107 (Maxwell) and a GK104 (Kepler) varient.
+- GT 920M is a Kepler card.
+
 
 
 Due to this confusing naming scheme, one should not look at just the model name when seeing their support status, but instead their architecture. Easiest way to check this is to [download and run GPU-Z](https://www.techpowerup.com/gpuz/), it'll show you your GPU architecture there, which you can cross reference to see its support status.

--- a/products/nvidiaproducts.md
+++ b/products/nvidiaproducts.md
@@ -10,7 +10,7 @@ iconSlug: nvidia
 link: https://www.nvidia.com/en-us/geforce/graphics-cards/
 activeSupportColumn: true
 releaseDateColumn: true
-discontinuedColumn: false
+discontinuedColumn: true
 sortReleasesBy: 'release'
 releaseColumn: false
 releases:
@@ -18,13 +18,13 @@ releases:
     release: 2010-03-26
     support: 2018-03-10
     eol: 2018-03-10
-    discontinued: 2021-09-01
+    discontinued: true
     
   - releaseCycle: "Professional Fermi (GF1xx)**"
     release: 2010-07-23
     support: 2018-07-31
     eol: 2022-12-31
-    discontinued: 2021-09-01
+    discontinued: true
 
 
 
@@ -32,28 +32,28 @@ releases:
     release: 2012-03-22
     support: true
     eol: 2024-07-01
-    discontinued: 2021-09-01
+    discontinued: true
 
     
   - releaseCycle: "Professional Kepler (GKxxx)"
     release: 2013-03-01
     support: true
     eol: 2024-07-01
-    discontinued: 2021-09-01
+    discontinued: true
 
 
   - releaseCycle: "Mobile Professional Kepler (GKxxx)" # Verify release date.
     release: 2012-03-22
     support: 2019-04-23
     eol: 2022-03-01
-    discontinued: 2021-09-01
+    discontinued: true
 
 
   - releaseCycle: "Mobile Consumer Kepler (GKxxx)" 
     release: 2012-03-22
     support: 2019-03-11
     eol: 2019-04-11
-    discontinued: 2021-09-01
+    discontinued: true
 
 
 
@@ -61,54 +61,54 @@ releases:
     release: 2014-09-19
     support: true
     eol: false
-    discontinued: 2021-09-01
+    discontinued: true
     
   - releaseCycle: "Professional Maxwell (GMxxx)"
     release: 2015-06-29
     support: true
     eol: false
-    discontinued: 2021-09-01
+    discontinued: true
 
 
   - releaseCycle: "Mobile Professional Maxwell (GMxxx)" 
     release: 2015-08-18
     support: true
     eol: false
-    discontinued: 2021-09-01
+    discontinued: true
 
 
   - releaseCycle: "Mobile Consumer Maxwell (GMxxx)" 
     release: 2014-10-07
     support: true
     eol: false
-    discontinued: 2021-09-01
+    discontinued: true
 
 
   - releaseCycle: "Consumer Pascal (GP10x)"
     release: 2016-05-27
     support: true
     eol: false
-    discontinued: 2021-09-01
+    discontinued: true
    
   - releaseCycle: "Professional Pascal (GP10x)"
     release: 2016-04-05
     support: true
     eol: false
-    discontinued: 2021-09-01
+    discontinued: true
 
 
   - releaseCycle: "Mobile Professional Pascal (GP10x)"
     release: 2017-02-06
     support: true
     eol: false
-    discontinued: 2021-09-01
+    discontinued: true
 
 
   - releaseCycle: "Mobile Consumer Pascal (GP10x)" 
     release: 2016-08-15
     support: true
     eol: false
-    discontinued: 2021-09-01
+    discontinued: true
 
 
   - releaseCycle: "Professional Volta (GV100)" 
@@ -122,27 +122,27 @@ releases:
     release: 2018-09-20
     support: true
     eol: false
-    discontinued: 2021-09-01
+    discontinued: false
 
   - releaseCycle: "Professional Turing (TU1xX)"
     release: 2018-08-13
     support: true
     eol: false
-    discontinued: 2021-09-01
+    discontinued: false
 
 
   - releaseCycle: "Mobile Professional Turing (TU1xX)"
     release: 2019-05-27
     support: true
     eol: false
-    discontinued: 2021-09-01
+    discontinued: false
 
 
   - releaseCycle: "Mobile Consumer Turing (TU1xX)" 
     release: 2019-01-29
     support: true
     eol: false
-    discontinued: 2021-09-01
+    discontinued: false
 
 
   - releaseCycle: "Consumer Ampere (GA10x)"

--- a/products/nvidiaproducts.md
+++ b/products/nvidiaproducts.md
@@ -14,13 +14,13 @@ releases:
     release: 2010-03-26
     support: 2018-03-10
     eol: 2018-03-10
-    discontinued: true
+    discontinued: -1
     
   - releaseCycle: "Professional Fermi (GF1xx)"
     release: 2010-07-23
     support: 2018-07-31
     eol: 2022-12-31
-    discontinued: true
+    discontinued: -1
 
 
 
@@ -28,28 +28,28 @@ releases:
     release: 2012-03-22
     support: true
     eol: 2024-07-01
-    discontinued: true
+    discontinued: -1
 
     
   - releaseCycle: "Professional Kepler (GKxxx)"
     release: 2013-03-01
     support: true
     eol: 2024-07-01
-    discontinued: true
+    discontinued: -1
 
 
   - releaseCycle: "Mobile Professional Kepler (GKxxx)" # Verify release date.
     release: 2012-03-22
     support: 2019-04-23
     eol: 2020-04-30
-    discontinued: true
+    discontinued: -1
 
 
   - releaseCycle: "Mobile Consumer Kepler (GKxxx)" 
     release: 2012-03-22
     support: 2019-03-11
     eol: 2019-04-11
-    discontinued: true
+    discontinued: -1
 
 
 
@@ -57,54 +57,54 @@ releases:
     release: 2014-09-19
     support: true
     eol: false
-    discontinued: true
+    discontinued: -1
     
   - releaseCycle: "Professional Maxwell (GMxxx)"
     release: 2015-06-29
     support: true
     eol: false
-    discontinued: true
+    discontinued: -1
 
 
   - releaseCycle: "Mobile Professional Maxwell (GMxxx)" 
     release: 2015-08-18
     support: true
     eol: false
-    discontinued: true
+    discontinued: -1
 
 
   - releaseCycle: "Mobile Consumer Maxwell (GMxxx)" 
     release: 2014-10-07
     support: true
     eol: false
-    discontinued: true
+    discontinued: -1
 
 
   - releaseCycle: "Consumer Pascal (GP10x)"
     release: 2016-05-27
     support: true
     eol: false
-    discontinued: true
+    discontinued: -1
    
   - releaseCycle: "Professional Pascal (GP10x)"
     release: 2016-04-05
     support: true
     eol: false
-    discontinued: true
+    discontinued: -1
 
 
   - releaseCycle: "Mobile Professional Pascal (GP10x)"
     release: 2017-02-06
     support: true
     eol: false
-    discontinued: true
+    discontinued: -1
 
 
   - releaseCycle: "Mobile Consumer Pascal (GP10x)" 
     release: 2016-08-15
     support: true
     eol: false
-    discontinued: true
+    discontinued: -1
 
 
   - releaseCycle: "Professional Volta (GV100)" 
@@ -118,27 +118,27 @@ releases:
     release: 2018-09-20
     support: true
     eol: false
-    discontinued: true
+    discontinued: -1
 
   - releaseCycle: "Professional Turing (TU1xX)"
     release: 2018-08-13
     support: true
     eol: false
-    discontinued: true
+    discontinued: -1
 
 
   - releaseCycle: "Mobile Professional Turing (TU1xX)"
     release: 2019-05-27
     support: true
     eol: false
-    discontinued: true
+    discontinued: -1
 
 
   - releaseCycle: "Mobile Consumer Turing (TU1xX)" 
     release: 2019-01-29
     support: true
     eol: false
-    discontinued: true
+    discontinued: -1
 
 
   - releaseCycle: "Consumer Ampere (GA10x)"

--- a/products/nvidiaproducts.md
+++ b/products/nvidiaproducts.md
@@ -199,14 +199,26 @@ There are multiple GPUs with the same name but part of a different architecture 
 - GT 920M is a Kepler card.
 - Most cards in the 800M series have multiple varients with varying architectures (A card in this series can be Fermi, Kepler or Maxwell). 
 
-## Identifying your GPU
+## Identifying your GPU 
+
 
 Due to this confusing naming scheme, one should not look at just the model name when seeing their support status, but instead their architecture. 
+
+
+### Windows
+
 
 1. [Download and run GPU-Z](https://www.techpowerup.com/gpuz/).
 2. First identify if you have a consumer or a professional card. If you see `GeForce` or `Titan` in the Name, you have a consumer card. If you see `NVS`, `Quadro`, `Quadro RTX`, `GRID`, or `Tesla` in the name, you have a professional card.
 3. Next identify the card architecture. This will be the GPU textbox. You can cross reference this with the support table at the top of this page. 
 
+
+### Linux
+
+
+1. Install the `lshw` package from your distribution's repositories.
+2. Run the command `sudo lshw -C display`, your GPU code is the `product` column. 
+3. Next identify the card architecture. This will be the GPU textbox. You can cross reference this with the support table at the top of this page. 
 
 This GPU Code follows a similar pattern for most cards, for example we have `GA102`:
 

--- a/products/nvidiaproducts.md
+++ b/products/nvidiaproducts.md
@@ -1,7 +1,7 @@
 ---
 title: NVIDIA products
 layout: post
-permalink: /nvidia-products
+permalink: /nvidiaproducts
 category: app
 iconSlug: nvidia
 link: https://www.nvidia.com/en-us/geforce/graphics-cards/
@@ -15,6 +15,7 @@ releases:
     support: 2018-03-10
     eol: 2018-03-10
     discontinued: true
+    
   - releaseCycle: "Professional Fermi (GF1xx)"
     release: 2010-07-23
     support: 2018-07-31

--- a/products/nvidiaproducts.md
+++ b/products/nvidiaproducts.md
@@ -10,7 +10,7 @@ releaseDateColumn: true
 discontinuedColumn: true
 sortReleasesBy: 'release'
 releases:
-  - releaseCycle: "Consumer Fermi (GF1xx)"
+  - releaseCycle: "Consumer Fermi (GF1xx)*"
     release: 2010-03-26
     support: 2018-03-10
     eol: 2018-03-10

--- a/products/nvidiaproducts.md
+++ b/products/nvidiaproducts.md
@@ -17,7 +17,7 @@ releases:
     eol: 2018-03-10
     discontinued: 2021-09-01
     
-  - releaseCycle: "Professional Fermi (GF1xx)"
+  - releaseCycle: "Professional Fermi (GF1xx)**"
     release: 2010-07-23
     support: 2018-07-31
     eol: 2022-12-31
@@ -206,3 +206,4 @@ Due to this confusing naming scheme, one should not look at just the model name 
 
 *Consumer GF1xx ("Fermi") GPUs are supported on Linux via the `R390` [legacy driver series](https://nvidia.custhelp.com/app/answers/detail/a_id/3142/~/support-timeframes-for-unix-legacy-gpu-releases) till the end of 2022.
 
+** Not all Professional Fermi (GF1xx) GPUs are still supported, see the [official GPU support list](https://us.download.nvidia.com/Windows/Quadro_Certified/392.67/392.67-win10-quadro-release-notes.pdf) for specific models. 

--- a/products/nvidiaproducts.md
+++ b/products/nvidiaproducts.md
@@ -206,4 +206,4 @@ Due to this confusing naming scheme, one should not look at just the model name 
 
 *Consumer GF1xx ("Fermi") GPUs are supported on Linux via the `R390` [legacy driver series](https://nvidia.custhelp.com/app/answers/detail/a_id/3142/~/support-timeframes-for-unix-legacy-gpu-releases) till the end of 2022.
 
-** Not all Professional Fermi (GF1xx) GPUs are still supported, see the [official GPU support list](https://us.download.nvidia.com/Windows/Quadro_Certified/392.67/392.67-win10-quadro-release-notes.pdf) for specific models. 
+** Not all Professional Fermi (GF1xx) GPUs are still supported on Windows, see the [official GPU support list](https://us.download.nvidia.com/Windows/Quadro_Certified/392.67/392.67-win10-quadro-release-notes.pdf) for specific models. On Linux there support is for all Fermi GPUs. 

--- a/products/nvidiaproducts.md
+++ b/products/nvidiaproducts.md
@@ -10,7 +10,7 @@ releaseDateColumn: true
 discontinuedColumn: true
 sortReleasesBy: 'release'
 releases:
-  - releaseCycle: "Consumer Fermi (GF1xx)*"
+  - releaseCycle: "Consumer Fermi (GF1xx)"
     release: 2010-03-26
     support: 2018-03-10
     eol: 2018-03-10

--- a/products/nvidiaproducts.md
+++ b/products/nvidiaproducts.md
@@ -14,13 +14,13 @@ releases:
     release: 2010-03-26
     support: 2018-03-10
     eol: 2018-03-10
-    discontinued: -1
+    discontinued: 2021-09-01
     
   - releaseCycle: "Professional Fermi (GF1xx)"
     release: 2010-07-23
     support: 2018-07-31
     eol: 2022-12-31
-    discontinued: -1
+    discontinued: 2021-09-01
 
 
 
@@ -28,28 +28,28 @@ releases:
     release: 2012-03-22
     support: true
     eol: 2024-07-01
-    discontinued: -1
+    discontinued: 2021-09-01
 
     
   - releaseCycle: "Professional Kepler (GKxxx)"
     release: 2013-03-01
     support: true
     eol: 2024-07-01
-    discontinued: -1
+    discontinued: 2021-09-01
 
 
   - releaseCycle: "Mobile Professional Kepler (GKxxx)" # Verify release date.
     release: 2012-03-22
     support: 2019-04-23
     eol: 2020-04-30
-    discontinued: -1
+    discontinued: 2021-09-01
 
 
   - releaseCycle: "Mobile Consumer Kepler (GKxxx)" 
     release: 2012-03-22
     support: 2019-03-11
     eol: 2019-04-11
-    discontinued: -1
+    discontinued: 2021-09-01
 
 
 
@@ -57,47 +57,47 @@ releases:
     release: 2014-09-19
     support: true
     eol: false
-    discontinued: -1
+    discontinued: 2021-09-01
     
   - releaseCycle: "Professional Maxwell (GMxxx)"
     release: 2015-06-29
     support: true
     eol: false
-    discontinued: -1
+    discontinued: 2021-09-01
 
 
   - releaseCycle: "Mobile Professional Maxwell (GMxxx)" 
     release: 2015-08-18
     support: true
     eol: false
-    discontinued: -1
+    discontinued: 2021-09-01
 
 
   - releaseCycle: "Mobile Consumer Maxwell (GMxxx)" 
     release: 2014-10-07
     support: true
     eol: false
-    discontinued: -1
+    discontinued: 2021-09-01
 
 
   - releaseCycle: "Consumer Pascal (GP10x)"
     release: 2016-05-27
     support: true
     eol: false
-    discontinued: -1
+    discontinued: 2021-09-01
    
   - releaseCycle: "Professional Pascal (GP10x)"
     release: 2016-04-05
     support: true
     eol: false
-    discontinued: -1
+    discontinued: 2021-09-01
 
 
   - releaseCycle: "Mobile Professional Pascal (GP10x)"
     release: 2017-02-06
     support: true
     eol: false
-    discontinued: -1
+    discontinued: 2021-09-01
 
 
   - releaseCycle: "Mobile Consumer Pascal (GP10x)" 
@@ -118,27 +118,27 @@ releases:
     release: 2018-09-20
     support: true
     eol: false
-    discontinued: -1
+    discontinued: 2021-09-01
 
   - releaseCycle: "Professional Turing (TU1xX)"
     release: 2018-08-13
     support: true
     eol: false
-    discontinued: -1
+    discontinued: 2021-09-01
 
 
   - releaseCycle: "Mobile Professional Turing (TU1xX)"
     release: 2019-05-27
     support: true
     eol: false
-    discontinued: -1
+    discontinued: 2021-09-01
 
 
   - releaseCycle: "Mobile Consumer Turing (TU1xX)" 
     release: 2019-01-29
     support: true
     eol: false
-    discontinued: -1
+    discontinued: 2021-09-01
 
 
   - releaseCycle: "Consumer Ampere (GA10x)"

--- a/products/nvidiaproducts.md
+++ b/products/nvidiaproducts.md
@@ -196,13 +196,25 @@ There are multiple GPUs with the same name but part of a different architecture 
 
 - GT 810M/820M are Fermi cards.
 - GT 825M/870M/880M are Kepler cards.
-- GTX 870M: Has a GM107 (Maxwell) and a GK104 (Kepler) varient.
 - GT 920M is a Kepler card.
+- Most cards in the 800M series have multiple varients with varying architectures (A card in this series can be Fermi, Kepler or Maxwell). 
 
+## Identifying your GPU
 
+Due to this confusing naming scheme, one should not look at just the model name when seeing their support status, but instead their architecture. 
 
-Due to this confusing naming scheme, one should not look at just the model name when seeing their support status, but instead their architecture. Easiest way to check this is to [download and run GPU-Z](https://www.techpowerup.com/gpuz/), it'll show you your GPU architecture there, which you can cross reference to see its support status.
+1. [Download and run GPU-Z](https://www.techpowerup.com/gpuz/).
+2. First identify if you have a consumer or a frofessional card. If you see `GeForce` or `Titan` in the Name, you have a consumer card. If you see `NVS`, `Quadro`, `Quadro RTX`, `GRID`, or `Tesla` in the name, you have a professional card.
+3. Next identify the card architecture. This will be the GPU textbox. You can cross reference this with the support table at the top of this page. 
 
+This GPU Code follows a similar pattern for most cards, for example we have `GA102`:
+
+`G`: This means generation
+`A`: This means it belongs to the **Ampere** generation.
+
+Most GPU codes follow this same pattern, with the exceptions of `TUxxx` which means Turing architecture. 
+
+## Support disclaimers
 
 *Consumer GF1xx ("Fermi") GPUs are supported on Linux via the `R390` [legacy driver series](https://nvidia.custhelp.com/app/answers/detail/a_id/3142/~/support-timeframes-for-unix-legacy-gpu-releases) till the end of 2022.
 

--- a/products/nvidiaproducts.md
+++ b/products/nvidiaproducts.md
@@ -2,13 +2,14 @@
 title: NVIDIA products
 layout: post
 permalink: /nvidiaproducts
-category: app
+category: device
 iconSlug: nvidia
 link: https://www.nvidia.com/en-us/geforce/graphics-cards/
 activeSupportColumn: true
 releaseDateColumn: true
 discontinuedColumn: true
 sortReleasesBy: 'release'
+releaseColumn: false
 releases:
   - releaseCycle: "Consumer Fermi (GF1xx)*"
     release: 2010-03-26

--- a/products/nvidiaproducts.md
+++ b/products/nvidiaproducts.md
@@ -26,28 +26,23 @@ releases:
     eol: 2022-12-31
     discontinued: true
 
-
-
   - releaseCycle: "Consumer Kepler (GKxxx)"
     release: 2012-03-22
     support: true
     eol: 2024-07-01
     discontinued: true
 
-    
   - releaseCycle: "Professional Kepler (GKxxx)"
     release: 2013-03-01
     support: true
     eol: 2024-07-01
     discontinued: true
 
-
-  - releaseCycle: "Mobile Professional Kepler (GKxxx)" # Verify release date.
-    release: 2012-03-22
+  - releaseCycle: "Mobile Professional Kepler (GKxxx)"
+    release: 2012-03-22 # Verify release date.
     support: 2019-04-23
     eol: 2022-03-01
     discontinued: true
-
 
   - releaseCycle: "Mobile Consumer Kepler (GKxxx)" 
     release: 2012-03-22
@@ -55,20 +50,17 @@ releases:
     eol: 2019-04-11
     discontinued: true
 
-
-
   - releaseCycle: "Consumer Maxwell (GMxxx)"
     release: 2014-09-19
     support: true
     eol: false
     discontinued: true
-    
+
   - releaseCycle: "Professional Maxwell (GMxxx)"
     release: 2015-06-29
     support: true
     eol: false
     discontinued: true
-
 
   - releaseCycle: "Mobile Professional Maxwell (GMxxx)" 
     release: 2015-08-18
@@ -76,26 +68,23 @@ releases:
     eol: false
     discontinued: true
 
-
   - releaseCycle: "Mobile Consumer Maxwell (GMxxx)" 
     release: 2014-10-07
     support: true
     eol: false
     discontinued: true
 
-
   - releaseCycle: "Consumer Pascal (GP10x)"
     release: 2016-05-27
     support: true
     eol: false
     discontinued: true
-   
+
   - releaseCycle: "Professional Pascal (GP10x)"
     release: 2016-04-05
     support: true
     eol: false
     discontinued: true
-
 
   - releaseCycle: "Mobile Professional Pascal (GP10x)"
     release: 2017-02-06
@@ -103,20 +92,17 @@ releases:
     eol: false
     discontinued: true
 
-
   - releaseCycle: "Mobile Consumer Pascal (GP10x)" 
     release: 2016-08-15
     support: true
     eol: false
     discontinued: true
 
-
   - releaseCycle: "Professional Volta (GV100)" 
     release: 2017-12-07
     support: true
     eol: false
     discontinued: false
-
 
   - releaseCycle: "Consumer Turing (TU1xX)"
     release: 2018-09-20
@@ -130,20 +116,17 @@ releases:
     eol: false
     discontinued: false
 
-
   - releaseCycle: "Mobile Professional Turing (TU1xX)"
     release: 2019-05-27
     support: true
     eol: false
     discontinued: false
 
-
   - releaseCycle: "Mobile Consumer Turing (TU1xX)" 
     release: 2019-01-29
     support: true
     eol: false
     discontinued: false
-
 
   - releaseCycle: "Consumer Ampere (GA10x)"
     release: 2020-09-01
@@ -157,29 +140,25 @@ releases:
     eol: false
     discontinued: false
 
-
   - releaseCycle: "Mobile Professional Ampere (GA10x)"
     release: 2021-04-12
     support: true
     eol: false
     discontinued: false
 
-
   - releaseCycle: "Mobile Consumer Ampere (GA10x)" 
     release: 2021-01-12
     support: true
     eol: false
     discontinued: false
-
 ---
 
-> Nvidia designs graphics processing units (GPUs) for the gaming and professional markets, as well as system on a chip units (SoCs) for the mobile computing and automotive market. This page tracks Nvidia GPUs, which provide support for their various GPU lineups and are [available for Windows, Linux, Solaris, and FreeBSD](https://www.nvidia.com/Download/index.aspx?lang=en-us).
+> Nvidia designs <abbr title="Graphics Processing Unit">GPUs</abbr> for the gaming and professional markets, as well as system on a chip units (SoCs) for the mobile computing and automotive market. This page tracks Nvidia GPUs, which provide support for their various GPU lineups and are [available for Windows, Linux, Solaris, and FreeBSD](https://www.nvidia.com/Download/index.aspx?lang=en-us).
 
 ## Naming scheme
 
 - Professional cards include cards under their `NVS`, `Quadro`, `Quadro RTX`, `GRID`, and `Tesla` lineups.
 - Consumer cards include their `GeForce` and `Titan` lineups. 
-
 
 ## Common misconceptions
 
@@ -187,37 +166,32 @@ There are multiple GPUs with the same name but part of a different architecture 
 
 ### Desktop:
 
-- GT 730: Has a GF108 (Fermi) and a GK208 (Kepler) varient.
-- GT 625: Has a GF108 (Fermi) and a GK107/GK208 (Kepler) varient. 
-- GT 640: Has a GF116 (Fermi) and a GK107/GK208 (Kepler) varient. 
-- GT 645/620 is a Fermi card, even though all other 600 series are Kepler varients (with the exception of the above)
-- GT 705 has a GF119 (Fermi) and a GK208 (Kepler) varient.
-- GTX 745, 750 and 750 Ti are Maxwell, even though all other 700 series are Kepler varients (with the exception of the above)
+- `GT730`: Has a `GF108` (Fermi) and a `GK208` (Kepler) varient.
+- `GT625`: Has a `GF108` (Fermi) and a `GK107`/`GK208` (Kepler) varient.
+- `GT640`: Has a `GF116` (Fermi) and a `GK107`/`GK208` (Kepler) varient.
+- `GT645/620` is a Fermi card, even though all other 600 series are Kepler variants (with the exception of the above)
+- `GT705` has a `GF119` (Fermi) and a `GK208` (Kepler) varient.
+- `GTX745`, `GTX750` and `GTX750 Ti` are Maxwell, even though all other `700` series are Kepler variants (with the exception of the above)
 - All-in-one **desktops** are known to feature Mobile GPUs, which would make them fall under a different (and often shorter) support cycle. 
 
 ### Laptop:
 
-- GT 810M/820M are Fermi cards.
-- GT 825M/870M/880M are Kepler cards.
-- GT 920M is a Kepler card.
-- Most cards in the 800M series have multiple varients with varying architectures (A card in this series can be Fermi, Kepler or Maxwell). 
+- `GT810M`/`GT820M` are Fermi cards.
+- `GT825M`/`GT870M`/`GT880M` are Kepler cards.
+- `GT920M` is a Kepler card.
+- Most cards in the `800M` series have multiple variant with varying architectures (A card in this series can be Fermi, Kepler or Maxwell).
 
 ## Identifying your GPU 
 
-
-Due to this confusing naming scheme, one should not look at just the model name when seeing their support status, but instead their architecture. 
-
+Due to this confusing naming scheme, one should not look at just the model name when seeing their support status, but instead their architecture.
 
 ### Windows
-
 
 1. [Download and run GPU-Z](https://www.techpowerup.com/gpuz/).
 2. First identify if you have a consumer or a professional card. If you see `GeForce` or `Titan` in the Name, you have a consumer card. If you see `NVS`, `Quadro`, `Quadro RTX`, `GRID`, or `Tesla` in the name, you have a professional card.
 3. Next identify the card architecture. This will be the GPU textbox. You can cross reference this with the support table at the top of this page. 
 
-
 ### Linux
-
 
 1. Install the `lshw` package from your distribution's repositories.
 2. Run the command `sudo lshw -C display`, your GPU code is the `product` column. 
@@ -225,15 +199,12 @@ Due to this confusing naming scheme, one should not look at just the model name 
 
 This GPU Code follows a similar pattern for most cards, for example we have `GA102`:
 
-
-`G`: This means generation
-
-`A`: This means it belongs to the **Ampere** generation.
+- `G`: This means generation
+- `A`: This means it belongs to the **Ampere** generation.
 
 Most GPU codes follow this same pattern, with the exceptions of `TUxxx` which means Turing architecture. 
 
-## Support disclaimers
+## Driver Support Exceptions
 
-*Consumer GF1xx ("Fermi") GPUs are supported on Linux via the `R390` [legacy driver series](https://nvidia.custhelp.com/app/answers/detail/a_id/3142/~/support-timeframes-for-unix-legacy-gpu-releases) till the end of 2022.
-
-** Not all Professional Fermi (GF1xx) GPUs are still supported on Windows, see the [official GPU support list](https://us.download.nvidia.com/Windows/Quadro_Certified/392.67/392.67-win10-quadro-release-notes.pdf) for specific models. On Linux there support is for all Fermi GPUs. 
+- Consumer `GF1xx` ("Fermi") GPUs are supported on Linux via the `R390` [legacy driver series](https://nvidia.custhelp.com/app/answers/detail/a_id/3142/~/support-timeframes-for-unix-legacy-gpu-releases) till the end of 2022.
+- Not all Professional Fermi (`GF1xx`) GPUs are still supported on Windows, see the [official GPU support list](https://us.download.nvidia.com/Windows/Quadro_Certified/392.67/392.67-win10-quadro-release-notes.pdf) for specific models. On Linux there support is for all Fermi GPUs.

--- a/products/nvidiaproducts.md
+++ b/products/nvidiaproducts.md
@@ -7,7 +7,7 @@ iconSlug: nvidia
 link: https://www.nvidia.com/en-us/geforce/graphics-cards/
 activeSupportColumn: true
 releaseDateColumn: true
-discontinuedColumn: true
+discontinuedColumn: false
 sortReleasesBy: 'release'
 releaseColumn: false
 releases:

--- a/products/nvidiaproducts.md
+++ b/products/nvidiaproducts.md
@@ -1,9 +1,9 @@
 ---
-title: NVIDIA products
+title: NVIDIA GPUs
 layout: post
-permalink: /nvidia-products
+permalink: /nvidia-gpu
 alternate_urls:
-  - /nvidia-gpu
+  - /nvidia-products
   - /nvidia-gpus
 category: device
 iconSlug: nvidia
@@ -188,7 +188,7 @@ Due to this confusing naming scheme, one should not look at just the model name 
 ### Windows
 
 1. [Download and run GPU-Z](https://www.techpowerup.com/gpuz/).
-2. First identify if you have a consumer or a professional card. If you see `GeForce` or `Titan` in the Name, you have a consumer card. If you see `NVS`, `Quadro`, `Quadro RTX`, `GRID`, or `Tesla` in the name, you have a professional card.
+2. First identify if you have a consumer or a professional card. See the "Naming scheme" section above.
 3. Next identify the card architecture. This will be the GPU textbox. You can cross reference this with the support table at the top of this page. 
 
 ### Linux

--- a/products/nvidiaproducts.md
+++ b/products/nvidiaproducts.md
@@ -204,7 +204,7 @@ There are multiple GPUs with the same name but part of a different architecture 
 Due to this confusing naming scheme, one should not look at just the model name when seeing their support status, but instead their architecture. 
 
 1. [Download and run GPU-Z](https://www.techpowerup.com/gpuz/).
-2. First identify if you have a consumer or a frofessional card. If you see `GeForce` or `Titan` in the Name, you have a consumer card. If you see `NVS`, `Quadro`, `Quadro RTX`, `GRID`, or `Tesla` in the name, you have a professional card.
+2. First identify if you have a consumer or a professional card. If you see `GeForce` or `Titan` in the Name, you have a consumer card. If you see `NVS`, `Quadro`, `Quadro RTX`, `GRID`, or `Tesla` in the name, you have a professional card.
 3. Next identify the card architecture. This will be the GPU textbox. You can cross reference this with the support table at the top of this page. 
 
 

--- a/products/nvidiaproducts.md
+++ b/products/nvidiaproducts.md
@@ -180,7 +180,7 @@ releases:
 
 ## Common misconceptions
 
-There are multiple GPUs with the same name but part of a different architecture (therefore different support status length), and there are also cases where a card is rebranded across series, for example:
+There are multiple GPUs with the same name but part of a different architecture (therefore different support status length), and there are also other cases to be careful of:
 
 ### Desktop:
 
@@ -190,6 +190,7 @@ There are multiple GPUs with the same name but part of a different architecture 
 - GT 645/620 is a Fermi card, even though all other 600 series are Kepler varients (with the exception of the above)
 - GT 705 has a GF119 (Fermi) and a GK208 (Kepler) varient.
 - GTX 745, 750 and 750 Ti are Maxwell, even though all other 700 series are Kepler varients (with the exception of the above)
+- All-in-one **desktops** are known to feature Mobile GPUs, which would make them fall under a different (and often shorter) support cycle. 
 
 ### Laptop:
 
@@ -202,9 +203,6 @@ There are multiple GPUs with the same name but part of a different architecture 
 
 Due to this confusing naming scheme, one should not look at just the model name when seeing their support status, but instead their architecture. Easiest way to check this is to [download and run GPU-Z](https://www.techpowerup.com/gpuz/), it'll show you your GPU architecture there, which you can cross reference to see its support status.
 
-
-
-In addition to different architectures being used on the same branded cards, all-in-one **desktops** are known to feature Mobile GPUs, which would make them fall under a different (and often shorter) support cycle. 
 
 *Consumer GF1xx ("Fermi") GPUs are supported on Linux via the `R390` [legacy driver series](https://nvidia.custhelp.com/app/answers/detail/a_id/3142/~/support-timeframes-for-unix-legacy-gpu-releases) till the end of 2022.
 


### PR DESCRIPTION
Sources used for this: 

https://en.wikipedia.org/wiki/Fermi_(microarchitecture)

https://en.wikipedia.org/wiki/List_of_Nvidia_graphics_processing_units

https://www.techpowerup.com/gpu-specs/nvidia-gf100.g85

https://nvidia.custhelp.com/app/answers/detail/a_id/3473/~/eol-windows-driver-support-for-legacy-products

https://nouveau.freedesktop.org/CodeNames.html

End of support for consumer fermi was stated by the posted date of this article: https://nvidia.custhelp.com/app/answers/detail/a_id/4654/kw/fermi

End of life for consumer fermi was stated by the same article, due there being no security updates for fermi during that period, last driver posted for consumer fermi was this: https://www.nvidia.com/Download/driverResults.aspx/132845/en-us

Release date for Professional Fermi was based off the Quadro 5000M: https://www.techpowerup.com/gpu-specs/quadro-5000m.c1396

End of support and end of life for professional Fermi was based off work in https://github.com/endoflife-date/endoflife.date/pull/366

Release date for Consumer Kepler was based off the GTX 680: https://www.techpowerup.com/gpu-specs/geforce-gtx-680.c342

End of support and end of life for Consumer Kepler was based off work in https://github.com/endoflife-date/endoflife.date/pull/366/

End of support for Mobile Professional Kepler was stated by the posted date of this article: https://nvidia.custhelp.com/app/answers/detail/a_id/4779/related/1

Release date for Mobile Kepler: https://www.techpowerup.com/gpu-specs/geforce-gt-650m.c547

End of support for mobile consumer kepler: https://nvidia.custhelp.com/app/answers/detail/a_id/4779/kw/kepler%20notebook

End of life for mobile consumer Kepler stated by the release of this driver: https://www.nvidia.com/Download/driverResults.aspx/145874/en-us

Release date for consumer Maxwell: https://www.techpowerup.com/gpu-specs/geforce-gtx-970.c2620

Release date for Professional Maxwell: https://www.techpowerup.com/gpu-specs/quadro-m5000.c2756

Release date for Mobile professional Maswell: https://www.techpowerup.com/gpu-specs/quadro-m3000m.c2759

Release date for Mobile consumer Maswell: https://www.techpowerup.com/gpu-specs/geforce-gtx-970m.c2623

Release date for Consumer Pascal: https://www.techpowerup.com/gpu-specs/geforce-gtx-1080.c2839

Release date for Professional Pascal: https://www.techpowerup.com/gpu-specs/tesla-p100-sxm2.c3183

Release date for Mobile Consumer Pascal: https://www.techpowerup.com/gpu-specs/geforce-gtx-1060-mobile.c3016

Release date for Mobile Professional Pascal: https://www.techpowerup.com/gpu-specs/quadro-p2000-mobile.c3202

Release date for Volta: https://www.nvidia.com/en-us/titan/titan-v

Release date for consumer Turing: https://www.techpowerup.com/gpu-specs/geforce-rtx-2080.c3224

Release date for professional Turing: https://www.techpowerup.com/gpu-specs/quadro-rtx-5000.c3308

Release date for mobile professional Turing: https://www.techpowerup.com/gpu-specs/quadro-t1000-mobile.c3435

Release date for consumer ampere: https://www.techpowerup.com/gpu-specs/geforce-rtx-3080.c3621

Release date for professional ampere: https://www.techpowerup.com/gpu-specs/rtx-a6000.c3686

Release date for mobile professional ampere: https://www.techpowerup.com/gpu-specs/rtx-a2000-mobile.c3827

Release date for mobile consumer ampere: https://www.techpowerup.com/gpu-specs/geforce-rtx-3060-max-q.c3752