### PR TITLE
[gitlab] Update 14.9.2, 14.8.5, 14.7.7, 14.6.7

### DIFF
--- a/products/gitlab.md
+++ b/products/gitlab.md
@@ -18,22 +18,22 @@ releases:
     release: 2022-03-22
     support: 2022-04-22
     eol: 2022-06-22
-    latest: "14.9.1"
+    latest: "14.9.2"
   - releaseCycle: "14.8"
     release: 2022-02-22
     support: 2022-03-22
     eol: 2022-05-22
-    latest: "14.8.4"
+    latest: "14.8.5"
   - releaseCycle: "14.7"
     release: 2022-01-22
     support: 2022-02-22
     eol: 2022-04-22
-    latest: "14.7.6"
+    latest: "14.7.7"
   - releaseCycle: "14.6"
     release: 2021-12-22
     support: 2022-01-22
     eol: 2022-03-22
-    latest: "14.6.6"
+    latest: "14.6.7"
   - releaseCycle: "14.5"
     release: 2021-11-22
     support: 2021-12-22


### PR DESCRIPTION
https://about.gitlab.com/releases/2022/03/31/critical-security-release-gitlab-14-9-2-released/
https://about.gitlab.com/releases/2022/04/01/gitlab-14-6-7-released/