### PR TITLE
Show the latest version info even if its support ended

### DIFF
--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -154,13 +154,11 @@ or +1 (EoL is in the future)
   </td>
 
   {% if page.releaseColumn != false %}
-  <td>
-    {% if releaseLink != "" and diff > 0 %}
+  <td {% if diff <= 0 %} class = "txt-linethrough" {% endif %} >      <!-- if the support finished add txt-linethrough class -->
+    {% if releaseLink != "" %}
       <a href="{{releaseLink}}" title="Release Notes / Changelog">{{latestVersionNumber}}</a>
-    {% elsif diff > 0 %}
-      {{latestVersionNumber}}
     {% else %}
-      NA
+      {{latestVersionNumber}}
     {% endif %}
   </td>
   {% endif %}
@@ -182,6 +180,9 @@ or +1 (EoL is in the future)
 .bg-light {
   background-color: #f8f9fa !important;
 }
+.txt-linethrough {
+  text-decoration:line-through;
+ }
 .card {
   position: relative;
   display: -ms-flexbox;


### PR DESCRIPTION
Before this path our system wasn't showing  latestVersionNumber  and even it just write it as NA
After this patch it will show the latestVersionNumber but it will have a linethrough if its support ended