### PR TITLE
[NVIDIA-Driver] R470 full support ended, R495 released

### DIFF
--- a/products/nvidiadriver.md
+++ b/products/nvidiadriver.md
@@ -92,7 +92,7 @@ releases:
     link: https://www.nvidia.com/Download/driverResults.aspx/180557/en-us
     cycleShortHand: 10
     
-  - releaseCycle: "R495-Windows (LTSB)"
+  - releaseCycle: "R495-Windows (NFB)"
     release: 2021-10-12
     support: true
     eol: false

--- a/products/nvidiadriver.md
+++ b/products/nvidiadriver.md
@@ -86,11 +86,20 @@ releases:
     
   - releaseCycle: "R470-Windows (LTSB)"
     release: 2021-06-22
-    support: true
+    support: 2021-09-20
     eol: 2024-07-01
     latest: "472.12"
     link: https://www.nvidia.com/Download/driverResults.aspx/180557/en-us
     cycleShortHand: 10
+    
+  - releaseCycle: "R495-Windows (LTSB)"
+    release: 2021-10-12
+    support: true
+    eol: false
+    latest: "496.13"
+    link: https://www.nvidia.com/Download/driverResults.aspx/181095/en-us
+    cycleShortHand: 11
+
 
 ---
 


### PR DESCRIPTION
R470 end of full support date was stated by these drivers:

Windows: https://www.nvidia.com/en-us/drivers/results/180558/
Linux: https://www.nvidia.com/Download/driverResults.aspx/180475/en-us

R495 Windows release: https://www.nvidia.com/Download/driverResults.aspx/181095/en-us
R495 Linux release is delayed: https://github.com/NVIDIA/egl-wayland/issues/40#issuecomment-930081940