### PR TITLE
[Django] add upcoming 4.x as a template and update 3.2.x version

### DIFF
--- a/products/django.md
+++ b/products/django.md
@@ -11,10 +11,15 @@ command: python -c "import django; print(django.get_version())"
 releaseDateColumn: false
 sortReleasesBy: 'releaseCycle'
 releases:
+#  - releaseCycle: "4.0"
+#    support: 2022-08-01
+#    eol: 2023-04-01
+#    latest: "4.0.0"
+#
   - releaseCycle: "3.2"
     support: 2021-12-01
     eol: 2024-04-01
-    latest: "3.2.8"
+    latest: "3.2.9"
     lts: true
   - releaseCycle: "3.1"
     support: 2021-04-05


### PR DESCRIPTION
update to 3.2.29
add a template for 4.x  it might need to adjust its eol and support dates whenever it releases