### PR TITLE
[unity] Add 2021.3.2; update 2021.2.19, 2020.3.34, 2019.4.38

### DIFF
--- a/products/unity.md
+++ b/products/unity.md
@@ -18,10 +18,15 @@ releases:
 #    eol: false
 #    latest: "2022.1.0"
 
+  - releaseCycle: "2021.3"
+    release: 2022-04-12
+    eol: false
+    latest: "2021.3.2"
+
   - releaseCycle: "2021.2"
     release: 2021-10-26
     eol: false
-    latest: "2021.2.16"
+    latest: "2021.2.19"
 
   - releaseCycle: "2021.1"
     release: 2021-03-19
@@ -32,13 +37,13 @@ releases:
     release: 2021-03-11
     eol: 2023-03-01
     lts: true
-    latest: "2020.3.31"
+    latest: "2020.3.34"
 
   - releaseCycle: "2019"
     release: 2020-06-09
     eol: 2022-06-01
     lts: true
-    latest: "2019.4.36"
+    latest: "2019.4.38"
 
   - releaseCycle: "2018"
     release: 2019-05-10


### PR DESCRIPTION
Unity 2021.3.0f1 release date source: https://unity3d.com/get-unity/download/archive