### PR TITLE
[gitlab] Update 14.5.2, 14.4.4, 14.3.6

### DIFF
--- a/products/gitlab.md
+++ b/products/gitlab.md
@@ -17,17 +17,17 @@ releases:
     release: 2021-11-22
     support: 2021-12-22
     eol: 2022-02-22
-    latest: "14.5.1"
+    latest: "14.5.2"
   - releaseCycle: "14.4"
     release: 2021-10-22
     support: 2021-11-22
     eol: 2022-01-22
-    latest: "14.4.3"
+    latest: "14.4.4"
   - releaseCycle: "14.3"
     release: 2021-09-22
     support: 2021-10-22
     eol: 2021-12-22
-    latest: "14.3.5"
+    latest: "14.3.6"
   - releaseCycle: "14.2"
     release: 2021-08-22
     support: 2021-09-22


### PR DESCRIPTION
https://about.gitlab.com/releases/2021/12/06/security-release-gitlab-14-5-2-released/