### PR TITLE
[magento] Update EoL for 2.4, 2.3

### DIFF
--- a/products/magento.md
+++ b/products/magento.md
@@ -10,17 +10,17 @@ command: php bin/magento --version
 releaseDateColumn: true
 sortReleasesBy: 'releaseCycle'
 releases:
-  - releaseCycle: "2.4"
+  - releaseCycle: "2.4.0-2.4.3"
     cycleShortHand: 2
     release: 2020-07-28
-    eol: false
-    support: true
+    eol: 2022-11-30
+    support: 2022-11-30
     latest: "2.4.3-p1"
   - releaseCycle: "2.3"
     cycleShortHand: 2
     release: 2018-11-28
-    eol: 2021-05-28
-    support: 2022-01-28
+    eol: 2022-07-31
+    support: 2022-09-30
     latest: "2.3.7-p2"
   - releaseCycle: "2.2"
     cycleShortHand: 2

--- a/products/magento.md
+++ b/products/magento.md
@@ -43,6 +43,7 @@ releases:
     release: 2018-11-28
     eol: 2022-09-30
     support: 2022-07-31
+    link: https://devdocs.magento.com/guides/v2.3/release-notes/2-3-7-p2.html
     latest: "2.3.7-p2"
   - releaseCycle: "2.2"
     cycleShortHand: 2

--- a/products/magento.md
+++ b/products/magento.md
@@ -15,25 +15,29 @@ releases:
     release: 2020-07-28
     eol: 2022-11-30
     support: 2022-11-30
+    link: https://devdocs.magento.com/guides/v2.4/release-notes/open-source-2-4-3.html
     latest: "2.4.3-p1"
   - releaseCycle: "2.4.2"
     cycleShortHand: 2
     release: 2020-07-28
     eol: 2022-11-30
     support: 2022-11-30
-    latest: "2.4.3-p1"
+    link: https://devdocs.magento.com/guides/v2.4/release-notes/open-source-2-4-2.html
+    latest: "2.4.2-p2"
   - releaseCycle: "2.4.1"
     cycleShortHand: 2
     release: 2020-07-28
     eol: 2022-11-30
     support: 2022-11-30
-    latest: "2.4.3-p1"
+    link: https://devdocs.magento.com/guides/v2.4/release-notes/open-source-2-4-1.html
+    latest: "2.4.1"
   - releaseCycle: "2.4.0"
     cycleShortHand: 2
     release: 2020-07-28
     eol: 2022-11-30
     support: 2022-11-30
-    latest: "2.4.3-p1"
+    link: https://devdocs.magento.com/guides/v2.4/release-notes/release-notes-2-4-0-open-source.html
+    latest: "2.4.0"
   - releaseCycle: "2.3"
     cycleShortHand: 2
     release: 2018-11-28

--- a/products/magento.md
+++ b/products/magento.md
@@ -10,7 +10,25 @@ command: php bin/magento --version
 releaseDateColumn: true
 sortReleasesBy: 'releaseCycle'
 releases:
-  - releaseCycle: "2.4.0-2.4.3"
+  - releaseCycle: "2.4.3"
+    cycleShortHand: 2
+    release: 2020-07-28
+    eol: 2022-11-30
+    support: 2022-11-30
+    latest: "2.4.3-p1"
+  - releaseCycle: "2.4.2"
+    cycleShortHand: 2
+    release: 2020-07-28
+    eol: 2022-11-30
+    support: 2022-11-30
+    latest: "2.4.3-p1"
+  - releaseCycle: "2.4.1"
+    cycleShortHand: 2
+    release: 2020-07-28
+    eol: 2022-11-30
+    support: 2022-11-30
+    latest: "2.4.3-p1"
+  - releaseCycle: "2.4.0"
     cycleShortHand: 2
     release: 2020-07-28
     eol: 2022-11-30

--- a/products/magento.md
+++ b/products/magento.md
@@ -19,8 +19,8 @@ releases:
   - releaseCycle: "2.3"
     cycleShortHand: 2
     release: 2018-11-28
-    eol: 2022-07-31
-    support: 2022-09-30
+    eol: 2022-09-30
+    support: 2022-07-31
     latest: "2.3.7-p2"
   - releaseCycle: "2.2"
     cycleShortHand: 2

--- a/products/magento.md
+++ b/products/magento.md
@@ -43,7 +43,7 @@ releases:
     release: 2018-11-28
     eol: 2022-09-30
     support: 2022-07-31
-    link: https://devdocs.magento.com/guides/v2.3/release-notes/2-3-7-p2.html
+    link: https://devdocs.magento.com/guides/v2.3/release-notes/open-source-2-3-7.html
     latest: "2.3.7-p2"
   - releaseCycle: "2.2"
     cycleShortHand: 2


### PR DESCRIPTION
According to https://www.adobe.com/content/dam/cc/en/legal/terms/enterprise/pdfs/Magento-Open-Source-Software-Maintenance-Policy.pdf

Open Source 2.3
End of Magentoprovided bug fix maintenance: July 2021 
End of Magento-provided security maintenance: September 2022

Open Source 2.4.0-2.4.3
End of Magentoprovided bug fix maintenance: November 2022
End of Magento-provided security maintenance: November 2022

