### PR TITLE
[Qt] Update 5.15 LTS commercial licence holder EOL

### DIFF
--- a/products/qt.md
+++ b/products/qt.md
@@ -40,7 +40,7 @@ releases:
     - releaseCycle: "5.15"
       cycleShortHand: 515
       release: 2020-05-26
-      eol: 2023-05-26
+      eol: 2023-12-08
       latest: "5.15.8"
       lts: true
       link: https://www.qt.io/blog/qt-5.15-released


### PR DESCRIPTION
Official support for Qt 5.15 LTS [1]:

"For our open source users, it will be supported in the same way as other regular Qt releases until the release of Qt 6."

-> 2020-12-08 [2]

"For commercial customers, Qt 5.15 will be long-term-supported (LTS) for three years with regular bug fix releases beyond the release of Qt 6. "

-> 2020-12-08 + 3 years = 2023-12-08

[1] https://www.qt.io/blog/qt-5.15-released
[2] https://www.qt.io/blog/qt-6.0-released

---

There was discussion in https://github.com/endoflife-date/endoflife.date/pull/282 about whether to show the commercial licence holder EOL for 5.15, or the earlier open-source one.

Because KDE is releasing the patches as open-source it was decided to show the commercial LTS for open source too.

(This does cause some confusion about EOLs for the Python bindings, PySide2 and PyQt5, but let's not go into that now ;)

So assuming we're sticking with commercial licence holder EOL == open-source EOL, the support info from https://www.qt.io/blog/qt-5.15-released suggests the Qt 5.15 EOL is really:

* Qt 6 release date + 3 years

And not:

* Qt 5.15 release date + 3 years
