### PR TITLE
Recommendations for maintainers

### DIFF
--- a/advise.md
+++ b/advise.md
@@ -1,0 +1,225 @@
+---
+layout: post
+nav_exclude: true
+permalink: /recommendations
+title: Recommendations for maintainers
+---
+
+If you maintain a product that has some notion of support lifecycle and end-of-life,
+these are our recommendations on how to best document this information for your users.
+Every recommendation includes a few examples (sometimes real) to help explain our rationale.
+
+## Publishing
+
+For larger projects, you'll often have this information split across multiple pages - our recommendation is to keep
+these documents well linked and hosted together in such case. For eg, do not keep your versioning policy in your wiki,
+and the EoL policy on your website.
+
+We recommend limiting yourselves to a single document with appropriate sections, if feasible.
+
+Such a document should be published ideally on your Website or Wiki.
+You can include it in your repository as well (`RELEASE.md` or `EOL.md` for eg), but
+best possible place is your website - it provides a stable URL that can be referenced
+by your users.
+
+Make sure that the URL is clearly linked in your release notes, and other places. Make it
+easy for users to discover.
+
+Do not publish this in the versioned part of your website - your support policy might change over
+time, but the link should not.
+
+- Bad: example.com/docs/v3.4/eol
+- Good: example.com/docs/eol
+
+## Bad
+
+Ubuntu has this information split between the (unmaintained) Ubuntu Wiki and the website:
+
+- https://wiki.ubuntu.com/ReleaseCadence
+- https://ubuntu.com/about/release-cycle
+- https://wiki.ubuntu.com/Releases
+
+Make sure this information is hosted alongside your end-user documentation, not your developer or team documentation.
+
+## Bad
+
+Python maintains the EoL status on the website for Python developers: https://devguide.python.org/#status-of-python-branches
+
+## Bad
+
+The "release and maintenance" document for Ansible is versioned so there are multiple copies:
+
+- https://docs.ansible.com/ansible/2.9/reference_appendices/release_and_maintenance.html
+- https://docs.ansible.com/ansible/latest/reference_appendices/release_and_maintenance.html
+- https://docs.ansible.com/ansible/devel/reference_appendices/release_and_maintenance.html
+
+This causes confusion, as users on the 2.9 branch might miss out on important information that is reflected on the latest version.
+
+## Bad
+
+Godot similarly uses a versioned release policy with multiple URLs:
+
+- https://docs.godotengine.org/en/stable/about/release_policy.html
+- https://docs.godotengine.org/en/latest/about/release_policy.html
+- https://docs.godotengine.org/en/3.4/about/release_policy.html
+- https://docs.godotengine.org/en/3.3/about/release_policy.html
+- https://docs.godotengine.org/en/3.2/about/release_policy.html
+
+Godot needs to maintain and redirect older pages to the stable one, which maintains the correct information.
+This is a workaround, and having a single stable URL would make this problem go away.
+
+## Document your support lifecycle
+
+Your support lifecycle is your guidance on how long each product will be supported.
+If you have LTS (Long Term Support) releases, clarify how this differs for those.
+
+- Bad: https://ubuntu.com/about/release-cycle (Does not explain how long LTS releases are supported)
+
+## Release Cadence
+
+Not every project has a stable release cadence, but if you have one (even a rough one), document it.
+It is always better if your release cadence is predictable and aligned with your support lifecycles.
+
+- Good: https://alpinelinux.org/releases/
+
+## Explain what's supported
+
+Every project will have differing levels of what counts as "support" - it is important to document what
+"support" means for your project. If there are different tiers (Active/Security/Extended for eg), document
+these clearly.
+
+Bad:
+
+> Extended Support beyond LTS is available to customers on a commercial basis.
+
+Good:
+
+> Extended Support beyond LTS is available to customers on a commercial basis. It includes critical
+security fixes only on the packages within the `base` repository.
+
+> Customers paying for "Premier Support" get additional access to our support team with a guaranteed SLA.
+
+- Good: https://ubuntu.com/security/esm (Clearly explains what ESM means for Ubuntu end users)
+
+## Versioning Policy
+
+Document your versioning policy. Even if the policy is homebrew and varies between major versions, a clearly
+documented policy is better than none.
+
+Good:
+
+> We follow Semantic Versioning, and limit breaking changes to major upgrades.
+
+> The project follows SemVer starting from v12. Prior releases may include breaking changes in minor version upgrades.
+
+## Release Notes
+
+Release notes are critical for your users doing actual upgrades. If certain upgrade pathways are unsupported
+(such as doing 2 major upgrades at once), document it. Highlight breaking changes in your release notes.
+
+If you have a migration guide, link it on all the release notes.
+
+## Listing Releases
+
+List your releases in a table with all the relevant information for each release cycle. This includes:
+
+1. Link to a changelog.
+2. What's the latest release in that cycle.
+3. What are the supported dates for this release (for *all* different support levels)
+4. Download URL, if needed
+5. Release notes
+6. Migration Guide, if available
+
+Prefer listing older/unsupported releases elsewhere (`/historical-releases`). If you think they are important to your
+users, mark them extremely well in the table as unsupported.
+
+## Dates
+
+### Always use absolute dates
+
+Many times, your support/EoL policies are relative. Common examples:
+
+1. The last major release becomes unsupported 90 days after a new major release.
+2. Bug fixes on previous releases will be made till the latest releases gets the first point release.
+
+However, none of this is relevant to your end-users. Make sure that all your releases always have a clear dates
+(I suggest `YYYY-MM-DD`) irrespective of how these dates are decided. You doing the math once will save your users much
+more time.
+
+### Bad:
+
+| K8s version | AKS GA   | End of life |
+|-------------|----------|-------------|
+| 1.19        | Nov 2020 | 1.22 GA     |
+| 1.20        | Mar 2021 | 1.23 GA     |
+| 1.21        | Jul 2021 | 1.24 GA     |
+| 1.22        | Nov 2021 | 1.25 GA     |
+| 1.23        | Feb 2022 | 1.26 GA     |
+
+(Source: [Azure Kubernetes Release Calendar][aks])
+
+### Bad:
+
+|Version|Release Date|
+---|---
+2.1|3rd March 2021
+2.0|1st March 2020
+
+Release are supported for 2 years from the release date.
+
+### Good:
+
+|Kubernetes version|Upstream release|Amazon EKS release|Amazon EKS end of support|
+|------|-------------------|-------------------|--------------------|
+| 1.16 | September 8, 2019 | April 30, 2020    | September 27, 2021 |
+| 1.17 | December 9, 2019  | July 10, 2020     | November 2, 2021   |
+| 1.18 | March 23, 2020    | October 13, 2020  | February 18, 2022  |
+| 1.19 | August 26, 2020   | February 16, 2021 | April, 2022        |
+| 1.20 | December 8, 2020  | May 18, 2021      | July, 2022         |
+| 1.21 | April 8, 2021     | July 19, 2021     | September, 2022    |
+
+(Source: [Amazon EKS Release Calendar][eks])
+
+## Provide Complete Date
+
+Always document complete dates, instead of just providing a month and year.
+Users should not be left guessing whether the EoL is on the 1st of December or 31st.
+
+## Provide a release schedule image
+
+This is optional, but a clear graphical representation of release cycles (with different colors for different levels of support) is always
+nice to have.
+
+- Label your axes clearly with year boundaries.
+- Have a straight line marking the current date.
+- If you can make it interactive, provide a start and end date on hover.
+- Make sure these images are kept updated - it is easy for them to get out of date.
+- Ensure that all the data in the image is also reflected in text (in a table) for accessibility reasons.
+- Limit the image scale by picking a cut-off date.
+
+- Good: https://www.php.net/supported-versions.php
+- Good: https://jefftriplett.com/django-release-cycle/
+- Good: https://hugovk.github.io/drupal-release-cycle/
+- Bad: https://docs.nvidia.com/datacenter/tesla/drivers/graphics/driver-branches-overview.png
+- Bad: https://ubuntu.com/about/release-cycle (Does not provide an accessible table)
+
+## Checklist
+
+Here's a nice checklist of all our recommendations. These are our recommendations - feel free to ignore what doesn't work for you.
+
+- [ ] Document all relevant information *together* in the same place.
+- [ ] Publish on a stable URL, and make sure this link is not versioned.
+- [ ] Document your release cadence
+- [ ] Explain all levels of support
+- [ ] Document your versioning policy
+- [ ] Demarcate your list of releases between supported and unsupported releases.
+- [ ] Provide the latest version in every support cycle
+- [ ] Provide absolute dates, instead of relative ones.
+- [ ] Provide complete dates, include the day of the month.
+- [ ] If you have a release schedule image, label it clearly and mark a current date line.
+
+
+Please provide your feedback on this advice on GitHub:
+
+[aks]: https://docs.microsoft.com/en-us/azure/aks/supported-kubernetes-versions?tabs=azure-cli#aks-kubernetes-release-calendar
+[eks]: https://docs.aws.amazon.com/eks/latest/userguide/kubernetes-versions.html#kubernetes-release-calendar

