### PR TITLE
[automation] Add upstream information for automation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -67,6 +67,21 @@ sortReleasesBy: "releaseCycle"
 # Do not use a localized URL (such as one containing en-us) if possible
 changelogTemplate: "https://link/of/the/__RELEASE_CYCLE__/and/__LATEST__/version"
 
+# Optional information about how release information can be fetched automatically
+# This is mainly used for the `latest` and `latestDate` fields of each release cycle
+# Please see https://github.com/endoflife-date/endoflife.date/wiki/Automation for more details
+# This is currently a WIP, and will not have any impact, but is highly recommended if this can be made available.
+auto:
+  # Any valid git clone URL will work
+  # Support for partialClone is necessary (GitHub does support this)
+  git: https://github.com/abc/def.git
+
+  # Valid OCI Image Registry URL
+  oci: https://index.docker.io/v2/_library/image
+
+  # Link to package on NPM
+  npm: https://www.npmjs.com/package/abc
+
 # A list of releases, supported or not
 # Newer releases go on top of the list, in order
 releases:
@@ -97,6 +112,9 @@ releases:
     # predictable and you can't use changelogTemplate.
     # Do not use a localized URL (such as one containing en-us) if possible
     link: https://example.com/news/2021-12-25/release-1.2.3
+    # Optioanlly, you can overwrite the `auto` key if this release was published on a different repository
+    # Or doesn't have public sources for eg.
+    auto: false
 
 # Set an icon for the product from https://simpleicons.org/
 # If the icon is not available on simpleicons, set it to "NA"

--- a/products/alpinelinux.md
+++ b/products/alpinelinux.md
@@ -11,6 +11,8 @@ changelogTemplate: https://alpinelinux.org/posts/Alpine-__LATEST__-released.html
 activeSupportColumn: false
 command: cat /etc/alpine-release
 releaseDateColumn: true
+auto:
+  git: git+https://git.alpinelinux.org/aports
 sortReleasesBy: 'cycleShortHand'
 releases:
   - releaseCycle: "v3.15"

--- a/products/alpinelinux.md
+++ b/products/alpinelinux.md
@@ -12,7 +12,7 @@ activeSupportColumn: false
 command: cat /etc/alpine-release
 releaseDateColumn: true
 auto:
-  git: git+https://git.alpinelinux.org/aports
+  git: https://git.alpinelinux.org/aports
 sortReleasesBy: 'cycleShortHand'
 releases:
   - releaseCycle: "v3.15"

--- a/products/amazon-linux.md
+++ b/products/amazon-linux.md
@@ -10,12 +10,15 @@ command: cat /etc/system-release
 eolColumn: Support
 releaseDateColumn: true
 sortReleasesBy: 'release'
+auto:
+  oci: https://index.docker.io/v2/_library/amazonlinux
 changelogTemplate: 'https://docs.aws.amazon.com/AL2/latest/relnotes/relnotes-{{"__LATEST__" | slice:4,8 }}.html'
 releases:
   - releaseCycle: 'Amazon Linux AMI'
     release: "2010-09-14"
     eol: 2020-12-31
     latest: "2018.03"
+    auto: false
   - releaseCycle: 'Amazon Linux 2'
     release: 2017-12-19
     eol: 2023-06-30

--- a/products/angular.md
+++ b/products/angular.md
@@ -8,6 +8,8 @@ activeSupportColumn: true
 releaseDateColumn: true
 sortReleasesBy: 'release'
 changelogTemplate: https://github.com/angular/angular/releases/tag/__LATEST__
+auto:
+  git: https://github.com/twbs/bootstrap.git
 releases:
   - releaseCycle: "13"
     release: 2021-11-04

--- a/products/ansible.md
+++ b/products/ansible.md
@@ -10,7 +10,8 @@ sortReleasesBy: "releaseCycle"
 activeSupportColumn: false
 eolColumn: Supported
 iconSlug: ansible
-
+auto:
+  git: https://github.com/ansible-community/ansible-build-data.git
 releases:
   - releaseCycle: "5"
     release: 2021-11-30

--- a/products/api-platform.md
+++ b/products/api-platform.md
@@ -11,6 +11,8 @@ changelogTemplate: |
 releaseDateColumn: true
 sortReleasesBy: 'releaseCycle'
 category: framework
+auto:
+  git: https://github.com/api-platform/core.git
 releases:
 #  - releaseCycle: "2.7"
 #    release: 2022-XX-XX

