### PR TITLE
[PostgreSQL] - update versions

### DIFF
--- a/products/postgresql.md
+++ b/products/postgresql.md
@@ -17,27 +17,27 @@ releases:
   - releaseCycle: "14"
     release: 2021-09-30
     eol: 2026-09-30
-    latest: "14.0"
+    latest: "14.1"
   - releaseCycle: "13"
     release: 2020-09-24
     eol: 2025-11-13
-    latest: "13.4"
+    latest: "13.5"
   - releaseCycle: "12"
     release: 2019-10-03
     eol: 2024-11-14
-    latest: "12.8"
+    latest: "12.9"
   - releaseCycle: "11"
     release: 2018-10-18
     eol: 2023-11-09
-    latest: "11.13"
+    latest: "11.14"
   - releaseCycle: "10"
     release: 2017-10-05
     eol: 2022-11-10
-    latest: "10.18"
+    latest: "10.19"
   - releaseCycle: "9.6"
     release: 2016-09-29
     eol: 2021-11-11
-    latest: "9.6.23"
+    latest: "9.6.24"
   - releaseCycle: "9.5"
     release: 2016-01-07
     eol: 2021-02-11


### PR DESCRIPTION
https://www.postgresql.org/about/news/postgresql-141-135-129-1114-1019-and-9624-released-2349/

[14.1](https://www.postgresql.org/docs/release/14.1/)
[13.5](https://www.postgresql.org/docs/release/13.5/)
[12.9](https://www.postgresql.org/docs/release/12.9/)
[11.14](https://www.postgresql.org/docs/release/11.14/)
[10.19](https://www.postgresql.org/docs/release/10.19/)
[9.6.24](https://www.postgresql.org/docs/release/9.6.24/)