### PR TITLE
[rabbitmq] Add 3.10

### DIFF
--- a/products/rabbitmq.md
+++ b/products/rabbitmq.md
@@ -4,7 +4,7 @@ layout: post
 permalink: /rabbitmq
 category: server-app
 releasePolicyLink: https://www.rabbitmq.com/versions.html
-sortReleasesBy: "releaseCycle"
+sortReleasesBy: "release"
 changelogTemplate: https://github.com/rabbitmq/rabbitmq-server/releases/tag/v__LATEST__
 activeSupportColumn: false
 releaseDateColumn: true

--- a/products/rabbitmq.md
+++ b/products/rabbitmq.md
@@ -13,6 +13,10 @@ auto:
   git: https://github.com/rabbitmq/rabbitmq-server.git
   regex: ^(rabbitmq_v(?<major>[1-9]\d*)_(?<minor>0|[1-9]\d*)_(?<patch>0|[1-9]\d*)|v(?<major>[1-9]\d*)\.(?<minor>0|[1-9]\d*)\.(?<patch>0|[1-9]\d*))$
 releases:
+  - releaseCycle: "3.10"
+    eol: false
+    release: 2022-05-03
+    latest: "3.10.0"
   - releaseCycle: "3.9"
     eol: false
     release: 2021-07-26


### PR DESCRIPTION
https://github.com/rabbitmq/rabbitmq-server/releases/tag/v3.10.0

EoL date for 3.9 not yet announced on https://www.rabbitmq.com/versions.html -> `eol: false`