### PR TITLE
Sort python by `release` instead of `releaseCycle`

### DIFF
--- a/products/python.md
+++ b/products/python.md
@@ -8,7 +8,7 @@ link: https://devguide.python.org/
 changelogTemplate: |
   https://python.org/downloads/release/python-{{"__LATEST__" | replace:'.',''}}/
 releaseDateColumn: true
-sortReleasesBy: 'releaseCycle'
+sortReleasesBy: 'release'
 releases:
     - releaseCycle: "3.10"
       release: 2021-10-04


### PR DESCRIPTION
fixes #438.
Because `releaseCycle` is stored as a string, Python version 3.10 was showing up underneath version 3.2 like this-

- 3.9
- 3.8
- 3.7
- 3.6
- 3.5
- 3.4
- 3.3
- 3.10
- 2.7

Which is wrong as 3.10 should be on the top, hence sorting by `release` (date) fixes the issue. The same behavior is also true for Elixir which is also sorted by `release`.
