### PR TITLE
Change Visual Studio servicing docs link to a generic one

### DIFF
--- a/products/visualstudio.md
+++ b/products/visualstudio.md
@@ -79,7 +79,7 @@ releases:
     
 iconSlug: visualstudio
 permalink: /visualstudio
-link: https://docs.microsoft.com/visualstudio/releases/2019/servicing-vs2019
+link: https://docs.microsoft.com/visualstudio/productinfo/vs-servicing
 activeSupportColumn: false
 releaseColumn: false
 releaseDateColumn: false


### PR DESCRIPTION
Change Visual Studio servicing documentation link from the [2019 specific one](https://docs.microsoft.com/en-au/visualstudio/releases/2019/servicing-vs2019) to [a generic one](https://docs.microsoft.com/en-au/visualstudio/productinfo/vs-servicing).

If you look at the headings under "In this article" on the right side of the pages, they're broadly the same. The generic one has additional headings for Community Edition and Preview Channel support.

[Original suggestion](https://github.com/endoflife-date/endoflife.date/pull/683#issuecomment-1002124758) from @usta.