### PR TITLE
[amazon linux] New release: 2.0.20211001.1

### DIFF
--- a/products/amazon-linux.md
+++ b/products/amazon-linux.md
@@ -18,7 +18,7 @@ releases:
   - releaseCycle: 'Amazon Linux 2'
     release: 2017-12-19
     eol: 2023-06-30
-    latest: "2.0.20210813.1"
+    latest: "2.0.20211001.1"
     link: https://aws.amazon.com/amazon-linux-2/release-notes/
 ---
 


### PR DESCRIPTION
Update details;

> Update of ca-certificates to version 2021.2.50-72.amzn2.0.1 addresses the expiring IdentTrust DST Root CA X3, which affected some Let’s Encrypt TLS certificates. The effect of the expiring certificate would be an inability of OpenSSL to validate impacted certificates issued by Let’s Encrypt. Impacted customers may have experienced connection or certificate errors when attempting to connect to certain websites or APIs that use Let's Encrypt certificates.