### PR TITLE
[ci] Add Lighthouse CI

### DIFF
--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -16,3 +16,4 @@ jobs:
         with:
           urls: |
             ${{ steps.netlify.outputs.url }}/django
+          uploadArtifacts: true

--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -1,0 +1,17 @@
+name: Lighthouse CI
+on: pull_request
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Wait for the Netlify Preview
+        uses: jakepartusch/wait-for-netlify-action@v1
+        id: netlify
+        with:
+          site_name: 'endoflife-date'
+      - name: Audit URLs using Lighthouse
+        uses: treosh/lighthouse-ci-action@v8
+        with:
+          urls: |
+            ${{ steps.netlify.outputs.url }}/django

--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -10,6 +10,7 @@ jobs:
         id: netlify
         with:
           site_name: 'endoflife-date'
+          max_timeout: 150
       - name: Audit URLs using Lighthouse
         uses: treosh/lighthouse-ci-action@v8
         with:


### PR DESCRIPTION
Picked Django as a representative page: It has enough content, 2 tables, and a release schedule image.