### PR TITLE
Add FFmpeg

### DIFF
--- a/products/ffmpeg.md
+++ b/products/ffmpeg.md
@@ -4,7 +4,7 @@ permalink: /ffmpeg
 layout: post
 category: framework
 icon: FFmpeg
-changelogTemplate: https://git.ffmpeg.org/gitweb/ffmpeg.git/shortlog/n{{"__LATEST__"}}
+changelogTemplate: https://ffmpeg.org/download.html#release_{{"__LATEST__"}}
 command: ffmpeg -version
 activeSupportColumn: false
 releaseDateColumn: true

--- a/products/ffmpeg.md
+++ b/products/ffmpeg.md
@@ -6,7 +6,7 @@ category: framework
 icon: FFmpeg
 changelogTemplate: https://git.ffmpeg.org/gitweb/ffmpeg.git/shortlog/n{{"__LATEST__"}}
 command: ffmpeg -version
-activeSupportColumn: false
+activeSupportColumn: true
 releaseDateColumn: true
 iconSlug: None
 eolColumn: Supported

--- a/products/ffmpeg.md
+++ b/products/ffmpeg.md
@@ -8,7 +8,6 @@ changelogTemplate: https://git.ffmpeg.org/gitweb/ffmpeg.git/shortlog/n{{"__LATES
 command: ffmpeg -version
 activeSupportColumn: true
 releaseDateColumn: true
-iconSlug: None
 eolColumn: Supported
 sortReleasesBy: cycleShortHand
 releases:

