### PR TITLE
[Tarantool] Fix timeline image

### DIFF
--- a/products/tarantool.md
+++ b/products/tarantool.md
@@ -3,7 +3,7 @@ permalink: /tarantool
 layout: post
 title: Tarantool
 command: $ tarantool --version
-releaseImage: https://www.tarantool.io/en/doc/latest/_images/releases_calendar.svg
+releaseImage: https://hb.bizmrg.com/tarantool-io/doc-builds/tarantool/latest/images_en/releases_calendar.svg
 releasePolicyLink: https://www.tarantool.io/en/doc/latest/release/policy/
 changelogTemplate: |
   https://github.com/tarantool/tarantool/releases/tag/__LATEST__


### PR DESCRIPTION
[Tarantool's page](https://endoflife.date/tarantool) cannot render timeline image. I suppose it's due to http redirection.