### PR TITLE
[symfony] update eol for 6.0

### DIFF
--- a/products/symfony.md
+++ b/products/symfony.md
@@ -13,14 +13,14 @@ category: framework
 releases:
 #  - releaseCycle: "6.1"
 #    release: 2022-05-XX
-#    support: 2023-12-XX
-#    eol: 2023-12-XX
+#    support: 2023-01-XX
+#    eol: 2023-01-XX
 #    latest: "6.1.0"
 
   - releaseCycle: "6.0"
     release: 2021-11-29
-    support: 2022-07-31
-    eol: 2022-07-31
+    support: 2023-01-31
+    eol: 2023-01-31
     latest: "6.0.4"
 
   - releaseCycle: "5.4"


### PR DESCRIPTION
according to this blog post symfony 6.0 has been given 6 more months of support
https://symfony.com/blog/symfony-6-1-will-require-php-8-1

> Even if community support is massive, we understand that they are special situations which will forbid some projects to be upgraded in a timely manner. So, to mitigate the minimum PHP version bump, we are extending Symfony 6.0 maintenance by an additional 6 months. So, end of life for both Symfony 6.0 and 6.1 will happen at the same time.