### PR TITLE
[Debian] Update 9.x , modify lts/nonlts version structure

### DIFF
--- a/products/debian.md
+++ b/products/debian.md
@@ -20,42 +20,38 @@ releases:
     eol: 2024-06-01
     latest: "10.11"
     link: https://www.debian.org/News/2021/2021100902
-  - releaseCycle: 'Debian 9 "Stretch" (LTS)'
+  - releaseCycle: 'Debian 9 "Stretch"'
+    # Debian has its LTS and non-LTS version in same time
+    # We are keeping both of them until non-LTS reaches EOL
     release: 2017-06-17
     eol: 2022-06-30
-    latest: "9.12"
-    link: https://lists.debian.org/debian-announce/2020/msg00001.html
+    lts: true
+    latest: "9.13"
+    link: https://lists.debian.org/debian-announce/2020/msg00004.html
   - releaseCycle: 'Debian 9 "Stretch"'
+    # Debian has its LTS and non-LTS version in same time
+    # We are keeping both of them until non-LTS reaches EOL
     release: 2017-06-17
     eol: 2020-01-01
-    latest: "9.12"
-    link: https://lists.debian.org/debian-announce/2020/msg00001.html
-  - releaseCycle: 'Debian 8 "Jessie" (LTS)'
-    release: 2015-04-26
-    eol: 2020-06-30
-    latest: "8.11"
-    link: https://www.debian.org/News/2015/20150426
+    latest: "9.13"
+    link: https://lists.debian.org/debian-announce/2020/msg00004.html
   - releaseCycle: 'Debian 8 "Jessie"'
     release: 2015-04-26
-    eol: 2018-06-17
+    eol: 2020-06-30
+    lts: true
     latest: "8.11"
     link: https://www.debian.org/News/2015/20150426
-  - releaseCycle: 'Debian 7 "Wheezy" (LTS)'
-    release: 2013-05-04
-    eol: 2018-05-31
-    link: https://www.debian.org/News/2013/20130504
   - releaseCycle: 'Debian 7 "Wheezy"'
     release: 2013-05-04
-    eol: 2016-04-25
+    eol: 2018-05-31
+    lts: true
     link: https://www.debian.org/News/2013/20130504
-  - releaseCycle: 'Debian 6 "Squeeze" (LTS)'
-    release: 2011-02-06
-    eol: 2016-02-29
-    link: https://www.debian.org/News/2011/20110205a
   - releaseCycle: 'Debian 6 "Squeeze"'
     release: 2011-02-06
-    eol: 2014-05-31
+    eol: 2016-02-29
+    lts: true
     link: https://www.debian.org/News/2011/20110205a
+
 ---
 
 > [Debian](https://www.debian.org/) is a free operating system for your computer. The Debian Stable branch is the most popular edition for personal computers and network servers, and is used as the basis for many other Linux distributions.


### PR DESCRIPTION
* Update 9.x latest version
* Remove non-LTS versions ( the ones which already passed its EOL ) ( NOT the ones which already in their life cycle )
* Add lts  tags for LTS versioned Timeframed versions instead of using (LTS) text to its release name 
* Add comments to make it clear for new contributors