### PR TITLE
Update LineageOS details.

### DIFF
--- a/products/lineageos.md
+++ b/products/lineageos.md
@@ -7,19 +7,28 @@ releases:
   - releaseCycle: "18.1"
     eol: false
     release: 2021-04-01
+    support: true
     link: https://lineageos.org/Changelog-25/
   - releaseCycle: "17.1"
     eol: false
     release: 2020-04-01
+    support: true
     link: https://lineageos.org/Changelog-24/
   - releaseCycle: "16.0"
-    eol: 2021-02-16
+    eol: false
     release: 2019-03-01
+    support: false
+    link: https://lineageos.org/Changelog-22/
+  - releaseCycle: "15.1"
+    eol: true
+    release: 2018-02-25
+    support: false
+    link: https://lineageos.org/Changelog-16/
 iconSlug: lineageos
 permalink: /lineageos
 alternate_urls:
   - /lineage
-activeSupportColumn: false
+activeSupportColumn: true
 releaseColumn: false
 releaseDateColumn: true
 discontinuedColumn: false


### PR DESCRIPTION
Since LineageOS separates their official builds and their source code, I think it should be displayed at two columns, or even more ( see below ).
LineageOS team is still merging monthly Android Security Patches for 16.0's source code, they only abandoned official builds for it.
So I think it's better to use "Active Support" column for whether you can or can not directly download ROMs at https://download.lineageos.org/ , and to use "Security Support" for whether their code base are still getting latest Android Security Patches.
But for 15.1 or older version, this still a problem. Their gerrit code review shows that haggertk@lineageos.org submitted a lot of updates for 15.1's code a week ago, but no Android Security Patches.
As LineageOS blog describes, they never lock any previous branch's source code, how to determin a branch reached EOL or not?