### PR TITLE
fix(go): major -> minor, minor -> patch

### DIFF
--- a/products/go.md
+++ b/products/go.md
@@ -64,4 +64,4 @@ releases:
 
 > [Go](https://golang.org/) is an open source programming language that makes it easy to build simple, reliable, and efficient software.
 
-Each major Go release is supported until there are two newer major releases. For example, Go 1.5 was supported until the Go 1.7 release, and Go 1.6 was supported until the Go 1.8 release. It fixes critical problems, including critical security problems, in supported releases as needed by issuing minor revisions (for example, Go 1.6.1, Go 1.6.2, and so on). The security policy can be found at <https://golang.org/security>.
+Each major Go release is supported until there are two newer minor releases. For example, Go 1.5 was supported until the Go 1.7 release, and Go 1.6 was supported until the Go 1.8 release. It fixes critical problems, including critical security problems, in supported releases as needed by issuing patch revisions (for example, Go 1.6.1, Go 1.6.2, and so on). The security policy can be found at <https://golang.org/security>.


### PR DESCRIPTION
Technically `1.X` is a minor and `1.X.X` is a patch, so updating the verbiage. If this was intentional we can close this!