### PR TITLE
Adding PAN-OS 10.2

### DIFF
--- a/products/pan-os.md
+++ b/products/pan-os.md
@@ -40,6 +40,6 @@ releases:
     eol: 2020-06-30
     release: 2016-03-29
 ---
-[Palo Alto Networks](https://www.paloaltonetworks.com/) [PAN-OS](https://docs.paloaltonetworks.com/pan-os) is the software that runs all Palo Alto Networks next-generation firewalls. These firewalls are deployed as physical appliances, virtual machines, containers, and cloud services.
+> [Palo Alto Networks](https://www.paloaltonetworks.com/) [PAN-OS](https://docs.paloaltonetworks.com/pan-os) is the software that runs all Palo Alto Networks next-generation firewalls. These firewalls are deployed as physical appliances, virtual machines, containers, and cloud services.
 
 Software updates are provided as part of a valid support agreement with major releases of new features in the .0 (e.g. 10.0) release and minor releases of new features in the .1 (e.g. 10.1) release. Bug fixes and security fixes are provided for supported major and minor releases.

--- a/products/pan-os.md
+++ b/products/pan-os.md
@@ -12,6 +12,9 @@ eolColumn: End-of-life Date
 sortReleasesBy: "release"
 command: show system info | match sw-version
 releases:
+  - releaseCycle: "10.2"
+    eol: 2025-08-27
+    release: 2022-02-27
   - releaseCycle: "10.1"
     eol: 2024-12-01
     release: 2021-05-31
@@ -37,6 +40,6 @@ releases:
     eol: 2020-06-30
     release: 2016-03-29
 ---
-> [Palo Alto Networks](https://www.paloaltonetworks.com/) [PAN-OS](https://docs.paloaltonetworks.com/pan-os) is the software that runs all Palo Alto Networks next-generation firewalls. These firewalls are deployed as physical appliances, virtual machines, containers, and cloud services.
+[Palo Alto Networks](https://www.paloaltonetworks.com/) [PAN-OS](https://docs.paloaltonetworks.com/pan-os) is the software that runs all Palo Alto Networks next-generation firewalls. These firewalls are deployed as physical appliances, virtual machines, containers, and cloud services.
 
 Software updates are provided as part of a valid support agreement with major releases of new features in the .0 (e.g. 10.0) release and minor releases of new features in the .1 (e.g. 10.1) release. Bug fixes and security fixes are provided for supported major and minor releases.


### PR DESCRIPTION
PAN-OS 10.2 (first .2 release ever from PAN!) added alongside a minor formatting tweak to account for the lack of logo.