### PR TITLE
[PHP] set correct EOL date for PHP 8.1

### DIFF
--- a/products/php.md
+++ b/products/php.md
@@ -15,7 +15,7 @@ releases:
     cycleShortHand: "801"
     release: 2021-11-25
     support: 2022-11-25
-    eol:     2023-11-25
+    eol:     2024-11-25
     latest:  "8.1.0"
 
   - releaseCycle: "8.0"


### PR DESCRIPTION
security updates are provided until 2024-11-25
https://www.php.net/supported-versions.php