### PR TITLE
Adds support for release and LTS templating

### DIFF
--- a/.github/workflows/auto-merge-release-updates.yml
+++ b/.github/workflows/auto-merge-release-updates.yml
@@ -18,7 +18,7 @@ jobs:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
       - name: Enable auto-merge for Dependabot PRs for release data
         if: ${{contains(steps.metadata.outputs.dependency-names, '_data/release-data')}}
-        run: gh pr merge --auto --merge "$PR_URL"
+        run: gh pr merge --auto --rebase "$PR_URL"
         env:
           PR_URL: ${{github.event.pull_request.html_url}}
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -69,10 +69,13 @@ sortReleasesBy: "releaseCycle"
 changelogTemplate: "https://link/of/the/__RELEASE_CYCLE__/and/__LATEST__/version"
 
 # Optional template that generates names for every release. Supports same templating as changelogTemplate.
+# Default value is `__RELEASE_CYCLE__``
 releaseLabel: "MoM Timeturner __RELEASE_CYCLE__ (__CODENAME__)"
 
 # The label that will be used alongside releases labelled with `lts: true`
 # Optional, only provide if the product has lts releases that are not called LTS, but something else.
+# Default Value is <abbr title='Long Term Support'>LTS</abbr>
+# Prefer using an HTML abbr tag, if possible.
 LTSLabel: "<abbr title='Extra Long Support'>ELS</abbr>"
 
 # Optional information about how release information can be fetched automatically
@@ -98,24 +101,37 @@ auto:
   # You can use liquid templating here
   template: '{{major}}.{{minor}}.{{patch}}{%if tiny %}p{{tiny}}{%endif%}'
 
+
 # A list of releases, supported or not
 # Newer releases go on top of the list, in order
 releases:
     # Release range (usually major.minor), always put in quotes
+    # Do not prefix with "v" or suffix with ".x"
+    # This becomes part of our API URL, so try to keep this hyphenated, instead of using spaces
+    # And use consistent case (lowercase prefered) if it uses words.
+    # Do not add releases that are not considered "stable" (such as RC/Alpha/Beta/Nightly)
   - releaseCycle: "1.2"
+    # Optionally, overwrite the release label on a per-release basis
+    # You can use templating here, though usually not required.
+    # Template parameters are same as releaseLabel above
+    releaseLabel: "Timeturner Firebolt (1.2)"
     # End of Security Support for the product. Alternatively, set to true|false if EOL is not pre-decided
-    # In case there is extended/commercial support available, pick the date most
+    # In case there is extended/commercial support available, pick the date that would apply to the majority of users.
     eol: 2019-01-01
     # End of Active Support for the product. This is where bugfixes usually stop coming in. (remove if activeSupportColumn=false)
     # Alternatively, set to true|false if it is not pre-decided
     support: 2018-01-31
     # Date of release for the product
     # remove if releaseDateColumn is false
+    # An approximate date is better than no date.
     release: 2017-03-12
     # Current latest release
     # remove if releaseColumn is false
     # always put in quotes
     latest: "1.2.3"
+    # Whether this is a "LTS" release. What LTS means may differ from product to product (see LTSLabel above)
+    # Optional, default false. Only provide for a release that will get a much longer support than usual.
+    lts: true
     # Can be true/false. Only use if discontinuedColumn is set to true
     discontinued: true
     # Optional, can be used to sort releases, and as part of the changelogTemplate (__LATEST_SHORT_HAND__).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -61,11 +61,19 @@ sortReleasesBy: "releaseCycle"
 # __CYCLE_SHORT_HAND__ will be replaced by the optional changelogTemplate
 # __LATEST__ will be replaced by the value of latest
 # __LATEST_SHORT_HAND__ will be replaced by the optional latestShortHand
+# __CODENAME__ will be replaced by the optional codename
 
 # You can even use Liquid Templating inside the template, such as:
 # https://godotengine.org/article/maintenance-release-godot-{{"__LATEST__" | replace:'.','-'}}
 # Do not use a localized URL (such as one containing en-us) if possible
 changelogTemplate: "https://link/of/the/__RELEASE_CYCLE__/and/__LATEST__/version"
+
+# Optional template that generates names for every release. Supports same templating as changelogTemplate.
+releaseLabel: "MoM Timeturner __RELEASE_CYCLE__ (__CODENAME__)"
+
+# The label that will be used alongside releases labelled with `lts: true`
+# Optional, only provide if the product has lts releases that are not called LTS, but something else.
+LTSLabel: "<abbr title='Extra Long Support'>ELS</abbr>"
 
 # Optional information about how release information can be fetched automatically
 # This is mainly used for the `latest` and `latestDate` fields of each release cycle
@@ -120,7 +128,10 @@ releases:
     # predictable and you can't use changelogTemplate.
     # Do not use a localized URL (such as one containing en-us) if possible
     link: https://example.com/news/2021-12-25/release-1.2.3
-    # Optioanlly, you can overwrite the `auto` key if this release was published on a different repository
+    # Optional field, not displayed anywhere by default. Can be used as __CODENAME__ in the releaseLabel and changelogTemplate
+    # Also returned as-as in the API.
+    codename: firebolt
+    # Optional. You can overwrite the `auto` key if this release was published on a different repository
     # Or doesn't have public sources for eg.
     auto: false
 

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -46,7 +46,7 @@ or +1 (EoL is in the future)
 {% assign LTSLabel = page.LTSLabel | default: '<abbr title="Long Term Support">LTS</abbr>' %}
 
 {% if r.releaseLabel %}{% assign t=r.releaseLabel%}{%else%}{%assign t=page.releaseLabel | default: '__RELEASE_CYCLE__' %}{%endif%}
-{% capture releaseCycleText %}{{t | replace: '__RELEASE_CYCLE__',r.releaseCycle  | replace: '__LATEST__',latestVersionNumber | replace: '__LATEST_SHORT_HAND__',r.latestShortHand | replace: '__CYCLE_SHORT_HAND__',r.cycleShortHand | replace: '__CODENAME__',r.codename}}{% if r.lts %} ({{LTSLabel}}){% endif %}{% endcapture %}
+{% capture releaseCycleText %}{{t | replace: '__RELEASE_CYCLE__',r.releaseCycle  | replace: '__LATEST__',latestVersionNumber | replace: '__LATEST_SHORT_HAND__',r.latestShortHand | replace: '__CYCLE_SHORT_HAND__',r.cycleShortHand | replace: '__CODENAME__',r.codename | liquify }}{% if r.lts %} ({{LTSLabel}}){% endif %}{% endcapture %}
 
 {% capture releaseLink %}
 {% if r.link and diff > 0 %}

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -39,17 +39,20 @@ or +1 (EoL is in the future)
 {% assign diff = r.eol | date: '%s' | plus:0 | minus:now %}
 {% endif %}
 
-
 {% assign diffSupport = support | minus:now %}
 {% assign diffSecurity6  = diff | minus:10651938 %}
 {% assign diffSupport6  = diffSupport | minus:10651938 %}
 {% assign latestVersionNumber = r.latest | liquify %}
-{% capture releaseCycleText %}{{r.releaseCycle}}{% if r.lts %} (LTS){% endif %}{% endcapture %}
+{% assign LTSLabel = page.LTSLabel | default: '<abbr title="Long Term Support">LTS</abbr>' %}
+
+{% if r.releaseLabel %}{% assign t=r.releaseLabel%}{%else%}{%assign t=page.releaseLabel | default: '__RELEASE_CYCLE__' %}{%endif%}
+{% capture releaseCycleText %}{{t | replace: '__RELEASE_CYCLE__',r.releaseCycle  | replace: '__LATEST__',latestVersionNumber | replace: '__LATEST_SHORT_HAND__',r.latestShortHand | replace: '__CYCLE_SHORT_HAND__',r.cycleShortHand | replace: '__CODENAME__',r.codename}}{% if r.lts %} ({{LTSLabel}}){% endif %}{% endcapture %}
+
 {% capture releaseLink %}
 {% if r.link and diff > 0 %}
 {{r.link}}
 {% elsif page.changelogTemplate and diff > 0 %}
-{{page.changelogTemplate | replace: '__RELEASE_CYCLE__',r.releaseCycle  | replace: '__LATEST__',latestVersionNumber | replace: '__LATEST_SHORT_HAND__',r.latestShortHand | replace: '__CYCLE_SHORT_HAND__',r.cycleShortHand }}
+{{page.changelogTemplate | replace: '__RELEASE_CYCLE__',r.releaseCycle  | replace: '__LATEST__',latestVersionNumber | replace: '__LATEST_SHORT_HAND__',r.latestShortHand | replace: '__CYCLE_SHORT_HAND__',r.cycleShortHand | replace: '__CODENAME__',r.codename}}
 {% endif %}
 {% endcapture %}
 {% assign releaseLink = releaseLink | liquify | strip %}
