### PR TITLE
[composer] Wrong EOL date for 2.2

### DIFF
--- a/products/composer.md
+++ b/products/composer.md
@@ -6,7 +6,7 @@ sortReleasesBy: "releaseCycle"
 changelogTemplate: "https://getcomposer.org/changelog/__LATEST__"
 releases:
   - releaseCycle: "2.2"
-    eol: 2023-12-12
+    eol: 2023-12-31
     support: false
     release: 2021-12-22
     latest: "2.2.6"


### PR DESCRIPTION
The [blog post](https://blog.packagist.com/composer-2-2/) says "at least the end of 2023".
12-12 is a typo I made while writing https://github.com/endoflife-date/endoflife.date/pull/815.