### PR TITLE
[rails] Update 7.0.2.4, 6.1.5.1, 6.0.4.8, 5.2.7.1

### DIFF
--- a/products/ruby-on-rails.md
+++ b/products/ruby-on-rails.md
@@ -20,21 +20,21 @@ releases:
   - releaseCycle: "7.0"
     release: 2021-12-15
     eol: false
-    latest: "7.0.2.3"
+    latest: "7.0.2.4"
   - releaseCycle: "6.1"
     release: 2020-12-09
     eol: false
-    latest: "6.1.5"
+    latest: "6.1.5.1"
   - releaseCycle: "6.0"
     release: 2019-08-16
     eol: 2023-06-01
     support: 2021-12-15
-    latest: "6.0.4.7"
+    latest: "6.0.4.8"
   - releaseCycle: "5.2"
     release: 2018-04-09
     eol: 2022-06-01
     support: 2021-12-15
-    latest: "5.2.7"
+    latest: "5.2.7.1"
   - releaseCycle: "5.1"
     release: 2017-04-27
     eol: 2019-08-25


### PR DESCRIPTION
https://rubyonrails.org/2022/4/26/Rails-7-0-2-4-6-1-5-1-6-0-4-8-and-5-2-7-1-have-been-released