### PR TITLE
[Kindle] Fix eol date

### DIFF
--- a/products/kindle.md
+++ b/products/kindle.md
@@ -43,7 +43,7 @@ releases:
     link: https://s3.amazonaws.com/firmwarereleasenotes/update_kindle_oasis/ATVPDKIKX0DER/en_US.html
   - releaseCycle: "Kindle Voyage (7th Generation)"
     release: 2014-11-04
-    eol: 2020-04-01
+    eol: 2021-04-01
     latest: "5.13.6"
     link: https://s3.amazonaws.com/firmwarereleasenotes/update_kindle_voyage/ATVPDKIKX0DER/en_US.html
   - releaseCycle: "Kindle Paperwhite 3 (7th Generation)"


### PR DESCRIPTION
I noticed that I inputted a small typo in my last commit 918af23d3723a54a91d04946e64b6d991d09d207, but it was merged before I noticed.

Also in the regards to the discussion on #723, If determined that I entirely botched the EoL dates beyond this typo then this PR can also serve to revert and rectify it.