### PR TITLE
Add UnrealIRCd to products

### DIFF
--- a/products/unrealircd.md
+++ b/products/unrealircd.md
@@ -9,6 +9,7 @@ releasePolicyLink: https://www.unrealircd.org/docs/UnrealIRCd_releases
 releaseDateColumn: true
 command: ./unrealircd version
 changelogTemplate: "https://github.com/unrealircd/unrealircd/blob/__CYCLE_SHORT_HAND__/doc/RELEASE-NOTES.md#unrealircd-{{'__LATEST__' | replace:'.',''}}"
+iconSlug: NA
 
 # A list of releases, supported or not
 # Newer releases go on top of the list, in order

--- a/products/unrealircd.md
+++ b/products/unrealircd.md
@@ -32,7 +32,7 @@ releases:
     support: 2019-05-20
     eol: 2020-12-31
     latest: "4.2.4.1"
-  - releaseCycle: "3"
+  - releaseCycle: "3.2"
     cycleShortHand: "unreal3_2_fixes"
     release: 2004-04-25
     support: 2015-12-11

--- a/products/unrealircd.md
+++ b/products/unrealircd.md
@@ -8,7 +8,7 @@ permalink: /unrealircd
 releasePolicyLink: https://www.unrealircd.org/docs/UnrealIRCd_releases
 releaseDateColumn: true
 command: ./unrealircd version
-changelogTemplate: "https://github.com/unrealircd/unrealircd/blob/__CYCLE_SHORT_HAND__/doc/RELEASE-NOTES.md#unrealircd-{{"__LATEST__" | replace:'-',''}}"
+changelogTemplate: "https://github.com/unrealircd/unrealircd/blob/__CYCLE_SHORT_HAND__/doc/RELEASE-NOTES.md#unrealircd-{{'__LATEST__' | replace:'-',''}}"
 
 # A list of releases, supported or not
 # Newer releases go on top of the list, in order

--- a/products/unrealircd.md
+++ b/products/unrealircd.md
@@ -26,6 +26,18 @@ releases:
     support: 2022-07-01
     eol: 2023-07-01
     latest: "5.2.4"
