### PR TITLE
[Python] Update 3.10.2 to 3.10.3, 3.9.10 to 3.9.11, 3.8.12 to 3.8.13, 3.7.12 to 3.7.13

### DIFF
--- a/products/python.md
+++ b/products/python.md
@@ -13,19 +13,19 @@ releases:
     - releaseCycle: "3.10"
       release: 2021-10-04
       eol: 2026-10-04
-      latest: "3.10.2"
+      latest: "3.10.3"
     - releaseCycle: "3.9"
       release: 2020-10-05
       eol: 2025-10-05
-      latest: "3.9.10"
+      latest: "3.9.11"
     - releaseCycle: "3.8"
       release: 2019-10-14
       eol: 2024-10-14
-      latest: "3.8.12"
+      latest: "3.8.13"
     - releaseCycle: "3.7"
       release: 2018-06-27
       eol: 2023-06-27
-      latest: "3.7.12"
+      latest: "3.7.13"
     - releaseCycle: "3.6"
       release: 2016-12-23
       eol: 2021-12-23


### PR DESCRIPTION
https://discuss.python.org/t/python-3-10-3-3-9-11-3-8-13-and-3-7-13-are-now-available-with-security-content/14353?u=hugovk