### PR TITLE
[composer] Update 2.2.12, 2.3.5; rename branch "2" to "2.3"

### DIFF
--- a/products/composer.md
+++ b/products/composer.md
@@ -7,17 +7,17 @@ changelogTemplate: "https://getcomposer.org/changelog/__LATEST__"
 auto:
   git: https://github.com/composer/composer.git
 releases:
-  - releaseCycle: "2"
+  - releaseCycle: "2.3"
     eol: false
     support: true
-    release: 2020-10-24
-    latest: "2.3.4"
+    release: 2022-03-30
+    latest: "2.3.5"
     link: https://blog.packagist.com/composer-2-3/
 
   - releaseCycle: "2.2"
     eol: 2023-12-31
     release: 2021-12-22
-    latest: "2.2.11"
+    latest: "2.2.12"
     lts: true
 
   - releaseCycle: "1.x"


### PR DESCRIPTION
The HTML page generator currently sorts the version
branches like this:

```
Version    Release
2.2        2.2.11
2          2.3.4
1.x        1.10.25
```

where the branch "2" appears as an *older* version than "2.2", which is
confusing, because in reality it's the other way around. I solved it by
renaming the branch "2" to "2.3".