### PR TITLE
🎃Add Samsung Galaxy devices 👻

### DIFF
--- a/products/samsungmobile.md
+++ b/products/samsungmobile.md
@@ -7,7 +7,7 @@ iconSlug: samsung
 link: https://security.samsungmobile.com/workScope.smsb
 discontinuedColumn: false
 activeSupportColumn: true
-eolColumn: Supported
+eolColumn: Security Updates
 releaseColumn: false
 releaseDateColumn: true
 sortReleasesBy: 'release'

--- a/products/samsungmobile.md
+++ b/products/samsungmobile.md
@@ -628,6 +628,273 @@ releases:
     eol: false
     
 
+# Current Models for Biannual Security Updates
+
+  - releaseCycle: "Galaxy View2"
+    release: 2019-04-01 #Unclear
+    support: false 
+    eol: false
+
+
+
+  - releaseCycle: "Galaxy Tab S5e"
+    release: 2019-04-01 #unclear
+    support: false 
+    eol: false
+
+
+
+  - releaseCycle: "Galaxy Tab S4 10.5"
+    release: 2018-08-01 #Unclear 
+    support: false 
+    eol: false
+
+
+
+  - releaseCycle: "Galaxy Tab E 8.0"
+    release: 2016-01-01 #Unclear 
+    support: false 
+    eol: false
+
+
+
+  - releaseCycle: "Galaxy Tab A 8.0 with S Pen (2019)"
+    release: 2019-04-01 #Unclear 
+    support: false 
+    eol: false
+
+
+
+  - releaseCycle: "Galaxy Tab A 10.1 (2019)"
+    release: 2019-04-01 #Unclear 
+    support: false 
+    eol: false
+
+
+
+  - releaseCycle: "Galaxy Tab A 8.0 (2019)"
+    release: 2019-07-01 #Unclear 
+    support: false 
+    eol: false
+
+
+
+  - releaseCycle: "Galaxy Tab A 10.5 (2018)"
+    release: 2018-08-01 #Unclear 
+    support: false 
+    eol: false
+
+
+
+  - releaseCycle: "Galaxy Tab A 8.0 (2017)"
+    release: 2017-09-01 #Unclear 
+    support: false 
+    eol: false
+
+
+
+  - releaseCycle: "Galaxy J8"
+    release: 2018-07-01 #Unclear 
+    support: false 
+    eol: false
+
+
+
+  - releaseCycle: "Galaxy J7+"
+    release: 2017-09-01 #Unclear 
+    support: false 
+    eol: false
+
+
+
+  - releaseCycle: "Galaxy J7 Top"
+    release: 2018-07-01 #Unclear 
+    support: false 
+    eol: false
+
+
+
+  - releaseCycle: "Galaxy J7 Prime 2"
+    release: 2018-04-01 #Unclear 
+    support: false 
+    eol: false
+
+
+
+  - releaseCycle: "Galaxy J7 Duo"
+    release: 2018-04-01 #Unclear 
+    support: false 
+    eol: false
+
+
+
+  - releaseCycle: "Galaxy J6+"
+    release: 2018-10-01 #Unclear
+    support: false 
+    eol: false
+
+
+
+  - releaseCycle: "Galaxy J6"
+    release: 2018-05-01 #Unclear
+    support: false 
+    eol: false
+
+
+
+  - releaseCycle: "Galaxy J4 Core"
+    release: 2018-11-01 #Unclear
+    support: false 
+    eol: false
+
+
+
+  - releaseCycle: "Galaxy J4+"
+    release: 2018-10-01 #Unclear
+    support: false 
+    eol: false
+
+
+
+  - releaseCycle: "Galaxy J4"
+    release: 2018-05-01 #Unclear
+    support: false 
+    eol: false
+
+
+
+  - releaseCycle: "Galaxy J3"
+    release: 2018-06-01 #Unclear
+    support: false 
+    eol: false
+
+
+
+  - releaseCycle: "Galaxy J2 Core"
+    release: 2018-08-01 #Unclear
+    support: false 
+    eol: false
+
+
+
+  - releaseCycle: "Galaxy A80"
+    release: 2019-05-01 #Unclear
+    support: false 
+    eol: false
+
+
+
+  - releaseCycle: "Galaxy A70"
+    release: 2019-05-01 #This is good
+    support: false 
+    eol: false
+
+
+
+  - releaseCycle: "Galaxy A60"
+    release: 2019-06-01 #Unclear
+    support: false 
+    eol: false
+
+
+
+  - releaseCycle: "Galaxy A30"
+    release: 2019-03-01 #Unclear
+    support: false 
+    eol: false
+
+
+
+  - releaseCycle: "Galaxy A20"
+    release: 2019-04-05
+    support: false 
+    eol: false
+
+
+
+  - releaseCycle: "Galaxy A20e"
+    release: 2019-05-01 #Unclear
+    support: false 
+    eol: false
+
+
+
+  - releaseCycle: "Galaxy A10s"
+    release: 2019-08-27
+    support: false 
+    eol: false
+
+
+
+  - releaseCycle: "Galaxy A10e"
+    release: 2019-08-27 #confirm
+    support: false 
+    eol: false
+
+
+
+  - releaseCycle: "Galaxy A10"
+    release: 2019-03-19
+    support: false 
+    eol: false
+
+
+
+  - releaseCycle: "Galaxy A9 (2018)"
+    release: 2018-11-01 #Unclear
+    support: false 
+    eol: false
+
+
+
+  - releaseCycle: "Galaxy A8s"
+    release: 2018-12-01 #Unclear
+    support: false 
+    eol: false
+
+
+
+  - releaseCycle: "Galaxy A8 Star"
+    release: 2018-06-01 #Unclear
+    support: false 
+    eol: false
+
+
+
+  - releaseCycle: "Galaxy A8+"
+    release: 2018-01-01 #Unclear
+    support: false 
+    eol: false
+
+
+
+  - releaseCycle: "Galaxy A7"
+    release: 2018-10-01 #Unclear
+    support: false 
+    eol: false
+
+
+
+  - releaseCycle: "Galaxy A6+"
+    release: 2018-05-01 #Unclear
+    support: false 
+    eol: false
+
+
+
+  - releaseCycle: "Galaxy A6"
+    release: 2018-05-01 #unclear
+    support: false 
+    eol: false
+
+
+
+  - releaseCycle: "Galaxy A2 Core"
+    release: 2019-04-01 #unclear
+    support: false 
+    eol: false
+
+
 
 
 

