### PR TITLE
Add Windows Server 2003 & 2000 end of life dates

### DIFF
--- a/products/windowsServer.md
+++ b/products/windowsServer.md
@@ -93,5 +93,10 @@ releases:
     release: 2003-05-28
     support: 2010-07-13
     eol: 2015-07-14
+  - releaseCycle: "2000"
+    cycleShortHand: 5.0.2195
+    release: 2000-02-17
+    support: 2005-06-30
+    eol: 2010-07-13
 ---
 

--- a/products/windowsServer.md
+++ b/products/windowsServer.md
@@ -88,5 +88,10 @@ releases:
     release: 2009-04-29
     support: 2015-01-13
     eol: 2020-01-14
+  - releaseCycle: "2003"
+    cycleShortHand: 5.2.3790
+    release: 2003-05-28
+    support: 2010-07-13
+    eol: 2015-07-14
 ---
 


### PR DESCRIPTION
Sources:

* W2K3: https://docs.microsoft.com/en-us/lifecycle/products/windows-server-2003-
* W2K: https://techcommunity.microsoft.com/t5/ask-the-performance-team/heads-up-end-of-life-support-for-windows-2000-and-windows-xp-sp2/ba-p/374486