@@ -59,7 +62,7 @@ or +1 (EoL is in the future)
   <td>
     {% comment %}Only put a link in the version column if the release column is not shown{% endcomment %}
     {% if releaseLink != "" and page.releaseColumn == false %}
-      <a href="{{releaseLink}}" title="Release Notes / Changelog">{{releaseCycleText}}</a>
+      <a href="{{releaseLink}}" title="Release Notes / Changelog for {{releaseCycleText}}">{{releaseCycleText}}</a>
     {% else %}
       {{releaseCycleText}}
     {% endif %}

--- a/products/alpinelinux.md
+++ b/products/alpinelinux.md
@@ -16,54 +16,54 @@ auto:
   git: https://github.com/alpinelinux/aports.git
 sortReleasesBy: 'cycleShortHand'
 releases:
-  - releaseCycle: "v3.15"
+  - releaseCycle: "3.15"
     release: 2021-11-24
     eol: 2023-11-01
     cycleShortHand: 315
     latest: "3.15.2"
-  - releaseCycle: "v3.14"
+  - releaseCycle: "3.14"
     release: 2021-06-15
     eol: 2023-05-01
     cycleShortHand: 314
     latest: "3.14.4"
     link: https://alpinelinux.org/posts/Alpine-3.12.10-3.13.8-3.14.4-released.html
-  - releaseCycle: "v3.13"
+  - releaseCycle: "3.13"
     release: 2021-01-14
     eol: 2022-11-01
     cycleShortHand: 313
     latest: "3.13.8"
     link: https://alpinelinux.org/posts/Alpine-3.12.10-3.13.8-3.14.4-released.html
-  - releaseCycle: "v3.12"
+  - releaseCycle: "3.12"
     release: 2020-05-29
     eol: 2022-05-01
     cycleShortHand: 312
     latest: "3.12.10"
     link: https://alpinelinux.org/posts/Alpine-3.12.10-3.13.8-3.14.4-released.html
-  - releaseCycle: "v3.11"
+  - releaseCycle: "3.11"
     release: 2019-12-19
     eol: 2021-11-01
     cycleShortHand: 311
     latest: "3.11.13"
     link: https://alpinelinux.org/posts/Alpine-3.11.13-3.12.9-3.13.7-released.html
-  - releaseCycle: "v3.10"
+  - releaseCycle: "3.10"
     release: 2019-06-19
     eol: 2021-05-01
     cycleShortHand: 310
     latest: "3.10.9"
     link: https://alpinelinux.org/posts/Alpine-3.10.9-3.11.11-3.12.7-released.html
-  - releaseCycle: "v3.9"
+  - releaseCycle: "3.9"
     release: 2019-01-29
     eol: 2021-01-01
     cycleShortHand: 309
     latest: "3.9.6"
     link: https://alpinelinux.org/posts/Alpine-3.9.6-and-3.10.5-released.html
-  - releaseCycle: "v3.8"
+  - releaseCycle: "3.8"
     release: 2018-06-26
     eol: 2020-05-01
     cycleShortHand: 308
     latest: "3.8.5"
     link: https://git.alpinelinux.org/aports/log/?h=3.8-stable
-  - releaseCycle: "v3.7"
+  - releaseCycle: "3.7"
     release: 2017-11-30
     eol: 2019-11-01
     cycleShortHand: 307

--- a/products/amazon-linux.md
+++ b/products/amazon-linux.md
@@ -14,12 +14,14 @@ auto:
   oci: https://index.docker.io/v2/_library/amazonlinux
 changelogTemplate: 'https://docs.aws.amazon.com/AL2/latest/relnotes/relnotes-{{"__LATEST__" | slice:4,8 }}.html'
 releases:
-  - releaseCycle: 'Amazon Linux AMI'
+  - releaseCycle: '1'
+    releaseLabel: 'Amaon Linux AMI'
     release: "2010-09-14"
     eol: 2020-12-31
     latest: "2018.03"
     auto: false
-  - releaseCycle: 'Amazon Linux 2'
+  - releaseCycle: '2'
+    releaseLabel: 'Amazon Linux 2'
     release: 2017-12-19
     eol: 2023-06-30
     latest: "2.0.20220316.0"

--- a/products/amazon-linux.md
+++ b/products/amazon-linux.md
@@ -15,7 +15,7 @@ auto:
 changelogTemplate: 'https://docs.aws.amazon.com/AL2/latest/relnotes/relnotes-{{"__LATEST__" | slice:4,8 }}.html'
 releases:
   - releaseCycle: '1'
-    releaseLabel: 'Amaon Linux AMI'
+    releaseLabel: 'Amazon Linux AMI'
     release: "2010-09-14"
     eol: 2020-12-31
     latest: "2018.03"

--- a/products/android.md
+++ b/products/android.md
@@ -13,84 +13,105 @@ releaseColumn: false
 releaseDateColumn: true
 eolColumn: Security Support
 sortReleasesBy: 'release'
+releaseLabel: "Android __RELEASE_CYCLE__ '__CODENAME__'"
 releases:
-  - releaseCycle: Snow Cone (Android 12)
+  - releaseCycle: "12"
+    codename: Snow Cone
     release: 2021-10-04
     eol: false
 
-  - releaseCycle: Red Velvet Cake (Android 11)
+  - releaseCycle: "11"
+    codename: Red Velvet Cake
     release: 2020-09-08
     eol: false
 
-  - releaseCycle: Queen Cake (Android 10)
+  - releaseCycle: "10"
+    codename: Queen Cake
     release: 2019-09-03
     eol: false
 
-  - releaseCycle: Pie (Android 9.x)
+  - releaseCycle: "9"
+    codename: Pie
     release: 2018-08-06
     eol: false
 
-  - releaseCycle: Oreo (Android 8.1.x)
+  - releaseCycle: "8.1"
+    codename: Oreo
     release: 2017-12-05
     eol: true
 
-  - releaseCycle: Oreo (Android 8.0.x)
+  - releaseCycle: "8.0"
+    codename: Oreo
     release: 2017-08-21
     eol: true
 
-  - releaseCycle: Nougat (Android 7.x)
+  - releaseCycle: "7"
+    codename: Nougat
     release: 2016-08-22
     eol: true
 
-  - releaseCycle: Marshmallow (Android 6.0.x)
+  - releaseCycle: "6"
+    codename: Marshmallow
     release: 2015-10-05
     eol: true
 
-  - releaseCycle: Lollipop (Android 5.0 – 5.1.1)
+  - releaseCycle: "5"
+    codename: Lollipop
     release: 2014-11-12
     eol: true
 
-  - releaseCycle: KitKat (Android 4.4.x)
+  - releaseCycle: "4.4"
+    codename: KitKat
     release: 2013-10-31
     eol: true
 
-  - releaseCycle: Jelly Bean (Android 4.1 – 4.3.1)
+  - releaseCycle: "4.1"
+    codename: Jelly Bean
     release: 2012-07-09
     eol: true
 
-  - releaseCycle: Ice Cream Sandwich (Android 4.0.x)
+  - releaseCycle: "4"
+    codename: Ice Cream Sandwich
     release: 2011-10-18
     eol: true
 
-  - releaseCycle: Honeycomb (Android 3.x)
+  - releaseCycle: "3"
+    codename: Honeycomb
     release: 2011-02-22
     eol: true
 
-  - releaseCycle: Gingerbread (Android 2.3.x)
+  - releaseCycle: "2.3"
+    codename: Gingerbread
     release: 2010-12-06
     eol: true
 
-  - releaseCycle: Froyo (Android 2.2.x)
+  - releaseCycle: "2.2"
+    codename: Froyo
     release: 2010-05-20
     eol: true
 
-  - releaseCycle: Eclair (Android 2.0-2.1)
+  - releaseCycle: "2.0"
+    codename: Eclair
     release: 2009-10-26
     eol: true
 
-  - releaseCycle: Donut (Android 1.6)
+  - releaseCycle: "1.6"
+    codename: Donut
     release: 2009-09-15
     eol: true
 
-  - releaseCycle: Cupcake (Android 1.5)
+  - releaseCycle: "1.5"
+    codename: Cupcake
     release: 2009-04-27
     eol: true
 
-  - releaseCycle: Petit Four (Android 1.1)
+  - releaseCycle: "1.1"
+    codename: Petit Four
     release: 2009-02-09
     eol: true
 
-  - releaseCycle: "Android 1.0"
+  - releaseCycle: "1.0"
+    releaseLabel: "Android __RELEASE_CYCLE__"
     release: 2008-09-23
     eol: true
 

--- a/products/coldfusion.md
+++ b/products/coldfusion.md
@@ -11,20 +11,21 @@ releaseDateColumn: true
 eolColumn: Core Support
 sortReleasesBy: "releaseCycle"
 command: writeoutput(server.coldfusion.productversion);
