### PR TITLE
[firefox] fix 91 release date

### DIFF
--- a/products/firefox.md
+++ b/products/firefox.md
@@ -19,7 +19,7 @@ releases:
     latest: "99.0"
 
   - releaseCycle: "91"
-    release: 2021-11-02
+    release: 2021-08-10
     eol: 2022-09-20
     latest: "91.8.0"
     lts: true


### PR DESCRIPTION
As discussed in #1016 the `release` attribute describes the release date of the release cycle. Firefox 91 ESR has been released on 2021-08-10 https://www.mozilla.org/en-US/firefox/91.0/releasenotes/ .