### PR TITLE
Adds Talk Page URL

### DIFF
--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -186,7 +186,8 @@ or +1 (EoL is in the future)
 
 <hr>
 
-You can submit an improvement to this page by
+<p>You can submit an improvement to this page
 <a href="https://github.com/endoflife-date/endoflife.date/blob/master/{{page.path}}"
-title="Click the Pencil, the link takes you directly to the correct page">visiting GitHub</a>.
-You will need to fork the website and submit a Pull Request. A JSON version of this page is available at <a href="/api{{page.permalink}}.json">/api{{page.permalink}}.json</a>. See the <a href="/docs/api/">API Documentation</a> for more.
+title="Click the Pencil, the link takes you directly to the correct page">on GitHub</a>. This page has a corresponding <a title="Talk Page for {{page.title}}" href="https://github.com/endoflife-date/talk/wiki{{page.permalink}}">Talk Page</a>.</p>
+
+<p>A JSON version of this page is available at <a href="/api{{page.permalink}}.json">/api{{page.permalink}}.json</a>. See the <a href="/docs/api/">API Documentation</a> for more.</p>


### PR DESCRIPTION
Discussion Here: https://github.com/endoflife-date/endoflife.date/discussions/1069

Created a few pages here: https://github.com/endoflife-date/talk/wiki

The intent is to capture any information that would otherwise be lost in closed issues or pull requests (usually the ones we tag as `product-fixes`). 