### PR TITLE
[jekyll] Force utf-8 as encoding

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -46,3 +46,4 @@ defaults:
       path: ""
     values:
       image: /logo.png
+encoding: utf-8


### PR DESCRIPTION
This is already the default, so shouldn't change anything
on most environments, but might help with #491