### PR TITLE
[ubuntu] updated to reflect ESM

### DIFF
--- a/products/ubuntu.md
+++ b/products/ubuntu.md
@@ -21,8 +21,8 @@ releases:
   - releaseCycle: "21.04 'Hirsute Hippo'"
     cycleShortHand: "HirsuteHippo"
     release: 2021-04-22
-    support: 2022-01-22
-    eol:     2022-01-22
+    support: 2022-01-20
+    eol:     2022-01-20
     latest: "21.10"
     link: https://wiki.ubuntu.com/HirsuteHippo/ReleaseNotes/
   - releaseCycle: "20.10 'Groovy Gorilla'"

--- a/products/ubuntu.md
+++ b/products/ubuntu.md
@@ -35,8 +35,8 @@ releases:
     cycleShortHand: "FocalFossa"
     lts: true
     release: 2020-04-23
-    support: 2030-04-01
-    eol:     2025-04-02
+    support: 2025-04-02
+    eol:     2030-04-01
     latest: "20.04.3"
   - releaseCycle: "19.10 'Karmic Koala'"
     cycleShortHand: "KarmicKoala"
@@ -48,23 +48,23 @@ releases:
     cycleShortHand: "BionicBeaver"
     lts: true
     release: 2018-04-26
-    support: 2028-04-01
-    eol:     2023-04-02
+    support: 2023-04-02
+    eol:     2028-04-01
     latest: "18.04.6"
     link: https://wiki.ubuntu.com/BionicBeaver/ReleaseNotes/
   - releaseCycle: "16.04 'Xenial Xerus'"
     cycleShortHand: "XenialXerus"
     lts: true
     release: 2016-04-21
-    support: 2026-04-01
-    eol:     2021-04-02
+    support: 2021-04-02
+    eol:     2026-04-01
     latest: "16.04.7"
   - releaseCycle: "14.04 'TrustyTahr'"
     cycleShortHand: "TrustyTahr"
     lts: true
     release: 2014-04-17
-    support: 2024-04-01
-    eol:     2019-04-02
+    support: 2019-04-02
+    eol:     2024-04-01
     latest: "14.04.6"
 ---
 >[Ubuntu](https://ubuntu.com) is a free and open-source Linux distribution based on Debian. Ubuntu is officially released in three editions: Desktop, Server, and Core (for IoT devices and robots).

--- a/products/ubuntu.md
+++ b/products/ubuntu.md
@@ -23,7 +23,7 @@ releases:
     release: 2021-04-22
     support: 2022-01-20
     eol:     2022-01-20
-    latest: "21.10"
+    latest: "21.04"
     link: https://wiki.ubuntu.com/HirsuteHippo/ReleaseNotes/
   - releaseCycle: "20.10 'Groovy Gorilla'"
     cycleShortHand: "GroovyGorilla"

--- a/products/ubuntu.md
+++ b/products/ubuntu.md
@@ -21,9 +21,9 @@ releases:
   - releaseCycle: "21.04 'Hirsute Hippo'"
     cycleShortHand: "HirsuteHippo"
     release: 2021-04-22
-    support: 2022-01-01
-    eol:     2022-01-01
-    latest: "21.04"
+    support: 2022-01-22
+    eol:     2022-01-22
+    latest: "21.10"
     link: https://wiki.ubuntu.com/HirsuteHippo/ReleaseNotes/
   - releaseCycle: "20.10 'Groovy Gorilla'"
     cycleShortHand: "GroovyGorilla"
@@ -35,7 +35,7 @@ releases:
     cycleShortHand: "FocalFossa"
     lts: true
     release: 2020-04-23
-    support: 2022-10-01
+    support: 2030-04-01
     eol:     2025-04-02
     latest: "20.04.3"
   - releaseCycle: "19.10 'Karmic Koala'"
@@ -48,7 +48,7 @@ releases:
     cycleShortHand: "BionicBeaver"
     lts: true
     release: 2018-04-26
-    support: 2020-09-30
+    support: 2028-04-01
     eol:     2023-04-02
     latest: "18.04.6"
     link: https://wiki.ubuntu.com/BionicBeaver/ReleaseNotes/
@@ -56,14 +56,14 @@ releases:
     cycleShortHand: "XenialXerus"
     lts: true
     release: 2016-04-21
-    support: 2018-10-01
+    support: 2026-04-01
     eol:     2021-04-02
     latest: "16.04.7"
   - releaseCycle: "14.04 'TrustyTahr'"
     cycleShortHand: "TrustyTahr"
     lts: true
     release: 2014-04-17
-    support: 2016-09-30
+    support: 2024-04-01
     eol:     2019-04-02
     latest: "14.04.6"
 ---
@@ -71,11 +71,11 @@ releases:
 
 Releases of Ubuntu get a development codename ("Breezy Badger") and are versioned by the year and month of delivery - for example Ubuntu 17.10 was released in October 2017. LTS or "Long Term Support" releases are published every two years in April. Every six months between LTS versions, Canonical publishes an interim release of Ubuntu. See [this link](https://www.ubuntu.com/about/release-cycle) for more details on the Ubuntu Release Cycle.
 
-LTS releases are supported for 5 years, while interim releases are supported for 9 months. Packages in `main` and `restricted` are supported for 5 years in long term support (LTS) releases. Ubuntu [Flavors](https://wiki.ubuntu.com/UbuntuFlavors) generally support their packages for 3 years in LTS releases but there are exceptions.
+LTS releases are in "General Support" for 5 years and "Extended Security Maintenance" (see below) for an additional 5 years. Interim releases are supported for 9 months. Packages in `main` and `restricted` are supported for 5 years in long term support (LTS) releases. Ubuntu [Flavors](https://wiki.ubuntu.com/UbuntuFlavors) generally support their packages for 3 years in LTS releases but there are exceptions.
 
 During the lifetime of an Ubuntu release, Canonical provides security maintenance. Basic Security Maintenance covers binary packages that reside in the `main` and `restricted` components of the Ubuntu archive, typically for a period of 5 years from LTS release.
 
-Extended Security Maintenance (ESM) is a paid option through Ubuntu Advantage to get extended support and security updates for select server packages. Please see the [Ubuntu Website]({{page.link}}) for details.
+Extended Security Maintenance (ESM) provides security updates on Ubuntu LTS releases for additional 5 years. It is available with the Ubuntu Advantage subscription or a Free subscription. Please see the [Ubuntu Website]({{page.link}}) for details.
 
 The dates for active and security support are taken from [here](https://github.com/canonical-web-and-design/ubuntu.com/blob/master/static/js/src/chart-data.js) what is used for the graph rendering on the [Release Cycle Page](https://www.ubuntu.com/about/release-cycle).
 


### PR DESCRIPTION
Updated with latest information from https://wiki.ubuntu.com/Releases

16.04 and 14.04 are not EOL and are still receiving security updates via ESM.