### PR TITLE
[gitlab] Update gitlab regex

### DIFF
--- a/products/gitlab.md
+++ b/products/gitlab.md
@@ -12,6 +12,8 @@ activeSupportColumn: true
 eolColumn: Maintenance Support
 iconSlug: gitlab
 auto:
+  # Reference: https://rubular.com/r/mFfxB8FgXXERX4
+  regex: '^v?(?<major>[1-9]\d*)\.(?<minor>0|[1-9]\d*)\.(?<patch>0|[1-9]\d*)-ee?$'
   git: https://gitlab.com/gitlab-org/gitlab.git
 releases:
   - releaseCycle: "14.9"


### PR DESCRIPTION
recent gitlab releases are only tagged with the `-ee` suffix