### PR TITLE
[Python] Fix 3.5 initial release date

### DIFF
--- a/products/python.md
+++ b/products/python.md
@@ -31,7 +31,7 @@ releases:
       eol: 2021-12-23
       latest: "3.6.15"
     - releaseCycle: "3.5"
-      release: 2015-09-30
+      release: 2015-09-13
       eol: 2020-09-13
       latest: "3.5.10"
     - releaseCycle: "3.4"


### PR DESCRIPTION
This can be confirmed on various places:

- [https\://docs.python.org/3/whatsnew/3.5.html](https://docs.python.org/3/whatsnew/3.5.html#:~:text=Python%203.5%20was%20released%20on%20September%2013%2C%202015.):
  > Python 3.5 was released on <ins>September 13, 2015</ins>.
- https://www.python.org/downloads/release/python-350/:
  > # Python 3.5.0
  > **Release Date:** <ins>Sept. 13, 2015</ins>
  > 
  > ## Python 3.5.0
  > **Python 3.5 has reached end-of-life. Python 3.5.10, the final release of the 3.5 series, is available [here.](https://www.python.org/downloads/release/python-3510/)**
  > 
  > Python 3.5.0 was released on <ins>September 13th, 2015</ins>.
- https://docs.python.org/3.5/whatsnew/changelog.html#python-3-5-0-final:
  > ## Python 3.5.0 final [¶](https://docs.python.org/3.5/whatsnew/changelog.html#python-3-5-0-final)
  > _Release date: <ins>2015-09-13</ins>_
- https://devguide.python.org/devcycle/#end-of-life-branches:
  > Branch | Schedule | First release | End-of-life | Release manager
  > -- | -- | -- | -- | --
  > 3.5 | PEP 478 | <ins>2015-09-13</ins> | 2020-09-30 | Larry Hastings