### PR TITLE
Bumps Elasticsearch latest versions

### DIFF
--- a/products/elasticsearch.md
+++ b/products/elasticsearch.md
@@ -13,7 +13,7 @@ releases:
   - releaseCycle: "7.16"
     cycleShortHand: 716
     eol: 2023-06-07
-    latest: 7.16.1
+    latest: 7.16.2
   - releaseCycle: "7.15"
     cycleShortHand: 715
     eol: 2023-03-22
@@ -81,7 +81,7 @@ releases:
   - releaseCycle: "6.8"
     cycleShortHand: 608
     eol: 2022-02-08
-    latest: 6.8.21
+    latest: 6.8.22
   - releaseCycle: "6.7"
     cycleShortHand: 607
     eol: 2020-09-26


### PR DESCRIPTION
7.16.2 - https://www.elastic.co/guide/en/elasticsearch/reference/current/release-notes-7.16.2.html
6.8.22 - https://www.elastic.co/guide/en/elasticsearch/reference/6.8/release-notes-6.8.22.html