### PR TITLE
Add Java 18

### DIFF
--- a/products/java.md
+++ b/products/java.md
@@ -12,6 +12,11 @@ releasePolicyLink: https://www.oracle.com/technetwork/java/java-se-support-roadm
 releaseDateColumn: true
 sortReleasesBy: 'releaseCycle'
 releases:
+  - releaseCycle: "18"
+    release: 2022-03-22
+    support: 2022-09-30
+    eol: 2022-09-30
+    latest: "18.0.0"
   - releaseCycle: "17"
     lts: true
     release: 2021-09-14


### PR DESCRIPTION
Add Java 18
Source: https://www.oracle.com/java/technologies/java-se-support-roadmap.html

I wasn't sure if "18.0.0" or "18" is the correct value for the latest-field.
`java -version` prints "18", but older versions were added with the ".0.0"-suffix.

```
$ java -version
openjdk version "18" 2022-03-22
...
`