### PR TITLE
[lineageos] Fix EOL for 17.1

### DIFF
--- a/products/lineageos.md
+++ b/products/lineageos.md
@@ -14,7 +14,7 @@ releases:
     link: https://lineageos.org/Changelog-25/
   - releaseCycle: "17.1"
     eol: 2022-04-26
-    release: 2020-04-01
+    release: 2020-02-01
     link: https://lineageos.org/Changelog-24/
   - releaseCycle: "16.0"
     eol: 2021-02-16


### PR DESCRIPTION
As pointed out on [HN](https://news.ycombinator.com/item?id=31168575), 17.1 builds stopped Jan-31, so the EOL date wasn't in April, but February.