--- a/products/ffmpeg.md
+++ b/products/ffmpeg.md
@@ -1,0 +1,38 @@
+---
+title: FFmpeg
+permalink: /ffmpeg
+layout: post
+category: framework
+changelogTemplate: https://git.ffmpeg.org/gitweb/ffmpeg.git/shortlog/n{{"__LATEST__"}}
+command: ffmpeg -version
+activeSupportColumn: false
+releaseDateColumn: true
+iconSlug: None
+eolColumn: Supported
+sortReleasesBy: cycleShortHand
+releases:
+  - releaseCycle: "FFmpeg 5.0 "Lorentz""
+    cycleShortHand: 50
+    release: 2022-01-17
+    eol: false
+    latest: "5.0"
+    lts: true
+  - releaseCycle: "FFmpeg 4.4 "Rao""
+    cycleShortHand: 44
+    release:  2021-04-09
+    eol: false
+    latest: "4.4.1"
+  - releaseCycle: "FFmpeg 4.3 "4:3""
+    cycleShortHand: 43
+    release: 2020-06-15
+    eol: 2021-10-21
+    latest: "4.3.3"
+    
+---
+
+> [FFmpeg](https://ffmpeg.org/) is a free and open-source software project consisting of a suite of libraries and programs for handling video, audio, and other multimedia files and streams. It is the core of software such as VLC, MPV, Blender, Audacity, HandBrake, OBS Studio, and much more. Full list of capabilities are found [in their documentation](https://ffmpeg.org/ffmpeg.html).
+
+
+## Releases
+
+Starting with the first LTS release FFmpeg 5.0 "Lorentz", FFmpeg is releasing one major release per year, and a LTS every other year.  Note that these releases are intended for distributors and system integrators, not for end users. End users are usually encouraged to use the [latest git snapshots instead](https://ffmpeg.org/download.html). 

--- a/products/ffmpeg.md
+++ b/products/ffmpeg.md
@@ -11,20 +11,20 @@ releaseDateColumn: true
 eolColumn: Supported
 sortReleasesBy: cycleShortHand
 releases:
-  - releaseCycle: "FFmpeg 5.0 'Lorentz'"
+  - releaseCycle: "5.0 'Lorentz'"
     cycleShortHand: 50
     release: 2022-01-17
     eol: false
     latest: "5.0"
     lts: true
     link: https://ffmpeg.org/download.html#release_5.0
-  - releaseCycle: "FFmpeg 4.4 'Rao'"
+  - releaseCycle: "4.4 'Rao'"
     cycleShortHand: 44
     release:  2021-04-09
     eol: false
     latest: "4.4.1"
     link: https://ffmpeg.org/download.html#release_4.4
-  - releaseCycle: "FFmpeg 4.3 '4:3'"
+  - releaseCycle: "4.3 '4:3'"
     cycleShortHand: 43
     release: 2020-06-15
     eol: 2021-10-21

--- a/products/ffmpeg.md
+++ b/products/ffmpeg.md
@@ -4,6 +4,7 @@ permalink: /ffmpeg
 layout: post
 category: framework
 icon: FFmpeg
+releasePolicyLink: https://ffmpeg.org/
 command: ffmpeg -version
 activeSupportColumn: false
 releaseDateColumn: true

--- a/products/ffmpeg.md
+++ b/products/ffmpeg.md
@@ -3,6 +3,7 @@ title: FFmpeg
 permalink: /ffmpeg
 layout: post
 category: framework
+icon: FFmpeg
 changelogTemplate: https://git.ffmpeg.org/gitweb/ffmpeg.git/shortlog/n{{"__LATEST__"}}
 command: ffmpeg -version
 activeSupportColumn: false

--- a/products/ffmpeg.md
+++ b/products/ffmpeg.md
@@ -4,7 +4,6 @@ permalink: /ffmpeg
 layout: post
 category: framework
 icon: FFmpeg
-changelogTemplate: https://ffmpeg.org/download.html#release_{{"__LATEST__"}}
 command: ffmpeg -version
 activeSupportColumn: false
 releaseDateColumn: true
@@ -17,16 +16,19 @@ releases:
     eol: false
     latest: "5.0"
     lts: true
+    link: https://ffmpeg.org/download.html#release_5.0
   - releaseCycle: "FFmpeg 4.4 'Rao'"
     cycleShortHand: 44
     release:  2021-04-09
     eol: false
     latest: "4.4.1"
+    link: https://ffmpeg.org/download.html#release_4.4
   - releaseCycle: "FFmpeg 4.3 '4:3'"
     cycleShortHand: 43
     release: 2020-06-15
     eol: 2021-10-21
     latest: "4.3.3"
+    link: https://ffmpeg.org/download.html#release_4.3
     
 ---
 

--- a/products/ffmpeg.md
+++ b/products/ffmpeg.md
@@ -6,7 +6,7 @@ category: framework
 icon: FFmpeg
 changelogTemplate: https://git.ffmpeg.org/gitweb/ffmpeg.git/shortlog/n{{"__LATEST__"}}
 command: ffmpeg -version
-activeSupportColumn: true
+activeSupportColumn: false
 releaseDateColumn: true
 eolColumn: Supported
 sortReleasesBy: cycleShortHand

--- a/products/ffmpeg.md
+++ b/products/ffmpeg.md
@@ -11,18 +11,18 @@ releaseDateColumn: true
 eolColumn: Supported
 sortReleasesBy: cycleShortHand
 releases:
-  - releaseCycle: "FFmpeg 5.0 "Lorentz""
+  - releaseCycle: "FFmpeg 5.0 'Lorentz'"
     cycleShortHand: 50
     release: 2022-01-17
     eol: false
     latest: "5.0"
     lts: true
-  - releaseCycle: "FFmpeg 4.4 "Rao""
+  - releaseCycle: "FFmpeg 4.4 'Rao'"
     cycleShortHand: 44
     release:  2021-04-09
     eol: false
     latest: "4.4.1"
-  - releaseCycle: "FFmpeg 4.3 "4:3""
+  - releaseCycle: "FFmpeg 4.3 '4:3'"
     cycleShortHand: 43
     release: 2020-06-15
     eol: 2021-10-21


### PR DESCRIPTION
Starting with FFmpeg 5.0, they are moving to releasing LTS and time-based releases, which makes it a great candidate to keep track of!

Sources used:

For release dates: https://ffmpeg.org/releases/

For list of software that use FFmpeg: https://en.wikipedia.org/wiki/Category:Software_that_uses_FFmpeg

Recommendation to use git snapshots instead of releases: https://ffmpeg.org/download.html