### PR TITLE
[Visual Studio] Update various EoL dates

### DIFF
--- a/products/visualstudio.md
+++ b/products/visualstudio.md
@@ -8,19 +8,22 @@ sortReleasesBy: "cycleShortHand"
 # Newer releases go on top of the list, in order
 releases:
   - releaseCycle: "2019 version 16.11"
-    eol: 2029-04-01
+    release: 2021-08-10
+    eol: 2029-04-10
     cycleShortHand: 20191611
   - releaseCycle: "2019 version 16.10"
     eol: true
     cycleShortHand: 20191610
   - releaseCycle: "2019 version 16.9"
+    release: 2021-03-02
     eol: 2022-10-01
     cycleShortHand: 20191609
   - releaseCycle: "2019 version 16.8"
     eol: true
     cycleShortHand: 20191608
   - releaseCycle: "2019 version 16.7"
-    eol: 2020-04-01
+    release: 2020-08-05
+    eol: 2020-04-12
     cycleShortHand: 20191607
   - releaseCycle: "2019 version 16.6"
     eol: true
@@ -29,7 +32,8 @@ releases:
     eol: true
     cycleShortHand: 20191605
   - releaseCycle: "2019 version 16.4"
-    eol: 2021-10-01
+    release: 2019-12-03
+    eol: 2021-10-12
     cycleShortHand: 20191604
   - releaseCycle: "2019 version 16.3"
     eol: true
@@ -41,22 +45,23 @@ releases:
     eol: true
     cycleShortHand: 20191601
   - releaseCycle: "2019 version 16.0"
-    eol: true
+    release: 2019-12-03
+    eol: 2021-01-12
     cycleShortHand: 20191600
   - releaseCycle: "2017"
-    eol: 2027-04-01
+    eol: 2027-04-13
     cycleShortHand: 2017
   - releaseCycle: "2015"
-    eol: 2025-10-01
+    eol: 2025-10-14
     cycleShortHand: 2015
   - releaseCycle: "2013"
-    eol: 2024-01-01
+    eol: 2024-04-09
     cycleShortHand: 2013
   - releaseCycle: "2012"
-    eol: 2023-01-01
+    eol: 2023-01-10
     cycleShortHand: 2012
   - releaseCycle: "2010"
-    eol: true
+    eol: 2020-07-14
     cycleShortHand: 2010
     
 iconSlug: visualstudio

--- a/products/visualstudio.md
+++ b/products/visualstudio.md
@@ -16,7 +16,7 @@ releases:
     cycleShortHand: 20191610
   - releaseCycle: "2019 version 16.9"
     release: 2021-03-02
-    eol: 2022-10-01
+    eol: 2022-10-11
     cycleShortHand: 20191609
   - releaseCycle: "2019 version 16.8"
     eol: true

--- a/products/visualstudio.md
+++ b/products/visualstudio.md
@@ -11,7 +11,7 @@ releases:
     eol: 2029-04-01
     cycleShortHand: 20191611
   - releaseCycle: "2019 version 16.10"
-    eol: false
+    eol: true
     cycleShortHand: 20191610
   - releaseCycle: "2019 version 16.9"
     eol: 2022-10-01

--- a/products/visualstudio.md
+++ b/products/visualstudio.md
@@ -48,19 +48,28 @@ releases:
     release: 2019-12-03
     eol: 2021-01-12
     cycleShortHand: 20191600
-  - releaseCycle: "2017"
+  - releaseCycle: "2017 version 15.9"
+    release: 2018-11-13
     eol: 2027-04-13
+    cycleShortHand: 20171509
+  - releaseCycle: "2017 version 15.0"
+    release: 2017-03-07
+    eol: 2020-01-14
     cycleShortHand: 2017
   - releaseCycle: "2015"
+    release: 2015-07-20
     eol: 2025-10-14
     cycleShortHand: 2015
   - releaseCycle: "2013"
+    release: 2014-01-15
     eol: 2024-04-09
     cycleShortHand: 2013
   - releaseCycle: "2012"
+    release: 2012-10-31
     eol: 2023-01-10
     cycleShortHand: 2012
   - releaseCycle: "2010"
+    release: 2010-06-29
     eol: 2020-07-14
     cycleShortHand: 2010
     

--- a/products/visualstudio.md
+++ b/products/visualstudio.md
@@ -23,7 +23,7 @@ releases:
     cycleShortHand: 20191608
   - releaseCycle: "2019 version 16.7"
     release: 2020-08-05
-    eol: 2020-04-12
+    eol: 2022-04-12
     cycleShortHand: 20191607
   - releaseCycle: "2019 version 16.6"
     eol: true


### PR DESCRIPTION
> Note as well that versions 16.10 is no longer under support either. These intermediary releases received servicing fixes only until the next minor update released.

https://docs.microsoft.com/en-us/visualstudio/releases/2019/release-notes