### PR TITLE
[elixir] Add 1.13 , update eol dates and update latest versions

### DIFF
--- a/products/elixir.md
+++ b/products/elixir.md
@@ -10,39 +10,54 @@ activeSupportColumn: true
 releaseDateColumn: true
 sortReleasesBy: "release"
 releases:
+  - releaseCycle: "1.13"
+    release: 2021-12-03 # https://github.com/elixir-lang/elixir/releases/tag/v1.13.0
+    eol: 2024-06-01 # projected release date of 1.18.0
+    support: 2022-06-01 # projected release date of 1.14.0
+    latest: "1.13.1"
+  - releaseCycle: "1.12"
+    release: 2021-05-19 # https://github.com/elixir-lang/elixir/releases/tag/v1.12.0
+    eol: 2023-12-01 # projected release date of 1.17.0
+    support: 2021-12-03 # release date of 1.13.0
+    latest: "1.12.3"
+  - releaseCycle: "1.11"
+    release: 2020-10-06 # https://github.com/elixir-lang/elixir/releases/tag/v1.11.0
+    eol: 2023-06-01 # projected release date of 1.16.0
+    support: 2021-05-19 # release date of 1.12.0
+    latest: "1.11.4"
   - releaseCycle: "1.10"
     release: 2020-01-27
-    eol: 2022-07-27 # projected release date of 1.15
-    support: 2020-06-27 # projected release date of 1.11.0
-    latest: "1.10.2"
+    eol: 2022-12-01 # projected release date of 1.15.0
+    support: 2020-10-06 # release date of 1.11.0
+    latest: "1.10.4"
   - releaseCycle: "1.9"
     release: 2019-06-24
-    eol: 2020-01-27 # projected release date of 1.14
+    eol: 2022-06-01 # projected release date of 1.14.0
     support: 2020-01-27 # release date of 1.10.0
     latest: "1.9.4"
   - releaseCycle: "1.8"
     release: 2019-01-14
-    eol: 2021-07-01 # projected release date of 1.13
+    eol: 2021-12-03 # release date of 1.13.0
     support: 2019-06-24 # release date of 1.9.0
     latest: "1.8.2"
   - releaseCycle: "1.7"
     release: 2018-07-25
-    eol: 2021-01-01 # projected release date of 1.12
+    eol: 2021-05-19 # release date of 1.12.0
     support: 2019-01-14 # release date of 1.8.0
     latest: "1.7.4"
   - releaseCycle: "1.6"
     release: 2018-01-17
-    eol: 2020-07-01 # projected release date of 1.11
+    eol: 2020-10-06 # release date of 1.11.0
     support: 2018-07-25 # release date of 1.7.0
     latest: "1.6.6"
   - releaseCycle: "1.5"
     release: 2017-07-25
-    eol: 2020-01-27 # release date of 1.10
+    eol: 2020-01-27 # release date of 1.10.0
     support: 2018-01-17 # release date of 1.6.0
     latest: "1.5.3"
   - releaseCycle: "1.4"
     release: 2017-01-05
-    eol: 2019-06-24 # release date of 1.9
+    eol: 2019-06-24 # release date of 1.9.0
     support: 2017-07-25 # release date of 1.5.0
     latest: "1.4.5"
 ---

--- a/products/elixir.md
+++ b/products/elixir.md
@@ -14,7 +14,7 @@ releases:
     release: 2021-12-03 # https://github.com/elixir-lang/elixir/releases/tag/v1.13.0
     eol: 2024-06-01 # projected release date of 1.18.0
     support: 2022-06-01 # projected release date of 1.14.0
-    latest: "1.13.1"
+    latest: "1.13.2"
   - releaseCycle: "1.12"
     release: 2021-05-19 # https://github.com/elixir-lang/elixir/releases/tag/v1.12.0
     eol: 2023-12-01 # projected release date of 1.17.0

--- a/products/elixir.md
+++ b/products/elixir.md
@@ -14,7 +14,7 @@ releases:
     release: 2021-12-03 # https://github.com/elixir-lang/elixir/releases/tag/v1.13.0
     eol: 2024-06-01 # projected release date of 1.18.0
     support: 2022-06-01 # projected release date of 1.14.0
-    latest: "1.13.2"
+    latest: "1.13.1"
   - releaseCycle: "1.12"
     release: 2021-05-19 # https://github.com/elixir-lang/elixir/releases/tag/v1.12.0
     eol: 2023-12-01 # projected release date of 1.17.0


### PR DESCRIPTION
This PR also makes version 1.9 marked as "Security Support **true** through the release of 1.14.0" which matches Elixir's website: https://hexdocs.pm/elixir/compatibility-and-deprecations.html