### PR TITLE
[Fedora-Linux] Update EOL dates and command

### DIFF
--- a/products/fedora.md
+++ b/products/fedora.md
@@ -5,7 +5,7 @@ layout: post
 releasePolicyLink: https://fedoraproject.org/wiki/End_of_life
 activeSupportColumn: false
 releaseDateColumn: true
-command: lsb_release -d
+command: cat /etc/fedora-release 
 sortReleasesBy: 'releaseCycle'
 changelogTemplate: https://fedoraproject.org/wiki/Releases/__LATEST__
 auto:
@@ -15,11 +15,11 @@ releases:
   - releaseCycle: "35"
     release: 2021-11-02
     latest: "35"
-    eol: 2022-12-07
+    eol: 2022-11-15
   - releaseCycle: "34"
     release: 2021-04-27
     latest: "34"
-    eol: 2022-05-17
+    eol: 2022-05-31
   - releaseCycle: "33"
     release: 2020-10-27
     latest: "33"


### PR DESCRIPTION
F36 was delayed, which pushed back the F34 end of life date: https://fedorapeople.org/groups/schedule/f-36/f-36-key-tasks.html

F35 EOL date from: https://fedorapeople.org/groups/schedule/f-37/f-37-key-tasks.html

As for the command change, it's due to lsb_release not being installed by default anymore

![image](https://user-images.githubusercontent.com/44484725/165415873-591c9f1b-9216-4ea9-9612-33b3e1bd844b.png)
