### PR TITLE
[site] Link to recommendations in header

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,9 @@
 
 Keep track of various End of Life dates and support lifecycles for various products. Visit <https://endoflife.date> for a list of supported products. This information is very often [hard to track or badly presented](https://twitter.com/captn3m0/status/1110504412064239617). This project collates this data and presents it in an easily accessible format, with URLs that are easy to guess and remember.
 
-Currently tracking 60+ products.
+If you maintain release information (end-of-life dates, or support information) for a product, we have a [set of recommendations](https://endoflife.date/recommendations) along with a checklist on some best practices for publishing this information.
+
+Currently tracking 89+ products.
 
 ## Contributing
 

--- a/_config.yml
+++ b/_config.yml
@@ -24,6 +24,8 @@ nav_sort: case_insensitive
 search_enabled: true
 # These links show up on the top
 aux_links:
+  recommendations:
+    - /recommendations
   contribute:
     - /contribute
   source:

--- a/recommendations.md
+++ b/recommendations.md
@@ -7,6 +7,7 @@ alternate_urls:
   - /advise
   - /advice
 ---
+# Recommendations for publishing End-of-life dates and support timelines
 
 If you maintain a product that has some notion of support lifecycle and end-of-life,
 these are our recommendations on how to best document this information for your users.


### PR DESCRIPTION
- [x] Link to Recommendations in the README
- [x] Link to recommendations in the top header
- [x] Add a header to the recommendations page (this is mainly for SEO, better suggestions are welcome).

I like the current main title: `Recommendations for maintainers | endoflife.date` (which will remain as-is as the page `<title>`), but the page feels like missing a bit of context if you link it to someone. Hence, this attempt at providing a heading. Using the existing title as heading also didn't feel good enough (not enough context).