--- a/products/samsungmobile.md
+++ b/products/samsungmobile.md
@@ -149,7 +149,7 @@ releases:
   - releaseCycle: "Galaxy A90 5G" #This loses active support with Android 12.
     release: 2019-09-03
     support: true
-    eol: false
+    eol: false # Quarterly Security Updates. This is a weird one. Getting 12 but not under the monthly security support branch.
     
   - releaseCycle: "Galaxy A01" #This loses active support with Android 12.
     release: 2019-12-18

--- a/products/samsungmobile.md
+++ b/products/samsungmobile.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-permalink: /samsungmobile
-title: Samsung Mobile
+permalink: /samsung
+title: Samsung
 category: device
 iconSlug: samsung
 link: https://security.samsungmobile.com/workScope.smsb

--- a/products/samsungmobile.md
+++ b/products/samsungmobile.md
@@ -902,4 +902,11 @@ releases:
 
 > Samsung Galaxy is a series of computing and mobile computing devices that are designed, manufactured and marketed by Samsung Electronics. 
 
+# Security brackets
+
+Samsung devices usually have four support brackets in which a device receives support. Which bracket your device falls under [can be found here](https://security.samsungmobile.com/workScope.smsb).
+ 
+* **Active Android support and Monthly Security Updates:** This bracket provides a device with new Android versions as they come out. This bracket also with limited exceptions provides monthly security updates. This covers a device for up to two years after launch, averaging a year. 
+* **Quarterly Security Updates**: This bracket provides a device with quarterly security update. This bracket takes over once monthly updates have ended, it usually lasts an a year. 
+* **Biannual Security Updates**: This bracket provides a device with biannual security update. This bracket takes over once quarterly updates have ended, it usually lasts an an additional year, or until four years have passed since the device has been released. 
 

--- a/products/samsungmobile.md
+++ b/products/samsungmobile.md
@@ -906,7 +906,9 @@ releases:
 
 Samsung devices usually have four support brackets in which a device receives support. Which bracket your device falls under [can be found here](https://security.samsungmobile.com/workScope.smsb).
  
-* **Active Android support and Monthly Security Updates:** This bracket provides a device with new Android versions as they come out. This bracket also with limited exceptions provides monthly security updates. This covers a device for up to two years after launch, averaging a year. 
+* **Active Android support:** This bracket provides a device with new Android versions as they come out. This bracket also with limited exceptions provides monthly security updates. This covers a device for up to two years after launch, averaging a year. 
+
 * **Quarterly Security Updates**: This bracket provides a device with quarterly security update. This bracket takes over once monthly updates have ended, it usually lasts an a year. 
+
 * **Biannual Security Updates**: This bracket provides a device with biannual security update. This bracket takes over once quarterly updates have ended, it usually lasts an an additional year, or until four years have passed since the device has been released. 
 

--- a/products/samsungmobile.md
+++ b/products/samsungmobile.md
@@ -154,32 +154,32 @@ releases:
   - releaseCycle: "Galaxy A01" #This loses active support with Android 12.
     release: 2019-12-18
     support: true
-    eol: false
+    eol: false # Quarterly
     
   - releaseCycle: "Galaxy A11" #This loses active support with Android 12.
     release: 2020-05-15
     support: true
-    eol: false
+    eol: false # Quarterly 
 
   - releaseCycle: "Galaxy A31" #This loses active support with Android 12.
     release: 2020-04-27
     support: true
-    eol: false
+    eol: false # Quarterly
 
   - releaseCycle: "Galaxy A41" #This loses active support with Android 12.
     release: 2020-03-18
     support: true
-    eol: false
+    eol: false # Quarterly
 
   - releaseCycle: "Galaxy A21" #This loses active support with Android 12.
     release: 2020-06-26
     support: true
-    eol: false
+    eol: false # Quarterly
 
   - releaseCycle: "Galaxy A21s" #This loses active support with Android 12.
     release: 2020-06-02
     support: true
-    eol: false
+    eol: false # Quarterly
 
   - releaseCycle: "Galaxy A Quantum"
     release: 2020-05-22
@@ -404,6 +404,230 @@ releases:
     release: 2020-09-28
     support: true #This loses active support with Android 12.
     eol: false
+
+# Current Models for Quarterly Security Updates
+# Excluding: Galaxy A90 5G, Galaxy A01, Galaxy A11, Galaxy A21, Galaxy A21s, Galaxy A31, Galaxy A31, Galaxy A41, Galaxy A51, Galaxy A51 5G, Galaxy A71, Galaxy A71 5G ...
+# ... Galaxy A02, Galaxy A02s, Galaxy A03s, Galaxy A12, Galaxy A22, Galaxy A22 5G, Galaxy A32, Galaxy A32 5G, Galaxy A42 5G, Galaxy A72,Galaxy M01,Galaxy M11, Galaxy M21 ...
+# Galaxy M31, Galaxy M31, Galaxy M51, Galaxy M12, Galaxy M32, Galaxy M42 5G, Galaxy M62, Galaxy F12, Galaxy F22, Galaxy F62, Galaxy Tab A 8.4 (2020), Galaxy Tab A7 ...
+# Galaxy Tab A7 Lite,  Galaxy Tab Active 3, Galaxy Tab S6, Galaxy Tab S6 5G, Galaxy Tab S6 Lite, Galaxy Tab S7, Galaxy Tab S7+, Galaxy Tab S7 FE
+
+  - releaseCycle: "Galaxy A70s"
+    release: 2019-09-01 #Unclear date
+    support: false 
+    eol: false
+    
+   
+
+
+
+  - releaseCycle: "Galaxy A50s"
+    release: 2019-09-01 #Unclear date
+    support: false 
+    eol: false
+    
+
+
+
+
+
+
+
+  - releaseCycle: "Galaxy A40"
+    release: 2019-04-01 #Unclear date
+    support: false 
+    eol: false
+    
+
+
+
+
+
+
+  - releaseCycle: "Galaxy A20s"
+    release: 2019-10-05
+    support: false 
+    eol: false
+    
+
+
+
+
+
+
+
+  - releaseCycle: "Galaxy Note 9"
+    release: 2018-08-24
+    support: false 
+    eol: false
+    
+
+
+
+
+
+
+
+
+
+  - releaseCycle: "Galaxy Note 8"
+    release: 2017-09-01 #Unclear release date
+    support: false 
+    eol: false
+    
+
+
+
+
+
+
+  - releaseCycle: "Galaxy S9+"
+    release: 2018-03-09
+    support: false 
+    eol: false
+    
+
+
+
+
+
+
+
+  - releaseCycle: "Galaxy S9"
+    release: 2018-03-09
+    support: false 
+    eol: false
+    
+
+
+
+
+
+
+  - releaseCycle: "Galaxy S8 Active"
+    release: 2017-08-01 #Unclear date
+    support: false 
+    eol: false
+    
+
+
+
+
+
+
+
+  - releaseCycle: "Galaxy A8 (2018) Enterprise"
+    release: 2018-01-01 #Unclear date
+    support: false 
+    eol: false
+    
+
+
+
+
+
+
+
+
+
+  - releaseCycle: "Samsung W21 5G"
+    release: 2020-11-04 #Using announcement date.
+    support: false 
+    eol: false
+    
+
+
+
+
+
+
+
+  - releaseCycle: "Samsung W20 5G"
+    release: 2019-11-20 #Using announcement date.
+    support: false 
+    eol: false
+    
+
+
+
+
+
+
+
+  - releaseCycle: "Galaxy Tab Active Pro"
+    release: 2019-10-01 #Unclear
+    support: false 
+    eol: false
+    
+
+
+
+
+
+
+
+  - releaseCycle: "Galaxy Tab Active 2"
+    release: 2017-10-20
+    support: false 
+    eol: false
+    
+
+
+
+
+
+
+
+
+  - releaseCycle: "Galaxy M21 2021"
+    release: 2021-07-26
+    support: false 
+    eol: false
+    
+
+
+
+
+
+
+
+
+  - releaseCycle: "Galaxy M30s"
+    release: 2019-10-30
+    support: false 
+    eol: false
+    
+
+
+
+
+
+
+  - releaseCycle: "Galaxy M10s"
+    release: 2019-09-01 #Unclear
+    support: false 
+    eol: false
+    
+
+
+
+
+
+
+  - releaseCycle: "Galaxy A82 5G"
+    release: 2021-05-05 #Unclear, using announcement date, or more like the day Samsung confirmed it existed.. https://www.gsmarena.com/samsung_accidentally_confirms_the_galaxy_a82_5g_existence-news-48968.php
+    support: false 
+    eol: false
+    
+
+
+
+
+  - releaseCycle: "Galaxy A01 Core"
+    release: 2020-08-06
+    support: false 
+    eol: false
+    
+
 
 
 

--- a/products/samsungmobile.md
+++ b/products/samsungmobile.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-permalink: /samsung
-title: Samsung
+permalink: /samsung-mobile
+title: Samsung Mobile
 category: device
 iconSlug: samsung
 link: https://security.samsungmobile.com/workScope.smsb

--- a/products/samsungmobile.md
+++ b/products/samsungmobile.md
@@ -1,0 +1,414 @@
+---
+layout: post
+permalink: /samsungmobile
+title: Samsung Mobile
+category: device
+iconSlug: samsung
+link: https://security.samsungmobile.com/workScope.smsb
+discontinuedColumn: false
+activeSupportColumn: true
+eolColumn: Supported
+releaseColumn: false
+releaseDateColumn: true
+sortReleasesBy: 'release'
+releases:
+
+  - releaseCycle: "Galaxy S21 Ultra"
+    release: 2021-01-14
+    support: true
+    eol: false
+  - releaseCycle: "Galaxy S21+"
+    release: 2021-01-14
+    support: true
+    eol: false
+  - releaseCycle: "Galaxy S21"
+    release: 2021-01-14
+    support: true
+    eol: false
+  - releaseCycle: "Galaxy S20 Ultra"
+    release: 2020-02-21
+    support: true
+    eol: false
+  - releaseCycle: "Galaxy S20+"
+    release: 2020-02-21
+    support: true
+    eol: false
+  - releaseCycle: "Galaxy S20"
+    release: 2020-02-21
+    support: true
+    eol: false
+    
+  - releaseCycle: "Galaxy S10 5G" #This loses active support with Android 12.
+    release: 2019-02-20
+    support: true
+    eol: false
+  - releaseCycle: "Galaxy S10" #This loses active support with Android 12.
+    release: 2019-02-20
+    support: true
+    eol: false
+  - releaseCycle: "Galaxy S10+" #This loses active support with Android 12.
+    release: 2019-02-20
+    support: true
+    eol: false
+  - releaseCycle: "Galaxy S10e" #This loses active support with Android 12.
+    release: 2019-02-20
+    support: true
+    eol: false
+  - releaseCycle: "Galaxy S10 Lite"
+    release: 2020-01-03
+    support: true
+    eol: false
+    
+  - releaseCycle: "Galaxy Note 20 Ultra"
+    release: 2020-08-21
+    support: true
+    eol: false
+  - releaseCycle: "Galaxy Note 20"
+    release: 2020-08-21
+    support: true
+    eol: false
+  - releaseCycle: "Galaxy Note 10+" #This loses active support with Android 12.
+    release: 2019-08-23
+    support: true
+    eol: false
+  - releaseCycle: "Galaxy Note 10" #This loses active support with Android 12.
+    release: 2019-08-23
+    support: true
+    eol: false
+  - releaseCycle: "Galaxy Note 10 Lite"
+    release: 2020-01-03
+    support: true
+    eol: false
+    
+  - releaseCycle: "Galaxy Fold" #This loses active support with Android 12.
+    release: 2019-09-06
+    support: true
+    eol: false
+    
+  - releaseCycle: "Galaxy Z Fold 2"
+    release: 2020-09-18
+    support: true
+    eol: false
+  - releaseCycle: "Galaxy Z Flip"
+    release: 2020-02-14
+    support: true
+    eol: false
+    
+  - releaseCycle: "Galaxy Z Flip 5G"
+    release: 2020-08-07
+    support: true
+    eol: false
+  - releaseCycle: "Galaxy Z Fold 3"
+    release: 2021-08-27
+    support: true
+    eol: false
+    
+  - releaseCycle: "Galaxy Z Flip 3"
+    release: 2021-08-11
+    support: true
+    eol: false
+
+  - releaseCycle: "Galaxy A71 5G"
+    release: 2020-06-15
+    support: true
+    eol: false
+  - releaseCycle: "Galaxy A71"
+    release: 2020-01-17
+    support: true
+    eol: false
+    
+  - releaseCycle: "Galaxy A51 5G"
+    release: 2020-08-07
+    support: true
+    eol: false
+  - releaseCycle: "Galaxy A51"
+    release: 2019-12-27
+    support: true
+    eol: false
+
+  - releaseCycle: "Galaxy A52"
+    release: 2021-03-26
+    support: true
+    eol: false
+
+  - releaseCycle: "Galaxy A52 5G"
+    release: 2021-03-17
+    support: true
+    eol: false
+  - releaseCycle: "Galaxy A52s"
+    release: 2021-09-01
+    support: true
+    eol: false
+    
+    
+  - releaseCycle: "Galaxy A72"
+    release: 2021-03-26
+    support: true
+    eol: false
+
+  - releaseCycle: "Galaxy A90 5G" #This loses active support with Android 12.
+    release: 2019-09-03
+    support: true
+    eol: false
+    
+  - releaseCycle: "Galaxy A01" #This loses active support with Android 12.
+    release: 2019-12-18
+    support: true
+    eol: false
+    
+  - releaseCycle: "Galaxy A11" #This loses active support with Android 12.
+    release: 2020-05-15
+    support: true
+    eol: false
+
+  - releaseCycle: "Galaxy A31" #This loses active support with Android 12.
+    release: 2020-04-27
+    support: true
+    eol: false
+
+  - releaseCycle: "Galaxy A41" #This loses active support with Android 12.
+    release: 2020-03-18
+    support: true
+    eol: false
+
+  - releaseCycle: "Galaxy A21" #This loses active support with Android 12.
+    release: 2020-06-26
+    support: true
+    eol: false
+
+  - releaseCycle: "Galaxy A21s" #This loses active support with Android 12.
+    release: 2020-06-02
+    support: true
+    eol: false
+
+  - releaseCycle: "Galaxy A Quantum"
+    release: 2020-05-22
+    support: true
+    eol: false
+  - releaseCycle: "Galaxy A Quantum 2"
+    release: 2021-04-23
+    support: true
+    eol: false
+    
+  - releaseCycle: "Galaxy A42 5G"
+    release: 2020-11-11
+    support: true
+    eol: false
+
+  - releaseCycle: "Galaxy A02" #This loses active support with Android 12.
+    release: 2021-01-27
+    support: true
+    eol: false
+
+  - releaseCycle: "Galaxy A02s" #This loses active support with Android 12.
+    release: 2021-01-04
+    support: true
+    eol: false
+    
+  - releaseCycle: "Galaxy A03s"
+    release: 2021-08-18
+    support: true
+    eol: false
+    
+  - releaseCycle: "Galaxy A12" #This loses active support with Android 12.
+    release: 2020-11-24
+    support: true
+    eol: false
+    
+  - releaseCycle: "Galaxy A32"
+    release: 2021-02-25
+    support: true
+    eol: false
+    
+  - releaseCycle: "Galaxy A32 5G"
+    release: 2021-01-13
+    support: true
+    eol: false
+    
+  - releaseCycle: "Galaxy A22"
+    release: 2021-06-03
+    support: true
+    eol: false
+  - releaseCycle: "Galaxy A22 5G"
+    release: 2021-06-24 # Unclear date, defaulting to announcement date
+    support: true
+    eol: false
+  - releaseCycle: "Galaxy M42 5G"
+    release: 2021-04-30
+    support: true
+    eol: false
+    
+  - releaseCycle: "Galaxy M12"
+    release: 2020-11-24
+    support: true
+    eol: false
+  - releaseCycle: "Galaxy M62"
+    release: 2021-03-03
+    support: true
+    eol: false
+    
+  - releaseCycle: "Galaxy M01"
+    release: 2020-06-02
+    support: true
+    eol: false
+    
+  - releaseCycle: "Galaxy M02s" #This loses active support with Android 12.
+    release: 2021-01-07
+    support: true
+    eol: false
+    
+  - releaseCycle: "Galaxy M02" #This loses active support with Android 12.
+    release: 2021-02-09
+    support: true
+    eol: false
+    
+  - releaseCycle: "Galaxy M21" #This loses active support with Android 12.
+    release: 2020-03-23
+    support: true
+    eol: false
+
+  - releaseCycle: "Galaxy M21s"
+    release: 2020-11-06
+    support: true
+    eol: false
+
+  - releaseCycle: "Galaxy M22" # Unclear date, defaulting to announcement date
+    release: 2021-09-14
+    support: true
+    eol: false
+
+  - releaseCycle: "Galaxy M31"
+    release: 2020-03-05
+    support: true
+    eol: false
+  - releaseCycle: "Galaxy M31 Prime" #This loses active support with Android 12.
+    release: 2020-10-17
+    support: true
+    eol: false
+  - releaseCycle: "Galaxy M32"
+    release: 2021-06-28
+    support: true
+    eol: false
+  - releaseCycle: "Galaxy M51" #This loses active support with Android 12.
+    release: 2020-08-06
+    support: true
+    eol: false
+  - releaseCycle: "Galaxy M31s" #This loses active support with Android 12.
+    release: 2021-02-09
+    support: true
+    eol: false
+  - releaseCycle: "Galaxy F41" #This loses active support with Android 12.
+    release: 2020-10-16
+    support: true
+    eol: false
+    
+    
+  - releaseCycle: "Galaxy F62"
+    release: 2021-02-22
+    support: true
+    eol: false
+    
+  - releaseCycle: "Galaxy F02s" #This loses active support with Android 12.
+    release: 2021-04-09
+    support: true
+    eol: false
+    
+    
+    
+    
+    
+    
+  - releaseCycle: "Galaxy F12"
+    release: 2021-04-12
+    support: true
+    eol: false
+    
+    
+    
+    
+    
+  - releaseCycle: "Galaxy F22"
+    release: 2021-07-13
+    support: true
+    eol: false
+    
+  - releaseCycle: "Galaxy XCover Pro" # Unclear release date.
+    release: 2020-01-01 
+    support: true #This loses active support with Android 12.
+    eol: false
+    
+  - releaseCycle: "Galaxy Xcover 5"
+    release: 2021-03-12
+    support: true
+    eol: false
+  - releaseCycle: "Galaxy Tab S7+"
+    release: 2020-08-05
+    support: true
+    eol: false
+    
+    
+    
+    
+  - releaseCycle: "Galaxy Tab S7 "
+    release: 2020-08-05
+    support: true
+    eol: false
+    
+    
+    
+  - releaseCycle: "Galaxy Tab S7 FE"
+    release: 2021-05-25
+    support: true
+    eol: false
+    
+    
+    
+    
+  - releaseCycle: "Galaxy Tab S6 5G"
+    release: 2020-01-30
+    support: true
+    eol: false
+    
+    
+    
+  - releaseCycle: "Galaxy Tab S6" #This loses active support with Android 12.
+    release: 2019-08-01
+    support: true
+    eol: false
+    
+    
+    
+  - releaseCycle: "Galaxy Tab S6 Lite"
+    release: 2020-05-16
+    support: true
+    eol: false
+  - releaseCycle: "Galaxy Tab A 8.4 (2020)" # Yeah we need to specify the year here, multiple models from different years with the same name.
+    release: 2020-03-25
+    support: true #This loses active support with Android 12.
+    eol: false
+    
+    
+  - releaseCycle: "Galaxy Tab A7" #This loses active support with Android 12.
+    release: 2020-09-11
+    support: true
+    eol: false
+    
+    
+  - releaseCycle: "Galaxy Tab A7 Lite"
+    release: 2021-05-27
+    support: true
+    eol: false
+    
+    
+  - releaseCycle: "Galaxy Tab Active 3" # Confirm this.
+    release: 2020-09-28
+    support: true #This loses active support with Android 12.
+    eol: false
+
+
+
+---
+
+> Samsung Galaxy is a series of computing and mobile computing devices that are designed, manufactured and marketed by Samsung Electronics. 
+
+


### PR DESCRIPTION
Sources used:

For phones that are getting active support, I defined this by which ones are receiving the next major Android update: https://www.sammobile.com/news/list-galaxy-devices-eligible-for-one-ui-4-0-android-12-update/

For archival purposes, here it is on the Wayback machine: https://web.archive.org/web/20210930212715/https://www.sammobile.com/news/list-galaxy-devices-eligible-for-one-ui-4-0-android-12-update/

~~This is very much a draft. I plan on adding all phones still receiving security updates: https://security.samsungmobile.com/workScope.smsb~~

~~This initial PR covers those still getting active support.~~

Done.

On the comments:

Unless specified otherwise, an unclear release date means that the year and month is known, but not the day. 