+releaseLabel: "ColdFusion __RELEASE_CYCLE__"
 releases:
-  - releaseCycle: "ColdFusion 2021"
+  - releaseCycle: "2021"
     eol: 2025-11-10
     release: 2020-11-11
-  - releaseCycle: "ColdFusion 2018"
+  - releaseCycle: "2018"
     eol: 2023-07-13
     release: 2018-07-12
-  - releaseCycle: "ColdFusion 2016"
+  - releaseCycle: "2016"
     eol: 2021-02-17
     release: 2016-02-16
-  - releaseCycle: "ColdFusion 11"
+  - releaseCycle: "11"
     eol: 2019-04-30
     release: 2014-04-29
-  - releaseCycle: "ColdFusion 10"
+  - releaseCycle: "10"
     eol: 2017-05-16
     release: 2012-05-15
 ---

--- a/products/debian.md
+++ b/products/debian.md
@@ -9,42 +9,43 @@ activeSupportColumn: false
 releaseColumn: true
 releaseDateColumn: true
 sortReleasesBy: 'release'
+releaseLabel: "__RELEASE_CYCLE__ (__CODENAME__)"
 releases:
   - releaseCycle: "11"
-    cycleShortHand: "Bullseye"
+    codename: "Bullseye"
     release: 2021-08-14
     eol: 2026-08-15
     latest: "11.2"
     link: https://www.debian.org/News/2021/20211218
   - releaseCycle: "10"
-    cycleShortHand: "Buster"
+    codename: "Buster"
     release: 2019-07-06
     eol: 2024-06-01
     latest: "10.11"
     link: https://www.debian.org/News/2021/2021100902
   - releaseCycle: "9"
-    cycleShortHand: "Stretch"
+    codename: "Stretch"
     release: 2017-06-17
     eol: 2022-06-30
     lts: true
     latest: "9.13"
     link: https://lists.debian.org/debian-announce/2020/msg00004.html
   - releaseCycle: "8"
-    cycleShortHand: "Jessie"
+    codename: "Jessie"
     release: 2015-04-26
     eol: 2020-06-30
     lts: true
     latest: "8.11"
     link: https://www.debian.org/News/2015/20150426
   - releaseCycle: "7"
-    cycleShortHand: "Wheezy"
+    codename: "Wheezy"
     release: 2013-05-04
     eol: 2018-05-31
     lts: true
     latest: "7.11"
     link: https://www.debian.org/News/2013/20130504
   - releaseCycle: "6"
-    cycleShortHand: "Squeeze"
+    codename: "Squeeze"
     release: 2011-02-06
     eol: 2016-02-29
     lts: true

--- a/products/ffmpeg.md
+++ b/products/ffmpeg.md
@@ -14,22 +14,26 @@ auto:
   # upstream https://git.ffmpeg.org/ffmpeg.git doesn't support filtering
   git: https://github.com/FFmpeg/FFmpeg.git
   regex: '^n?(?<major>[1-9]\d*)\.(?<minor>0|[1-9]\d*)\.?(?<patch>0|[1-9]\d*)?$'
+releaseLabel: "__RELEASE_CYCLE__ '__CODENAME__'"
 releases:
-  - releaseCycle: "5.0 'Lorentz'"
+  - releaseCycle: "5.0"
     cycleShortHand: 50
+    codename: Lorentz
     release: 2022-01-17
     eol: false
     latest: "5.0"
     lts: true
     link: https://ffmpeg.org/download.html#release_5.0
-  - releaseCycle: "4.4 'Rao'"
+  - releaseCycle: "4.4"
     cycleShortHand: 44
+    codename: Rao
     release:  2021-04-09
     eol: false
     latest: "4.4.1"
     link: https://ffmpeg.org/download.html#release_4.4
-  - releaseCycle: "4.3 '4:3'"
+  - releaseCycle: "4.3"
     cycleShortHand: 43
+    codename: '4:3'
     release: 2020-06-15
     eol: 2021-10-21
     latest: "4.3.3"

--- a/products/filemaker.md
+++ b/products/filemaker.md
@@ -9,7 +9,7 @@ activeSupportColumn: false
 releaseColumn: false
 eolColumn: Support Status
 sortReleasesBy: 'release'
-releaseLabel: 'Filemaker Platform __RELEASE_CYCLE__'
+releaseLabel: 'FileMaker Platform __RELEASE_CYCLE__'
 releases:
   - releaseCycle: "19"
     release: 2020-05-01

--- a/products/filemaker.md
+++ b/products/filemaker.md
@@ -9,44 +9,45 @@ activeSupportColumn: false
 releaseColumn: false
 eolColumn: Support Status
 sortReleasesBy: 'release'
+releaseLabel: 'Filemaker Platform __RELEASE_CYCLE__'
 releases:
-  - releaseCycle: "FileMaker Platform 19"
+  - releaseCycle: "19"
     release: 2020-05-01
     eol: false
-  - releaseCycle: "FileMaker Platform 18"
+  - releaseCycle: "18"
     release: 2019-05-01
     eol: 2021-05-30
-  - releaseCycle: "FileMaker Platform 17"
+  - releaseCycle: "17"
     release: 2018-05-01
     eol: 2020-09-18
-  - releaseCycle: "FileMaker Platform 16"
+  - releaseCycle: "16"
     release: 2017-05-01
     eol: 2020-09-18
-  - releaseCycle: "FileMaker Platform 15"
+  - releaseCycle: "15"
     release: 2016-05-01
     eol: 2019-09-20
-  - releaseCycle: "FileMaker Platform 14"
+  - releaseCycle: "14"
     release: 2015-05-01
     eol: 2018-09-21
-  - releaseCycle: "FileMaker Platform 13"
+  - releaseCycle: "13"
     release: 2013-12-01
     eol: 2017-09-22
-  - releaseCycle: "FileMaker Platform 12"
+  - releaseCycle: "12"
     release: 2012-04-01
     eol: 2016-09-23
-  - releaseCycle: "FileMaker Platform 11"
+  - releaseCycle: "11"
     release: 2010-03-01
     eol: 2015-09-25
-  - releaseCycle: "FileMaker Platform 10"
+  - releaseCycle: "10"
     release: 2009-01-01
     eol: 2014-09-27
-  - releaseCycle: "FileMaker Platform 9"
+  - releaseCycle: "9"
     release: 2007-07-01
     eol: 2011-11-15
-  - releaseCycle: "FileMaker Platform 8"
+  - releaseCycle: "8"
     release: 2005-08-01
     eol: 2010-09-23
-  - releaseCycle: "FileMaker Platform 7"
+  - releaseCycle: "7"
     release: 2004-03-01
     eol: 2008-09-26
 ---

--- a/products/firefox.md
+++ b/products/firefox.md
@@ -7,7 +7,7 @@ releasePolicyLink: https://www.mozilla.org/firefox/
 releaseDateColumn: true
 releaseColumn: true
 iconSlug: firefox
-ltsLabel: ESR
+LTSLabel: "<abbr title='Extended Support Release'>ESR</abbr>"
 changelogTemplate: |
   https://www.mozilla.org/firefox/__LATEST__/releasenotes/
 sortReleasesBy: 'release'

--- a/products/laravel.md
+++ b/products/laravel.md
@@ -4,7 +4,7 @@ layout: post
 permalink: /laravel
 category: framework
 releasePolicyLink: https://laravel.com/docs/9.x/releases#support-policy
-changelogTemplate: https://laravel.com/docs/__RELEASE_CYCLE__/releases
+changelogTemplate: https://laravel.com/docs/__RELEASE_CYCLE__.x/releases
 activeSupportColumn: true
 command: composer show laravel/framework|grep versions
 releaseDateColumn: true
@@ -12,25 +12,25 @@ sortReleasesBy: 'releaseCycle'
 auto:
   git: https://github.com/laravel/framework.git
 releases:
-  - releaseCycle: "9.x"
+  - releaseCycle: "9"
     release: 2022-02-08
     support: 2023-08-08
     eol: 2024-02-08
     latest: 9.5.1
     lts: false
-  - releaseCycle: "8.x"
+  - releaseCycle: "8"
     release: 2020-09-08
     support: 2022-07-26
     eol: 2023-01-24
     latest: 8.83.5
     lts: false
-  - releaseCycle: "7.x"
+  - releaseCycle: "7"
     release: 2020-03-03
     support: 2020-10-06
     eol: 2021-03-03
     latest: 7.30.6
     lts: false
-  - releaseCycle: "6.x"
+  - releaseCycle: "6"
     release: 2019-09-03
     support: 2022-01-25
     eol: 2022-09-06

--- a/products/linuxmint.md
+++ b/products/linuxmint.md
@@ -9,16 +9,19 @@ activeSupportColumn: true
 releaseDateColumn: true
 iconSlug: linuxmint
 sortReleasesBy: "releaseCycle"
