### PR TITLE
[react] Fix Git URL

### DIFF
--- a/products/react.md
+++ b/products/react.md
@@ -10,7 +10,7 @@ changelogTemplate: https://github.com/facebook/react/releases/tag/v__LATEST__
 activeSupportColumn: true
 releaseDateColumn: true
 auto:
-  git: https://github.com/react/react.git
+  git: https://github.com/facebook/react.git
 releases:
   - releaseCycle: "18"
     release: 2022-03-29


### PR DESCRIPTION
We got an empty list of releases: https://github.com/endoflife-date/release-data/blob/main/releases/git/react.json