### PR TITLE
[NVIDIA-Products] Kepler lost full support

### DIFF
--- a/products/nvidiaproducts.md
+++ b/products/nvidiaproducts.md
@@ -28,13 +28,13 @@ releases:
 
   - releaseCycle: "Consumer Kepler (GKxxx)"
     release: 2012-03-22
-    support: true
+    support: 2021-09-20
     eol: 2024-07-01
     discontinued: true
 
   - releaseCycle: "Professional Kepler (GKxxx)"
     release: 2013-03-01
-    support: true
+    support: 2021-09-20
     eol: 2024-07-01
     discontinued: true
 


### PR DESCRIPTION
See https://github.com/endoflife-date/endoflife.date/pull/463 for more information. R495 does not support Kepler.