### PR TITLE
Fix Debian API URLs

### DIFF
--- a/products/debian.md
+++ b/products/debian.md
@@ -10,43 +10,48 @@ releaseColumn: true
 releaseDateColumn: true
 sortReleasesBy: 'release'
 releases:
-  - releaseCycle: 'Debian 11 "Bullseye"'
+  - releaseCycle: "11"
+    cycleShortHand: "Bullseye"
     release: 2021-08-14
     eol: 2026-08-15
     latest: "11.2"
     link: https://www.debian.org/News/2021/20211009
-  - releaseCycle: 'Debian 10 "Buster"'
+  - releaseCycle: "10"
+    cycleShortHand: "Buster"
     release: 2019-07-06
     eol: 2024-06-01
     latest: "10.11"
     link: https://www.debian.org/News/2021/2021100902
-  - releaseCycle: 'Debian 9 "Stretch"'
     # Debian has its LTS and non-LTS version in same time
     # We are keeping both of them until non-LTS reaches EOL
+  - releaseCycle: "9"
+    cycleShortHand: "Stretch"
     release: 2017-06-17
     eol: 2022-06-30
     lts: true
     latest: "9.13"
     link: https://lists.debian.org/debian-announce/2020/msg00004.html
-  - releaseCycle: 'Debian 9 "Stretch"'
     # Debian has its LTS and non-LTS version in same time
     # We are keeping both of them until non-LTS reaches EOL
     release: 2017-06-17
     eol: 2020-01-01
     latest: "9.13"
     link: https://lists.debian.org/debian-announce/2020/msg00004.html
-  - releaseCycle: 'Debian 8 "Jessie"'
+  - releaseCycle: "8"
+    cycleShortHand: "Jessie"
     release: 2015-04-26
     eol: 2020-06-30
     lts: true
     latest: "8.11"
     link: https://www.debian.org/News/2015/20150426
-  - releaseCycle: 'Debian 7 "Wheezy"'
+  - releaseCycle: "7"
+    cycleShortHand: "Wheezy"
     release: 2013-05-04
     eol: 2018-05-31
     lts: true
     link: https://www.debian.org/News/2013/20130504
-  - releaseCycle: 'Debian 6 "Squeeze"'
+  - releaseCycle: "6"
+    cycleShortHand: "Squeeze"
     release: 2011-02-06
     eol: 2016-02-29
     lts: true

--- a/products/debian.md
+++ b/products/debian.md
@@ -15,7 +15,7 @@ releases:
     release: 2021-08-14
     eol: 2026-08-15
     latest: "11.2"
-    link: https://www.debian.org/News/2021/20211009
+    link: https://www.debian.org/News/2021/20211218
   - releaseCycle: "10"
     cycleShortHand: "Buster"
     release: 2019-07-06

--- a/products/debian.md
+++ b/products/debian.md
@@ -22,19 +22,11 @@ releases:
     eol: 2024-06-01
     latest: "10.11"
     link: https://www.debian.org/News/2021/2021100902
-    # Debian has its LTS and non-LTS version in same time
-    # We are keeping both of them until non-LTS reaches EOL
   - releaseCycle: "9"
     cycleShortHand: "Stretch"
     release: 2017-06-17
     eol: 2022-06-30
     lts: true
-    latest: "9.13"
-    link: https://lists.debian.org/debian-announce/2020/msg00004.html
-    # Debian has its LTS and non-LTS version in same time
-    # We are keeping both of them until non-LTS reaches EOL
-    release: 2017-06-17
-    eol: 2020-01-01
     latest: "9.13"
     link: https://lists.debian.org/debian-announce/2020/msg00004.html
   - releaseCycle: "8"

--- a/products/debian.md
+++ b/products/debian.md
@@ -51,13 +51,11 @@ releases:
     eol: 2016-02-29
     lts: true
     link: https://www.debian.org/News/2011/20110205a
-
 ---
