### PR TITLE
[rails] Release ver 6.0.4.4, 6.1.4.4

### DIFF
--- a/products/ruby-on-rails.md
+++ b/products/ruby-on-rails.md
@@ -16,11 +16,11 @@ releases:
   - releaseCycle: "6.1"
     release: 2020-12-09
     eol: false
-    latest: "6.1.4.3"
+    latest: "6.1.4.4"
   - releaseCycle: "6.0"
     release: 2019-08-16
     eol: false
-    latest: "6.0.4.3"
+    latest: "6.0.4.4"
   - releaseCycle: "5.2"
     release: 2018-04-09
     eol: false


### PR DESCRIPTION
- Rails 6.0.4.4, and 6.1.4.4 have been released | Ruby on Rails
  - https://rubyonrails.org/2021/12/15/Rails-6-0-4-4-and-6-1-4-4-have-been-released