### PR TITLE
[apache] Adds two more older major versions

### DIFF
--- a/products/apache-http-server.md
+++ b/products/apache-http-server.md
@@ -22,6 +22,14 @@ releases:
     release: 2005-12-01
     eol: 2017-07-11
     latest: "2.2.34"
+  - releaseCycle: "2.0"
+    release: 2002-04-06
+    eol: 2013-07-10
+    latest: "2.0.65"
+  - releaseCycle: "1.3"
+    release: 1998-06-06
+    eol: 2010-02-03
+    latest: "1.3.42"
 ---
 > [Apache HTTP Server](https://httpd.apache.org/) is a collaborative software development effort aimed at creating a robust, commercial-grade, feature-rich and freely available source code implementation of an HTTP (Web) server.
 


### PR DESCRIPTION
Data taken from the Wikipedia page for [Apache HTTP Server](https://en.wikipedia.org/wiki/Apache_HTTP_Server)
<img width="344" alt="Screen Shot 2022-01-07 at 7 11 33 PM" src="https://user-images.githubusercontent.com/16943514/148627630-c1a47e06-73c3-4928-8e4c-4d736d77ac8b.png">

Sources for data:
Original release for 1.3 - 1998-06-06 - https://marc.info/?l=apache-httpd-announce&m=90221040625561
1.3 final release was 1.3.4, EOL 2010-02-03 - https://lists.apache.org/thread/w6hp1srpq0l0k2n445t0q9z0rs0mhodk

Original release for 2.0 - 2002-04-06 - https://marc.info/?l=apache-httpd-announce&m=101810732100356
2.0 final release was 2.0.65, EOL 2013-07-10 - https://lists.apache.org/thread/98t1yjk1c3ngzh8wdx55d1ct9vd1koov