### PR TITLE
update contributing with missing options

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -52,13 +52,15 @@ layout: post
 category: os
 
 # What should be used to sort releases. Set to one of:
-# releaseCycle/eol/support/release/cycleShortHand
+# releaseCycle/eol/support/release/cycleShortHand/latest/latestShortHand
 # which must be present in the releases underneath
 sortReleasesBy: "releaseCycle"
 
 # Template to be used to generate a link for the release
 # __RELEASE_CYCLE__ will be replaced by the value of releaseCycle
+# __CYCLE_SHORT_HAND__ will be replaced by the optional changelogTemplate
 # __LATEST__ will be replaced by the value of latest
+# __LATEST_SHORT_HAND__ will be replaced by the optional latestShortHand
 
 # You can even use Liquid Templating inside the template, such as:
 # https://godotengine.org/article/maintenance-release-godot-{{"__LATEST__" | replace:'.','-'}}
@@ -85,6 +87,8 @@ releases:
     latest: "1.2.3"
     # Can be true/false. Only use if discontinuedColumn is set to true
     discontinued: true
+    # Optional, can be used to sort releases, and as part of the changelogTemplate (__LATEST_SHORT_HAND__).
+    latestShortHand: "10203"
     # Optional, can be used to sort releases, and as part of the changelogTemplate (__CYCLE_SHORT_HAND__).
     # Useful for sorting because 1.2 comes after 1.10 in normal sorting, so using cycleShortHand values of 102, 110
     # makes sorting much easier


### PR DESCRIPTION
- add missing options to CONTRIBUTING

---

EDIT: Below no longer included

~- show release notes for all released~

previously it'd only show links for non EOL releases

this had the downside of having no links for EOL releases that do indeed
have release notes, and also presented release notes for release that
don't exist yet

this now shows releases for all actuall releases sand hides the link for
not yet released releases


**Before:**

1
![eol-before](https://user-images.githubusercontent.com/9866621/152357748-3ac90c88-2a65-42c3-b7fc-81cd644182b1.png)
2
![eol-before2](https://user-images.githubusercontent.com/9866621/152357767-8b478f69-d941-4be0-9ae7-e931e28b8986.png)

---

**After:**

1
![eol-after](https://user-images.githubusercontent.com/9866621/152357787-938f377a-3ec9-4cea-9969-9503639c27ab.png)
2
![eol-after2](https://user-images.githubusercontent.com/9866621/152357794-9b4a1a0b-45ae-4bc2-9529-a0a9de7f092e.png)

