### PR TITLE
Automation: Embed release data and keep it updated

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,3 +10,9 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "daily"
+  # This updates the _data/release-data submodule once a day
+  # which itself is updated twice a day.
+  - package-ecosystem: "gitsubmodule"
+    directory: "/"
+    schedule:
+      interval: "daily"

--- a/.github/workflows/auto-merge-release-updates.yml
+++ b/.github/workflows/auto-merge-release-updates.yml
@@ -1,0 +1,24 @@
+name: Dependabot auto-merge release-updates
+on: pull_request
+
+# Based on https://docs.github.com/en/code-security/dependabot/working-with-dependabot/automating-dependabot-with-github-actions#enable-auto-merge-on-a-pull-request
+permissions:
+  pull-requests: write
+  contents: write
+
+jobs:
+  dependabot:
+    runs-on: ubuntu-latest
+    if: ${{ github.actor == 'dependabot[bot]' }}
+    steps:
+      - name: Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@v1.1.1
+        with:
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+      - name: Enable auto-merge for Dependabot PRs for release data
+        if: ${{contains(steps.metadata.outputs.dependency-names, '_data/release-data')}}
+        run: gh pr merge --auto --merge "$PR_URL"
+        env:
+          PR_URL: ${{github.event.pull_request.html_url}}
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,4 @@
+[submodule "_data/release-data"]
+	path = _data/release-data
+	url = https://github.com/endoflife-date/release-data.git
+	branch = main

--- a/products/qt.md
+++ b/products/qt.md
@@ -8,7 +8,8 @@ releasePolicyLink: https://cdn2.hubspot.net/hubfs/149513/_Website_Blog/Qt%20offe
 releaseDateColumn: true
 sortReleasesBy: 'cycleShortHand'
 auto:
-  git: https://code.qt.io/qt/qt5.git
+  # Upstream does not support filtering https://code.qt.io/qt/qt5.git
+  git: https://github.com/qt/qt5.git
 releases:
     - releaseCycle: "6.2"
       cycleShortHand: 602


### PR DESCRIPTION
There's 3 parts to this:

1. https://github.com/endoflife-date/release-data repository, which maintains release data (https://github.com/endoflife-date/release-data/tree/main/releases/git) for many products and automatically updates twice a day (hopefully). This also acts as a nice historical record. It fetches the list of upstream sources to track from this repo, so contributors need never touch anything else.
2. This PR, which embeds the above repo in `_data/release-data` subdirectory as a git submodule. With this in place, we can switch our Jekyll templates/API to use the data from `_data/release-data` as a preferred source (we do something similar with GKE). However, we face the problem of updating the submodule itself. This PR adds dependabot to track the above so dependabot will file PRs.
3. Dependabot PRs are not automatically merged, so this adds support for the same as well, but only for our release data. It will still ensure the build passes before the PR is merged.

Opposite of previous approaches (#322), I'm trying to break this into smaller mergeable chunks so I don't have to keep up with changes. This PR, post merging should have no impact on current workflows, while letting me test the update/PR/automerge flows.

There's still some concerns I have with the approach (primarily around new additions - the automation doesn't kick in till a PR is merged, so first PRs can't rely on it).