### PR TITLE
[macOS] Add 12.0 (Monterey) and EOL of 10.14 (Mojave)

### DIFF
--- a/products/macos.md
+++ b/products/macos.md
@@ -8,6 +8,9 @@ category: device
 sortReleasesBy: "release"
 changelogTemplate: "https://link/of/the/__RELEASE_CYCLE__/and/__LATEST__/version"
 releases:
+  - releaseCycle: "macOS 12 (Monterey)"
+    release: 2021-10-25
+    eol: false
   - releaseCycle: "macOS 11 (Big Sur)"
     release: 2020-11-12
     eol: false
@@ -16,7 +19,7 @@ releases:
     eol: false
   - releaseCycle: "macOS 10.14 (Mojave)"
     release: 2018-09-24
-    eol: false
+    eol: 2021-10-25
   - releaseCycle: "macOS 10.13 (High Sierra)"
     release: 2017-09-25
     eol: 2020-12-01


### PR DESCRIPTION
# macOS Mojave

> **Support status**: Support ending on October 25, 2021 with release of macOS Monterey

https://en.wikipedia.org/wiki/MacOS_Mojave

# macOS Monterey

> General availability: October 25, 2021

https://en.wikipedia.org/wiki/MacOS_Monterey

> Available 10.25

https://www.apple.com/macos/monterey/