### PR TITLE
[Linux] 5.14 became EOL with its latest update, update version info

### DIFF
--- a/products/linuxkernel.md
+++ b/products/linuxkernel.md
@@ -20,27 +20,27 @@ releases:
     release: 2021-10-31
     eol: 2023-10-31
     lts: true
-    latest: "5.15.2"
+    latest: "5.15.4"
 
   - releaseCycle: "5.14"
     cycleShortHand: 514
     release: 2021-08-29
-    eol: false
-    latest: "5.14.18"
+    eol: true
+    latest: "5.14.21"
         
   - releaseCycle: "5.10"
     cycleShortHand: 510
     release: 2020-12-13
     eol: 2026-12-01
     lts: true
-    latest: "5.10.79"
+    latest: "5.10.81"
     
   - releaseCycle: "5.4"
     cycleShortHand: 504
     release: 2019-11-24
     eol: 2025-12-01
     lts: true
-    latest: "5.4.159"
+    latest: "5.4.161"
     
   - releaseCycle: "4.19"
     cycleShortHand: 419


### PR DESCRIPTION
* Update to latest versions
* Mark 5.14 as EOL
Source : https://www.kernel.org/