### PR TITLE
Remove locale from upstream URLs

### DIFF
--- a/products/citrix-apps-desktops.md
+++ b/products/citrix-apps-desktops.md
@@ -9,7 +9,7 @@ alternate_urls:
 layout: post
 iconSlug: citrix
 category: app
-link: https://www.citrix.com/en-gb/support/product-lifecycle/product-matrix.html
+link: https://www.citrix.com/support/product-lifecycle/product-matrix
 activeSupportColumn: true
 releaseColumn: false
 releaseDateColumn: true

--- a/products/consul.md
+++ b/products/consul.md
@@ -4,7 +4,7 @@ layout: post
 permalink: /consul
 category: server-app
 iconSlug: consul
-link: https://support.hashicorp.com/hc/en-us/articles/360021185113-Support-Period-and-End-of-Life-EOL-Policy
+link: https://support.hashicorp.com/hc/articles/360021185113
 sortReleasesBy: "release"
 changelogTemplate: https://github.com/hashicorp/consul/blob/v__LATEST__/CHANGELOG.md
 activeSupportColumn: false

--- a/products/dotnetfx.md
+++ b/products/dotnetfx.md
@@ -54,4 +54,4 @@ releases:
 
 > [.NET Framework](https://dotnet.microsoft.com/) is a software framework developed by Microsoft that runs primarily on Microsoft Windows. It includes a large class library called Framework Class Library (FCL) and provides language interoperability across several programming languages.
 
-On operating systems prior to Windows 10 version 1809 and Windows Server 2019, .NET 3.5 SP1 [assumes the same lifecycle policy](https://docs.microsoft.com/en-us/lifecycle/faq/dotnet-framework) as the underlying OS on which it is installed.
+On operating systems prior to Windows 10 version 1809 and Windows Server 2019, .NET 3.5 SP1 [assumes the same lifecycle policy](https://docs.microsoft.com/lifecycle/faq/dotnet-framework) as the underlying OS on which it is installed.

--- a/products/firefox.md
+++ b/products/firefox.md
@@ -3,7 +3,7 @@ permalink: /firefox
 title: Firefox
 
 layout: post
-link: https://www.mozilla.org/en-US/firefox/
+link: https://www.mozilla.org/firefox/
 releaseDateColumn: true
 releaseColumn: true
 iconSlug: firefox
@@ -40,13 +40,13 @@ releases:
 
 
 ---
-> [Firefox](https://www.mozilla.org/en-US/firefox/browsers/), is a free and open-source web browser developed by the Mozilla. Firefox is available for [Windows][ff-win], [macOS][ff-mac], [Android][ff-android], [iOS][ff-ios], and [Linux][ff-linux], and [ChromeOS][ff-chromeos].
+> [Firefox](https://www.mozilla.org/firefox/browsers/), is a free and open-source web browser developed by the Mozilla. Firefox is available for [Windows][ff-win], [macOS][ff-mac], [Android][ff-android], [iOS][ff-ios], and [Linux][ff-linux], and [ChromeOS][ff-chromeos].
 
 ## Firefox has two main release channels:
 
  - **Firefox:** Simply named Firefox, this is the default channel and is the one recommended. It's the stable branch with the latest features available. Once a new release is out, the older release immediately stops receiving support and everyone must migrate to the next Firefox release.
 
- - **Firefox Extended Support Release (ESR):** is an official version of Firefox developed for large organizations like universities and businesses that need to set up and maintain Firefox on a large scale. Firefox ESR does not come with the latest features, but it has the latest security and stability fixes. Usually these branches are supported for a year, [with a planned release calendar for new ESR branches.](https://wiki.mozilla.org/Release_Management/Calendar) For more information you should review the [release cycle documentation.](https://support.mozilla.org/en-US/kb/firefox-esr-release-cycle)
+ - **Firefox Extended Support Release (ESR):** is an official version of Firefox developed for large organizations like universities and businesses that need to set up and maintain Firefox on a large scale. Firefox ESR does not come with the latest features, but it has the latest security and stability fixes. Usually these branches are supported for a year, [with a planned release calendar for new ESR branches.](https://wiki.mozilla.org/Release_Management/Calendar) For more information you should review the [release cycle documentation.](https://support.mozilla.org/kb/firefox-esr-release-cycle)
 
 ## Firefox also has three testing channels:
 
@@ -62,12 +62,12 @@ releases:
 
 - Firefox 78 ESR is the last version of Firefox that supports Flash. The last version of that ESR will be 78.15, which is scheduled to be released on 2021-10-05. This means that Flash will officially be out of support on Firefox when Firefox 78 ESR reaches EOL on 2021-11-02.
 - Firefox 78 ESR is the last version of Firefox that supports macOS versions < 10.12.
-- Firefox only supports last 3 macOS releases, [matching the Apple support cycle.](https://support.mozilla.org/en-US/kb/firefox-mac-osx-users-esr)
+- Firefox only supports last 3 macOS releases, [matching the Apple support cycle.](https://support.mozilla.org/kb/firefox-mac-osx-users-esr)
 - On iOS Firefox is forced by Apple to use WebKit rendering engine instead of Firefox's own Gecko, for similar reasons browser-addons are not allowed on iOS unlike on Android. [Both of these limitations are due to Apple's rules for submitting apps to the App Store.](https://developer.apple.com/app-store/review/guidelines/)
 
-[ff-win]: https://support.mozilla.org/en-US/kb/how-download-and-install-firefox-windows
-[ff-android]: https://support.mozilla.org/en-US/products/mobile
-[ff-ios]: https://support.mozilla.org/en-US/products/ios
-[ff-mac]: https://support.mozilla.org/en-US/kb/how-download-and-install-firefox-mac
-[ff-linux]: https://support.mozilla.org/en-US/kb/install-firefox-linux
-[ff-chromeos]: https://support.mozilla.org/en-US/kb/run-firefox-chromeos
+[ff-win]: https://support.mozilla.org/kb/how-install-firefox-windows
+[ff-android]: https://support.mozilla.org/products/mobile
+[ff-ios]: https://support.mozilla.org/products/ios
+[ff-mac]: https://support.mozilla.org/kb/how-download-and-install-firefox-mac
+[ff-linux]: https://support.mozilla.org/kb/install-firefox-linux
+[ff-chromeos]: https://support.mozilla.org/kb/run-firefox-chromeos

--- a/products/iphone.md
+++ b/products/iphone.md
@@ -90,6 +90,6 @@ releases:
 
 > The iPhone is a line of smartphones designed and marketed by Apple Inc. that use Apple's iOS mobile operating system.
 
-Most likely, new iPhone models will come out in September every year (with a few possible exceptions). iPhone support (supported devices gets the latest iOS updates) is quite long. Apple occasionally releases security updates for much older devices, such as [this security fix in iOS 12.5.2](https://support.apple.com/en-us/HT212257) which was pushed to iPhone 6 and iPhone 5S.
+Most likely, new iPhone models will come out in September every year (with a few possible exceptions). iPhone support (supported devices gets the latest iOS updates) is quite long. Apple occasionally releases security updates for much older devices, such as [this security fix in iOS 12.5.2](https://support.apple.com/HT212257) which was pushed to iPhone 6 and iPhone 5S.
 
-Apple maintains a list of Supported iPhone models at <https://support.apple.com/en-in/guide/iphone/iphe3fa5df43/ios>.
+Apple maintains a list of Supported iPhone models at <https://support.apple.com/guide/iphone/iphe3fa5df43>.

--- a/products/looker.md
+++ b/products/looker.md
@@ -98,5 +98,5 @@ A list of officially supported releases is [published](https://docs.looker.com/r
 [esr]: https://docs.looker.com/relnotes/esr-overview "Standard extended support release program overview"
 [emails]: https://docs.looker.com/relnotes/release-emails "Release deployment emails"
 [schedule]: https://docs.looker.com/relnotes/hosted-maintenance-hours "Google maintenance policy for Looker-hosted services"
-[best-practices]: https://help.looker.com/hc/en-us/articles/360023639354-Best-Practices-when-Updating-your-Looker-Instance "Best Practices when Updating your Looker Instance"
+[best-practices]: https://help.looker.com/hc/articles/360023639354 "Best Practices when Updating your Looker Instance"
 [lfs]: https://docs.looker.com/relnotes/legacy-feature-schedule#legacy_feature_schedule "Legacy feature schedule"

--- a/products/msexchange.md
+++ b/products/msexchange.md
@@ -4,7 +4,7 @@ permalink: /msexchange
 layout: post
 iconSlug: microsoftexchange
 category: server-app
-link: https://docs.microsoft.com/en-gb/lifecycle/products/?terms=Exchange%20Server
+link: https://docs.microsoft.com/lifecycle/products/?terms=Exchange%20Server
 activeSupportColumn: true
 command: Get-ExchangeServer | Format-List Name,Edition,AdminDisplayVersion
 releaseDateColumn: true
@@ -44,7 +44,7 @@ releases:
 
 > [Microsoft Exchange Server](https://en.wikipedia.org/wiki/Microsoft_Exchange_Server) is a mail server and calendaring server developed by Microsoft.
 
-[Exchange Server build numbers and release dates](https://docs.microsoft.com/en-us/exchange/new-features/build-numbers-and-release-dates)
+[Exchange Server build numbers and release dates](https://docs.microsoft.com/exchange/new-features/build-numbers-and-release-dates)
 
 CU: Cumulative Update  
 SU: Security Update  

--- a/products/mssqlserver.md
+++ b/products/mssqlserver.md
@@ -4,7 +4,7 @@ permalink: /mssqlserver
 layout: post
 iconSlug: microsoftsqlserver
 category: db
-link: https://support.microsoft.com/en-us/lifecycle/search?terms=SQL%20Server
+link: https://docs.microsoft.com/lifecycle/products/?terms=SQL%20Server
 activeSupportColumn: true
 command: select @@version
 releaseDateColumn: true
@@ -42,9 +42,9 @@ releases:
     latest: "10.50.6560.0 SP3 GDR"
 ---
 
->[SQLServer](https://www.microsoft.com/en-us/sql-server/): Microsoft SQL Server is a relational database management system developed by Microsoft.
+>[SQLServer](https://www.microsoft.com/sql-server/): Microsoft SQL Server is a relational database management system developed by Microsoft.
 
-[Latest updates for Microsoft SQL Server](https://docs.microsoft.com/en-us/sql/database-engine/install-windows/latest-updates-for-microsoft-sql-server)
+[Latest updates for Microsoft SQL Server](https://docs.microsoft.com/sql/database-engine/install-windows/latest-updates-for-microsoft-sql-server)
 
 Each of the products has its own Technical Support Policy, which determine the lifetime and scope of product support.
 

--- a/products/nomad.md
+++ b/products/nomad.md
@@ -4,7 +4,7 @@ layout: post
 permalink: /nomad
 iconSlug: "NA"
 category: server-app
-link: https://support.hashicorp.com/hc/en-us/articles/360021185113-Support-Period-and-End-of-Life-EOL-Policy
+link: https://support.hashicorp.com/hc/articles/360021185113
 sortReleasesBy: "releaseCycle"
 changelogTemplate: https://github.com/hashicorp/nomad/blob/v__LATEST__/CHANGELOG.md
 activeSupportColumn: false

--- a/products/nvidiadriver.md
+++ b/products/nvidiadriver.md
@@ -33,7 +33,7 @@ releases:
     support: 2019-03-20
     eol: 2022-03-01
     latest: "418.197.02"
-    link: https://docs.nvidia.com/datacenter/tesla/tesla-release-notes-418-19702
+    link: https://docs.nvidia.com/datacenter/tesla/tesla-release-notes-418-19702/
     cycleShortHand: 3
     
   - releaseCycle: "R418-Windows (LTSB)"
@@ -41,7 +41,7 @@ releases:
     support: 2019-04-23
     eol: 2022-03-01
     latest: "427.45"
-    link: https://docs.nvidia.com/datacenter/tesla/tesla-release-notes-418-19702
+    link: https://docs.nvidia.com/datacenter/tesla/tesla-release-notes-418-19702/
     cycleShortHand: 4
 
   - releaseCycle: "R450-Linux (LTSB)"
@@ -49,7 +49,7 @@ releases:
     support: 2020-10-7
     eol: 2023-07-01
     latest: "450.142.00"
-    link: https://docs.nvidia.com/datacenter/tesla/tesla-release-notes-450-142-00
+    link: https://docs.nvidia.com/datacenter/tesla/tesla-release-notes-450-142-00/
     cycleShortHand: 5
     
   - releaseCycle: "R450-Windows (LTSB)"
@@ -57,7 +57,7 @@ releases:
     support: 2020-12-15
     eol: 2023-07-01
     latest: "453.10"
-    link: https://docs.nvidia.com/datacenter/tesla/tesla-release-notes-450-142-00
+    link: https://docs.nvidia.com/datacenter/tesla/tesla-release-notes-450-142-00/
     cycleShortHand: 6
 
   - releaseCycle: "R460-Linux (PB)"
@@ -65,7 +65,7 @@ releases:
     support: 2021-7-19
     eol: 2022-01-01
     latest: "460.91.03"
-    link: https://docs.nvidia.com/datacenter/tesla/tesla-release-notes-460-91-03
+    link: https://docs.nvidia.com/datacenter/tesla/tesla-release-notes-460-91-03/
     cycleShortHand: 7
     
   - releaseCycle: "R460-Windows (PB)"
@@ -73,7 +73,7 @@ releases:
     support: 2021-06-23
     eol: 2022-01-01
     latest: "462.96"
-    link: https://docs.nvidia.com/datacenter/tesla/tesla-release-notes-460-91-03
+    link: https://docs.nvidia.com/datacenter/tesla/tesla-release-notes-460-91-03/
     cycleShortHand: 8
 
   - releaseCycle: "R470-Linux (LTSB)"

--- a/products/nvidiadriver.md
+++ b/products/nvidiadriver.md
@@ -17,7 +17,7 @@ releases:
     support: 2018-03-10
     eol: 2022-12-31
     latest: "390.144"
-    link: https://www.nvidia.com/Download/driverResults.aspx/177153/en-us
+    link: https://www.nvidia.com/Download/driverResults.aspx/177153
     cycleShortHand: 1
 
   - releaseCycle: "R390-Windows (LTSB)"
@@ -25,7 +25,7 @@ releases:
     support: 2018-07-31
     eol: 2022-12-31
     latest: "392.67"
-    link: https://www.nvidia.com/download/driverResults.aspx/177167/en-us
+    link: https://www.nvidia.com/download/driverResults.aspx/177167
     cycleShortHand: 2
 
   - releaseCycle: "R418-Linux (LTSB)"
@@ -33,7 +33,7 @@ releases:
     support: 2019-03-20
     eol: 2022-03-01
     latest: "418.197.02"
-    link: https://docs.nvidia.com/datacenter/tesla/tesla-release-notes-418-19702/index.html
+    link: https://docs.nvidia.com/datacenter/tesla/tesla-release-notes-418-19702
     cycleShortHand: 3
     
   - releaseCycle: "R418-Windows (LTSB)"
@@ -41,7 +41,7 @@ releases:
     support: 2019-04-23
     eol: 2022-03-01
     latest: "427.45"
-    link: https://docs.nvidia.com/datacenter/tesla/tesla-release-notes-418-19702/index.html
+    link: https://docs.nvidia.com/datacenter/tesla/tesla-release-notes-418-19702
     cycleShortHand: 4
 
   - releaseCycle: "R450-Linux (LTSB)"
@@ -49,7 +49,7 @@ releases:
     support: 2020-10-7
     eol: 2023-07-01
     latest: "450.142.00"
-    link: https://docs.nvidia.com/datacenter/tesla/tesla-release-notes-450-142-00/index.html
+    link: https://docs.nvidia.com/datacenter/tesla/tesla-release-notes-450-142-00
     cycleShortHand: 5
     
   - releaseCycle: "R450-Windows (LTSB)"
@@ -57,7 +57,7 @@ releases:
     support: 2020-12-15
     eol: 2023-07-01
     latest: "453.10"
-    link: https://docs.nvidia.com/datacenter/tesla/tesla-release-notes-450-142-00/index.html
+    link: https://docs.nvidia.com/datacenter/tesla/tesla-release-notes-450-142-00
     cycleShortHand: 6
 
   - releaseCycle: "R460-Linux (PB)"
@@ -65,7 +65,7 @@ releases:
     support: 2021-7-19
     eol: 2022-01-01
     latest: "460.91.03"
-    link: https://docs.nvidia.com/datacenter/tesla/tesla-release-notes-460-91-03/index.html
+    link: https://docs.nvidia.com/datacenter/tesla/tesla-release-notes-460-91-03
     cycleShortHand: 7
     
   - releaseCycle: "R460-Windows (PB)"
@@ -73,7 +73,7 @@ releases:
     support: 2021-06-23
     eol: 2022-01-01
     latest: "462.96"
-    link: https://docs.nvidia.com/datacenter/tesla/tesla-release-notes-460-91-03/index.html
+    link: https://docs.nvidia.com/datacenter/tesla/tesla-release-notes-460-91-03
     cycleShortHand: 8
 
   - releaseCycle: "R470-Linux (LTSB)"
@@ -81,7 +81,7 @@ releases:
     support: 2021-10-26
     eol: 2024-09-01
     latest: "470.86"
-    link: https://www.nvidia.com/Download/driverResults.aspx/183575/en-us
+    link: https://www.nvidia.com/Download/driverResults.aspx/183575
     cycleShortHand: 9
     
   - releaseCycle: "R470-Windows (LTSB)"
@@ -97,7 +97,7 @@ releases:
     support: true
     eol: false
     latest: "496.98"
-    link: https://nvidia.custhelp.com/app/answers/detail/a_id/5281/?linkId=100000087757792
+    link: https://nvidia.custhelp.com/app/answers/detail/a_id/5281
     cycleShortHand: 11
 
   - releaseCycle: "R495-Linux (NFB)"
@@ -105,12 +105,12 @@ releases:
     support: true
     eol: false
     latest: "495.44"
-    link: https://www.nvidia.com/Download/driverResults.aspx/181274/en-us
+    link: https://www.nvidia.com/Download/driverResults.aspx/181274
     cycleShortHand: 11
 
 ---
 
-> Nvidia designs graphics processing units (GPUs) for the gaming and professional markets, as well as system on a chip units (SoCs) for the mobile computing and automotive market. This page tracks Nvidia drivers, which provide support for their various GPU lineups and are [available for Windows, Linux, Solaris, and FreeBSD](https://www.nvidia.com/Download/index.aspx?lang=en-us).
+> Nvidia designs graphics processing units (GPUs) for the gaming and professional markets, as well as system on a chip units (SoCs) for the mobile computing and automotive market. This page tracks Nvidia drivers, which provide support for their various GPU lineups and are [available for Windows, Linux, Solaris, and FreeBSD](https://www.nvidia.com/Download/index.aspx).
 
 Nvidia drivers are released in various release branches, with varying support timelines and GPU support.
 

--- a/products/nvidiaproducts.md
+++ b/products/nvidiaproducts.md
@@ -189,7 +189,7 @@ releases:
     discontinued: false
 ---
 
-> Nvidia designs <abbr title="Graphics Processing Unit">GPUs</abbr> for the gaming and professional markets, as well as system on a chip units (SoCs) for the mobile computing and automotive market. This page tracks Nvidia GPUs, which provide support for their various GPU lineups and are [available for Windows, Linux, Solaris, and FreeBSD](https://www.nvidia.com/Download/index.aspx?lang=en-us).
+> Nvidia designs <abbr title="Graphics Processing Unit">GPUs</abbr> for the gaming and professional markets, as well as system on a chip units (SoCs) for the mobile computing and automotive market. This page tracks Nvidia GPUs, which provide support for their various GPU lineups and are [available for Windows, Linux, Solaris, and FreeBSD](https://www.nvidia.com/Download/index.aspx).
 
 ## Naming scheme
 

--- a/products/office.md
+++ b/products/office.md
@@ -6,7 +6,7 @@ alternate_urls:
 layout: post
 iconSlug: microsoftoffice
 category: app
-link: https://support.microsoft.com/en-us/lifecycle/search?terms=Office
+link: https://docs.microsoft.com/lifecycle/products/?terms=Office
 activeSupportColumn: true
 releaseColumn: false
 releaseDateColumn: true
@@ -48,4 +48,4 @@ releases:
 
 > Microsoft Office, or simply Office, is a family of client software, server software, and services developed by Microsoft.
 
-Note that Microsoft Office 2019 for Mac is [only supported until 2023-10-10](https://docs.microsoft.com/en-us/lifecycle/products/microsoft-office-2019-for-mac).
+Note that Microsoft Office 2019 for Mac is [only supported until 2023-10-10](https://docs.microsoft.com/lifecycle/products/microsoft-office-2019-for-mac).

--- a/products/visualstudio.md
+++ b/products/visualstudio.md
@@ -79,7 +79,7 @@ releases:
     
 iconSlug: visualstudio
 permalink: /visualstudio
-link: https://docs.microsoft.com/en-us/visualstudio/releases/2019/servicing
+link: https://docs.microsoft.com/visualstudio/releases/2019/servicing-vs2019
 activeSupportColumn: false
 releaseColumn: false
 releaseDateColumn: false

--- a/products/windows.md
+++ b/products/windows.md
@@ -86,8 +86,8 @@ releases:
 | (W)  | Home, Pro, Pro Education and Pro for Workstations editions |
 | LTS  | Long-Term Servicing Channel                                |
 
-[Windows 11 release information](https://docs.microsoft.com/en-us/windows/release-health/windows11-release-information)  
-[Windows 10 release information](https://docs.microsoft.com/en-us/windows/release-health/release-information)  
+[Windows 11 release information](https://docs.microsoft.com/windows/release-health/windows11-release-information)
+[Windows 10 release information](https://docs.microsoft.com/windows/release-health/release-information)
 [Microsoft Support Windows Lifecycle Fact Sheet](https://support.microsoft.com/en-in/help/13853/windows-lifecycle-fact-sheet)
 
 Beginning with Windows 10, version 21H2, feature updates for Windows 10 release are released annually, in the second half of the calendar year.

--- a/products/windows.md
+++ b/products/windows.md
@@ -92,4 +92,4 @@ releases:
 
 Beginning with Windows 10, version 21H2, feature updates for Windows 10 release are released annually, in the second half of the calendar year.
 
-Prior releases (to Windows 10) are governed by the Fixed Lifecycle Policy. This policy comprises two phases: mainstream support and extended support.
+Prior releases (to Windows 10) are governed by the [Fixed Lifecycle Policy](https://docs.microsoft.com/lifecycle/policies/fixed). This policy comprises two phases: mainstream support and extended support.

--- a/products/windows.md
+++ b/products/windows.md
@@ -86,8 +86,8 @@ releases:
 | (W)  | Home, Pro, Pro Education and Pro for Workstations editions |
 | LTS  | Long-Term Servicing Channel                                |
 
-[Windows 11 release information](https://docs.microsoft.com/windows/release-health/windows11-release-information)
-[Windows 10 release information](https://docs.microsoft.com/windows/release-health/release-information)
+[Windows 11 release information](https://docs.microsoft.com/windows/release-health/windows11-release-information)  
+[Windows 10 release information](https://docs.microsoft.com/windows/release-health/release-information)  
 [Windows Lifecycle FAQ](https://docs.microsoft.com/lifecycle/faq/windows)
 
 Beginning with Windows 10, version 21H2, feature updates for Windows 10 release are released annually, in the second half of the calendar year.

--- a/products/windows.md
+++ b/products/windows.md
@@ -88,7 +88,7 @@ releases:
 
 [Windows 11 release information](https://docs.microsoft.com/windows/release-health/windows11-release-information)
 [Windows 10 release information](https://docs.microsoft.com/windows/release-health/release-information)
-[Microsoft Support Windows Lifecycle Fact Sheet](https://support.microsoft.com/en-in/help/13853/windows-lifecycle-fact-sheet)
+[Windows Lifecycle FAQ](https://docs.microsoft.com/lifecycle/faq/windows)
 
 Beginning with Windows 10, version 21H2, feature updates for Windows 10 release are released annually, in the second half of the calendar year.
 

--- a/products/windows.md
+++ b/products/windows.md
@@ -2,7 +2,7 @@
 title: Windows
 layout: post
 permalink: /windows
-link: https://support.microsoft.com/en-us/lifecycle/search?terms=Windows
+link: https://docs.microsoft.com/lifecycle/products/?terms=Windows
 category: os
 activeSupportColumn: true
 releaseColumn: false

--- a/products/windowsEmbedded.md
+++ b/products/windowsEmbedded.md
@@ -3,7 +3,7 @@ title: Windows Embedded
 layout: post
 permalink: /windowsembedded
 iconSlug: windows
-link: https://support.microsoft.com/en-us/lifecycle/search?terms=Windows%20Embedded
+link: https://docs.microsoft.com/lifecycle/products/?terms=Windows%20Embedded
 category: os
 activeSupportColumn: true
 releaseColumn: false

--- a/products/windowsServer.md
+++ b/products/windowsServer.md
@@ -3,7 +3,7 @@ title: Windows Server
 permalink: /windowsserver
 iconSlug: windows
 layout: post
-link: https://support.microsoft.com/en-us/lifecycle/search?terms=Windows%20Server
+link: https://docs.microsoft.com/lifecycle/products/?terms=Windows%20Server
 category: os
 activeSupportColumn: true
 command: winver

--- a/recommendations.md
+++ b/recommendations.md
@@ -233,5 +233,5 @@ nice to have. If you do provide such an image, here's some recommendations:
 
 Feedback on this document is welcome [on GitHub](https://github.com/endoflife-date/endoflife.date/discussions/new?title=Feedback%20on%20Recommendations%20for%20Maintainers&category=general).
 
-[aks]: https://docs.microsoft.com/en-us/azure/aks/supported-kubernetes-versions?tabs=azure-cli#aks-kubernetes-release-calendar
+[aks]: https://docs.microsoft.com/azure/aks/supported-kubernetes-versions?tabs=azure-cli#aks-kubernetes-release-calendar
 [eks]: https://docs.aws.amazon.com/eks/latest/userguide/kubernetes-versions.html#kubernetes-release-calendar


### PR DESCRIPTION
1. If Microsoft Documentation links do not have a locale, it will automatically detect and redirect to the user's locale.

Currently, the links to Windows 11 and 10 release information have "en-us" in them and Windows Lifecycle Fact Sheet has "en-in".

So having `https://docs.microsoft.com/windows/release-health/windows11-release-information` will automatically redirect to `https://docs.microsoft.com/{USER'S LOCALE}/windows/release-health/windows11-release-information` instead of having the locale of the person who originally copy pasted it.

2. The current Lifecycle Fact Sheet link redirects to a Windows Lifecycle FAQ page. The URL has been changed to the newer one.

3. A link to Fixed Lifecycle Policy documentation has been added.