--- a/products/blender.md
+++ b/products/blender.md
@@ -7,6 +7,8 @@ releaseDateColumn: true
 releaseColumn: true
 iconSlug: blender
 releaseImage: https://code.blender.org/wp-content/uploads/2020/05/release_cadence_4th_wall-1-1024x224.png
+auto:
+  git: https://git.blender.org/blender.git
 changelogTemplate: |
   https://www.blender.org/download/releases/{{"__RELEASE_CYCLE__" | replace:'.','-'}}
 sortReleasesBy: "release"

--- a/products/blender.md
+++ b/products/blender.md
@@ -8,7 +8,8 @@ releaseColumn: true
 iconSlug: blender
 releaseImage: https://code.blender.org/wp-content/uploads/2020/05/release_cadence_4th_wall-1-1024x224.png
 auto:
-  git: https://git.blender.org/blender.git
+  # https://git.blender.org/blender.git does not support partialClone
+  git: https://github.com/blender/blender.git
 changelogTemplate: |
   https://www.blender.org/download/releases/{{"__RELEASE_CYCLE__" | replace:'.','-'}}
 sortReleasesBy: "release"

--- a/products/bootstrap.md
+++ b/products/bootstrap.md
@@ -6,6 +6,8 @@ category: framework
 sortReleasesBy: "releaseCycle"
 activeSupportColumn: true
 changelogTemplate: https://github.com/twbs/bootstrap/releases/tag/v__LATEST__
+auto:
+  git: https://github.com/twbs/bootstrap.git
 releases:
   - releaseCycle: 5.x
     release: 2021-05-05

--- a/products/composer.md
+++ b/products/composer.md
@@ -4,6 +4,8 @@ layout: post
 category: app
 sortReleasesBy: "releaseCycle"
 changelogTemplate: "https://getcomposer.org/changelog/__LATEST__"
+auto:
+  git: https://github.com/composer/composer.git
 releases:
   - releaseCycle: "2.2"
     eol: 2023-12-31

--- a/products/consul.md
+++ b/products/consul.md
@@ -7,6 +7,8 @@ iconSlug: consul
 releasePolicyLink: https://support.hashicorp.com/hc/articles/360021185113
 sortReleasesBy: "release"
 changelogTemplate: https://github.com/hashicorp/consul/blob/v__LATEST__/CHANGELOG.md
+auto:
+  git: https://github.com/hashicorp/consul.git
 activeSupportColumn: false
 releaseDateColumn: true
 command: consul --version

--- a/products/couchbase-server.md
+++ b/products/couchbase-server.md
@@ -9,6 +9,8 @@ iconSlug: couchbase
 releasePolicyLink: https://www.couchbase.com/support-policy/enterprise-software
 sortReleasesBy: "releaseCycle"
 changelogTemplate: https://docs.couchbase.com/server/__RELEASE_CYCLE__/release-notes/relnotes.html
+auto:
+  oci: ttps://index.docker.io/v2/_library/couchbase
 activeSupportColumn: false
 releaseDateColumn: true
 command: cat /opt/couchbase/VERSION.txt

--- a/products/django.md
+++ b/products/django.md
@@ -10,6 +10,8 @@ activeSupportColumn: true
 command: python -c "import django; print(django.get_version())"
 releaseDateColumn: false
 sortReleasesBy: 'releaseCycle'
+auto:
+  git: https://github.com/django/django.git
 releases:
   - releaseCycle: "4.0"
     support: 2022-08-01

--- a/products/docker-engine.md
+++ b/products/docker-engine.md
@@ -13,7 +13,8 @@ releaseColumn: true
 releaseDateColumn: true
 discontinuedColumn: false
 command: docker version --format '{{.Server.Version}}'
-
+auto:
+  git: https://github.com/moby/moby.git
 releases:
   - releaseCycle: "20.10"
     eol: false

--- a/products/dotnet.md
+++ b/products/dotnet.md
@@ -14,7 +14,7 @@ releaseDateColumn: true
 sortReleasesBy: "release"
 eolColumn: Support Status
 auto:
-  github: https://github.com/dotnet/runtime.git
+  git: https://github.com/dotnet/runtime.git
 releases:
   - releaseCycle: "6.0"
     cycleShortHand: "6.0"