+  - releaseCycle: "4"
+    cycleShortHand: "unreal42"
+    release: 2015-12-24
+    support: 2019-05-20
+    eol: 2020-12-31
+    latest: "4.2.4.1"
+  - releaseCycle: "3"
+    cycleShortHand: "unreal3_2_fixes"
+    release: 2004-04-25
+    support: 2015-12-11
+    eol: 2016-12-31
+    latest: "3.2.10.7"
 ---
 
 > [UnrealIRCd](https://www.unrealircd.org) is an Open Source IRC Server since 1999. It implements almost all IRCv3 features.

--- a/products/unrealircd.md
+++ b/products/unrealircd.md
@@ -8,17 +8,6 @@ permalink: /unrealircd
 releasePolicyLink: https://www.unrealircd.org/docs/UnrealIRCd_releases
 releaseDateColumn: true
 command: ./unrealircd version
-
-# Template to be used to generate a link for the release
-# __RELEASE_CYCLE__ will be replaced by the value of releaseCycle
-# __CYCLE_SHORT_HAND__ will be replaced by the optional changelogTemplate
-# __LATEST__ will be replaced by the value of latest
-# __LATEST_SHORT_HAND__ will be replaced by the optional latestShortHand
-# __CODENAME__ will be replaced by the optional codename
-
-# You can even use Liquid Templating inside the template, such as:
-# https://godotengine.org/article/maintenance-release-godot-{{"__LATEST__" | replace:'.','-'}}
-# Do not use a localized URL (such as one containing en-us) if possible
 changelogTemplate: "https://github.com/unrealircd/unrealircd/blob/__CYCLE_SHORT_HAND__/doc/RELEASE-NOTES.md#unrealircd-{{"__LATEST__" | replace:'-',''}}"
 
 # A list of releases, supported or not

--- a/products/unrealircd.md
+++ b/products/unrealircd.md
@@ -8,7 +8,7 @@ permalink: /unrealircd
 releasePolicyLink: https://www.unrealircd.org/docs/UnrealIRCd_releases
 releaseDateColumn: true
 command: ./unrealircd version
-changelogTemplate: "https://github.com/unrealircd/unrealircd/blob/__CYCLE_SHORT_HAND__/doc/RELEASE-NOTES.md#unrealircd-{{'__LATEST__' | replace:'-',''}}"
+changelogTemplate: "https://github.com/unrealircd/unrealircd/blob/__CYCLE_SHORT_HAND__/doc/RELEASE-NOTES.md#unrealircd-{{'__LATEST__' | replace:'.',''}}"
 
 # A list of releases, supported or not
 # Newer releases go on top of the list, in order
@@ -16,6 +16,7 @@ releases:
   - releaseCycle: "6"
     cycleShortHand: "unreal60_dev"
     release: 2021-12-17
+    support: true
     eol: false
     latest: "6.0.3"
   - releaseCycle: "5"

--- a/products/unrealircd.md
+++ b/products/unrealircd.md
@@ -1,0 +1,44 @@
+---
+title: UnrealIRCd
+layout: post
+category: server-app
+sortReleasesBy: "releaseCycle"
+activeSupportColumn: true
+permalink: /unrealircd
+releasePolicyLink: https://www.unrealircd.org/docs/UnrealIRCd_releases
+releaseDateColumn: true
+command: ./unrealircd version
+
+# Template to be used to generate a link for the release
+# __RELEASE_CYCLE__ will be replaced by the value of releaseCycle
+# __CYCLE_SHORT_HAND__ will be replaced by the optional changelogTemplate
+# __LATEST__ will be replaced by the value of latest
+# __LATEST_SHORT_HAND__ will be replaced by the optional latestShortHand
+# __CODENAME__ will be replaced by the optional codename
+
+# You can even use Liquid Templating inside the template, such as:
+# https://godotengine.org/article/maintenance-release-godot-{{"__LATEST__" | replace:'.','-'}}
+# Do not use a localized URL (such as one containing en-us) if possible
+changelogTemplate: "https://github.com/unrealircd/unrealircd/blob/unreal60_dev/doc/RELEASE-NOTES.md#unrealircd-{{"__LATEST__" | replace:'-',''}}"
+
+# A list of releases, supported or not
+# Newer releases go on top of the list, in order
+releases:
+  - releaseCycle: "6"
+    release: 2021-12-17
+    eol: false
+    latest: "6.0.3"
+  - releaseCycle: "5"
+    release: 2019-12-13
+    support: 2022-07-01
+    eol: 2023-07-01
+    latest: "5.2.4"
+---
+
+> [UnrealIRCd](https://www.unrealircd.org) is an Open Source IRC Server since 1999. It implements almost all IRCv3 features.
+
+UnrealIRCd does not have a strict release cadence. When a new major version is released,
+the EOL dates of the previous major version is announced.
+The previous major version is guaranteed to be supported for at least 12 months.
+The final support period starts with a period where bugs are still being fixed (but no new
+features are being implemented), followed by a "security fixes only" period.

--- a/products/unrealircd.md
+++ b/products/unrealircd.md
@@ -19,16 +19,18 @@ command: ./unrealircd version
 # You can even use Liquid Templating inside the template, such as:
 # https://godotengine.org/article/maintenance-release-godot-{{"__LATEST__" | replace:'.','-'}}
 # Do not use a localized URL (such as one containing en-us) if possible
-changelogTemplate: "https://github.com/unrealircd/unrealircd/blob/unreal60_dev/doc/RELEASE-NOTES.md#unrealircd-{{"__LATEST__" | replace:'-',''}}"
+changelogTemplate: "https://github.com/unrealircd/unrealircd/blob/__CYCLE_SHORT_HAND__/doc/RELEASE-NOTES.md#unrealircd-{{"__LATEST__" | replace:'-',''}}"
 
 # A list of releases, supported or not
 # Newer releases go on top of the list, in order
 releases:
   - releaseCycle: "6"
+    cycleShortHand: "unreal60_dev"
     release: 2021-12-17
     eol: false
     latest: "6.0.3"
   - releaseCycle: "5"
+    cycleShortHand: "unreal52"
     release: 2019-12-13
     support: 2022-07-01
     eol: 2023-07-01
@@ -37,8 +39,8 @@ releases:
 
 > [UnrealIRCd](https://www.unrealircd.org) is an Open Source IRC Server since 1999. It implements almost all IRCv3 features.
 
-UnrealIRCd does not have a strict release cadence. When a new major version is released,
-the EOL dates of the previous major version is announced.
+UnrealIRCd always has one "stable" version. It does not have a strictly timed release cadence.
+When a new major version is released, the EOL dates of the previous major version ("oldstable") is announced.
 The previous major version is guaranteed to be supported for at least 12 months.
 The final support period starts with a period where bugs are still being fixed (but no new
 features are being implemented), followed by a "security fixes only" period.


### PR DESCRIPTION
This adds UnrealIRCd (an open source IRC server) to the products list.

This is my first contribution to endoflife.date so I hope I got all the fields right and it renders well...