### PR TITLE
Add ReadyNAS devices

### DIFF
--- a/products/readynas.md
+++ b/products/readynas.md
@@ -1,0 +1,74 @@
+---
+title: Netgear ReadyNAS
+layout: post
+category: device
+sortReleasesBy: "releaseCycle"
+changelogTemplate: "https://www.netgear.com/support/product/__RELEASE_CYCLE__.aspx"
+releases:
+- releaseCycle: "RN102"
+  eol: true
+- releaseCycle: "RN104"
+  eol: true
+- releaseCycle: "RN202"
+  eol: true
+- releaseCycle: "RN204"
+  eol: true
+- releaseCycle: "RN212"
+  eol: false
+- releaseCycle: "RN214"
+  eol: false
+- releaseCycle: "RN2120"
+  eol: true
+- releaseCycle: "RN312"
+  eol: true
+- releaseCycle: "RN314"
+  eol: true
+- releaseCycle: "RN316"
+  eol: true
+- releaseCycle: "RN422"
+  eol: false
+- releaseCycle: "RN424"
+  eol: false
+- releaseCycle: "RN426"
+  eol: false
+- releaseCycle: "RN516"
+  eol: true
+- releaseCycle: "RN524X"
+  eol: false
+- releaseCycle: "RN526X"
+  eol: false
+- releaseCycle: "RN528X"
+  eol: false
+- releaseCycle: "RN626X"
+  eol: false
+- releaseCycle: "RN628X"
+  eol: false
+- releaseCycle: "RN716X"
+  eol: true
+- releaseCycle: "RR2304"
+  eol: false
+- releaseCycle: "RN3130"
+  eol: false
+- releaseCycle: "RN3138"
+  eol: false
+- releaseCycle: "RN3220"
+  eol: true
+- releaseCycle: "RR3312"
+  eol: false
+- releaseCycle: "RR4312X"
+  eol: false
+- releaseCycle: "RR4360X"
+  eol: false
+- releaseCycle: "RR4360X"
+  eol: false
+- releaseCycle: "RR4360S"
+  eol: false
+iconSlug: NA
+permalink: /readynas
+activeSupportColumn: false
+releaseColumn: false
+releaseDateColumn: false
+---
+> ReadyNAS is a line of network-attached storages sold by [Netgear](https://www.netgear.com/).
+
+These devices run [ReadyNAS OS](https://www.netgear.fr/support/product/readynas_os_6.aspx), a Linux distribution based on Debian 8.

--- a/products/readynas.md
+++ b/products/readynas.md
@@ -59,8 +59,6 @@ releases:
   eol: false
 - releaseCycle: "RR4360X"
   eol: false
-- releaseCycle: "RR4360X"
-  eol: false
 - releaseCycle: "RR4360S"
   eol: false
 iconSlug: NA


### PR DESCRIPTION
I have one of those and noticed it is not supported anymore, so I thought this information could be useful to other people..

I could not find a support policy or EOL dates, but at least each device page mentions if it is EOL.