### PR TITLE
[Consul] Added 1.11.x

### DIFF
--- a/products/consul.md
+++ b/products/consul.md
@@ -12,18 +12,22 @@ releaseDateColumn: true
 command: consul --version
 
 releases:
+  - releaseCycle: "1.11"
+    eol: false
+    release: 2021-12-14
+    latest: "1.11.1"
   - releaseCycle: "1.10"
     eol: false
     release: 2021-06-22
-    latest: "1.10.5"
+    latest: "1.10.6"
   - releaseCycle: "1.9"
     eol: false
     release: 2020-11-24
-    latest: "1.9.12"
+    latest: "1.9.13"
   - releaseCycle: "1.8"
-    eol: false
+    eol: true
     release: 2020-06-18
-    latest: "1.8.18"
+    latest: "1.8.19"
 ---
 > [Hashicorp Consul](https://www.consul.io/) automates networking for simple and secure application delivery.
 


### PR DESCRIPTION
Added the 1.11.x release cycle. Release date has been set to the release date of 1.11.0, but the latest has been set to 1.11.1 (which was released one day after).
Also the latest versions in the 1.10.x, 1.9.x and 1.8.x have been updated.
1.8.x has been marked End Of Life as discussed here: https://discuss.hashicorp.com/t/question-about-supported-consul-versions/33222