### PR TITLE
[macos] Fix release specific links

### DIFF
--- a/products/macos.md
+++ b/products/macos.md
@@ -6,17 +6,19 @@ layout: post
 category: os
 category: device
 sortReleasesBy: "release"
-changelogTemplate: "https://link/of/the/__RELEASE_CYCLE__/and/__LATEST__/version"
 releases:
   - releaseCycle: "macOS 12 (Monterey)"
     release: 2021-10-25
     eol: false
+    link: https://support.apple.com/en-us/HT212585
   - releaseCycle: "macOS 11 (Big Sur)"
     release: 2020-11-12
     eol: false
+    link: https://support.apple.com/en-us/HT211896
   - releaseCycle: "macOS 10.15 (Catalina)"
     release: 2019-10-07
     eol: false
+    link: https://support.apple.com/en-asia/HT210642
   - releaseCycle: "macOS 10.14 (Mojave)"
     release: 2018-09-24
     eol: 2021-10-25

--- a/products/macos.md
+++ b/products/macos.md
@@ -10,15 +10,15 @@ releases:
   - releaseCycle: "macOS 12 (Monterey)"
     release: 2021-10-25
     eol: false
-    link: https://support.apple.com/en-us/HT212585
+    link: https://support.apple.com/HT212585
   - releaseCycle: "macOS 11 (Big Sur)"
     release: 2020-11-12
     eol: false
-    link: https://support.apple.com/en-us/HT211896
+    link: https://support.apple.com/HT211896
   - releaseCycle: "macOS 10.15 (Catalina)"
     release: 2019-10-07
     eol: false
-    link: https://support.apple.com/en-asia/HT210642
+    link: https://support.apple.com/HT210642
   - releaseCycle: "macOS 10.14 (Mojave)"
     release: 2018-09-24
     eol: 2021-10-25


### PR DESCRIPTION
Using point-release changelogs since those are more relevant
for the current latest release.

We could follow the features link, such as 
https://www.apple.com/macos/monterey/features/

for a new release cycle, and switch to the support.apple
link once a point release is made.