### PR TITLE
[Firefox] version update

### DIFF
--- a/products/firefox.md
+++ b/products/firefox.md
@@ -15,7 +15,7 @@ releases:
   - releaseCycle: "Firefox 94"
     release: 2021-11-02
     eol: false
-    latest: "94.0"
+    latest: "94.0.2"
     cycleShortHand: 3
 
 


### PR DESCRIPTION
Firefox 94.0.2 was released on November 22nd 2021 - https://www.mozilla.org/en-US/firefox/94.0.2/releasenotes/