### PR TITLE
[apache] Minor tweaks to the Apache HTTP Server product

### DIFF
--- a/products/apache-http-server.md
+++ b/products/apache-http-server.md
@@ -7,14 +7,14 @@ iconSlug: apache
 layout: post
 link: https://httpd.apache.org/
 category: server-app
-activeSupportColumn: true
+activeSupportColumn: false
 command: httpd -v
-releaseColumn: false
+releaseColumn: true
 releaseDateColumn: true
 sortReleasesBy: "releaseCycle"
 releases:
   - releaseCycle: "2.4"
-    release: 2012-02-21
+    release: 2021-12-20
     eol: false
     latest: "2.4.52"
   - releaseCycle: "2.2"
@@ -23,5 +23,6 @@ releases:
     latest: "2.2.34"
 ---
 > [Apache HTTP Server](https://httpd.apache.org/) is a collaborative software development effort aimed at creating a robust, commercial-grade, feature-rich and freely available source code implementation of an HTTP (Web) server.
-The update and release strategy is _complex_. For release policy information, see https://httpd.apache.org/dev/release.html.
-For licensing information, see https://www.apache.org/licenses/
+
+The update and release strategy is _complex_. For release policy information, see <https://httpd.apache.org/dev/release.html>.
+For licensing information, see <https://www.apache.org/licenses/>

--- a/products/apache-http-server.md
+++ b/products/apache-http-server.md
@@ -14,9 +14,10 @@ releaseDateColumn: true
 sortReleasesBy: "releaseCycle"
 releases:
   - releaseCycle: "2.4"
-    release: 2021-12-20
+    release: 2012-02-21
     eol: false
     latest: "2.4.52"
+    link: https://downloads.apache.org/httpd/Announcement2.4.html
   - releaseCycle: "2.2"
     release: 2005-12-01
     eol: 2017-07-11


### PR DESCRIPTION
I'm suggesting a few format changes to make this product display more like this other product, https://endoflife.date/dotnet , as I think it's more similar.

*Change 1 - hide Active Support column*
The Apache HTTP Server page currently shows Active Support "No" for the 2.4 version, which I believe is incorrect, though I'll admit I'm not sure what "Active Support" is meant to mean nor am I clear on how "supported" Apache HTTP Server is. Feels safer to omit this column rather that represent information which may be inaccurate.

*Change 2 - update the release date to reflect when 2.4.52 was released (rather than the original 2012 release date)*
The page shows 2.4 was released in 2012... technically correct, but I believe it's more helpful to show that the latest version 2.4.52 was released very recently on 12/2021.

*Change 3 - show release column*
According to the announcement https://downloads.apache.org/httpd/Announcement2.4.html , this latest version "is recommended over all previous releases" which implies consumers should update. Thus, seems important to make sure we show the minor version in the release column.