### PR TITLE
[PHP] Correct 7.0 and 5.5 (latest version, dates)

### DIFF
--- a/products/php.md
+++ b/products/php.md
@@ -56,7 +56,7 @@ releases:
   - releaseCycle: "7.0"
     cycleShortHand: "700"
     release: 2015-12-03
-    support: 2017-12-03
+    support: 2018-01-04
     eol:     2019-01-10
     latest:  "7.0.33"
 

--- a/products/php.md
+++ b/products/php.md
@@ -56,8 +56,8 @@ releases:
   - releaseCycle: "7.0"
     cycleShortHand: "700"
     release: 2015-12-03
-    support: 2018-12-12
-    eol:     2019-01-01
+    support: 2017-12-03
+    eol:     2019-01-10
     latest:  "7.0.33"
 
   - releaseCycle: "5.6"
@@ -71,8 +71,8 @@ releases:
     cycleShortHand: "505"
     release: 2013-06-20
     support: 2015-07-10
-    eol:     2016-07-10
-    latest:  "5.5.27"
+    eol:     2016-07-21
+    latest:  "5.5.38"
 
   - releaseCycle: "5.4"
     cycleShortHand: "504"


### PR DESCRIPTION
References (I also looked at older versions of these pages via https://web.archive.org/):

* https://www.php.net/eol.php
* https://www.php.net/supported-versions.php

The following is a simple JavaScript snippet I used to show dates in tables in the `YYYY-MM-DD` format for easier comparison if all dates match.

It's ready to be pasted to the Console tab in DevTools of your browser on the corresponding page ( <kbd>F12</kbd> or <kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>I</kbd>).

```js
document.querySelector('tbody')
  .querySelectorAll('td:nth-child(2), td:nth-child(4), td:nth-child(6)') // for php.net/supported-versions.php
  // .querySelectorAll('td:nth-child(2)') // for php.net/eol.php
  .forEach(m => {
    const d = m.innerText.match(/(\d+) ([a-z]+) (\d+)/i);
    d[2] = new Date(`14 ${d[2]} 1970`).getMonth() + 1;
    m.innerText += '\n' + [
      (d[3]+'').padStart(4, '0'),
      (d[2]+'').padStart(2, '0'),
      (d[1]+'').padStart(2, '0'),
    ].join('-');
  });
```

To use it on the page for which the relevant line is commented out (i.e. disabled), comment out the currently enabled line (<kbd>Ctrl</kbd>+<kbd>/</kbd> if your cursor is somewhere on that line) and uncomment the corresponding line (<kbd>Ctrl</kbd>+<kbd>/</kbd> as well) for that page.