### PR TITLE
[Android] 8.1.x Reached EOL

### DIFF
--- a/products/android.md
+++ b/products/android.md
@@ -2,10 +2,11 @@
 title: Android OS
 alternate_urls:
   - /aosp
+  - /androidos
 layout: post
 permalink: /android
 category: device
-link: https://developer.android.com/about/versions/11
+link: https://developer.android.com/about/versions
 category: os
 activeSupportColumn: false
 releaseColumn: false
@@ -13,68 +14,86 @@ releaseDateColumn: true
 eolColumn: Security Support
 sortReleasesBy: 'release'
 releases:
-  - releaseCycle: "Android 1.0"
-    release: 2008-09-23
-    eol: true
-  - releaseCycle: Petit Four (Android 1.1)
-    release: 2009-02-09
-    eol: true
-  - releaseCycle: Cupcake (Android 1.5)
-    release: 2009-04-27
-    eol: true
-  - releaseCycle: Donut (Android 1.6)
-    release: 2009-09-15
-    eol: true
-  - releaseCycle: Eclair (Android 2.0-2.1)
-    release: 2009-10-26
-    eol: true
-  - releaseCycle: Froyo (Android 2.2.x)
-    release: 2010-05-20
-    eol: true
-  - releaseCycle: Gingerbread (Android 2.3.x)
-    release: 2010-12-06
-    eol: true
-  - releaseCycle: Honeycomb (Android 3.x)
-    release: 2011-02-22
-    eol: true
-  - releaseCycle: Ice Cream Sandwich (Android 4.0.x)
-    release: 2011-10-18
-    eol: true
-  - releaseCycle: Jelly Bean (Android 4.1 – 4.3.1)
-    release: 2012-07-09
-    eol: true
-  - releaseCycle: KitKat (Android 4.4.x)
-    release: 2013-10-31
-    eol: true
-  - releaseCycle: Lollipop (Android 5.0 – 5.1.1)
-    release: 2014-11-12
-    eol: true
-  - releaseCycle: Marshmallow (Android 6.0.x)
-    release: 2015-10-05
-    eol: true
-  - releaseCycle: Nougat (Android 7.x)
-    release: 2016-08-22
-    eol: true
-  - releaseCycle: Oreo (Android 8.0.x)
-    release: 2017-08-21
-    eol: true
-    
-  - releaseCycle: Oreo (Android 8.1.x)
-    release: 2017-12-05
+  - releaseCycle: Snow Cone (Android 12)
+    release: 2021-10-04
+    eol: false
+
+  - releaseCycle: Red Velvet Cake (Android 11)
+    release: 2020-09-08
+    eol: false
+
+  - releaseCycle: Queen Cake (Android 10)
+    release: 2019-09-03
     eol: false
 
   - releaseCycle: Pie (Android 9.x)
     release: 2018-08-06
     eol: false
-  - releaseCycle: Queen Cake (Android 10)
-    release: 2019-09-03
-    eol: false
-  - releaseCycle: Red Velvet Cake (Android 11)
-    release: 2020-09-08
-    eol: false
-  - releaseCycle: Snow Cone (Android 12)
-    release: 2021-10-04
-    eol: false
+
+  - releaseCycle: Oreo (Android 8.1.x)
+    release: 2017-12-05
+    eol: true
+
+  - releaseCycle: Oreo (Android 8.0.x)
+    release: 2017-08-21
+    eol: true
+
+  - releaseCycle: Nougat (Android 7.x)
+    release: 2016-08-22
+    eol: true
+
+  - releaseCycle: Marshmallow (Android 6.0.x)
+    release: 2015-10-05
+    eol: true
+
+  - releaseCycle: Lollipop (Android 5.0 – 5.1.1)
+    release: 2014-11-12
+    eol: true
+
+  - releaseCycle: KitKat (Android 4.4.x)
+    release: 2013-10-31
+    eol: true
+
+  - releaseCycle: Jelly Bean (Android 4.1 – 4.3.1)
+    release: 2012-07-09
+    eol: true
+
+  - releaseCycle: Ice Cream Sandwich (Android 4.0.x)
+    release: 2011-10-18
+    eol: true
+
+  - releaseCycle: Honeycomb (Android 3.x)
+    release: 2011-02-22
+    eol: true
+
+  - releaseCycle: Gingerbread (Android 2.3.x)
+    release: 2010-12-06
+    eol: true
+
+  - releaseCycle: Froyo (Android 2.2.x)
+    release: 2010-05-20
+    eol: true
+
+  - releaseCycle: Eclair (Android 2.0-2.1)
+    release: 2009-10-26
+    eol: true
+
+  - releaseCycle: Donut (Android 1.6)
+    release: 2009-09-15
+    eol: true
+
+  - releaseCycle: Cupcake (Android 1.5)
+    release: 2009-04-27
+    eol: true
+
+  - releaseCycle: Petit Four (Android 1.1)
+    release: 2009-02-09
+    eol: true
+
+  - releaseCycle: "Android 1.0"
+    release: 2008-09-23
+    eol: true
+
 ---
 
 >Android is a mobile operating system based on a modified version of the Linux kernel and other open source software, designed primarily for touchscreen mobile devices such as smartphones and tablets.


### PR DESCRIPTION
* Mark 8.1.x as EOL
* Reorder versions
* Add /androidos as alternative url
* Update link to cover all versions