### PR TITLE
move docs link from left to top nav

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -30,8 +30,8 @@ aux_links:
     - /contribute
   source:
     - https://github.com/endoflife-date/endoflife.date
-  donate:
-    - https://github.com/sponsors/endoflife-date
+  api:
+    - /docs/api
 jekyll_timeago:
   # Use 2 terms in relative timestamps:
   # [YES] x years, y months

--- a/schema.html
+++ b/schema.html
@@ -2,4 +2,5 @@
 permalink: /docs/api
 layout: schema
 title: endoflife.date API Documentation
+nav_exclude: true
 ---


### PR DESCRIPTION
Docs was showing up in the left nav bar. This PR moves it to the top nav bar instead, replacing the donation link (we have one on the home page anyway).