### PR TITLE
[go] Update 1.18.2, 1.17.10

### DIFF
--- a/products/go.md
+++ b/products/go.md
@@ -19,12 +19,12 @@ releases:
     cycleShortHand: 118
     release: 2022-03-15
     eol: false
-    latest: "1.18.1"
+    latest: "1.18.2"
   - releaseCycle: "1.17"
     cycleShortHand: 117
     release: 2021-08-16
     eol: false
-    latest: "1.17.9"
+    latest: "1.17.10"
   - releaseCycle: "1.16"
     cycleShortHand: 116
     release: 2021-02-16


### PR DESCRIPTION
https://go.dev/doc/devel/release#policy
go1.18.2 (released 2022-05-10) -> https://github.com/golang/go/issues?q=milestone%3AGo1.18.2+label%3ACherryPickApproved
go1.17.10 (released 2022-05-10) -> https://github.com/golang/go/issues?q=milestone%3AGo1.17.10+label%3ACherryPickApproved