--- a/products/dotnet.md
+++ b/products/dotnet.md
@@ -13,6 +13,8 @@ changelogTemplate: https://github.com/dotnet/core/blob/master/release-notes/__CY
 releaseDateColumn: true
 sortReleasesBy: "release"
 eolColumn: Support Status
+auto:
+  github: https://github.com/dotnet/runtime.git
 releases:
   - releaseCycle: "6.0"
     cycleShortHand: "6.0"

--- a/products/drupal.md
+++ b/products/drupal.md
@@ -11,7 +11,7 @@ releaseColumn: true
 command: drush status
 releaseImage: https://www.drupal.org/files/2019_minor_release_schedule.png
 auto:
-  github: https://github.com/drupal/core.git
+  git: https://github.com/drupal/core.git
 sortReleasesBy: 'releaseCycle'
 releases:
   - releaseCycle: "9.3"

--- a/products/drupal.md
+++ b/products/drupal.md
@@ -10,6 +10,8 @@ releaseDateColumn: true
 releaseColumn: true
 command: drush status
 releaseImage: https://www.drupal.org/files/2019_minor_release_schedule.png
+auto:
+  github: https://github.com/drupal/core.git
 sortReleasesBy: 'releaseCycle'
 releases:
   - releaseCycle: "9.3"

--- a/products/elasticsearch.md
+++ b/products/elasticsearch.md
@@ -9,6 +9,8 @@ activeSupportColumn: false
 command: $ES_HOME/bin/elasticsearch -v
 releaseDateColumn: false
 sortReleasesBy: 'cycleShortHand'
+auto:
+  github: https://github.com/elastic/elasticsearch.git
 releases:
   - releaseCycle: "8.0"
     cycleShortHand: 800

--- a/products/elasticsearch.md
+++ b/products/elasticsearch.md
@@ -10,7 +10,7 @@ command: $ES_HOME/bin/elasticsearch -v
 releaseDateColumn: false
 sortReleasesBy: 'cycleShortHand'
 auto:
-  github: https://github.com/elastic/elasticsearch.git
+  git: https://github.com/elastic/elasticsearch.git
 releases:
   - releaseCycle: "8.0"
     cycleShortHand: 800

--- a/products/electron.md
+++ b/products/electron.md
@@ -11,7 +11,7 @@ eolColumn: Supported
 activeSupportColumn: false
 command: npm show electron version
 auto:
-  github: https://github.com/electron/electron.git
+  git: https://github.com/electron/electron.git
 releaseDateColumn: true
 sortReleasesBy: releaseCycle
 releases:

--- a/products/electron.md
+++ b/products/electron.md
@@ -10,6 +10,8 @@ releasePolicyLink: https://www.electronjs.org/docs/latest/tutorial/support
 eolColumn: Supported
 activeSupportColumn: false
 command: npm show electron version
+auto:
+  github: https://github.com/electron/electron.git
 releaseDateColumn: true
 sortReleasesBy: releaseCycle
 releases:

--- a/products/elixir.md
+++ b/products/elixir.md
@@ -10,7 +10,7 @@ activeSupportColumn: true
 releaseDateColumn: true
 sortReleasesBy: "release"
 auto:
-  github: https://github.com/elixir-lang/elixir.git
+  git: https://github.com/elixir-lang/elixir.git
 releases:
   - releaseCycle: "1.13"
     release: 2021-12-03 # https://github.com/elixir-lang/elixir/releases/tag/v1.13.0

--- a/products/elixir.md
+++ b/products/elixir.md
@@ -9,6 +9,8 @@ changelogTemplate: https://github.com/elixir-lang/elixir/blob/v__RELEASE_CYCLE__
 activeSupportColumn: true
 releaseDateColumn: true
 sortReleasesBy: "release"
+auto:
+  github: https://github.com/elixir-lang/elixir.git
 releases:
   - releaseCycle: "1.13"
     release: 2021-12-03 # https://github.com/elixir-lang/elixir/releases/tag/v1.13.0

--- a/products/emberjs.md
+++ b/products/emberjs.md
@@ -11,6 +11,8 @@ releasePolicyLink: https://emberjs.com/releases
 changelogTemplate: https://github.com/emberjs/ember.js/releases/tag/v__LATEST__
 activeSupportColumn: true
 releaseDateColumn: true
+auto:
+  github: https://github.com/emberjs/ember.js.git
 releases:
   - releaseCycle: "4"
     release: 2021-12-28

