### PR TITLE
[nix] Update 2.8.1

### DIFF
--- a/products/nix.md
+++ b/products/nix.md
@@ -17,7 +17,7 @@ releaseColumn: true
 releaseDateColumn: true
 releases:
   - releaseCycle: "2.8"
-    latest: "2.8.0"
+    latest: "2.8.1"
     release: 2022-04-19
     eol: false
   - releaseCycle: "2.7"


### PR DESCRIPTION
https://nixos.org/download.html
Current version 2.8.1

I could not yet find a working official link to release notes. On the download page there is https://nixos.org/manual/nix/stable/release-notes/rl-2.8.1.html but actually leads to a 404 error page.