### PR TITLE
[NVIDIA-GPUs] Volta no longer in production

### DIFF
--- a/products/nvidiaproducts.md
+++ b/products/nvidiaproducts.md
@@ -102,7 +102,7 @@ releases:
     release: 2017-12-07
     support: true
     eol: false
-    discontinued: false
+    discontinued: true
 
   - releaseCycle: "Consumer Turing (TU1xX)"
     release: 2018-09-20


### PR DESCRIPTION
No GV100 GPUs are listed as under production anymore: https://www.techpowerup.com/gpu-specs/?architecture=Volta&sort=generation