### PR TITLE
[Firefox] Update 98.0.2 and 91.7.1 ESR

### DIFF
--- a/products/firefox.md
+++ b/products/firefox.md
@@ -13,15 +13,15 @@ changelogTemplate: |
 sortReleasesBy: 'release'
 releases:
 
-  - releaseCycle: "97"
-    release: 2022-01-11
+  - releaseCycle: "98"
+    release: 2022-03-08
     eol: false
-    latest: "97.0.0"
+    latest: "98.0.2"
 
   - releaseCycle: "91"
     release: 2021-11-02
     eol: 2022-09-20
-    latest: "91.6.0"
+    latest: "91.7.1"
     lts: true
 
   - releaseCycle: "78"


### PR DESCRIPTION
https://www.mozilla.org/en-US/firefox/releases/

Firefox 98 initial release date (https://www.mozilla.org/en-US/firefox/98.0/releasenotes/):

<table>
<tbody>
<tr>
<td>
<h1>98.0</h1>
<b>Firefox Release</b>
<p>March 8, 2022</p>
</td>
<td>
<b>Version 98.0, first offered to Release channel users on <ins>March 8, 2022</ins></b>
</td>