### PR TITLE
[New release] Ansible

### DIFF
--- a/products/ansible.md
+++ b/products/ansible.md
@@ -16,7 +16,7 @@ releases:
   - releaseCycle: "5"
     release: 2021-11-30
     eol: false
-    latest: "5.4.0"
+    latest: "5.6.0"
   - releaseCycle: "4"
     release: 2021-05-11
     eol: true


### PR DESCRIPTION
Updated Ansible to version 5.6.0

Version 5.6.0 was release on 2022-04-05: https://github.com/ansible-community/ansible-build-data/blob/main/5/CHANGELOG-v5.rst