### PR TITLE
MediaWiki: add timeline image

### DIFF
--- a/products/mediawiki.md
+++ b/products/mediawiki.md
@@ -4,6 +4,7 @@ layout: post
 category: server-app
 sortReleasesBy: "releaseCycle"
 changelogTemplate: "https://www.mediawiki.org/wiki/Release_notes/__RELEASE_CYCLE__"
+releaseImage: https://upload.wikimedia.org/wikipedia/mediawiki/timeline/j6ewb6m3bxxticwu9ifde277qxob995.png
 releases:
 #  - releaseCycle: "1.38"
 #    lts: false


### PR DESCRIPTION
But I guess https://github.com/endoflife-date/endoflife.date/pull/285 might make this useless?