### PR TITLE
[fedora] Update 34 EoL

### DIFF
--- a/products/fedora.md
+++ b/products/fedora.md
@@ -19,7 +19,7 @@ releases:
   - releaseCycle: "34"
     release: 2021-04-27
     latest: "34"
-    eol: 2022-05-31
+    eol: 2022-06-07
   - releaseCycle: "33"
     release: 2020-10-27
     latest: "33"


### PR DESCRIPTION
https://fedorapeople.org/groups/schedule/f-36/f-36-key-tasks.html -> Fedora Linux 34 EOL auto closure: 2022-06-07

Hint from: https://github.com/endoflife-date/endoflife.date/pull/1102#issuecomment-1114201183 Thanks @istiak101