--- a/products/emberjs.md
+++ b/products/emberjs.md
@@ -12,7 +12,7 @@ changelogTemplate: https://github.com/emberjs/ember.js/releases/tag/v__LATEST__
 activeSupportColumn: true
 releaseDateColumn: true
 auto:
-  github: https://github.com/emberjs/ember.js.git
+  git: https://github.com/emberjs/ember.js.git
 releases:
   - releaseCycle: "4"
     release: 2021-12-28

--- a/products/fedora.md
+++ b/products/fedora.md
@@ -8,6 +8,8 @@ releaseDateColumn: true
 command: lsb_release -d
 sortReleasesBy: 'releaseCycle'
 changelogTemplate: https://fedoraproject.org/wiki/Releases/__LATEST__
+auto:
+  oci: https://index.docker.io/v2/_library/fedora
 category: os
 releases:
   - releaseCycle: "35"

--- a/products/ffmpeg.md
+++ b/products/ffmpeg.md
@@ -10,6 +10,8 @@ activeSupportColumn: false
 releaseDateColumn: true
 eolColumn: Supported
 sortReleasesBy: cycleShortHand
+auto:
+  git: https://git.ffmpeg.org/ffmpeg.git
 releases:
   - releaseCycle: "5.0 'Lorentz'"
     cycleShortHand: 50

--- a/products/gitlab.md
+++ b/products/gitlab.md
@@ -11,7 +11,8 @@ sortReleasesBy: "releaseCycle"
 activeSupportColumn: true
 eolColumn: Maintenance Support
 iconSlug: gitlab
-
+auto:
+  git: https://gitlab.com/gitlab-org/gitlab.git
 releases:
   - releaseCycle: "14.9"
     release: 2022-03-22

--- a/products/go.md
+++ b/products/go.md
@@ -11,6 +11,8 @@ eolColumn: Supported
 command: go version
 releaseDateColumn: true
 sortReleasesBy: 'cycleShortHand'
+auto:
+  github: https://github.com/golang/go.git
 releases:
   - releaseCycle: "1.18"
     cycleShortHand: 118

--- a/products/go.md
+++ b/products/go.md
@@ -12,7 +12,7 @@ command: go version
 releaseDateColumn: true
 sortReleasesBy: 'cycleShortHand'
 auto:
-  github: https://github.com/golang/go.git
+  git: https://github.com/golang/go.git
 releases:
   - releaseCycle: "1.18"
     cycleShortHand: 118

--- a/products/godot.md
+++ b/products/godot.md
@@ -13,6 +13,8 @@ eolColumn: Critical, Security and Platform support
 activeSupportColumn: true
 releaseDateColumn: true
 sortReleasesBy: "releaseCycle"
+auto:
+  oci: https://index.docker.io/v2/barichello/godot-ci
 releases:
   - releaseCycle: "3.4"
     release: 2021-11-05

--- a/products/haproxy.md
+++ b/products/haproxy.md
@@ -10,6 +10,8 @@ command: haproxy -v
 iconSlug: NA
 releaseDateColumn: true
 sortReleasesBy: 'cycleShortHand'
+auto:
+  git: http://git.haproxy.org/git/haproxy.git/
 releases:
   - releaseCycle: "2.5"
     cycleShortHand: 205

--- a/products/jquery.md
+++ b/products/jquery.md
@@ -3,6 +3,8 @@ title: jQuery
 layout: post
 category: framework
 sortReleasesBy: "releaseCycle"
+auto:
+  git: https://github.com/jquery/jquery.git
 releases:
   - releaseCycle: "3"
     eol: false

--- a/products/kotlin.md
+++ b/products/kotlin.md
@@ -10,7 +10,8 @@ command: kotlinc-native -version
 releasePolicyLink: https://kotlinlang.org/docs/releases.html
 sortReleasesBy: "cycleShortHand"
 changelogTemplate: "https://github.com/JetBrains/kotlin/releases/tag/v__LATEST__"
-
+auto:
+  git: https://github.com/JetBrains/kotlin.git
 activeSupportColumn: false
 discontinuedColumn: false
 releaseDateColumn: true

--- a/products/kubernetes.md
+++ b/products/kubernetes.md
@@ -11,6 +11,8 @@ releaseDateColumn: true
 sortReleasesBy: "release"
 activeSupportColumn: true
 eolColumn: Maintenance Support