--- a/index.md
+++ b/index.md
@@ -5,7 +5,7 @@ title: Home
 # This is the content for the website homepage (https://endoflife.date/)
 ---
 
-endoflife.date is a community-maintained project to document End of Life dates, and support lifecycles of various products.
+endoflife.date is a community-maintained project to document end-of-life dates, and support lifecycles of various products.
 
 If you maintain such information for a project, please read our [Recommendations for Product Maintainers](/recommendations).
 

--- a/index.md
+++ b/index.md
@@ -5,16 +5,9 @@ title: Home
 # This is the content for the website homepage (https://endoflife.date/)
 ---
 
-This site maintains quick links for checking End Of Life dates for various products.
+endoflife.date is a community-maintained project to document End of Life dates, and support lifecycles of various products.
 
-## Suggestion
-
-The reason this site exists is because this information is very often hidden away. If you're releasing something on a regular basis:
-
-1.  List only supported releases.
-2.  Give EoL dates/policy if possible.
-3.  Hide unsupported releases behind a few extra clicks.
-4.  Mention security/active release difference if needed.
+If you maintain such information for a project, please read our [Recommendations for Product Maintainers](/recommendations).
 
 ## Contributing
 

--- a/products/ruby.md
+++ b/products/ruby.md
@@ -67,4 +67,4 @@ releases:
 
 > [Ruby](https://www.ruby-lang.org/) is a dynamic, open source programming language with a focus on simplicity and productivity. It has an elegant syntax that is natural to read and easy to write.
 
-Since Ruby 2.1 a new major version of Ruby has been released every year on December 25th, and EOLed 3 years, 3 months later. Another resource that can help is [here](https://endoflife.software/programming-languages/server-side-scripting/ruby).
+Since Ruby 2.1 a new major version of Ruby has been released every year on December 25th, and EOLed 3 years, 3 months later.

--- a/recommendations.md
+++ b/recommendations.md
@@ -17,7 +17,7 @@ Every recommendation includes a few examples (sometimes real) to help explain ou
 Here's a nice checklist of all our recommendations. These are our recommendations - feel free to ignore what doesn't work for you.
 Every item is linked to the relevant section in the document below.
 
-- [ ] [Document all relevant information *together*](#publishing) in the same place.
+- [ ] [Document all relevant information *together*](#publishing), accessible to your end-users.
 - [ ] [Publish at a stable URL](#publishing), and make sure this link is not versioned.
 - [ ] [Document your release cadence](#release-cadence).
 - [ ] [Explain all levels of support](#explain-whats-supported).
@@ -59,13 +59,13 @@ Ubuntu has this information split between the (unmaintained) Ubuntu Wiki and the
 - https://ubuntu.com/about/release-cycle
 - https://wiki.ubuntu.com/Releases
 
-Make sure this information is hosted alongside your end-user documentation, not your developer or team documentation.
+Make sure this information is hosted _alongside your end-user documentation_, not your developer or team documentation.
 
-### Bad
+### Bad - Python
 
 Python maintains the EoL status on the website for Python developers: https://devguide.python.org/#status-of-python-branches
 
-### Bad
+### Bad - Ansible
 
 The "release and maintenance" document for Ansible is versioned so there are multiple copies:
 
@@ -74,15 +74,6 @@ The "release and maintenance" document for Ansible is versioned so there are mul
 - https://docs.ansible.com/ansible/devel/reference_appendices/release_and_maintenance.html
 
 This causes confusion, as users on the 2.9 branch might miss out on important information that is reflected on the latest version.
-
-### Bad
-
-Godot similarly uses a versioned release policy with multiple URLs: [stable](https://docs.godotengine.org/en/stable/about/release_policy.html),
-[latest](https://docs.godotengine.org/en/latest/about/release_policy.html), [3.4](https://docs.godotengine.org/en/3.4/about/release_policy.html),
-[3.3](https://docs.godotengine.org/en/3.3/about/release_policy.html), [3.2](https://docs.godotengine.org/en/3.2/about/release_policy.html)
-
-Godot needs to maintain and redirect older pages to the stable one, which maintains the correct information.
-This is a workaround, and having a single stable URL would make this problem go away.
 
 ## Document your support lifecycle
 
@@ -96,7 +87,7 @@ If you have LTS (Long Term Support) releases, clarify how this differs for those
 Not every project has a stable release cadence, but if you have one (even a rough one), document it.
 It is always better if your release cadence is predictable and aligned with your support lifecycles.
 
-### Good
+### Good - Alpine Linux
 
 >There are several release branches for Alpine Linux available at the same time.
 Each May and November we make a release branch from edge.
@@ -128,7 +119,7 @@ security fixes only on the packages within the `base` repository.
 Document your versioning policy. Even if the policy is homebrew and varies between major versions, a clearly
 documented policy is better than none.
 
-Good:
+### Good
 
 > We follow Semantic Versioning, and limit breaking changes to major upgrades.
 
@@ -136,24 +127,27 @@ Good:
 
 ## Release Notes
 
-Release notes are critical for your users doing actual upgrades. If certain upgrade pathways are unsupported
-(such as doing 2 major upgrades at once), document it. Highlight breaking changes in your release notes.
+Release notes are critical for your end-users doing upgrades. If certain upgrade pathways are unsupported
+(such as doing 2 major upgrades at once), document the same. *Highlight breaking changes* in your release notes.
 
-If you have a migration guide, link it on all the release notes.
+If you have a migration guide, ensure it is linked in the release notes.
 
 ## Listing releases
 
 List your releases in a table with all the relevant information for each release cycle. This includes:
 
-1. Link to a changelog.
-2. What's the latest release in that cycle.
-3. What are the supported dates for this release (for *all* different support levels).
+1. Link to a changelog (and/or Release Notes). See [keepachangelog.com](https://keepachangelog.com/) for getting started with one.
+2. What's the latest release in that cycle. This helps users validate whether they are running a supported release or not.
+3. What are the important dates for this release -  EoL/Release/GA/LTS etc. Do this for *all* different support levels.
 4. Download URL, if needed.
-5. Release notes.
-6. Migration guide, if available.
+5. Migration guide, if available.
 
 Prefer listing older/unsupported releases elsewhere (`/historical-releases`). If you think they are important to your
 users, mark them extremely well in the table as unsupported.
+
+- Good: https://nodejs.org/en/about/releases/
+- Good: https://www.php.net/supported-versions.php
+- Bad: https://www.python.org/downloads/ (Lists an unsupported release alongside supported ones)
 
 ## Dates
 
@@ -164,7 +158,7 @@ Many times, your support/EoL policies are relative. Common examples:
 1. The last major release becomes unsupported 90 days after a new major release.
 2. Bug fixes on previous releases will be made till the latest releases gets the first point release.
 
-However, none of this is relevant to your end users. Make sure that all your releases always have a clear dates
+However, your end-users shouldn't have to do the math. Make sure that all your releases always have a clear dates
 (I suggest `YYYY-MM-DD`) irrespective of how these dates are decided. You doing the math once will save your users much
 more time.
 
@@ -179,7 +173,9 @@ more time.
 
 ### Bad:
 
-|Version|Release Date|
+Some projects will often put a note instead of documenting absolute dates:
+
+Version|Release Date
 ---|---
 2.1|3rd March 2021
 2.0|1st March 2020
@@ -203,7 +199,7 @@ Version|Release Date|EoL Date
 | 1.20 | December 8, 2020  | May 18, 2021      | July, 2022         |
 | 1.21 | April 8, 2021     | July 19, 2021     | September, 2022    |
 
-(Source: [Amazon EKS Release Calendar][eks])
+Source: [Amazon EKS Release Calendar][eks].
 
 ## Provide complete dates
 
@@ -215,7 +211,7 @@ Bad: See above AKS and EKS examples.
 ## Provide a release schedule image
 
 This is optional, but a clear graphical representation of release cycles (with different colors for different levels of support) is always
-nice to have.
+nice to have. If you provide such an image, here's some recommendations:
 
 - Label your axes clearly with year boundaries.
 - Have a straight line marking the current date.
@@ -230,7 +226,7 @@ nice to have.
 - Bad: <https://docs.nvidia.com/datacenter/tesla/drivers/graphics/driver-branches-overview.png> (Cryptic)
 - Bad: <https://ubuntu.com/about/release-cycle> (Does not provide an accessible table)
 
-Feedback is welcome [on GitHub](https://github.com/endoflife-date/endoflife.date/discussions/new?title=Feedback%20on%20Recommendations%20for%20Maintainers&category=general).
+Feedback on this document is welcome [on GitHub](https://github.com/endoflife-date/endoflife.date/discussions/new?title=Feedback%20on%20Recommendations%20for%20Maintainers&category=general).
 
 [aks]: https://docs.microsoft.com/en-us/azure/aks/supported-kubernetes-versions?tabs=azure-cli#aks-kubernetes-release-calendar
 [eks]: https://docs.aws.amazon.com/eks/latest/userguide/kubernetes-versions.html#kubernetes-release-calendar

--- a/recommendations.md
+++ b/recommendations.md
@@ -15,14 +15,14 @@ Every recommendation includes a few examples (sometimes real) to help explain ou
 ## Publishing
 
 For larger projects, you'll often have this information split across multiple pages - our recommendation is to keep
-these documents well linked and hosted together in such case. For eg, do not keep your versioning policy in your wiki,
+these documents well linked and hosted together in such case. For example, do not keep your versioning policy in your wiki,
 and the EoL policy on your website.
 
 We recommend limiting yourselves to a single document with appropriate sections, if feasible.
 
-Such a document should be published ideally on your Website or Wiki.
-You can include it in your repository as well (`RELEASE.md` or `EOL.md` for eg), but
-best possible place is your website - it provides a stable URL that can be referenced
+Such a document should be published ideally on your website or wiki.
+You can include it in your repository as well (`RELEASE.md` or `EOL.md` for example), but
+the best place to host it is your website - it provides a stable URL that can be referenced
 by your users.
 
 Make sure that the URL is clearly linked in your release notes, and other places. Make it
@@ -125,16 +125,16 @@ Release notes are critical for your users doing actual upgrades. If certain upgr
 
 If you have a migration guide, link it on all the release notes.
 
-## Listing Releases
+## Listing releases
 
 List your releases in a table with all the relevant information for each release cycle. This includes:
 
 1. Link to a changelog.
 2. What's the latest release in that cycle.
-3. What are the supported dates for this release (for *all* different support levels)
-4. Download URL, if needed
-5. Release notes
-6. Migration Guide, if available
+3. What are the supported dates for this release (for *all* different support levels).
+4. Download URL, if needed.
+5. Release notes.
+6. Migration guide, if available.
 
 Prefer listing older/unsupported releases elsewhere (`/historical-releases`). If you think they are important to your
 users, mark them extremely well in the table as unsupported.
@@ -148,7 +148,7 @@ Many times, your support/EoL policies are relative. Common examples:
 1. The last major release becomes unsupported 90 days after a new major release.
 2. Bug fixes on previous releases will be made till the latest releases gets the first point release.
 
-However, none of this is relevant to your end-users. Make sure that all your releases always have a clear dates
+However, none of this is relevant to your end users. Make sure that all your releases always have a clear dates
 (I suggest `YYYY-MM-DD`) irrespective of how these dates are decided. You doing the math once will save your users much
 more time.
 
@@ -189,7 +189,7 @@ Version|Release Date|EoL Date
 
 (Source: [Amazon EKS Release Calendar][eks])
 
-## Provide Complete Date
+## Provide complete dates
 
 Always document complete dates, instead of just providing a month and year.
 Users should not be left guessing whether the EoL is on the 1st of December or 31st.
@@ -219,18 +219,18 @@ nice to have.
 Here's a nice checklist of all our recommendations. These are our recommendations - feel free to ignore what doesn't work for you.
 
 - [ ] Document all relevant information *together* in the same place.
-- [ ] Publish on a stable URL, and make sure this link is not versioned.
-- [ ] Document your release cadence
-- [ ] Explain all levels of support
-- [ ] Document your versioning policy
+- [ ] Publish at a stable URL, and make sure this link is not versioned.
+- [ ] Document your release cadence.
+- [ ] Explain all levels of support.
+- [ ] Document your versioning policy.
 - [ ] Demarcate your list of releases between supported and unsupported releases.
-- [ ] Provide the latest version in every support cycle
+- [ ] Provide the latest version in every support cycle.
 - [ ] Provide absolute dates, instead of relative ones.
 - [ ] Provide complete dates, include the day of the month.
 - [ ] If you have a release schedule image, label it clearly and mark a current date line.
 
 
-Please provide your feedback on this advice on GitHub:
+Feedback is welcome [on GitHub](https://github.com/endoflife-date/endoflife.date/discussions/new?title=Feedback%20on%20Recommendations%20for%20Maintainers&category=general).
 
 [aks]: https://docs.microsoft.com/en-us/azure/aks/supported-kubernetes-versions?tabs=azure-cli#aks-kubernetes-release-calendar
 [eks]: https://docs.aws.amazon.com/eks/latest/userguide/kubernetes-versions.html#kubernetes-release-calendar

--- a/recommendations.md
+++ b/recommendations.md
@@ -1,8 +1,11 @@
 ---
-layout: post
+layout: home
 nav_exclude: true
 permalink: /recommendations
 title: Recommendations for maintainers
+alternate_urls:
+  - /advise
+  - /advice
 ---
 
 If you maintain a product that has some notion of support lifecycle and end-of-life,
@@ -30,8 +33,9 @@ time, but the link should not.
 
 - Bad: example.com/docs/v3.4/eol
 - Good: example.com/docs/eol
+- Good: example.com/release-policy
 
-## Bad
+### Bad
 
 Ubuntu has this information split between the (unmaintained) Ubuntu Wiki and the website:
 
@@ -41,11 +45,11 @@ Ubuntu has this information split between the (unmaintained) Ubuntu Wiki and the
 
 Make sure this information is hosted alongside your end-user documentation, not your developer or team documentation.
 
-## Bad
+### Bad
 
 Python maintains the EoL status on the website for Python developers: https://devguide.python.org/#status-of-python-branches
 
-## Bad
+### Bad
 
 The "release and maintenance" document for Ansible is versioned so there are multiple copies:
 
@@ -55,15 +59,11 @@ The "release and maintenance" document for Ansible is versioned so there are mul
 
 This causes confusion, as users on the 2.9 branch might miss out on important information that is reflected on the latest version.
 
-## Bad
+### Bad
 
-Godot similarly uses a versioned release policy with multiple URLs:
-
-- https://docs.godotengine.org/en/stable/about/release_policy.html
-- https://docs.godotengine.org/en/latest/about/release_policy.html
-- https://docs.godotengine.org/en/3.4/about/release_policy.html
-- https://docs.godotengine.org/en/3.3/about/release_policy.html
-- https://docs.godotengine.org/en/3.2/about/release_policy.html
+Godot similarly uses a versioned release policy with multiple URLs: [stable](https://docs.godotengine.org/en/stable/about/release_policy.html),
+[latest](https://docs.godotengine.org/en/latest/about/release_policy.html), [3.4](https://docs.godotengine.org/en/3.4/about/release_policy.html),
+[3.3](https://docs.godotengine.org/en/3.3/about/release_policy.html), [3.2](https://docs.godotengine.org/en/3.2/about/release_policy.html)
 
 Godot needs to maintain and redirect older pages to the stable one, which maintains the correct information.
 This is a workaround, and having a single stable URL would make this problem go away.
@@ -80,7 +80,13 @@ If you have LTS (Long Term Support) releases, clarify how this differs for those
 Not every project has a stable release cadence, but if you have one (even a rough one), document it.
 It is always better if your release cadence is predictable and aligned with your support lifecycles.
 
-- Good: https://alpinelinux.org/releases/
+### Good
+
+>There are several release branches for Alpine Linux available at the same time.
+Each May and November we make a release branch from edge.
+The main repository is typically supported for 2 years and the community repository is supported until next stable release.
+
+Source: <https://alpinelinux.org/releases/>
 
 ## Explain what's supported
 
@@ -150,9 +156,6 @@ more time.
 
 | K8s version | AKS GA   | End of life |
 |-------------|----------|-------------|
-| 1.19        | Nov 2020 | 1.22 GA     |
-| 1.20        | Mar 2021 | 1.23 GA     |
-| 1.21        | Jul 2021 | 1.24 GA     |
 | 1.22        | Nov 2021 | 1.25 GA     |
 | 1.23        | Feb 2022 | 1.26 GA     |
 
@@ -167,14 +170,20 @@ more time.
 
 Release are supported for 2 years from the release date.
 
+### Good
+
+Same as above, but we do the math:
+
+Version|Release Date|EoL Date
+---|---|---
+2.1|3rd March 2021|3rd March 2023
+2.0|1st March 2020|1st March 2022
+
+
 ### Good:
 
 |Kubernetes version|Upstream release|Amazon EKS release|Amazon EKS end of support|
 |------|-------------------|-------------------|--------------------|
-| 1.16 | September 8, 2019 | April 30, 2020    | September 27, 2021 |
-| 1.17 | December 9, 2019  | July 10, 2020     | November 2, 2021   |
-| 1.18 | March 23, 2020    | October 13, 2020  | February 18, 2022  |
-| 1.19 | August 26, 2020   | February 16, 2021 | April, 2022        |
 | 1.20 | December 8, 2020  | May 18, 2021      | July, 2022         |
 | 1.21 | April 8, 2021     | July 19, 2021     | September, 2022    |
 
@@ -184,6 +193,8 @@ Release are supported for 2 years from the release date.
 
 Always document complete dates, instead of just providing a month and year.
 Users should not be left guessing whether the EoL is on the 1st of December or 31st.
+
+Bad: See above AKS and EKS examples.
 
 ## Provide a release schedule image
 
@@ -197,11 +208,11 @@ nice to have.
 - Ensure that all the data in the image is also reflected in text (in a table) for accessibility reasons.
 - Limit the image scale by picking a cut-off date.
 
-- Good: https://www.php.net/supported-versions.php
-- Good: https://jefftriplett.com/django-release-cycle/
-- Good: https://hugovk.github.io/drupal-release-cycle/
-- Bad: https://docs.nvidia.com/datacenter/tesla/drivers/graphics/driver-branches-overview.png
-- Bad: https://ubuntu.com/about/release-cycle (Does not provide an accessible table)
+- Good: <https://www.php.net/supported-versions.php>
+- Good: <https://jefftriplett.com/django-release-cycle/>
+- Good: <https://hugovk.github.io/drupal-release-cycle/>
+- Bad: <https://docs.nvidia.com/datacenter/tesla/drivers/graphics/driver-branches-overview.png> (Cryptic)
+- Bad: <https://ubuntu.com/about/release-cycle> (Does not provide an accessible table)
 
 ## Checklist
 

--- a/recommendations.md
+++ b/recommendations.md
@@ -12,6 +12,22 @@ If you maintain a product that has some notion of support lifecycle and end-of-l
 these are our recommendations on how to best document this information for your users.
 Every recommendation includes a few examples (sometimes real) to help explain our rationale.
 
+## Checklist
+
+Here's a nice checklist of all our recommendations. These are our recommendations - feel free to ignore what doesn't work for you.
+Every item is linked to the relevant section in the document below.
+
+- [ ] [Document all relevant information *together*](#publishing) in the same place.
+- [ ] [Publish at a stable URL](#publishing), and make sure this link is not versioned.
+- [ ] [Document your release cadence](#release-cadence).
+- [ ] [Explain all levels of support](#explain-whats-supported).
+- [ ] [Document your versioning policy](#versioning-policy).
+- [ ] [Demarcate your list of releases](#listing-releases) between supported and unsupported releases.
+- [ ] [Provide the latest version](#listing-releases) in every support cycle.
+- [ ] [Provide absolute dates](#always-use-absolute-dates), instead of relative ones.
+- [ ] [Provide complete dates](#provide-complete-dates), include the day of the month.
+- [ ] If you have a release schedule image, [label it clearly](provide-a-release-schedule-image) and mark a current date line.
+
 ## Publishing
 
 For larger projects, you'll often have this information split across multiple pages - our recommendation is to keep
@@ -213,22 +229,6 @@ nice to have.
 - Good: <https://hugovk.github.io/drupal-release-cycle/>
 - Bad: <https://docs.nvidia.com/datacenter/tesla/drivers/graphics/driver-branches-overview.png> (Cryptic)
 - Bad: <https://ubuntu.com/about/release-cycle> (Does not provide an accessible table)
-
-## Checklist
-
-Here's a nice checklist of all our recommendations. These are our recommendations - feel free to ignore what doesn't work for you.
-
-- [ ] Document all relevant information *together* in the same place.
-- [ ] Publish at a stable URL, and make sure this link is not versioned.
-- [ ] Document your release cadence.
-- [ ] Explain all levels of support.
-- [ ] Document your versioning policy.
-- [ ] Demarcate your list of releases between supported and unsupported releases.
-- [ ] Provide the latest version in every support cycle.
-- [ ] Provide absolute dates, instead of relative ones.
-- [ ] Provide complete dates, include the day of the month.
-- [ ] If you have a release schedule image, label it clearly and mark a current date line.
-
 
 Feedback is welcome [on GitHub](https://github.com/endoflife-date/endoflife.date/discussions/new?title=Feedback%20on%20Recommendations%20for%20Maintainers&category=general).
 

--- a/recommendations.md
+++ b/recommendations.md
@@ -55,32 +55,36 @@ time, but the link should not.
 
 Ubuntu has this information split between the (unmaintained) Ubuntu Wiki and the website:
 
-- https://wiki.ubuntu.com/ReleaseCadence
-- https://ubuntu.com/about/release-cycle
-- https://wiki.ubuntu.com/Releases
+- <https://wiki.ubuntu.com/ReleaseCadence>
+- <https://ubuntu.com/about/release-cycle>
+- <https://wiki.ubuntu.com/Releases>
 
 Make sure this information is hosted _alongside your end-user documentation_, not your developer or team documentation.
 
 ### Bad - Python
 
-Python maintains the EoL status on the website for Python developers: https://devguide.python.org/#status-of-python-branches
+Python maintains the EoL status on the website for Python developers: <https://devguide.python.org/#status-of-python-branches>
 
 ### Bad - Ansible
 
 The "release and maintenance" document for Ansible is versioned so there are multiple copies:
 
-- https://docs.ansible.com/ansible/2.9/reference_appendices/release_and_maintenance.html
-- https://docs.ansible.com/ansible/latest/reference_appendices/release_and_maintenance.html
-- https://docs.ansible.com/ansible/devel/reference_appendices/release_and_maintenance.html
+- <https://docs.ansible.com/ansible/2.9/reference_appendices/release_and_maintenance.html>
+- <https://docs.ansible.com/ansible/latest/reference_appendices/release_and_maintenance.html>
+- <https://docs.ansible.com/ansible/devel/reference_appendices/release_and_maintenance.html>
 
 This causes confusion, as users on the 2.9 branch might miss out on important information that is reflected on the latest version.
+
+### Good - Angular
+
+The Angular project has a single URL documenting all the information: <https://angular.io/guide/releases>
 
 ## Document your support lifecycle
 
 Your support lifecycle is your guidance on how long each product will be supported.
 If you have LTS (Long Term Support) releases, clarify how this differs for those.
 
-- Bad: https://ubuntu.com/about/release-cycle (Does not explain how long LTS releases are supported)
+- Bad: <https://ubuntu.com/about/release-cycle> (Does not explain how long LTS releases are supported)
 
 ## Release Cadence
 
@@ -112,7 +116,7 @@ security fixes only on the packages within the `base` repository.
 
 > Customers paying for "Premier Support" get additional access to our support team with a guaranteed SLA.
 
-- Good: https://ubuntu.com/security/esm (Clearly explains what ESM means for Ubuntu end users)
+- Good: <https://ubuntu.com/security/esm> (Clearly explains what ESM means for Ubuntu end users)
 
 ## Versioning Policy
 
@@ -130,7 +134,7 @@ documented policy is better than none.
 Release notes are critical for your end-users doing upgrades. If certain upgrade pathways are unsupported
 (such as doing 2 major upgrades at once), document the same. *Highlight breaking changes* in your release notes.
 
-If you have a migration guide, ensure it is linked in the release notes.
+If you have a migration guide, ensure it is linked in all the release notes.
 
 ## Listing releases
 
@@ -145,9 +149,9 @@ List your releases in a table with all the relevant information for each release
 Prefer listing older/unsupported releases elsewhere (`/historical-releases`). If you think they are important to your
 users, mark them extremely well in the table as unsupported.
 
-- Good: https://nodejs.org/en/about/releases/
-- Good: https://www.php.net/supported-versions.php
-- Bad: https://www.python.org/downloads/ (Lists an unsupported release alongside supported ones)
+- Good: <https://nodejs.org/en/about/releases/>
+- Good: <https://www.php.net/supported-versions.php>
+- Bad: <https://www.python.org/downloads/> (Lists an unsupported release alongside supported ones)
 
 ## Dates
 
@@ -207,16 +211,17 @@ Always document complete dates, instead of just providing a month and year.
 Users should not be left guessing whether the EoL is on the 1st of December or 31st.
 
 Bad: See above AKS and EKS examples.
+Good: <https://nodejs.org/en/about/releases/>
 
 ## Provide a release schedule image
 
 This is optional, but a clear graphical representation of release cycles (with different colors for different levels of support) is always
-nice to have. If you provide such an image, here's some recommendations:
+nice to have. If you do provide such an image, here's some recommendations:
 
 - Label your axes clearly with year boundaries.
 - Have a straight line marking the current date.
 - If you can make it interactive, provide a start and end date on hover.
-- Make sure these images are kept updated - it is easy for them to get out of date.
+- Make sure these images are kept updated - it is easy for them to get out of date. An outdated graphic is worse than none.
 - Ensure that all the data in the image is also reflected in text (in a table) for accessibility reasons.
 - Limit the image scale by picking a cut-off date.
 
@@ -224,7 +229,7 @@ nice to have. If you provide such an image, here's some recommendations:
 - Good: <https://jefftriplett.com/django-release-cycle/>
 - Good: <https://hugovk.github.io/drupal-release-cycle/>
 - Bad: <https://docs.nvidia.com/datacenter/tesla/drivers/graphics/driver-branches-overview.png> (Cryptic)
-- Bad: <https://ubuntu.com/about/release-cycle> (Does not provide an accessible table)
+- Bad: <https://ubuntu.com/about/release-cycle> (Does not provide an accessible table for desktop users)
 
 Feedback on this document is welcome [on GitHub](https://github.com/endoflife-date/endoflife.date/discussions/new?title=Feedback%20on%20Recommendations%20for%20Maintainers&category=general).
 

--- a/recommendations.md
+++ b/recommendations.md
@@ -86,14 +86,14 @@ If you have LTS (Long Term Support) releases, clarify how this differs for those
 
 - Bad: <https://ubuntu.com/about/release-cycle> (Does not explain how long LTS releases are supported)
 
-## Release Cadence
+## Release cadence
 
 Not every project has a stable release cadence, but if you have one (even a rough one), document it.
 It is always better if your release cadence is predictable and aligned with your support lifecycles.
 
 ### Good - Alpine Linux
 
->There are several release branches for Alpine Linux available at the same time.
+> There are several release branches for Alpine Linux available at the same time.
 Each May and November we make a release branch from edge.
 The main repository is typically supported for 2 years and the community repository is supported until next stable release.
 
@@ -102,7 +102,7 @@ Source: <https://alpinelinux.org/releases/>
 ## Explain what's supported
 
 Every project will have differing levels of what counts as "support" - it is important to document what
-"support" means for your project. If there are different tiers (Active/Security/Extended for eg), document
+"support" means for your project. If there are different tiers (Active/Security/Extended for example), document
 these clearly.
 
 Bad:
@@ -129,7 +129,7 @@ documented policy is better than none.
 
 > The project follows SemVer starting from v12. Prior releases may include breaking changes in minor version upgrades.
 
-## Release Notes
+## Release notes
 
 Release notes are critical for your end-users doing upgrades. If certain upgrade pathways are unsupported
 (such as doing 2 major upgrades at once), document the same. *Highlight breaking changes* in your release notes.


### PR DESCRIPTION
In continuation to discussion at #432, I felt that the small list of suggestions on the homepage was missing a lot of nuance.

To clarify pre-emptively, this is a set of recommendations to maintainers who provide this documentation on _their products_. This is not the guidelines we follow for endoflife.date - those are listed on [our wiki](https://github.com/endoflife-date/endoflife.date/wiki/Guiding-Principles).

These are different, because for endoflife.date, we prefer being concise and summarizing things. While the upstream projects might want to be more exhaustive and detailed in their approach.

Suggestions are welcome. In particular I'd like feedback on:

- [x] Should we move the checklist to the top (and link it to relevant sections)
- [ ] Dropping links to real projects under "bad" examples.
- [ ] Drop a few examples (Godot/Ansible felt superfluous for eg)
- [ ] Other recommendations that I might have missed out on