-
-> [Debian](https://www.debian.org/) is a free operating system for your computer. The Debian Stable branch is the most popular edition for personal computers and network servers, and is used as the basis for many other Linux distributions.
+> [Debian](https://www.debian.org/) is a free operating system for your computer. The Debian stable branch is the most popular edition for personal computers and network servers, and is used as the basis for many other Linux distributions.
 
 At any given time, there is one stable release of Debian, which has the support of the Debian security team. When a new stable version is released, the security team will usually cover the previous version for a year or so, while they also cover the new/current version. Only stable is recommended for production use.
 
 [Debian Long Term Support (LTS)](https://wiki.debian.org/LTS) is a project to extend the lifetime of all Debian stable releases to (at least) 5 years. Debian LTS will not be handled by the Debian security team, but by a separate group of volunteers and companies interested in making it a success. Not all packages of the Debian archive are supported by LTS, the [debian-security-support](https://wiki.debian.org/LTS/Using#Check_for_unsupported_packages) package can check for unsupported packages.
 
-A commercial offering for [Extended Long Term Support](https://wiki.debian.org/LTS/Extended) is available
+A commercial offering for [Extended Long Term Support](https://wiki.debian.org/LTS/Extended) is available.

--- a/products/debian.md
+++ b/products/debian.md
@@ -49,12 +49,14 @@ releases:
     release: 2013-05-04
     eol: 2018-05-31
     lts: true
+    latest: "7.11"
     link: https://www.debian.org/News/2013/20130504
   - releaseCycle: "6"
     cycleShortHand: "Squeeze"
     release: 2011-02-06
     eol: 2016-02-29
     lts: true
+    latest: "6.0.10"
     link: https://www.debian.org/News/2011/20110205a
 ---
 > [Debian](https://www.debian.org/) is a free operating system for your computer. The Debian stable branch is the most popular edition for personal computers and network servers, and is used as the basis for many other Linux distributions.

--- a/products/debian.md
+++ b/products/debian.md
@@ -2,7 +2,7 @@
 permalink: /debian
 layout: post
 title: Debian
-command: lsb_release --release
+command: cat /etc/os-release
 category: os
 link: https://wiki.debian.org/DebianReleases
 activeSupportColumn: false


### PR DESCRIPTION
I would like to make a couple of suggestions. 

I want to use the API. The issue here is that the URL is very inconvenient as the path needs to be urlencoded and is generated from the `releaseCycle` field. Example:
```
$ curl -sf https://endoflife.date/api/debian/Debian%209%20%22Stretch%22.json | jq
```

Something like this would be much easier to work with:
```
curl -sf https://endoflife.date/api/debian/9.json | jq
```

This means also that you can already understand how the API works, even if you dont know much details about your requesting product. At the moment you have to request the product, urlencode the releaseCycle and generate a new request.
My shorter path would be usable even if you don't know the current release tag. urlencoding is probbaly not a problem with JavaScript. But doing this on a shell is a nightmare. So I split the fields and introduced `cycleShortHand` for Debian.

Debian 9 is in LTS now. So I removed the 2nd Debian 9 block. But there is also something to discuss. Its not true that there is a non-LTS and a LTS version of a release at the same time. The LTS starts when the support for a release is dropped by the Debian Security Team. The Question is how to handle this? Just add a LTS flag at the end of the official support? Should be EOL date the point when official support is dropped? Or when the LTS is dropped?
An other way could be to add releases like `9-LTS`. This is "released" when the official support is dropped. 
Here is also another idea for this: https://github.com/endoflife-date/endoflife.date/issues/156
Here was this also a topic: https://github.com/endoflife-date/endoflife.date/pull/456 I have checked it and there is no need to change something on the system to get LTS support. The apt sources are the same as for the regular stable release.

I have added a some other changes: `cat /etc/os-release` contains more and better information than `lsb_release`. I have also added the latest version of 6 and 7. also some typos.

Some of my points also hit other products like Ubuntu.