+auto:
+  git: https://github.com/kubernetes/kubernetes.git
 alternate_urls:
   - /k8s
 # The release date for "N" should match the eol date for N-3 release.

--- a/products/laravel.md
+++ b/products/laravel.md
@@ -9,6 +9,8 @@ activeSupportColumn: true
 command: composer show laravel/framework|grep versions
 releaseDateColumn: true
 sortReleasesBy: 'releaseCycle'
+auto:
+  git: https://github.com/laravel/framework.git
 releases:
   - releaseCycle: "9.x"
     release: 2022-02-08

--- a/products/linuxkernel.md
+++ b/products/linuxkernel.md
@@ -13,6 +13,8 @@ releaseDateColumn: true
 releaseColumn: true
 sortReleasesBy: 'cycleShortHand'
 command: uname -r
+auto:
+  git: https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git
 releases:
   - releaseCycle: "5.17"
     cycleShortHand: 517

--- a/products/magento.md
+++ b/products/magento.md
@@ -7,6 +7,8 @@ releasePolicyLink: https://magento.com/tech-resources/download
 changelogTemplate: https://devdocs.magento.com/guides/v__RELEASE_CYCLE__/release-notes/ReleaseNotes__LATEST__OpenSource.html
 activeSupportColumn: true
 command: php bin/magento --version
+auto:
+  git: https://github.com/magento/magento2.git
 releaseDateColumn: true
 sortReleasesBy: 'releaseCycle'
 releases:

--- a/products/mariadb.md
+++ b/products/mariadb.md
@@ -7,6 +7,8 @@ releasePolicyLink: https://mariadb.org/about/maintenance-policy/
 changelogTemplate: https://mariadb.com/kb/en/mariadb-__LATEST_SHORT_HAND__-changelog/
 activeSupportColumn: false
 releaseDateColumn: true
+auto:
+  git: https://github.com/MariaDB/server.git
 command: mysqld --version
 eolColumn: Support Status
 sortReleasesBy: 'releaseCycle'

--- a/products/mediawiki.md
+++ b/products/mediawiki.md
@@ -5,6 +5,8 @@ category: server-app
 sortReleasesBy: "releaseCycle"
 changelogTemplate: "https://www.mediawiki.org/wiki/Release_notes/__RELEASE_CYCLE__"
 releaseImage: https://upload.wikimedia.org/wikipedia/mediawiki/timeline/j6ewb6m3bxxticwu9ifde277qxob995.png
+auto:
+  git: https://github.com/wikimedia/mediawiki.git
 releases:
 #  - releaseCycle: "1.38"
 #    lts: false

--- a/products/mongodb.md
+++ b/products/mongodb.md
@@ -9,6 +9,8 @@ changelogTemplate: https://docs.mongodb.com/manual/release-notes/__RELEASE_CYCLE
 activeSupportColumn: false
 releaseDateColumn: true
 command: mongod --version
+auto:
+  git: https://github.com/mongodb/mongo.git
 releases:
   - releaseCycle: "5.0"
     eol: false

--- a/products/mysql.md
+++ b/products/mysql.md
@@ -8,6 +8,8 @@ changelogTemplate: "https://dev.mysql.com/doc/relnotes/mysql/__RELEASE_CYCLE__/e
 # support -> GA+5 years = Premier support
 # eol -> GA+8 years = Extended Support
 # We show Extended support dates since that match Community Edition timelines
+auto:
+  git: https://github.com/mysql/mysql-server.git
 releases:
   - releaseCycle: "8.0"
     release: 2018-04-01

--- a/products/nginx.md
+++ b/products/nginx.md
@@ -11,6 +11,9 @@ releaseColumn: true
 releaseDateColumn: true
 sortReleasesBy: "release"
 changelogTemplate: https://nginx.org/en/CHANGES-__RELEASE_CYCLE__
+auto:
+  git: https://github.com/nginx/nginx.git
+  hg: https://hg.nginx.org/nginx
 releases:
   - releaseCycle: "1.21"
     release: 2021-05-25

--- a/products/nodejs.md
+++ b/products/nodejs.md
@@ -11,6 +11,8 @@ releasePolicyLink: https://nodejs.org/about/releases/
 releaseImage: https://raw.githubusercontent.com/nodejs/Release/master/schedule.svg?sanitize=true
 changelogTemplate: https://github.com/nodejs/node/blob/master/doc/changelogs/CHANGELOG_V__RELEASE_CYCLE__.md#__LATEST__
 activeSupportColumn: true
