### PR TITLE
[kubernetes] Add 1.24

### DIFF
--- a/products/kubernetes.md
+++ b/products/kubernetes.md
@@ -18,6 +18,11 @@ alternate_urls:
   - /k8s
 # The release date for "N" should match the eol date for N-3 release.
 releases:
+  - releaseCycle: "1.24"
+    release: 2022-05-03
+    latest: "1.24"
+    support: true
+    eol: false
   - releaseCycle: "1.23"
     release: 2021-12-07
     latest: "1.23.6"

--- a/products/kubernetes.md
+++ b/products/kubernetes.md
@@ -22,7 +22,7 @@ releases:
     release: 2022-05-03
     latest: "1.24"
     support: true
-    eol: false
+    eol: 2023-09-29
   - releaseCycle: "1.23"
     release: 2021-12-07
     latest: "1.23.6"

--- a/products/kubernetes.md
+++ b/products/kubernetes.md
@@ -21,7 +21,7 @@ releases:
   - releaseCycle: "1.24"
     release: 2022-05-03
     latest: "1.24"
-    support: true
+    support: 2023-09-29
     eol: 2023-09-29
   - releaseCycle: "1.23"
     release: 2021-12-07


### PR DESCRIPTION
https://kubernetes.io/blog/2022/05/03/kubernetes-1-24-release-announcement/

Draft because support/eol not yet officially announced at https://kubernetes.io/releases/patch-releases/#detailed-release-history-for-active-branches

ToDo
- [x] Update support date
- [x] Update eol date