### PR TITLE
Switch to rebase merges for dependabot

### DIFF
--- a/.github/workflows/auto-merge-release-updates.yml
+++ b/.github/workflows/auto-merge-release-updates.yml
@@ -18,7 +18,7 @@ jobs:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
       - name: Enable auto-merge for Dependabot PRs for release data
         if: ${{contains(steps.metadata.outputs.dependency-names, '_data/release-data')}}
-        run: gh pr merge --auto --merge "$PR_URL"
+        run: gh pr merge --auto --rebase "$PR_URL"
         env:
           PR_URL: ${{github.event.pull_request.html_url}}
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}


### PR DESCRIPTION
Since we have normal merges disabled, dependabot PRs weren't auto-merging.