### PR TITLE
[Drupal] Drupal 8 EOL was 2021-11-02

### DIFF
--- a/products/drupal.md
+++ b/products/drupal.md
@@ -30,7 +30,7 @@ releases:
   - releaseCycle: "8.9"
     release: 2020-06-03
     support: 2020-12-01
-    eol:     2021-11-01
+    eol:     2021-11-02
     latest:  "8.9.19"
     lts: true
   - releaseCycle: "8.8"


### PR DESCRIPTION
> **Drupal 8 will still be end-of-life on November 2, 2021**, due to [Symfony 3's end of life](https://symfony.com/releases/3.4).

https://www.drupal.org/psa-2020-06-24