+releaseLabel: "__RELEASE_CYCLE__ '__CODENAME__'"
 releases:
 
-  - releaseCycle: "LMDE 4"
+  - releaseCycle: "lmde4"
+    releaseLabel: "LMDE 4"
     release: 2020-03-20
     support: true
     eol:     false
     latest: "4"
     link: https://linuxmint.com/rel_debbie.php
     
-  - releaseCycle: "20.3 'Una'"
+  - releaseCycle: "20.3"
+    codename: Una
     lts: true
     release: 2022-01-07
     support: true
@@ -26,7 +29,8 @@ releases:
     latest: "20.3"
     link: https://linuxmint.com/edition.php?id=292
 
-  - releaseCycle: "20.2 'Uma'"
+  - releaseCycle: "20.2"
+    codename: Uma
     lts: true
     release: 2021-07-08
     support: true
@@ -34,7 +38,8 @@ releases:
     latest: "20.2"
     link: https://linuxmint.com/edition.php?id=288
     
-  - releaseCycle: "20.1 'Ulyssa'"
+  - releaseCycle: "20.1"
+    codename: Ulyssa
     lts: true
     release: 2021-01-08
     support: false
@@ -42,7 +47,8 @@ releases:
     latest: "20.1"
     link: https://blog.linuxmint.com/?p=4011
     
-  - releaseCycle: "20 'Ulyana'"
+  - releaseCycle: "20"
+    codename: Ulyana
     lts: true
     release: 2020-06-27
     support: false
@@ -50,7 +56,8 @@ releases:
     latest: "20"
     link: https://blog.linuxmint.com/?p=3928
    
-  - releaseCycle: "19.3 'Tricia'"
+  - releaseCycle: "19.3"
+    codename: Tricia
     lts: true
     release: 2019-12-18
     support: false
@@ -58,7 +65,8 @@ releases:
     latest: "19.3"
     link: https://blog.linuxmint.com/?p=3832
     
-  - releaseCycle: "19.2 'Tina'"
+  - releaseCycle: "19.2"
+    codename: Tina
     lts: true
     release: 2019-08-02
     support: false
@@ -66,7 +74,8 @@ releases:
     latest: "19.2"
     link: https://blog.linuxmint.com/?p=3786
     
-  - releaseCycle: "19.1 'Tessa'"
+  - releaseCycle: "19.1"
+    codename: Tessa
     lts: true
     release: 2018-12-19
     support: false
@@ -74,7 +83,8 @@ releases:
     latest: "19.1"
     link: https://blog.linuxmint.com/?p=3669
 
-  - releaseCycle: "19 'Tara'"
+  - releaseCycle: "19"
+    codename: Tara
     lts: true
     release: 2018-06-29
     support: false
@@ -82,7 +92,8 @@ releases:
     latest: "19"
     link: https://blog.linuxmint.com/?p=3597
 
-  - releaseCycle: "18.3 'Sylvia'"
+  - releaseCycle: "18.3"
+    codename: Sylvia
     lts: true
     release: 2017-11-27
     support: false

--- a/products/log4j.md
+++ b/products/log4j.md
@@ -11,12 +11,12 @@ iconSlug: apache
 eolColumn: Supported
 sortReleasesBy: cycleShortHand
 releases:
-  - releaseCycle: "2.x"
+  - releaseCycle: "2"
     cycleShortHand: 299
     release:  2014-07-12
     eol: false
     latest: "2.17.1"
-  - releaseCycle: "2.12.x"
+  - releaseCycle: "2.12"
     cycleShortHand: 212
     release: 2019-06-23
     eol: 2021-12-14

--- a/products/looker.md
+++ b/products/looker.md
@@ -7,6 +7,7 @@ iconSlug: looker
 releasePolicyLink: https://docs.looker.com/relnotes/release-overview
 changelogTemplate: |
   https://docs.looker.com/relnotes/v{{"__RELEASE_CYCLE__" | split:'.' | first}}-changelog#{{"__RELEASE_CYCLE__"}}
+LTSLabel: "<abbr title='Extended Support Release'>ESR</abbr>"
 eolColumn: Support Status
 activeSupportColumn: false
 releaseDateColumn: true

--- a/products/macos.md
+++ b/products/macos.md
@@ -6,35 +6,48 @@ layout: post
 category: os
 category: device
 sortReleasesBy: "release"
+releaseLabel: "macOS __RELEASE_CYCLE__ (__CODENAME__)"
 releases:
-  - releaseCycle: "macOS 12 (Monterey)"
+  - releaseCycle: "12"
+    codename: "Monterey"
     release: 2021-10-25
     eol: false
     link: https://support.apple.com/HT212585
-  - releaseCycle: "macOS 11 (Big Sur)"
+  - releaseCycle: "11"
+    codename: "Big Sur"
     release: 2020-11-12
     eol: false
     link: https://support.apple.com/HT211896
-  - releaseCycle: "macOS 10.15 (Catalina)"
+  - releaseCycle: "10.15"
+    codename: "Catalina"
     release: 2019-10-07
     eol: false
     link: https://support.apple.com/HT210642
-  - releaseCycle: "macOS 10.14 (Mojave)"
+  - releaseCycle: "10.14"
+    codename: "Mojave"
     release: 2018-09-24
     eol: 2021-10-25
-  - releaseCycle: "macOS 10.13 (High Sierra)"
+  - releaseCycle: "10.13"
+    codename: "High Sierra"
     release: 2017-09-25
     eol: 2020-12-01
-  - releaseCycle: "macOS 10.12 (Sierra)"
+  - releaseCycle: "10.12"
+    codename: "Sierra"
     release: 2016-09-20
     eol: 2019-10-01
-  - releaseCycle: "OS X 10.11 (El Capitan)"
+  - releaseCycle: "10.11"
+    codename: "El Capitan"
+    releaseLabel: "macOS __RELEASE_CYCLE__ (__CODENAME__)"
     release: 2015-09-30
     eol: 2018-12-01
-  - releaseCycle: "OS X 10.10 (Yosemite)"
+  - releaseCycle: "10.10"
+    releaseLabel: "macOS __RELEASE_CYCLE__ (__CODENAME__)"
+    codename: "Yosemite"
     release: 2014-10-16
     eol: 2017-08-01
-  - releaseCycle: "OS X 10.9 (Mavericks)"
+  - releaseCycle: "10.9"
+    releaseLabel: "macOS __RELEASE_CYCLE__ (__CODENAME__)"
+    codename: "Mavericks"
     release: 2013-10-22
     eol: 2016-12-01
 permalink: /macos

--- a/products/macos.md
+++ b/products/macos.md
@@ -37,16 +37,16 @@ releases:
     eol: 2019-10-01
   - releaseCycle: "10.11"
     codename: "El Capitan"
-    releaseLabel: "macOS __RELEASE_CYCLE__ (__CODENAME__)"
+    releaseLabel: "OS X __RELEASE_CYCLE__ (__CODENAME__)"
     release: 2015-09-30
     eol: 2018-12-01
   - releaseCycle: "10.10"
-    releaseLabel: "macOS __RELEASE_CYCLE__ (__CODENAME__)"
+    releaseLabel: "OS X __RELEASE_CYCLE__ (__CODENAME__)"
     codename: "Yosemite"
     release: 2014-10-16
     eol: 2017-08-01
   - releaseCycle: "10.9"
-    releaseLabel: "macOS __RELEASE_CYCLE__ (__CODENAME__)"
+    releaseLabel: "OS X __RELEASE_CYCLE__ (__CODENAME__)"
     codename: "Mavericks"
     release: 2013-10-22
     eol: 2016-12-01

--- a/products/nvidiadriver.md
+++ b/products/nvidiadriver.md
@@ -10,9 +10,11 @@ activeSupportColumn: true
 releaseDateColumn: true
 releaseColumn: true
 sortReleasesBy: 'cycleShortHand'
-command: nvidia-smi 
+command: nvidia-smi
+LTSLabel: "<abbr title='Long Term Support Branch'>LTSB</abbr>"
 releases:
-  - releaseCycle: "R390-Linux (LTSB)"
+  - releaseCycle: "R390-Linux"
+    lts: true
     release: 2018-01-04
     support: 2018-03-10
     eol: 2022-12-31
@@ -20,7 +22,8 @@ releases:
     link: https://www.nvidia.com/Download/driverResults.aspx/184603
     cycleShortHand: 1
 
-  - releaseCycle: "R390-Windows (LTSB)"
+  - releaseCycle: "R390-Windows"
+    lts: true
     release: 2018-01-08
     support: 2018-07-31
     eol: 2022-12-31
@@ -28,7 +31,8 @@ releases:
     link: https://www.nvidia.com/download/driverResults.aspx/181267
     cycleShortHand: 2
 
