### PR TITLE
[Laravel] Update supported and end of life

### DIFF
--- a/products/laravel.md
+++ b/products/laravel.md
@@ -12,7 +12,7 @@ sortReleasesBy: 'releaseCycle'
 releases:
   - releaseCycle: "8.x"
     release: 2020-09-08
-    support: 2022-03-01
+    support: 2022-07-26
     eol: 2023-01-24
     latest: 8.70.2
     lts: false
@@ -24,7 +24,7 @@ releases:
     lts: false
   - releaseCycle: "6.x"
     release: 2019-09-03
-    support: 2021-09-07
+    support: 2022-01-25
     eol: 2022-09-06
     latest: 6.20.38
     lts: true


### PR DESCRIPTION
Copied from:

https://laravel.com/docs/8.x/releases#support-policy

![image](https://user-images.githubusercontent.com/1423115/142155457-c1f372ed-e02c-4b26-a88a-a237660bb9e9.png)


it was changed months ago [here](https://github.com/laravel/docs/commit/9c8a850882c6a208f6ada159664423d38512f22f#diff-1d2b91d957f8612017f196e6cc2e83c33bcfe3fd348dc3619e9e9672e797d46f) and [there](https://github.com/laravel/docs/commit/e2141d784be1c70bc5fbbf438707ec544d6e5f7a#diff-1d2b91d957f8612017f196e6cc2e83c33bcfe3fd348dc3619e9e9672e797d46f)