### PR TITLE
[mysql] Fix shorthands to match latest versions

### DIFF
--- a/products/mysql.md
+++ b/products/mysql.md
@@ -15,13 +15,13 @@ releases:
   - releaseCycle: "8.0"
     release: 2018-04-01
     latest: 8.0.29
-    latestShortHand: 8-0-28
+    latestShortHand: 8-0-29
     support: 2023-04-30
     eol: 2026-04-30
   - releaseCycle: "5.7"
     release: 2015-10-01
     latest: 5.7.38
-    latestShortHand: 5-7-37
+    latestShortHand: 5-7-38
     support: 2020-10-31
     eol: 2023-10-31
   - releaseCycle: "5.6"


### PR DESCRIPTION
I forgot to do this already in https://github.com/endoflife-date/endoflife.date/pull/1117, where I updated the versions.