+auto:
+  git: https://github.com/nodejs/node.git
 command: node --version
 releaseDateColumn: true
 sortReleasesBy: 'releaseCycle'

--- a/products/nomad.md
+++ b/products/nomad.md
@@ -10,7 +10,8 @@ changelogTemplate: https://github.com/hashicorp/nomad/blob/v__LATEST__/CHANGELOG
 activeSupportColumn: false
 releaseDateColumn: true
 command: nomad --version
-
+auto:
+  git: https://github.com/hashicorp/nomad.git
 releases:
   - releaseCycle: "1.2"
     eol: false

--- a/products/openzfs.md
+++ b/products/openzfs.md
@@ -9,6 +9,8 @@ command: zpool get version [zpool name]
 releasePolicyLink: https://github.com/openzfs/zfs/blob/master/RELEASES.md
 changelogTemplate: |
   https://github.com/openzfs/zfs/releases/tag/zfs-__LATEST__
+auto:
+  git: https://github.com/openzfs/zfs.git
 releaseDateColumn: true
 sortReleasesBy: 'releaseCycle'
 iconSlug: openzfs

--- a/products/perl.md
+++ b/products/perl.md
@@ -4,6 +4,8 @@ layout: post
 category: lang
 sortReleasesBy: "releaseCycle"
 changelogTemplate: "https://perldoc.perl.org/__LATEST__/perldelta"
+auto:
+  git: https://github.com/Perl/perl5.git
 releases:
   - releaseCycle: "5.34"
     eol: 2024-05-20

--- a/products/php.md
+++ b/products/php.md
@@ -7,6 +7,8 @@ releasePolicyLink: https://www.php.net/supported-versions.php
 changelogTemplate: |
   https://www.php.net/ChangeLog-{{ "__LATEST__" | split: "." | first }}.php#__LATEST__
 activeSupportColumn: true
+auto:
+  git: https://github.com/php/php-src.git
 command: php --version
 releaseDateColumn: true
 sortReleasesBy: 'cycleShortHand'

--- a/products/postgresql.md
+++ b/products/postgresql.md
@@ -13,6 +13,8 @@ eolColumn: Support Status
 command: psql -c "SELECT version();"
 releaseDateColumn: true
 sortReleasesBy: 'releaseCycle'
+auto:
+  git: https://github.com/postgres/postgres.git
 releases:
   - releaseCycle: "14"
     release: 2021-09-30

--- a/products/powershell.md
+++ b/products/powershell.md
@@ -9,6 +9,8 @@ changelogTemplate: https://github.com/PowerShell/PowerShell/blob/master/CHANGELO
 releaseDateColumn: true
 sortReleasesBy: "release"
 eolColumn: Support Status
+auto:
+  git: https://github.com/PowerShell/PowerShell.git
 releases:
   - releaseCycle: "7.2"
     cycleShortHand: 7.2

--- a/products/python.md
+++ b/products/python.md
@@ -9,6 +9,8 @@ changelogTemplate: |
   https://python.org/downloads/release/python-{{"__LATEST__" | replace:'.',''}}/
 releaseDateColumn: true
 sortReleasesBy: 'release'
+auto:
+  git: https://github.com/python/cpython.git
 releases:
     - releaseCycle: "3.10"
       release: 2021-10-04

--- a/products/qt.md
+++ b/products/qt.md
@@ -7,6 +7,8 @@ command: qmake --version
 releasePolicyLink: https://cdn2.hubspot.net/hubfs/149513/_Website_Blog/Qt%20offering%20change%20FAQ-2020-01-27.pdf
 releaseDateColumn: true
 sortReleasesBy: 'cycleShortHand'
+auto:
+  git: https://code.qt.io/qt/qt5.git
 releases:
     - releaseCycle: "6.2"
       cycleShortHand: 602

--- a/products/rabbitmq.md
+++ b/products/rabbitmq.md
@@ -9,6 +9,8 @@ changelogTemplate: https://github.com/rabbitmq/rabbitmq-server/releases/tag/v__L
 activeSupportColumn: false
 releaseDateColumn: true
 command: rabbitmqctl --version
+auto:
+  git: https://github.com/rabbitmq/rabbitmq-server.git
 releases:
   - releaseCycle: "3.9"
     eol: false

