### PR TITLE
[Python] 3.9.8 is out

### DIFF
--- a/products/python.md
+++ b/products/python.md
@@ -17,7 +17,7 @@ releases:
     - releaseCycle: "3.9"
       release: 2020-10-05
       eol: 2025-10-05
-      latest: "3.9.7"
+      latest: "3.9.8"
     - releaseCycle: "3.8"
       release: 2019-10-14
       eol: 2024-10-14


### PR DESCRIPTION
https://discuss.python.org/t/python-3-9-8-and-3-11-0a2-are-now-available/11763?u=hugovk