-  - releaseCycle: "R418-Linux (LTSB)"
+  - releaseCycle: "R418-Linux"
+    lts: true
     release: 2019-01-30
     support: 2019-03-20
     eol: 2022-03-01
@@ -36,7 +40,8 @@ releases:
     link: https://docs.nvidia.com/datacenter/tesla/tesla-release-notes-418-19702/
     cycleShortHand: 3
     
-  - releaseCycle: "R418-Windows (LTSB)"
+  - releaseCycle: "R418-Windows"
+    lts: true
     release: 2019-02-04
     support: 2019-04-23
     eol: 2022-03-01
@@ -44,7 +49,8 @@ releases:
     link: https://docs.nvidia.com/datacenter/tesla/tesla-release-notes-418-19702/
     cycleShortHand: 4
 
-  - releaseCycle: "R450-Linux (LTSB)"
+  - releaseCycle: "R450-Linux"
+    lts: true
     release: 2020-06-24
     support: 2020-10-7
     eol: 2023-07-01
@@ -52,7 +58,8 @@ releases:
     link: https://docs.nvidia.com/datacenter/tesla/tesla-release-notes-450-142-00/
     cycleShortHand: 5
     
-  - releaseCycle: "R450-Windows (LTSB)"
+  - releaseCycle: "R450-Windows"
+    lts: true
     release: 2020-06-24
     support: 2020-12-15
     eol: 2023-07-01
@@ -76,7 +83,8 @@ releases:
     link: https://docs.nvidia.com/datacenter/tesla/tesla-release-notes-460-91-03/
     cycleShortHand: 8
 
-  - releaseCycle: "R470-Linux (LTSB)"
+  - releaseCycle: "R470-Linux"
+    lts: true
     release: 2021-7-19
     support: 2021-10-26
     eol: 2024-09-01
@@ -84,7 +92,8 @@ releases:
     link: https://www.nvidia.com/Download/driverResults.aspx/184163
     cycleShortHand: 9
     
-  - releaseCycle: "R470-Windows (LTSB)"
+  - releaseCycle: "R470-Windows"
+    lts: true
     release: 2021-06-22
     support: 2021-09-20
     eol: 2024-09-01