--- a/products/redis.md
+++ b/products/redis.md
@@ -9,6 +9,8 @@ activeSupportColumn: false
 command: $ redis-server --version
 releaseDateColumn: false
 sortReleasesBy: 'releaseCycle'
+auto:
+  git: https://github.com/redis/redis.git
 releases:
   - releaseCycle: "6.2"
     eol: false

--- a/products/roundcube.md
+++ b/products/roundcube.md
@@ -6,6 +6,8 @@ category: tool
 sortReleasesBy: "releaseCycle"
 activeSupportColumn: true
 changelogTemplate: https://github.com/roundcube/roundcubemail/releases/tag/__LATEST__
+auto:
+  git: https://github.com/roundcube/roundcubemail.git
 releases:
   - releaseCycle: "1.5"
     latest: "1.5.2"

--- a/products/ruby-on-rails.md
+++ b/products/ruby-on-rails.md
@@ -12,6 +12,8 @@ changelogTemplate: https://github.com/rails/rails/releases/tag/v__LATEST__
 releaseDateColumn: true
 category: framework
 sortReleasesBy: release
+auto:
+  git: https://github.com/rails/rails.git
 releases:
   - releaseCycle: "7.0"
     release: 2021-12-15

--- a/products/ruby.md
+++ b/products/ruby.md
@@ -6,6 +6,8 @@ command: ruby --version
 releasePolicyLink: https://www.ruby-lang.org/en/downloads/releases/
 changelogTemplate: |
   https://rubychangelog.com/versions-all/#ruby-{{"__LATEST__"|replace:'.',''}}
+auto:
+  git: https://git.ruby-lang.org/ruby.git
 category: lang
 releaseDateColumn: true
 eolColumn: Support Status

--- a/products/spring-framework.md
+++ b/products/spring-framework.md
@@ -6,6 +6,8 @@ layout: post
 category: framework
 sortReleasesBy: "releaseCycle"
 changelogTemplate: "https://github.com/spring-projects/spring-framework/releases/tag/__LATEST__"
+auto:
+  git: https://github.com/spring-projects/spring-framework.git
 releases:
   - releaseCycle: "5.3"
     eol: false

--- a/products/symfony.md
+++ b/products/symfony.md
@@ -9,6 +9,8 @@ changelogTemplate: |
   https://symfony.com/blog/symfony-{{"__LATEST__" | replace:'.','-'}}-released
 releaseDateColumn: true
 sortReleasesBy: 'releaseCycle'
+auto:
+  git: https://github.com/symfony/symfony.git
 category: framework
 releases:
 #  - releaseCycle: "6.1"

--- a/products/tarantool.md
+++ b/products/tarantool.md
@@ -7,6 +7,8 @@ releaseImage: https://hb.bizmrg.com/tarantool-io/doc-builds/tarantool/latest/ima
 releasePolicyLink: https://www.tarantool.io/en/doc/latest/release/policy/
 changelogTemplate: |
   https://github.com/tarantool/tarantool/releases/tag/__LATEST__
+auto:
+  git: https://github.com/tarantool/tarantool.git
 category: db
 iconSlug: NA
 eolColumn: Support Status

--- a/products/vue.md
+++ b/products/vue.md
@@ -11,6 +11,9 @@ command: npm list vue
 releaseDateColumn: true
 sortReleasesBy: 'releaseCycle'
 iconSlug: vuedotjs
+auto:
+  git: https://github.com/vuejs/core.git
+  npm: https://www.npmjs.com/package/vue
 releases:
   - releaseCycle: "3"
     release: 2020-09-18

--- a/products/wagtail.md
+++ b/products/wagtail.md
@@ -7,6 +7,8 @@ releasePolicyLink: https://github.com/wagtail/wagtail/wiki/Release-schedule
 changelogTemplate: https://docs.wagtail.io/en/stable/releases/__LATEST__.html
 activeSupportColumn: true
 command: python -c "import wagtail; print(wagtail.__version__)"
+auto:
+  git: https://github.com/wagtail/wagtail.git
 sortReleasesBy: "release"
 releases:
   - releaseCycle: "2.15"


### PR DESCRIPTION
By merging this separately from #322, we can work on automation engineering and testing the flow much more easily. This will also have the side-effect of keeping this information updated, since we can mandate this as part of contributions.