@@ -133,7 +142,7 @@ GPUs supported by any given branch is dependent on the operating system.
 
 The following table explains the release cadence and lifecycle for [datacenter GPU drivers](https://docs.nvidia.com/datacenter/tesla/drivers/#lifecycle):
 
-|   | New Feature Branch (NFB) | Production Branch (PB) | Long Term Support Branch (LTSB) |
+|   | New Feature Branch (NFB) | Production Branch (PB) | Long Term Support Branch|
 |---|---|---|---|
 | Target Customers | Early adopters who want to evaluate new features | Use in production for enterprise/datacenter GPUs | Use in production for enterprise/datacenter GPUs and for customers looking for a longer cycle of support.  |
 | Major Release Cadence | At least once every 3 months | Twice a year. | At least once per hardware architecture. |

--- a/products/opensuse.md
+++ b/products/opensuse.md
@@ -9,75 +9,82 @@ category: os
 sortReleasesBy: "release"
 releaseImage: https://upload.wikimedia.org/wikipedia/en/timeline/qaub9pjgtzf5zjbrlbjruujp47jv6r5.png
 changelogTemplate: https://doc.opensuse.org/release-notes/x86_64/openSUSE/Leap/__CYCLE_SHORT_HAND__/
-
+releaseLabel: "openSUSE Leap __RELEASE_CYCLE__"
 releases:
-  - releaseCycle: "openSUSE Leap 15.3"
+  - releaseCycle: "15.3"
+    releaseLabel: "openSUSE Leap __RELEASE_CYCLE__"
     release: 2021-06-02
     support: 2022-12-1
     eol: 2022-12-1
     cycleShortHand: 15.3
-  - releaseCycle: "openSUSE Leap 15.2"
+  - releaseCycle: "15.2"
+    releaseLabel: "openSUSE Leap __RELEASE_CYCLE__"
     release: 2020-07-02
     support: 2021-12-1
     eol: 2021-12-1
     cycleShortHand: 15.2
-  - releaseCycle: "openSUSE Leap 15.1"
+  - releaseCycle: "15.1"
+    releaseLabel: "openSUSE Leap __RELEASE_CYCLE__"
     release: 2019-05-22
     support: 2021-02-02
     eol: 2021-02-02
-  - releaseCycle: "openSUSE Leap 15.0"
+  - releaseCycle: "15.0"
+    releaseLabel: "openSUSE Leap __RELEASE_CYCLE__"
     release: 2018-05-25
     support: 2019-12-03
     eol: 2019-12-03
-  - releaseCycle: "openSUSE Leap 42.3"
+  - releaseCycle: "42.3"
+    releaseLabel: "openSUSE Leap __RELEASE_CYCLE__"
     release: 2017-07-26
     support: 2019-07-01
     eol: 2019-07-01
-  - releaseCycle: "openSUSE Leap 42.2"
+  - releaseCycle: "42.2"
+    releaseLabel: "openSUSE Leap __RELEASE_CYCLE__"
     release: 2016-11-16
     support: 2018-01-26
     eol: 2018-01-26
-  - releaseCycle: "openSUSE Leap 42.1"
+  - releaseCycle: "42.1"
+    releaseLabel: "openSUSE Leap __RELEASE_CYCLE__"
     release: 2015-11-4
     support: 2017-05-17
     eol: 2017-05-17
-  - releaseCycle: "openSUSE 13.2"
+  - releaseCycle: "13.2"
     release: 2015-12-14
     support: 2017-01-17
     eol: 2017-01-17
-  - releaseCycle: "openSUSE 13.1"
+  - releaseCycle: "13.1"
     release: 2014-01-08
     support: 2016-02-03
     eol: 2016-02-03
-  - releaseCycle: "openSUSE 12.3"
+  - releaseCycle: "12.3"
     release: 2013-03-13
     support: 2015-01-29
     eol: 2015-01-29
-  - releaseCycle: "openSUSE 12.2"
+  - releaseCycle: "12.2"
     release: 2012-09-05
     support: 2014-01-15
     eol: 2014-01-15
-  - releaseCycle: "openSUSE 12.1"
+  - releaseCycle: "12.1"
     release: 2011-11-16
     support: 2013-05-15
     eol: 2013-05-15
-  - releaseCycle: "openSUSE 11.4"
+  - releaseCycle: "11.4"
     release: 2011-03-10
     support: 2012-11-05
     eol: 2012-11-05
-  - releaseCycle: "openSUSE 11.3"
+  - releaseCycle: "11.3"
     release: 2010-07-15
     support: 2012-01-20
     eol: 2012-01-20
-  - releaseCycle: "openSUSE 11.2"
+  - releaseCycle: "11.2"
     release: 2009-11-12
     support: 2011-05-12
     eol: 2011-05-12
-  - releaseCycle: "openSUSE 11.1"
+  - releaseCycle: "11.1"
     release: 2008-12-18
     support: 2011-01-14
     eol: 2011-01-14
-  - releaseCycle: "openSUSE 11.0"
+  - releaseCycle: "11.0"
     release: 2008-06-19
     support: 2010-07-26
     eol: 2010-07-26

--- a/products/openzfs.md
+++ b/products/openzfs.md
@@ -16,20 +16,21 @@ releaseDateColumn: true
 sortReleasesBy: 'releaseCycle'
 iconSlug: openzfs
 eolColumn: Critical bug fixes
+releaseLabel: "OpenZFS __RELEASE_CYCLE__"
 releases:
 
-    - releaseCycle: "OpenZFS 2.1"
+    - releaseCycle: "2.1"
       release: 2021-07-02
       eol: 2023-07-02
       lts: true
       latest: "2.1.4"
 
-    - releaseCycle: "OpenZFS 2.0"
+    - releaseCycle: "2.0"
       release: 2020-11-30
       eol: 2021-12-23
       latest: "2.0.7"
 
-    - releaseCycle: "OpenZFS 0.8"
+    - releaseCycle: "0.8"
       release: 2019-06-23
       eol: 2020-12-14
       latest: "0.8.6"

--- a/products/pan-xdr.md
+++ b/products/pan-xdr.md
@@ -41,28 +41,28 @@ releases:
   - releaseCycle: "6.1"
     eol: 2022-07-01
     release: 2019-07-02
-  - releaseCycle: "7.0 (Cortex XDR agent)"
+  - releaseCycle: "7.0"
     eol: 2021-06-04
     release: 2019-12-04
-  - releaseCycle: "7.1 (Cortex XDR agent)"
+  - releaseCycle: "7.1"
     eol: 2021-06-04
     release: 2020-04-22
-  - releaseCycle: "7.2 (Cortex XDR agent)"
+  - releaseCycle: "7.2"
     eol: 2022-03-07
     release: 2020-09-07
-  - releaseCycle: "7.3 (Cortex XDR agent)"
+  - releaseCycle: "7.3"
     eol: 2022-02-01
     release: 2021-02-01
-  - releaseCycle: "7.4 (Cortex XDR agent)"
+  - releaseCycle: "7.4"
     eol: 2022-05-24
     release: 2021-05-24
-  - releaseCycle: "7.5 (Cortex XDR agent)"
+  - releaseCycle: "7.5"
     eol: 2022-08-22
     release: 2021-08-22
-  - releaseCycle: "7.5 CE (Cortex XDR agent)"
+  - releaseCycle: "7.5 CE"
     eol: 2024-03-06
     release: 2022-03-06
-  - releaseCycle: "7.6 (Cortex XDR agent)"
+  - releaseCycle: "7.6"
     eol: 2022-08-05
     release: 2021-12-05
 ---

--- a/products/redhat.md
+++ b/products/redhat.md
@@ -13,26 +13,27 @@ activeSupportColumn: true
 releaseDateColumn: true
 releaseColumn: false
 sortReleasesBy: 'release'
+releaseLabel: "RHEL __RELEASE_CYCLE__"
 releases:
-  - releaseCycle: "RHEL 8"
+  - releaseCycle: "8"
     release: 2019-05-01
     support: 2024-05-31
     eol: 2029-05-31
     latest: "8.5"
-  - releaseCycle: "RHEL 7"
+  - releaseCycle: "7"
     release: 2014-06-10
     support: 2019-12-31
     eol: 2024-06-30
     latest: "7.9"
-  - releaseCycle: "RHEL 6"
+  - releaseCycle: "6"
     release: 2010-11-10
     support: 2016-05-10
     eol: 2020-11-30
-  - releaseCycle: "RHEL 5"
+  - releaseCycle: "5"
     release: 2007-03-15
     support: 2013-01-08
     eol: 2017-03-31
-  - releaseCycle: "RHEL 4"
+  - releaseCycle: "4"
     release: 2005-02-14
     support: 2009-03-31
     eol: 2012-02-29

--- a/products/rockylinux.md
+++ b/products/rockylinux.md
@@ -13,8 +13,9 @@ releasePolicyLink: https://forums.rockylinux.org/t/what-is-eol-of-rl8/3316/2
 activeSupportColumn: true
 releaseDateColumn: true
 sortReleasesBy: 'release'
+releaseLabel: "Rocky Linux __RELEASE_CYCLE__"
 releases:
-  - releaseCycle: "Rocky Linux 8"
+  - releaseCycle: "8"
     release: 2021-06-21
     support: 2024-05-31
     eol: 2029-05-31

--- a/products/ros.md
+++ b/products/ros.md
@@ -11,17 +11,23 @@ command: rosversion -d
 releaseDateColumn: true
 releaseColumn: false
 sortReleasesBy: 'releaseCycle'
+releaseLabel: '__CODENAME__'
+changelogTemplate: 'https://wiki.ros.org/__RELEASE_CYCLE__'
 releases:
-  - releaseCycle: 'Noetic Ninjemys'
+  - releaseCycle: 'noetic'
+    codename: 'Noetic Ninjemys'
     eol: 2025-05-01
     release: 2020-05-23
-  - releaseCycle: 'Melodic Morenia'
+  - releaseCycle: 'melodic'
+    codename: 'Melodic Morenia'
     eol: 2023-04-01
     release: 2018-05-23
-  - releaseCycle: 'Lunar Loggerhead'
+  - releaseCycle: 'lunar'
+    codename: 'Lunar Loggerhead'
     eol: 2019-05-01
     release: 2017-05-23
-  - releaseCycle: 'Kinetic Kame'
+  - releaseCycle: 'kinetic'
+    codename: 'Kinetic Kame'
     eol: 2021-05-01
     release: 2016-04-23
 ---

--- a/products/sles.md
+++ b/products/sles.md
@@ -4,29 +4,29 @@ layout: post
 category: os
 sortReleasesBy: "release"
 changelogTemplate: https://www.suse.com/releasenotes/x86_64/SUSE-SLES/__CYCLE_SHORT_HAND__/
-
+releaseLabel: "SUSE Linux Enterprise Server __RELEASE_CYCLE__"
 # A list of releases, supported or not
 # Newer releases go on top of the list, in order
 releases:
-  - releaseCycle: "SUSE Linux Enterprise Server 15"
+  - releaseCycle: "15"
     release: 2018-07-15
     support: 2028-07-31
     eol: 2031-07-31
     latest: "SLES 15 SP 3"
     cycleShortHand: 15-SP3
-  - releaseCycle: "SUSE Linux Enterprise Server 12"
+  - releaseCycle: "12"
     release: 2014-10-27
     support: 2024-10-31
     eol: 2027-10-31
     latest: "SLES 12 SP5"
     cycleShortHand: 12-SP5
-  - releaseCycle: "SUSE Linux Enterprise Server 11"
+  - releaseCycle: "11"
     release: 2009-03-23
     support: 2019-03-31
     eol: 2022-03-31
     latest: "SLES 11 SP4"
     cycleShortHand: 11-SP4
-  - releaseCycle: "SUSE Linux Enterprise Server 10"
+  - releaseCycle: "10"
     release: 2006-07-17
     support: 2013-07-31
     eol: 2016-07-31
@@ -50,7 +50,7 @@ releaseColumn: true
 # Whether to show the release date column
 # optional, default false
 releaseDateColumn: true
-eolColumn: LTSS
+LTSLabel: "<abbr title='Long Term Service Pack Support'>LTSS</abbr>"
 command: cat /etc/os-release
 
 ---

--- a/products/ubuntu.md
+++ b/products/ubuntu.md
@@ -10,57 +10,58 @@ activeSupportColumn: true
 releaseDateColumn: true
 releaseImage: https://user-images.githubusercontent.com/44484725/135176160-a1d5dd88-fc56-44ee-9ce8-98d52a41da2b.png
 sortReleasesBy: "releaseCycle"
+releaseLabel: "__RELEASE_CYCLE__ '__CODENAME__'"
 releases:
-  - releaseCycle: "21.10 'Impish Indri'"
-    cycleShortHand: "ImpishIndri"
+  - releaseCycle: "21.10"
+    codename: "Impish Indri"
     release: 2021-10-14
     support: 2022-07-31
     eol:     2022-07-31
     latest: "21.10"
     link: https://wiki.ubuntu.com/ImpishIndri/ReleaseNotes/
-  - releaseCycle: "21.04 'Hirsute Hippo'"
-    cycleShortHand: "HirsuteHippo"
+  - releaseCycle: "21.04"
+    codename: "Hirsute Hippo"
     release: 2021-04-22
     support: 2022-01-20
     eol:     2022-01-20
     latest: "21.04"
     link: https://wiki.ubuntu.com/HirsuteHippo/ReleaseNotes/
-  - releaseCycle: "20.10 'Groovy Gorilla'"
-    cycleShortHand: "GroovyGorilla"
+  - releaseCycle: "20.10"
+    codename: "Groovy Gorilla"
     release: 2020-10-22
     support: 2021-07-22
     eol:     2021-07-22
     latest: "20.10"
-  - releaseCycle: "20.04 'Focal Fossa'"
-    cycleShortHand: "FocalFossa"
+  - releaseCycle: "20.04"
+    codename: "Focal Fossa"
     lts: true
     release: 2020-04-23
     support: 2025-04-02
     eol:     2030-04-01
     latest: "20.04.3"
-  - releaseCycle: "19.10 'Karmic Koala'"
-    cycleShortHand: "KarmicKoala"
+  - releaseCycle: "19.10"
+    codename: "Karmic Koala"
     release: 2019-10-17
     support: 2020-07-06
     eol:     2020-07-06
     latest: "19.10"
-  - releaseCycle: "18.04 'Bionic Beaver'"
-    cycleShortHand: "BionicBeaver"
+  - releaseCycle: "18.04"
+    codename: "Bionic Beaver"
     lts: true
     release: 2018-04-26
     support: 2023-04-02
     eol:     2028-04-01
     latest: "18.04.6"
     link: https://wiki.ubuntu.com/BionicBeaver/ReleaseNotes/
-  - releaseCycle: "16.04 'Xenial Xerus'"
-    cycleShortHand: "XenialXerus"
+  - releaseCycle: "16.04"
+    codename: "Xenial Xerus"
     lts: true
     release: 2016-04-21
     support: 2021-04-02
     eol:     2026-04-01
     latest: "16.04.7"
-  - releaseCycle: "14.04 'TrustyTahr'"
-    cycleShortHand: "TrustyTahr"
+  - releaseCycle: "14.04"
+    codename: "Trusty Tahr"
     lts: true
     release: 2014-04-17
     support: 2019-04-02

--- a/products/visualstudio.md
+++ b/products/visualstudio.md
@@ -3,60 +3,75 @@ title: Visual Studio
 layout: post
 category: app
 sortReleasesBy: "cycleShortHand"
-
+releaseLabel: '__RELEASE_CYCLE__ __CODENAME__'
 # A list of releases, supported or not
 # Newer releases go on top of the list, in order
 releases:
-  - releaseCycle: "2022 version 17.0"
+  - releaseCycle: "2022"
+    codename: "17.0"
     release: 2021-11-08
     eol: 2023-07-11
     cycleShortHand: 20221700
-  - releaseCycle: "2019 version 16.11"
+  - releaseCycle: "2019"
+    codename: "16.11"
     release: 2021-08-10
     eol: 2029-04-10
     cycleShortHand: 20191611
-  - releaseCycle: "2019 version 16.10"
+  - releaseCycle: "2019"
+    codename: "16.10"
     eol: true
     cycleShortHand: 20191610
-  - releaseCycle: "2019 version 16.9"
+  - releaseCycle: "2019"
+    codename: "16.9"
     release: 2021-03-02
     eol: 2022-10-11
     cycleShortHand: 20191609
-  - releaseCycle: "2019 version 16.8"
+  - releaseCycle: "2019"
+    codename: "16.8"
     eol: true
     cycleShortHand: 20191608
-  - releaseCycle: "2019 version 16.7"
+  - releaseCycle: "2019"
+    codename: "16.7"
     release: 2020-08-05
     eol: 2022-04-12
     cycleShortHand: 20191607
-  - releaseCycle: "2019 version 16.6"
+  - releaseCycle: "2019"
+    codename: "16.6"
     eol: true
     cycleShortHand: 20191606
-  - releaseCycle: "2019 version 16.5"
+  - releaseCycle: "2019"
+    codename: "16.5"
     eol: true
     cycleShortHand: 20191605
-  - releaseCycle: "2019 version 16.4"
+  - releaseCycle: "2019"
+    codename: "16.4"
     release: 2019-12-03
     eol: 2021-10-12
     cycleShortHand: 20191604
-  - releaseCycle: "2019 version 16.3"
+  - releaseCycle: "2019"
+    codename: "16.3"
     eol: true
     cycleShortHand: 20191603
-  - releaseCycle: "2019 version 16.2"
+  - releaseCycle: "2019"
+    codename: "16.2"
     eol: true
     cycleShortHand: 20191602
-  - releaseCycle: "2019 version 16.1"
+  - releaseCycle: "2019"
+    codename: "16.1"
     eol: true
     cycleShortHand: 20191601
-  - releaseCycle: "2019 version 16.0"
+  - releaseCycle: "2019"
+    codename: "16.0"
     release: 2019-12-03
     eol: 2021-01-12
     cycleShortHand: 20191600
-  - releaseCycle: "2017 version 15.9"
+  - releaseCycle: "2017"
+    codename: "15.9"
     release: 2018-11-13
     eol: 2027-04-13
     cycleShortHand: 20171509
-  - releaseCycle: "2017 version 15.0"
+  - releaseCycle: "2017"
+    codename: "15.0"
     release: 2017-03-07
     eol: 2020-01-14
     cycleShortHand: 2017

--- a/products/vmware-horizon.md
+++ b/products/vmware-horizon.md
@@ -12,40 +12,49 @@ activeSupportColumn: true
 releaseColumn: false
 releaseDateColumn: true
 sortReleasesBy: 'release'
+releaseLabel: 'Horizon __RELEASE_CYCLE__ __CYCLE_SHORT_HAND__'
+LTSLabel: "<abbr title='Extended Service Branch'>ESB</abbr>"
 releases:
-  - releaseCycle: "Horizon 8 2111"
+  - releaseCycle: "8"
+    cycleShortHand: "2111"
     release: 2021-11-30
     support: 2024-11-30
     eol: 2025-11-30
-  - releaseCycle: "Horizon 8 2106"
+  - releaseCycle: "8"
+    cycleShortHand: "2106"
     release: 2021-07-15
     support: 2024-07-15
     eol: 2025-07-15
-  - releaseCycle: "Horizon 8 2103"
+  - releaseCycle: "8"
+    cycleShortHand: "2103"
     release: 2021-03-23
     support: 2024-03-23
     eol: 2025-03-23
-  - releaseCycle: "Horizon 8 2012"
+  - releaseCycle: "8"
+    cycleShortHand: "2012"
     release: 2021-01-07
     support: 2024-01-07
     eol: 2025-01-07
-  - releaseCycle: "Horizon 8 2006"
+  - releaseCycle: "8"
+    cycleShortHand: "2006"
     release: 2020-08-11
     support: 2025-08-11
     eol: 2027-08-11
-  - releaseCycle: "Horizon 7.5 ESB"
+  - releaseCycle: "7.5"
+    lts: true
     release: 2018-05-29
     support: 2020-11-30
     eol: 2023-03-22
-  - releaseCycle: "Horizon 7.13"
+  - releaseCycle: "7.13"
     release: 2020-10-15
     support: 2022-10-15
     eol: 2023-03-23
-  - releaseCycle: "Horizon 7.10 ESB"
+  - releaseCycle: "7.10"
+    lts: true
     release: 2019-09-17
     support: 2022-03-17
     eol: 2023-03-22
-  - releaseCycle: "Horizon 7.0 – 7.9, 7.11, 7.12"
+  - releaseCycle: "7.0 – 7.9, 7.11, 7.12"
     release: 2016-03-22
     support: 2021-03-22
     eol: 2023-03-22

--- a/products/windowsEmbedded.md
+++ b/products/windowsEmbedded.md
@@ -10,28 +10,29 @@ releaseColumn: false
 releaseDateColumn: true
 command: winver
 sortReleasesBy: 'release'
+releaseLabel: "Windows Embedded __RELEASE_CYCLE__"
 releases:
-  - releaseCycle: "Windows Embedded Compact 2013"
+  - releaseCycle: "Compact 2013"
     release: 2013-08-11
     support: 2018-10-09
     eol: 2023-10-10
-  - releaseCycle: "Windows Embedded 8.1 Industry"
+  - releaseCycle: "8.1 Industry"
     release: 2013-11-25
     support: 2018-07-10
     eol: 2023-07-11
-  - releaseCycle: "Windows Embedded 8.1 Pro"
+  - releaseCycle: "8.1 Pro"
     release: 2013-11-13
     support: 2018-01-01
     eol: 2023-01-01
-  - releaseCycle: "Windows Embedded POSReady 7"
+  - releaseCycle: "POSReady 7"
     release: 2011-09-10
     support: 2016-10-11
     eol: 2021-10-12
-  - releaseCycle: "Windows Embedded Compact 7"
+  - releaseCycle: "Compact 7"
     release: 2011-03-15
     support: 2016-04-12
     eol: 2021-04-13
-  - releaseCycle: "Windows Embedded Standard 7 SP1"
+  - releaseCycle: "Standard 7 SP1"
     release: 2011-02-28
     support: 2015-10-13
     eol: 2020-10-13

--- a/products/windowsServer.md
+++ b/products/windowsServer.md
@@ -10,78 +10,80 @@ command: winver
 releaseColumn: false
 releaseDateColumn: true
 sortReleasesBy: 'release'
+releaseLabel: 'Windows Server __RELEASE_CYCLE__'
 releases:
-  - releaseCycle: "Windows Server 2022 (Datacenter, Datacenter Azure Edition, Standard)"
+  - releaseCycle: "2022"
     cycleShortHand: 10.0.20348
     release: 2021-08-18
     support: 2026-10-13
     eol: 2031-10-14
-  - releaseCycle: "Windows Server, version 20H2 (Datacenter, Standard)"
+  - releaseCycle: "20H2"
     cycleShortHand: 10.0.19042
     release: 2020-10-20
     support: 2022-05-10
     eol: 2022-05-10
-  - releaseCycle: "Windows Server, version 2004 (Datacenter, Standard)"
+  - releaseCycle: "2004"
     cycleShortHand: 10.0.19041
     release: 2020-05-27
     support: 2021-12-14
     eol: 2021-12-14
-  - releaseCycle: "Windows Server, version 1909 (Datacenter, Standard)"
+  - releaseCycle: "1909"
     cycleShortHand: 10.0.18363
     release: 2019-11-12
     support: 2021-05-11
     eol: 2021-05-11
-  - releaseCycle: "Windows Server, version 1903 (Datacenter, Standard)"
+  - releaseCycle: "1903"
     cycleShortHand: 10.0.18362
     release: 2018-05-21
     support: 2020-12-08
     eol: 2020-12-08
-  - releaseCycle: "Windows Server, version 1809 (Datacenter, Standard)"
+  - releaseCycle: "1809"
     cycleShortHand: 10.0.17763
     release: 2018-11-13
     support: 2020-11-10
     eol: 2020-11-10
-  - releaseCycle: "Windows Server 2019 (Datacenter, Essentials, Standard)"
+  - releaseCycle: "2019"
     cycleShortHand: 10.0.17763
     release: 2018-11-13
     support: 2024-01-09
     eol: 2029-01-09
-  - releaseCycle: "Windows Server, version 1803 (Datacenter, Standard)"
+  - releaseCycle: "1803"
     cycleShortHand: 10.0.17134
     release: 2018-04-30
     support: 2019-11-12
     eol: 2019-11-12
-  - releaseCycle: "Windows Server, version 1709 (Datacenter, Standard)"
+  - releaseCycle: "1709"
     cycleShortHand: 10.0.16299
     release: 2017-10-17
     support: 2019-04-09
     eol: 2019-04-09
-  - releaseCycle: "Windows Server 2016 (Datacenter, Essentials, Standard)"
+  - releaseCycle: "2016"
     cycleShortHand: 10.0.14393
     release: 2016-10-15
     support: 2022-01-11
     eol: 2027-01-12
-  - releaseCycle: "Windows Storage Server 2016"
+  - releaseCycle: "2016"
+    releaseLabel: "Windows Storage Server 2016"
     cycleShortHand: 10.0.14393
     release: 2016-10-15
     support: 2022-01-11
     eol: 2027-01-12
-  - releaseCycle: "Windows Server 2012 R2"
+  - releaseCycle: "2012-R2"
     cycleShortHand: 6.3.9600
     release: 2013-11-25
     support: 2018-10-09
     eol: 2023-10-10
-  - releaseCycle: "Windows Server 2012"
+  - releaseCycle: "2012"
     cycleShortHand: 6.2.9200
     release: 2012-10-30
     support: 2018-10-09
     eol: 2023-10-10
-  - releaseCycle: "Windows Server 2008 R2 Service Pack 1"
+  - releaseCycle: "2008-R2-SP1"
     cycleShortHand: 6.1.7601
     release: 2011-02-22
     support: 2015-01-13
     eol: 2020-01-14
-  - releaseCycle: "Windows Server 2008 Service Pack 2"
+  - releaseCycle: "2008-SP2"
     cycleShortHand: 6.0.6002
     release: 2009-04-29
     support: 2015-01-13

--- a/products/yocto.md
+++ b/products/yocto.md
@@ -6,47 +6,54 @@ sortReleasesBy: "cycleShortHand"
 changelogTemplate: |
   https://docs.yoctoproject.org/migration-guides/migration-{{"__RELEASE_CYCLE__"| split: " " | first}}.html
 iconSlug: NA
-
+releaseLabel:
 releases:
-#  - releaseCycle: "3.5 'kirkstone'"
+#  - releaseCycle: "3.5"
+#    codename: 'kirkstone'
 #    cycleShortHand: 305
 #    lts: true
 #    latest: "3.5.0"
 #    release: 2022-04-01
 #    eol:     2024-04-01
 #
-  - releaseCycle: "3.4 'honister'"
+  - releaseCycle: "3.4"
+    codename:  'honister'
     cycleShortHand: 304
     latest: "3.4.1"
     release: 2021-10-25
     eol:     2022-05-01
 
-  - releaseCycle: "3.3 'hardknott'"
+  - releaseCycle: "3.3"
+    codename:  'hardknott'
     cycleShortHand: 303
     latest: "3.3.4"
     release: 2021-04-01
     eol:     2021-11-01
 
-  - releaseCycle: "3.2 'gatesgarth'"
+  - releaseCycle: "3.2"
+    codename:  'gatesgarth'
     cycleShortHand: 302
     latest: "3.2.4"
     release: 2020-10-01
     eol:     2021-05-01
 
-  - releaseCycle: "3.1 'dunfell'"
+  - releaseCycle: "3.1"
+    codename:  'dunfell'
     cycleShortHand: 301
     lts: true
     latest: "3.1.12"
     release: 2020-04-01
     eol:     2024-04-01
 
-  - releaseCycle: "3.0 'zeus'"
+  - releaseCycle: "3.0"
+    codename:  'zeus'
     cycleShortHand: 300
     latest: "3.0.4"
     release: 2019-10-01
     eol:     2020-08-01
 
-  - releaseCycle: "2.7 'warrior'"
+  - releaseCycle: "2.7"
+    codename:  'warrior'
     cycleShortHand: 207
     latest: "2.7.4"
     release: 2019-04-01

--- a/products/yocto.md
+++ b/products/yocto.md
@@ -6,7 +6,7 @@ sortReleasesBy: "cycleShortHand"
 changelogTemplate: |
   https://docs.yoctoproject.org/migration-guides/migration-{{"__RELEASE_CYCLE__"| split: " " | first}}.html
 iconSlug: NA
-releaseLabel:
+releaseLabel: "__RELEASE_CYCLE__ '__CODENAME__'"
 releases:
 #  - releaseCycle: "3.5"
 #    codename: 'kirkstone'


### PR DESCRIPTION
## Why

We want to make sure that our "release cycle" field is as clean as possible, since it is used in the API. Using anything that is not guessable makes it harder. However, removing descriptive information from pages (like how we did with Debian in #757) to make the API cleaner isn't a long-term solution.

## What

This PR lets us keep `releaseCycle` clean, while providing 2 new attributes: `releaseLabel` and `LTSLabel` that decide how the release name will be rendered. `LTSLabel` is set for the page. `releaseLabel` is set for the page, but can be overridden on a per-release basis.

This also adds a new `codename` attribute, so we can stop abusing `cycleShortHand` like we were till now. It is also available in the `changelogTemplate` (see `/ros` for eg).

- Closes #653
- Closes #884 

## TODO

- [x] Update contribution documentation

## Previews

I updated most of the pages where it made sense to use a release label. There are lots more where it gets more complicated, so I haven't attempted those yet. Here's links for the impacted pages to easily review the relevant pages:

Current | New
--------| ----
https://endoflife.date/amazon-linux | 	https://deploy-preview-891--endoflife-date.netlify.app/amazon-linux
https://endoflife.date/android | 	https://deploy-preview-891--endoflife-date.netlify.app/android
https://endoflife.date/coldfusion | 	https://deploy-preview-891--endoflife-date.netlify.app/coldfusion
https://endoflife.date/debian | 	https://deploy-preview-891--endoflife-date.netlify.app/debian
https://endoflife.date/ffmpeg | 	https://deploy-preview-891--endoflife-date.netlify.app/ffmpeg
https://endoflife.date/filemaker | 	https://deploy-preview-891--endoflife-date.netlify.app/filemaker
https://endoflife.date/firefox | 	https://deploy-preview-891--endoflife-date.netlify.app/firefox
https://endoflife.date/laravel | 	https://deploy-preview-891--endoflife-date.netlify.app/laravel
https://endoflife.date/linuxmint | 	https://deploy-preview-891--endoflife-date.netlify.app/linuxmint
https://endoflife.date/log4j | 	https://deploy-preview-891--endoflife-date.netlify.app/log4j
https://endoflife.date/looker | 	https://deploy-preview-891--endoflife-date.netlify.app/looker
https://endoflife.date/macos | 	https://deploy-preview-891--endoflife-date.netlify.app/macos
https://endoflife.date/nvidiadriver | 	https://deploy-preview-891--endoflife-date.netlify.app/nvidiadriver
https://endoflife.date/opensuse | 	https://deploy-preview-891--endoflife-date.netlify.app/opensuse
https://endoflife.date/openzfs | 	https://deploy-preview-891--endoflife-date.netlify.app/openzfs
https://endoflife.date/pan-xdr | 	https://deploy-preview-891--endoflife-date.netlify.app/pan-xdr
https://endoflife.date/redhat | 	https://deploy-preview-891--endoflife-date.netlify.app/redhat
https://endoflife.date/rockylinux | 	https://deploy-preview-891--endoflife-date.netlify.app/rockylinux
https://endoflife.date/ros | 	https://deploy-preview-891--endoflife-date.netlify.app/ros
https://endoflife.date/sles | 	https://deploy-preview-891--endoflife-date.netlify.app/sles
https://endoflife.date/ubuntu | 	https://deploy-preview-891--endoflife-date.netlify.app/ubuntu
https://endoflife.date/visualstudio | 	https://deploy-preview-891--endoflife-date.netlify.app/visualstudio
https://endoflife.date/vmware-horizon | 	https://deploy-preview-891--endoflife-date.netlify.app/vmware-horizon
https://endoflife.date/windowsembedded | 	https://deploy-preview-891--endoflife-date.netlify.app/windowsembedded
https://endoflife.date/windowsserver | 	https://deploy-preview-891--endoflife-date.netlify.app/windowsserver
https://endoflife.date/yocto | 	https://deploy-preview-891--endoflife-date.netlify.app/yocto