### PR TITLE
[auto] Automatically update latest, release, and latestReleaseDate

### DIFF
--- a/.github/workflows/auto-merge-release-updates.yml
+++ b/.github/workflows/auto-merge-release-updates.yml
@@ -16,6 +16,22 @@ jobs:
         uses: dependabot/fetch-metadata@v1.3.1
         with:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
+      - uses: actions/checkout@v3
+        name: Clone self repository
+        with:
+          ref: ${{ github.head_ref }}
+      - name:
+        run: |
+          pip install -r requirements.txt
+          python _auto/latest.py
+      - uses: stefanzweifel/git-auto-commit-action@v4
+        name: Update latest and latestReleaseDate
+        with:
+          file_pattern: products/*
+          commit_message: "🤖: Update latest release data"
+          status_options: '--untracked-files=no'
+          commit_author: 'github-actions[bot] <github-actions[bot]@users.noreply.github.com>'
+      # TODO: Leave a comment if there is a new major release that we don't match
       - name: Enable auto-merge for Dependabot PRs for release data
         if: ${{contains(steps.metadata.outputs.dependency-names, '_data/release-data')}}
         run: gh pr merge --auto --rebase "$PR_URL"

--- a/_auto/latest.py
+++ b/_auto/latest.py
@@ -1,0 +1,95 @@
+import sys
+import frontmatter
+import json
+import re
+import datetime
+from glob import glob
+from pathlib import Path
+from distutils.version import StrictVersion
+from ruamel.yaml import YAML
+from deepdiff import DeepDiff
+from io import StringIO
+
+"""
+Updates the `release`, `latest` and `latestReleaseDate` property in automatically updated pages
+As per data from _data/release-data. This script runs on dependabot upgrade PRs via GitHub Actions for
+_data/release-data and commits back the updated data.
+This is written in Python because the only package that supports writing back YAML with comments is ruamel
+"""
+
+DEFAULT_POST_TEMPLATE = """\
+---
+{metadata}
+---
+
+{content}
+"""
+
+# https://stackoverflow.com/a/63092850/368328
+def sort_versions(data):
+    def key(n):
+        a = re.split(r'(\d+)', n)
+        a[1::2] = map(int, a[1::2])
+        return a
+    return sorted(data, key=lambda n: key(n))
+
+def find_first(releases, prefix):
+  return next(filter(lambda r: r.startswith(prefix), releases), None)
+
+def find_last(releases, prefix):
+  return next(filter(lambda r: r.startswith(prefix), reversed(releases)), None)
+
+def yaml_to_str(obj):
+  yaml = YAML()
+  yaml.indent(sequence=4)
+  string_stream = StringIO()
+  yaml.dump(obj, string_stream)
+  output_str = string_stream.getvalue()
+  string_stream.close()
+  return output_str
+
+for x in glob('products/*.md'):
+  product_name = Path(x).stem
+  with open(x, 'r+') as f:
+    yaml = YAML()
+    yaml.preserve_quotes = True
+    data = next(yaml.load_all(f))
+
+    f.seek(0)
+    _, content = frontmatter.parse(f.read())
+
+    try:
+      if(data['auto']['git']):
+        print(product_name)
+        with open('_data/release-data/releases/git/%s.json' % product_name) as releases_file:
+          R1 = json.loads(releases_file.read())
+          R2 = sort_versions(R1.keys())
+
+      for release in data['releases']:
+        old = release.copy()
+
+        prefix = release['releaseCycle']
+        first_version = find_first(R2, prefix)
+        latest_version = find_last(R2, prefix)
+
+        if first_version:
+          release['release'] = datetime.date.fromisoformat(R1[first_version])
+          release['latestReleaseDate'] = datetime.date.fromisoformat(R1[latest_version])
+          release['latest'] = latest_version
+          diff = DeepDiff(old, release, ignore_order=True)
+
+          if(diff!={}):
+            # We write back to the file
+
+            final_contents = DEFAULT_POST_TEMPLATE.format(
+              metadata=yaml_to_str(data),
+              content=content)
+
+            f.seek(0)
+            f.write(final_contents)
+
+    except KeyError:
+      pass
+    except FileNotFoundError:
+      print("Failed with file: %s" % x)
+      pass

--- a/_auto/latest.py
+++ b/_auto/latest.py
@@ -67,38 +67,37 @@ def update_product(name):
     f.seek(0)
     _, content = frontmatter.parse(f.read())
 
-    for t in ['git', 'custom']:
-      fn = '_data/release-data/releases/%s/%s.json' % (t, name)
-      if exists(fn):
-        print("Updating %s" % fn)
-        with open(fn) as releases_file:
-          # Entire releases data as a dict
-          R1 = json.loads(releases_file.read())
-          # Just the list of versions
-          R2 = sort_versions(R1.keys())
+    fn = '_data/release-data/releases/%s.json' % (name)
+    if exists(fn):
+      print("Updating %s" % fn)
+      with open(fn) as releases_file:
+        # Entire releases data as a dict
+        R1 = json.loads(releases_file.read())
+        # Just the list of versions
+        R2 = sort_versions(R1.keys())
 
-        for release in data['releases']:
-          old = release.copy()
+      for release in data['releases']:
+        old = release.copy()
 
-          prefix = release['releaseCycle']
-          first_version = find_first(R2, prefix)
-          latest_version = find_last(R2, prefix)
+        prefix = release['releaseCycle']
+        first_version = find_first(R2, prefix)
+        latest_version = find_last(R2, prefix)
 
-          if first_version:
-            release['release'] = datetime.date.fromisoformat(R1[first_version])
-            release['latestReleaseDate'] = datetime.date.fromisoformat(R1[latest_version])
-            release['latest'] = latest_version
-            diff = DeepDiff(old, release, ignore_order=True)
+        if first_version:
+          release['release'] = datetime.date.fromisoformat(R1[first_version])
+          release['latestReleaseDate'] = datetime.date.fromisoformat(R1[latest_version])
+          release['latest'] = latest_version
+          diff = DeepDiff(old, release, ignore_order=True)
 
-            if(diff!={}):
-              # We write back to the file
+          if(diff!={}):
+            # We write back to the file
 
-              final_contents = DEFAULT_POST_TEMPLATE.format(
-                metadata=yaml_to_str(data),
-                content=content)
+            final_contents = DEFAULT_POST_TEMPLATE.format(
+              metadata=yaml_to_str(data),
+              content=content)
 
-              f.seek(0)
-              f.write(final_contents)
+            f.seek(0)
+            f.write(final_contents)
 
 if __name__ == '__main__':
   if len(sys.argv) > 1:

--- a/_auto/latest.py
+++ b/_auto/latest.py
@@ -34,11 +34,19 @@ def sort_versions(data):
         return a
     return sorted(data, key=lambda n: key(n))
 
+"""
+matches releases that are exact (such as 4.1 being the first release for the 4.1 release cycle)
+or releases that include a dot just after the release cycle (4.1.*)
+This is important to avoid edge cases like a 4.10.x release being marked under the 4.1 release cycle.
+"""
+def releases_matches(r, prefix):
+  return (r.startswith(prefix) and (r == prefix or r.startswith(prefix + '.')))
+
 def find_first(releases, prefix):
-  return next(filter(lambda r: r.startswith(prefix), releases), None)
+  return next(filter(lambda r: releases_matches(r, prefix), releases), None)
 
 def find_last(releases, prefix):
-  return next(filter(lambda r: r.startswith(prefix), reversed(releases)), None)
+  return next(filter(lambda r: releases_matches(r, prefix), reversed(releases)), None)
 
 def yaml_to_str(obj):
   yaml = YAML()

--- a/_auto/latest.py
+++ b/_auto/latest.py
@@ -93,7 +93,7 @@ def update_product(name):
               f.write(final_contents)
 
 if __name__ == '__main__':
-  if sys.argv[1]:
+  if len(sys.argv) > 1:
     update_product(sys.argv[1])
   else:
     for x in glob('products/*.md'):

--- a/_auto/latest.py
+++ b/_auto/latest.py
@@ -49,9 +49,9 @@ def yaml_to_str(obj):
   string_stream.close()
   return output_str
 
-for x in glob('products/*.md'):
-  product_name = Path(x).stem
-  with open(x, 'r+') as f:
+def update_product(name):
+  fn = 'products/%s.md' % name
+  with open(fn, 'r+') as f:
     yaml = YAML()
     yaml.preserve_quotes = True
     data = next(yaml.load_all(f))
@@ -60,7 +60,7 @@ for x in glob('products/*.md'):
     _, content = frontmatter.parse(f.read())
 
     for t in ['git', 'custom']:
-      fn = '_data/release-data/releases/%s/%s.json' % (t, product_name)
+      fn = '_data/release-data/releases/%s/%s.json' % (t, name)
       if exists(fn):
         print("Updating %s" % fn)
         with open(fn) as releases_file:
@@ -91,3 +91,10 @@ for x in glob('products/*.md'):
 
               f.seek(0)
               f.write(final_contents)
+
+if __name__ == '__main__':
+  if sys.argv[1]:
+    update_product(sys.argv[1])
+  else:
+    for x in glob('products/*.md'):
+      update_product(Path(x).stem)

--- a/products/alpinelinux.md
+++ b/products/alpinelinux.md
@@ -1,7 +1,7 @@
 ---
 permalink: /alpine
 alternate_urls:
-  - /alpinelinux
+-   /alpinelinux
 title: Alpine Linux
 layout: post
 category: os
@@ -16,60 +16,70 @@ auto:
 -   git: https://github.com/alpinelinux/aports.git
 sortReleasesBy: 'cycleShortHand'
 releases:
-  - releaseCycle: "3.15"
+-   releaseCycle: "3.15"
     release: 2021-11-24
     eol: 2023-11-01
     cycleShortHand: 315
     latest: "3.15.4"
     link: https://alpinelinux.org/posts/Alpine-3.12.12-3.13.10-3.14.6-3.15.4-released.html
-  - releaseCycle: "3.14"
+    latestReleaseDate: 2022-04-04
+-   releaseCycle: "3.14"
     release: 2021-06-15
     eol: 2023-05-01
     cycleShortHand: 314
     latest: "3.14.6"
     link: https://alpinelinux.org/posts/Alpine-3.12.12-3.13.10-3.14.6-3.15.4-released.html
-  - releaseCycle: "3.13"
+    latestReleaseDate: 2022-04-04
+-   releaseCycle: "3.13"
     release: 2021-01-14
     eol: 2022-11-01
     cycleShortHand: 313
     latest: "3.13.10"
     link: https://alpinelinux.org/posts/Alpine-3.12.12-3.13.10-3.14.6-3.15.4-released.html
-  - releaseCycle: "3.12"
+    latestReleaseDate: 2022-04-04
+-   releaseCycle: "3.12"
     release: 2020-05-29
     eol: 2022-05-01
     cycleShortHand: 312
     latest: "3.12.12"
     link: https://alpinelinux.org/posts/Alpine-3.12.12-3.13.10-3.14.6-3.15.4-released.html
-  - releaseCycle: "3.11"
+    latestReleaseDate: 2022-04-04
+-   releaseCycle: "3.11"
     release: 2019-12-19
     eol: 2021-11-01
     cycleShortHand: 311
     latest: "3.11.13"
     link: https://alpinelinux.org/posts/Alpine-3.11.13-3.12.9-3.13.7-released.html
-  - releaseCycle: "3.10"
+    latestReleaseDate: 2021-11-12
+-   releaseCycle: "3.10"
     release: 2019-06-19
     eol: 2021-05-01
     cycleShortHand: 310
     latest: "3.10.9"
     link: https://alpinelinux.org/posts/Alpine-3.10.9-3.11.11-3.12.7-released.html
-  - releaseCycle: "3.9"
+    latestReleaseDate: 2021-04-14
+-   releaseCycle: "3.9"
     release: 2019-01-29
     eol: 2021-01-01
     cycleShortHand: 309
     latest: "3.9.6"
     link: https://alpinelinux.org/posts/Alpine-3.9.6-and-3.10.5-released.html
-  - releaseCycle: "3.8"
+    latestReleaseDate: 2020-04-23
+-   releaseCycle: "3.8"
     release: 2018-06-26
     eol: 2020-05-01
     cycleShortHand: 308
     latest: "3.8.5"
     link: https://git.alpinelinux.org/aports/log/?h=3.8-stable
-  - releaseCycle: "3.7"
+    latestReleaseDate: 2020-01-23
+-   releaseCycle: "3.7"
     release: 2017-11-30
     eol: 2019-11-01
     cycleShortHand: 307
     latest: "3.7.3"
     link: https://git.alpinelinux.org/aports/log/?h=3.7-stable
+    latestReleaseDate: 2019-03-06
+
 ---
 
 > [Alpine Linux](https://alpinelinux.org/) is a security-oriented, lightweight Linux distribution based on musl libc and busybox.

--- a/products/amazon-linux.md
+++ b/products/amazon-linux.md
@@ -12,20 +12,23 @@ releaseDateColumn: true
 sortReleasesBy: 'release'
 auto:
 -   dockerhub: library/amazonlinux
+    # TODO: Fix this regex to exclude RC releases
     regex: ^(?<version>\d+(\.\d+){2,4})$
     template: "{{version}}"
-changelogTemplate: 'https://docs.aws.amazon.com/AL2/latest/relnotes/relnotes-{{"__LATEST__"| slice:4,8 }}.html'
+changelogTemplate: |
+  https://docs.aws.amazon.com/AL2/latest/relnotes/relnotes-{{"__LATEST__"|slice:4,8 }}.html
 releases:
-  - releaseCycle: '1'
+-   releaseCycle: '1'
     releaseLabel: 'Amazon Linux AMI'
     release: "2010-09-14"
     eol: 2020-12-31
     latest: "2018.03"
-  - releaseCycle: '2'
+-   releaseCycle: '2'
     releaseLabel: 'Amazon Linux 2'
-    release: 2017-12-19
+    release: 2018-06-26
     eol: 2023-06-30
-    latest: "2.0.20220316.0"
+    latest: "2.0.20220426.0"
+    latestReleaseDate: 2022-05-03
 
 ---
 

--- a/products/amazon-linux.md
+++ b/products/amazon-linux.md
@@ -26,6 +26,7 @@ releases:
     release: 2017-12-19
     eol: 2023-06-30
     latest: "2.0.20220316.0"
+
 ---
 
 > [Amazon Linux][al2] is a Linux server operating system from Amazon Web Services (AWS) available as an Amazon Machine Image (AMI) for use on Amazon Elastic Compute Cloud ([Amazon EC2](https://aws.amazon.com/ec2/)). It is also available as a [Docker container image](https://hub.docker.com/_/amazonlinux/) and as a [virtual machine image](https://cdn.amazonlinux.com/os-images/latest/) for use on Kernel-based Virtual Machine (KVM), Oracle VM VirtualBox, Microsoft Hyper-V, and VMware ESXi.

--- a/products/angular.md
+++ b/products/angular.md
@@ -18,11 +18,11 @@ releases:
     latest: "13.3.9"
   - releaseCycle: "12"
     lts: true
-    release: 2021-05-12
+    release: 2021-05-13
     support: 2021-11-12
     eol: 2022-11-12
     latest: "12.2.16"
-    latestReleaseDate: 2022-01-27
+    latestReleaseDate: 2022-01-26
 -   releaseCycle: "11"
     lts: true
     release: 2020-11-11
@@ -44,7 +44,7 @@ releases:
     eol: 2021-08-06
     latest: "9.1.13"
 
-    latestReleaseDate: 2020-12-17
+    latestReleaseDate: 2020-12-16
 
 ---
 

--- a/products/angular.md
+++ b/products/angular.md
@@ -11,8 +11,8 @@ changelogTemplate: https://github.com/angular/angular/releases/tag/__LATEST__
 auto:
 -   git: https://github.com/angular/angular.git
 releases:
-  - releaseCycle: "13"
-    release: 2021-11-04
+-   releaseCycle: "13"
+    release: 2021-11-03
     support: 2022-05-04
     eol: 2023-05-04
     latest: "13.3.9"
@@ -22,24 +22,29 @@ releases:
     support: 2021-11-12
     eol: 2022-11-12
     latest: "12.2.16"
-  - releaseCycle: "11"
+    latestReleaseDate: 2022-01-27
+-   releaseCycle: "11"
     lts: true
     release: 2020-11-11
     support: 2021-05-11
     eol: 2022-05-11
     latest: "11.2.14"
-  - releaseCycle: "10"
+    latestReleaseDate: 2021-05-12
+-   releaseCycle: "10"
     lts: true
     release: 2020-06-24
     support: 2020-12-24
     eol: 2021-12-24
     latest: "10.2.5"
-  - releaseCycle: "9"
+    latestReleaseDate: 2021-04-21
+-   releaseCycle: "9"
     lts: true
     release: 2020-02-06
     support: 2020-08-06
     eol: 2021-08-06
     latest: "9.1.13"
+
+    latestReleaseDate: 2020-12-17
 
 ---
 

--- a/products/angular.md
+++ b/products/angular.md
@@ -16,7 +16,8 @@ releases:
     support: 2022-05-04
     eol: 2023-05-04
     latest: "13.3.9"
-  - releaseCycle: "12"
+    latestReleaseDate: 2022-05-18
+-   releaseCycle: "12"
     lts: true
     release: 2021-05-13
     support: 2021-11-12

--- a/products/ansible.md
+++ b/products/ansible.md
@@ -14,14 +14,14 @@ auto:
 -   git: https://github.com/ansible-community/ansible-build-data.git
 releases:
 -   releaseCycle: "5"
-    release: 2021-11-30
+    release: 2021-12-02
     eol: false
     latest: "5.8.0"
   - releaseCycle: "4"
     release: 2021-05-11
     eol: true
     latest: "4.10.0"
-    latestReleaseDate: 2021-12-14
+    latestReleaseDate: 2021-12-21
 -   releaseCycle: "3"
     release: 2021-02-18
     eol: true

--- a/products/ansible.md
+++ b/products/ansible.md
@@ -17,8 +17,9 @@ releases:
     release: 2021-12-02
     eol: false
     latest: "5.8.0"
-  - releaseCycle: "4"
-    release: 2021-05-11
+    latestReleaseDate: 2022-05-18
+-   releaseCycle: "4"
+    release: 2021-05-18
     eol: true
     latest: "4.10.0"
     latestReleaseDate: 2021-12-21

--- a/products/ansible.md
+++ b/products/ansible.md
@@ -13,7 +13,7 @@ iconSlug: ansible
 auto:
 -   git: https://github.com/ansible-community/ansible-build-data.git
 releases:
-  - releaseCycle: "5"
+-   releaseCycle: "5"
     release: 2021-11-30
     eol: false
     latest: "5.8.0"
@@ -21,14 +21,18 @@ releases:
     release: 2021-05-11
     eol: true
     latest: "4.10.0"
-  - releaseCycle: "3"
-    release: 2021-02-09
+    latestReleaseDate: 2021-12-14
+-   releaseCycle: "3"
+    release: 2021-02-18
     eol: true
     latest: "3.4.0"
-  - releaseCycle: "2.10"
-    release: 2020-09-15
+    latestReleaseDate: 2021-05-13
+-   releaseCycle: "2.10"
+    release: 2020-09-22
     eol: true
     latest: "2.10.7"
+
+    latestReleaseDate: 2021-02-09
 
 ---
 

--- a/products/api-platform.md
+++ b/products/api-platform.md
@@ -19,47 +19,55 @@ releases:
 #    eol: false
 #    latest: "2.7.0"
 
-  - releaseCycle: "2.6"
+-   releaseCycle: "2.6"
     release: 2021-01-22
     support: true
     eol: false
     latest: "2.6.8"
 
-  - releaseCycle: "2.5"
+    latestReleaseDate: 2022-01-11
+-   releaseCycle: "2.5"
     release: 2019-09-30
     support: 2021-01-22
     eol: false
-    latest: "2.5.7"
+    latest: "2.5.10"
 
-  - releaseCycle: "2.4"
+    latestReleaseDate: 2021-01-22
+-   releaseCycle: "2.4"
     release: 2019-03-22
     support: 2019-09-30
     eol: 2021-01-22
     latest: "2.4.7"
 
-  - releaseCycle: "2.3"
+    latestReleaseDate: 2019-09-17
+-   releaseCycle: "2.3"
     release: 2018-07-06
     support: 2019-03-22
     eol: 2019-09-30
     latest: "2.3.6"
 
-  - releaseCycle: "2.2"
+    latestReleaseDate: 2019-01-15
+-   releaseCycle: "2.2"
     release: 2018-02-16
     support: 2018-07-06
     eol: 2019-03-22
-    latest: "2.2.8"
+    latest: "2.2.10"
 
-  - releaseCycle: "2.1"
+    latestReleaseDate: 2019-01-15
+-   releaseCycle: "2.1"
     release: 2017-09-08
     support: 2018-02-16
     eol: 2018-07-06
     latest: "2.1.6"
 
-  - releaseCycle: "2.0"
-    release: 2017-01-06
+    latestReleaseDate: 2018-02-12
+-   releaseCycle: "2.0"
+    release: 2016-11-24
     support: 2017-09-08
     eol: 2018-02-16
     latest: "2.0.11"
+
+    latestReleaseDate: 2017-09-08
 
 ---
 

--- a/products/blender.md
+++ b/products/blender.md
@@ -17,21 +17,21 @@ eolColumn: Critical bug fixes
 activeSupportColumn: true
 releases:
 -   releaseCycle: "3.1"
-    release: 2022-03-08
+    release: 2022-03-09
     eol: false
     support: true
     latest: "3.1.2"
     lts: false
 
-    latestReleaseDate: 2022-03-31
+    latestReleaseDate: 2022-04-01
 -   releaseCycle: "3.0"
-    release: 2021-12-02
+    release: 2021-12-03
     eol: 2022-03-09
     support: true
     latest: "3.0.1"
     lts: false
 
-    latestReleaseDate: 2022-01-25
+    latestReleaseDate: 2022-01-26
 -   releaseCycle: "2.93"
     release: 2021-06-02
     eol: 2023-06-01
@@ -40,7 +40,7 @@ releases:
     lts: true
     link: https://www.blender.org/download/releases/2-93/
 
-    latestReleaseDate: 2022-04-19
+    latestReleaseDate: 2022-04-20
 -   releaseCycle: "2.83"
     release: 2020-06-03
     eol: 2022-06-01

--- a/products/blender.md
+++ b/products/blender.md
@@ -16,21 +16,23 @@ sortReleasesBy: "release"
 eolColumn: Critical bug fixes
 activeSupportColumn: true
 releases:
-  - releaseCycle: "3.1"
-    release: 2022-03-09
+-   releaseCycle: "3.1"
+    release: 2022-03-08
     eol: false
     support: true
     latest: "3.1.2"
     lts: false
 
-  - releaseCycle: "3.0"
-    release: 2021-12-03
+    latestReleaseDate: 2022-03-31
+-   releaseCycle: "3.0"
+    release: 2021-12-02
     eol: 2022-03-09
     support: true
     latest: "3.0.1"
     lts: false
 
-  - releaseCycle: "2.93"
+    latestReleaseDate: 2022-01-25
+-   releaseCycle: "2.93"
     release: 2021-06-02
     eol: 2023-06-01
     support: true
@@ -38,7 +40,8 @@ releases:
     lts: true
     link: https://www.blender.org/download/releases/2-93/
 
-  - releaseCycle: "2.83"
+    latestReleaseDate: 2022-04-19
+-   releaseCycle: "2.83"
     release: 2020-06-03
     eol: 2022-06-01
     support: 2020-08-31
@@ -56,6 +59,3 @@ With the release of Blender 2.83, Blender Foundation will start a LTS (Long Term
 Currently, for non-LTS releases, Blender only has a corrective release if severity 1 issues (high priority bugs) are found. When the corrective release is agreed on, however, severity 2 (high priority and normal bugs) fixes are ported along.
 
 For the LTS releases, a more limited policy would apply (only porting severity 1 issues after the next stable release), on a fixed schedule (e.g., every 3 months) after the fix was tested in master for some time (e.g., 1 week). For more information on how this process works see the [related wiki.](https://wiki.blender.org/wiki/Process/LTS)
-
-
-

--- a/products/blender.md
+++ b/products/blender.md
@@ -48,7 +48,7 @@ releases:
     latest: "2.83.20"
     lts: true
     link: https://www.blender.org/download/releases/2-83/
-    
+    latestReleaseDate: 2022-04-20
 
 ---
 

--- a/products/bootstrap.md
+++ b/products/bootstrap.md
@@ -30,11 +30,11 @@ releases:
     support: false
     latestReleaseDate: 2019-02-13
 -   releaseCycle: "2"
-    release: 2012-02-01
+    release: 2012-01-31
     eol: 2013-08-19
     latest: "2.3.2"
     support: false
-    latestReleaseDate: 2013-07-27
+    latestReleaseDate: 2013-07-26
 releasePolicyLink: https://github.com/twbs/release
 releaseDateColumn: true
 eolColumn: Critical Support

--- a/products/bootstrap.md
+++ b/products/bootstrap.md
@@ -9,31 +9,36 @@ changelogTemplate: https://github.com/twbs/bootstrap/releases/tag/v__LATEST__
 auto:
 -   git: https://github.com/twbs/bootstrap.git
 releases:
-  - releaseCycle: "5"
+-   releaseCycle: "5"
     release: 2021-05-05
     eol: false
     support: true
     lts: true
     latest: "5.1.3"
-  - releaseCycle: "4"
+    latestReleaseDate: 2021-10-09
+-   releaseCycle: "4"
     release: 2018-01-18
     eol: 2022-11-01
     latest: "4.6.1"
     lts: true
     support: false
-  - releaseCycle: "3"
+    latestReleaseDate: 2021-10-28
+-   releaseCycle: "3"
     release: 2013-08-19
     eol: 2019-07-24
     latest: "3.4.1"
     support: false
-  - releaseCycle: "2"
-    release: 2013-07-18
+    latestReleaseDate: 2019-02-13
+-   releaseCycle: "2"
+    release: 2012-02-01
     eol: 2013-08-19
     latest: "2.3.2"
     support: false
+    latestReleaseDate: 2013-07-27
 releasePolicyLink: https://github.com/twbs/release
 releaseDateColumn: true
 eolColumn: Critical Support
+
 ---
 
 > [Bootstrap](https://getbootstrap.com/) is the most popular HTML, CSS, and JavaScript framework for developing responsive, mobile first projects on the web.

--- a/products/composer.md
+++ b/products/composer.md
@@ -7,20 +7,22 @@ changelogTemplate: "https://getcomposer.org/changelog/__LATEST__"
 auto:
 -   git: https://github.com/composer/composer.git
 releases:
-  - releaseCycle: "2.3"
+-   releaseCycle: "2.3"
     eol: false
     support: true
     release: 2022-03-30
     latest: "2.3.5"
     link: https://blog.packagist.com/composer-2-3/
 
-  - releaseCycle: "2.2"
+    latestReleaseDate: 2022-04-13
+-   releaseCycle: "2.2"
     eol: 2023-12-31
     release: 2021-12-22
     latest: "2.2.12"
     lts: true
 
-  - releaseCycle: "1.x"
+    latestReleaseDate: 2022-04-13
+-   releaseCycle: "1.x"
     release: 2016-04-05
     latest: "1.10.26"
     eol: 2020-10-24
@@ -31,6 +33,7 @@ activeSupportColumn: false
 releaseColumn: true
 releaseDateColumn: true
 command: composer --version
+
 ---
 
 > [Composer](https://getcomposer.org/) is a package manager that is commonly used to manage libraries and other dependencies for PHP projects.

--- a/products/consul.md
+++ b/products/consul.md
@@ -14,26 +14,32 @@ releaseDateColumn: true
 command: consul --version
 
 releases:
-  - releaseCycle: "1.12"
+-   releaseCycle: "1.12"
     eol: false
-    release: 2022-04-20
+    release: 2022-04-19
     latest: "1.12.0"
-  - releaseCycle: "1.11"
+    latestReleaseDate: 2022-04-19
+-   releaseCycle: "1.11"
     eol: false
     release: 2021-12-14
     latest: "1.11.5"
-  - releaseCycle: "1.10"
+    latestReleaseDate: 2022-04-13
+-   releaseCycle: "1.10"
     eol: false
     release: 2021-06-22
     latest: "1.10.10"
-  - releaseCycle: "1.9"
+    latestReleaseDate: 2022-04-13
+-   releaseCycle: "1.9"
     eol: true
     release: 2020-11-24
     latest: "1.9.17"
-  - releaseCycle: "1.8"
+    latestReleaseDate: 2022-04-14
+-   releaseCycle: "1.8"
     eol: true
     release: 2020-06-18
     latest: "1.8.19"
+    latestReleaseDate: 2021-12-15
+
 ---
 
 > [Hashicorp Consul](https://www.consul.io/) automates networking for simple and secure application delivery.

--- a/products/couchbase-server.md
+++ b/products/couchbase-server.md
@@ -3,7 +3,7 @@ title: Couchbase Server
 layout: post
 permalink: /couchbase-server
 alternate_urls:
-  - /couchbase
+-   /couchbase
 category: db
 iconSlug: couchbase
 releasePolicyLink: https://www.couchbase.com/support-policy/enterprise-software
@@ -17,22 +17,27 @@ releaseDateColumn: true
 command: cat /opt/couchbase/VERSION.txt
 
 releases:
-  - releaseCycle: "7.0"
+-   releaseCycle: "7.0"
     eol: 2023-01-01
-    release: 2021-10-01
+    release: 2021-08-31
     latest: "7.0.3"
-  - releaseCycle: "6.6"
+    latestReleaseDate: 2022-04-30
+-   releaseCycle: "6.6"
     eol: 2023-01-01
-    release: 2021-08-01
+    release: 2021-07-26
     latest: "6.6.5"
-  - releaseCycle: "6.5"
+    latestReleaseDate: 2022-02-02
+-   releaseCycle: "6.5"
     eol: 2021-02-01
-    release: 2021-01-01
+    release: 2021-07-26
     latest: "6.5.2"
-  - releaseCycle: "6.0"
+    latestReleaseDate: 2022-04-30
+-   releaseCycle: "6.0"
     eol: 2020-07-01
-    release: 2021-01-01
+    release: 2019-01-23
     latest: "6.0.5"
+    latestReleaseDate: 2022-04-30
+
 ---
 
 > [Couchbase Server](https://www.couchbase.com/products/server) is a modern cloud-native, distributed database that fuses the strengths of relational databases such as SQL and ACID transactions with JSON flexibility and scale that defines NoSQL. It is available as a service in commercial clouds and supports hybrid and private cloud deployments. 

--- a/products/django.md
+++ b/products/django.md
@@ -13,48 +13,65 @@ sortReleasesBy: 'releaseCycle'
 auto:
 -   git: https://github.com/django/django.git
 releases:
-  - releaseCycle: "4.0"
+-   releaseCycle: "4.0"
     support: 2022-08-01
     eol: 2023-04-01
     latest: "4.0.4"
 
-  - releaseCycle: "3.2"
+    release: 2021-12-07
+    latestReleaseDate: 2022-04-11
+-   releaseCycle: "3.2"
     support: 2021-12-01
     eol: 2024-04-01
     latest: "3.2.13"
     lts: true
 
-  - releaseCycle: "3.1"
+    release: 2021-04-06
+    latestReleaseDate: 2022-04-11
+-   releaseCycle: "3.1"
     support: 2021-04-05
     eol: 2021-12-07
     latest: "3.1.14"
 
-  - releaseCycle: "3.0"
+    release: 2020-08-04
+    latestReleaseDate: 2021-12-07
+-   releaseCycle: "3.0"
     support: 2020-08-01
     eol: 2021-04-06
     latest: "3.0.14"
 
-  - releaseCycle: "2.2"
+    release: 2019-12-02
+    latestReleaseDate: 2021-04-06
+-   releaseCycle: "2.2"
     lts: true
     support: 2019-12-01
     eol: 2022-04-01
     latest: "2.2.28"
 
-  - releaseCycle: "2.1"
+    release: 2019-04-01
+    latestReleaseDate: 2022-04-11
+-   releaseCycle: "2.1"
     support: 2019-04-01
     eol: 2019-12-02
     latest: "2.1.15"
 
-  - releaseCycle: "2.0"
+    release: 2018-08-01
+    latestReleaseDate: 2019-12-02
+-   releaseCycle: "2.0"
     support: 2018-08-01
     eol: 2019-04-01
     latest: "2.0.13"
 
-  - releaseCycle: "1.11"
+    release: 2017-12-02
+    latestReleaseDate: 2019-02-12
+-   releaseCycle: "1.11"
     lts: true
     support: 2017-12-02
     eol: 2020-04-01
     latest: "1.11.29"
+
+    release: 2017-04-04
+    latestReleaseDate: 2020-03-04
 
 ---
 

--- a/products/docker-engine.md
+++ b/products/docker-engine.md
@@ -25,87 +25,87 @@ releases:
   - releaseCycle: "19.03"
     eol: 2021-01-08
     support: false
-    release: 2019-07-17
+    release: 2019-07-22
     latest: "19.03.15"
-    latestReleaseDate: 2021-01-28
+    latestReleaseDate: 2021-02-01
 -   releaseCycle: "18.09"
     eol: 2019-08-22
     support: false
-    release: 2018-11-06
+    release: 2018-11-08
     latest: "18.09.9"
-    latestReleaseDate: 2019-08-22
+    latestReleaseDate: 2019-09-04
 -   releaseCycle: "18.06"
     eol: 2018-12-08
     support: false
     release: 2018-07-18
     latest: "18.06.3"
-    latestReleaseDate: 2019-02-19
+    latestReleaseDate: 2019-02-20
 -   releaseCycle: "18.05"
     eol: 2018-08-18
     support: false
-    release: 2020-03-23
+    release: 2018-04-25
     latest: "18.05.0"
-    latestReleaseDate: 2020-03-23
+    latestReleaseDate: 2018-04-25
 -   releaseCycle: "18.04"
     eol: 2018-06-09
     support: false
-    release: 2020-03-23
+    release: 2018-03-27
     latest: "18.04.0"
-    latestReleaseDate: 2020-03-23
+    latestReleaseDate: 2018-03-27
 -   releaseCycle: "18.03"
     eol: 2018-05-10
     support: false
-    release: 2020-03-23
+    release: 2018-03-14
     latest: "18.03.1"
-    latestReleaseDate: 2020-03-23
+    latestReleaseDate: 2018-04-25
 -   releaseCycle: "18.02"
     eol: 2018-04-21
     support: false
-    release: 2020-03-23
+    release: 2018-01-26
     latest: "18.02.0"
-    latestReleaseDate: 2020-03-23
+    latestReleaseDate: 2018-01-26
 -   releaseCycle: "18.01"
     eol: 2018-03-07
     support: false
-    release: 2020-03-23
+    release: 2017-12-12
     latest: "18.01.0"
-    latestReleaseDate: 2020-03-23
+    latestReleaseDate: 2017-12-12
 -   releaseCycle: "17.12"
     eol: 2018-02-10
     support: false
-    release: 2020-03-23
+    release: 2017-12-15
     latest: "17.12.1"
-    latestReleaseDate: 2020-03-23
+    latestReleaseDate: 2018-02-07
 -   releaseCycle: "17.11"
     eol: 2018-01-27
     support: false
-    release: 2020-03-23
+    release: 2017-11-17
     latest: "17.11.0"
-    latestReleaseDate: 2020-03-23
+    latestReleaseDate: 2017-11-17
 -   releaseCycle: "17.10"
     eol: 2017-12-20
     support: false
-    release: 2020-03-23
+    release: 2017-10-13
     latest: "17.10.0"
-    latestReleaseDate: 2020-03-23
+    latestReleaseDate: 2017-10-13
 -   releaseCycle: "17.09"
     eol: 2017-11-17
     support: false
-    release: 2020-03-23
+    release: 2017-09-22
     latest: "17.09.1"
-    latestReleaseDate: 2020-03-23
+    latestReleaseDate: 2017-12-07
 -   releaseCycle: "17.07"
     eol: 2017-10-26
     support: false
-    release: 2020-03-23
+    release: 2017-08-28
     latest: "17.07.0"
-    latestReleaseDate: 2020-03-23
+    latestReleaseDate: 2017-08-28
 -   releaseCycle: "17.06"
     eol: 2017-09-29
     support: false
-    release: 2020-03-23
+    release: 2017-06-20
     latest: "17.06.2"
-    latestReleaseDate: 2020-03-23
+    latestReleaseDate: 2017-09-05
 -   releaseCycle: "17.05"
     eol: 2017-07-28
     support: false
@@ -125,7 +125,7 @@ releases:
     latest: "17.03.2"
 
 
-    latestReleaseDate: 2017-06-01
+    latestReleaseDate: 2017-06-27
 
 ---
 

--- a/products/docker-engine.md
+++ b/products/docker-engine.md
@@ -17,7 +17,7 @@ auto:
 -   git: https://github.com/moby/moby.git
     regex: ^v(?<major>0|[1-9]\d*)\.(?<minor>\d*)\.(?<patch>0|[1-9]\d*)(-ce)?$
 releases:
-  - releaseCycle: "20.10"
+-   releaseCycle: "20.10"
     eol: false
     support: false
     release: 2020-12-08
@@ -25,89 +25,107 @@ releases:
   - releaseCycle: "19.03"
     eol: 2021-01-08
     support: false
-    release: 2019-07-22
+    release: 2019-07-17
     latest: "19.03.15"
-  - releaseCycle: "18.09"
+    latestReleaseDate: 2021-01-28
+-   releaseCycle: "18.09"
     eol: 2019-08-22
     support: false
-    release: 2018-11-08
+    release: 2018-11-06
     latest: "18.09.9"
-  - releaseCycle: "18.06"
+    latestReleaseDate: 2019-08-22
+-   releaseCycle: "18.06"
     eol: 2018-12-08
     support: false
     release: 2018-07-18
-    latest: "18.06.3-ce"
-  - releaseCycle: "18.05"
+    latest: "18.06.3"
+    latestReleaseDate: 2019-02-19
+-   releaseCycle: "18.05"
     eol: 2018-08-18
     support: false
-    release: 2018-05-09
-    latest: "18.05.0-ce"
-  - releaseCycle: "18.04"
+    release: 2020-03-23
+    latest: "18.05.0"
+    latestReleaseDate: 2020-03-23
+-   releaseCycle: "18.04"
     eol: 2018-06-09
     support: false
-    release: 2018-04-10
-    latest: "18.04.0-ce"
-  - releaseCycle: "18.03"
+    release: 2020-03-23
+    latest: "18.04.0"
+    latestReleaseDate: 2020-03-23
+-   releaseCycle: "18.03"
     eol: 2018-05-10
     support: false
-    release: 2018-03-21
-    latest: "18.03.1-ce"
-  - releaseCycle: "18.02"
+    release: 2020-03-23
+    latest: "18.03.1"
+    latestReleaseDate: 2020-03-23
+-   releaseCycle: "18.02"
     eol: 2018-04-21
     support: false
-    release: 2018-02-07
-    latest: "18.02.0-ce"
-  - releaseCycle: "18.01"
+    release: 2020-03-23
+    latest: "18.02.0"
+    latestReleaseDate: 2020-03-23
+-   releaseCycle: "18.01"
     eol: 2018-03-07
     support: false
-    release: 2018-01-10
-    latest: "18.01.0-ce"
-  - releaseCycle: "17.12"
+    release: 2020-03-23
+    latest: "18.01.0"
+    latestReleaseDate: 2020-03-23
+-   releaseCycle: "17.12"
     eol: 2018-02-10
     support: false
-    release: 2017-12-27
-    latest: "17.12.1-ce"
-  - releaseCycle: "17.11"
+    release: 2020-03-23
+    latest: "17.12.1"
+    latestReleaseDate: 2020-03-23
+-   releaseCycle: "17.11"
     eol: 2018-01-27
     support: false
-    release: 2017-11-20
-    latest: "17.11.0-ce"
-  - releaseCycle: "17.10"
+    release: 2020-03-23
+    latest: "17.11.0"
+    latestReleaseDate: 2020-03-23
+-   releaseCycle: "17.10"
     eol: 2017-12-20
     support: false
-    release: 2017-10-17
-    latest: "17.10.0-ce"
-  - releaseCycle: "17.09"
+    release: 2020-03-23
+    latest: "17.10.0"
+    latestReleaseDate: 2020-03-23
+-   releaseCycle: "17.09"
     eol: 2017-11-17
     support: false
-    release: 2017-09-26
-    latest: "17.09.1-ce"
-  - releaseCycle: "17.07"
+    release: 2020-03-23
+    latest: "17.09.1"
+    latestReleaseDate: 2020-03-23
+-   releaseCycle: "17.07"
     eol: 2017-10-26
     support: false
-    release: 2017-08-29
-    latest: "17.07.0-ce"
-  - releaseCycle: "17.06"
+    release: 2020-03-23
+    latest: "17.07.0"
+    latestReleaseDate: 2020-03-23
+-   releaseCycle: "17.06"
     eol: 2017-09-29
     support: false
-    release: 2017-06-28
-    latest: "17.06.2-ce"
-  - releaseCycle: "17.05"
+    release: 2020-03-23
+    latest: "17.06.2"
+    latestReleaseDate: 2020-03-23
+-   releaseCycle: "17.05"
     eol: 2017-07-28
     support: false
     release: 2017-05-04
-    latest: "17.05.0-ce"
-  - releaseCycle: "17.04"
+    latest: "17.05.0"
+    latestReleaseDate: 2017-05-04
+-   releaseCycle: "17.04"
     eol: 2017-06-04
     support: false
-    release: 2017-04-05
-    latest: "17.04.0-ce"
-  - releaseCycle: "17.03"
+    release: 2017-04-03
+    latest: "17.04.0"
+    latestReleaseDate: 2017-04-03
+-   releaseCycle: "17.03"
     eol: 2017-05-05
     support: false
-    release: 2017-03-01
-    latest: "17.03.3-ce"
+    release: 2017-02-23
+    latest: "17.03.2"
 
+
+    latestReleaseDate: 2017-06-01
 
 ---
 

--- a/products/docker-engine.md
+++ b/products/docker-engine.md
@@ -20,9 +20,10 @@ releases:
 -   releaseCycle: "20.10"
     eol: false
     support: false
-    release: 2020-12-08
+    release: 2020-12-09
     latest: "20.10.16"
-  - releaseCycle: "19.03"
+    latestReleaseDate: 2022-05-12
+-   releaseCycle: "19.03"
     eol: 2021-01-08
     support: false
     release: 2019-07-22

--- a/products/dotnet.md
+++ b/products/dotnet.md
@@ -2,9 +2,9 @@
 permalink: /dotnet
 category: framework
 alternate_urls:
-  - /.net
-  - /.netcore
-  - /dotnetcore
+-   /.net
+-   /.netcore
+-   /dotnetcore
 layout: post
 title: .NET
 command: dotnet --version
@@ -16,55 +16,58 @@ eolColumn: Support Status
 auto:
 -   git: https://github.com/dotnet/runtime.git
 releases:
-  - releaseCycle: "6.0"
+-   releaseCycle: "6.0"
     cycleShortHand: "6.0"
     lts: true
-    release: 2021-11-08
+    release: 2021-10-22
     eol: 2024-11-08
     latest: "6.0.5"
-  - releaseCycle: "5.0"
+    latestReleaseDate: 2022-04-13
+-   releaseCycle: "5.0"
     cycleShortHand: "5.0"
     lts: false
-    release: 2020-11-10
+    release: 2020-10-19
     eol: 2022-05-08
     latest: "5.0.17"
-  - releaseCycle: "Core 3.1"
+    latestReleaseDate: 2022-04-14
+-   releaseCycle: "Core 3.1"
     cycleShortHand: "3.1"
     lts: true
     release: 2019-12-03
     latest: "3.1.25"
     eol: 2022-12-03
-  - releaseCycle: "Core 3.0"
+-   releaseCycle: "Core 3.0"
     cycleShortHand: "3.0"
     release: 2019-09-23
     latest: "3.0.3"
     eol: 2020-03-03
-  - releaseCycle: "Core 2.2"
+-   releaseCycle: "Core 2.2"
     cycleShortHand: "2.2"
     release: 2018-12-04
     latest: "2.2.8"
     eol: 2019-12-23
-  - releaseCycle: "Core 2.1"
+-   releaseCycle: "Core 2.1"
     cycleShortHand: "2.1"
     lts: true
     release: 2018-05-30
     latest: "2.1.30"
     eol: 2021-08-21
-  - releaseCycle: "Core 2.0"
+-   releaseCycle: "Core 2.0"
     cycleShortHand: "2.0"
     release: 2017-08-14
     eol: 2018-10-01
     latest: "2.0.9"
-  - releaseCycle: "Core 1.1"
+-   releaseCycle: "Core 1.1"
     cycleShortHand: "1.1"
     release: 2016-11-16
     eol: 2019-06-27
     latest: "1.1.13"
-  - releaseCycle: "Core 1.0"
+-   releaseCycle: "Core 1.0"
     cycleShortHand: "1.0"
     release: 2016-06-27
     eol: 2019-06-27
     latest: "1.0.16"
+
 ---
 
 > [.NET](https://dotnet.microsoft.com/) is a free, cross-platform, open source developer platform for building many different types of applications.

--- a/products/drupal.md
+++ b/products/drupal.md
@@ -49,7 +49,7 @@ releases:
     support: 2020-06-03
     eol: 2020-12-01
     latest: "8.8.12"
-    latestReleaseDate: 2020-11-26
+    latestReleaseDate: 2020-11-25
 -   releaseCycle: "7"
     release: 2011-01-05
     support: 2015-11-19

--- a/products/drupal.md
+++ b/products/drupal.md
@@ -14,42 +14,49 @@ auto:
 -   git: https://github.com/drupal/core.git
 sortReleasesBy: 'releaseCycle'
 releases:
-  - releaseCycle: "9.3"
+-   releaseCycle: "9.3"
     release: 2021-12-08
     support: 2022-06-15
-    eol:     2022-12-14
+    eol: 2022-12-14
     latest: "9.3.13"
-  - releaseCycle: "9.2"
+    latestReleaseDate: 2022-05-11
+-   releaseCycle: "9.2"
     release: 2021-06-16
     support: 2021-12-08
-    eol:     2022-06-01
+    eol: 2022-06-01
     latest: "9.2.19"
-  - releaseCycle: "9.1"
+    latestReleaseDate: 2022-05-11
+-   releaseCycle: "9.1"
     release: 2020-12-02
     support: 2021-06-16
-    eol:     2021-12-08
+    eol: 2021-12-08
     latest: "9.1.15"
-  - releaseCycle: "9.0"
+    latestReleaseDate: 2021-11-24
+-   releaseCycle: "9.0"
     release: 2020-06-03
     support: 2020-12-02
-    eol:     2021-06-16
+    eol: 2021-06-16
     latest: "9.0.14"
-  - releaseCycle: "8.9"
+    latestReleaseDate: 2021-05-25
+-   releaseCycle: "8.9"
     release: 2020-06-03
     support: 2020-12-01
-    eol:     2021-11-02
+    eol: 2021-11-02
     latest: "8.9.20"
-  - releaseCycle: "8.8"
+    latestReleaseDate: 2021-11-17
+-   releaseCycle: "8.8"
     release: 2019-12-04
     support: 2020-06-03
-    eol:     2020-12-01
+    eol: 2020-12-01
     latest: "8.8.12"
-  - releaseCycle: "7"
+    latestReleaseDate: 2020-11-26
+-   releaseCycle: "7"
     release: 2011-01-05
     support: 2015-11-19
-    eol:     2023-11-01
+    eol: 2023-11-01
     latest: "7.89"
     lts: true
+
 ---
 
 > [Drupal](https://www.drupal.org/) is a free and open-source content management framework written in PHP and distributed under the GNU General Public License.

--- a/products/elasticsearch.md
+++ b/products/elasticsearch.md
@@ -16,194 +16,194 @@ releases:
     cycleShortHand: 802
     eol: 2023-10-26
     latest: 8.2.0
-    release: 2022-04-20
-    latestReleaseDate: 2022-04-20
+    release: 2022-05-03
+    latestReleaseDate: 2022-05-03
 -   releaseCycle: "8.1"
     cycleShortHand: 801
     eol: 2023-09-08
     latest: 8.1.3
-    release: 2022-03-03
-    latestReleaseDate: 2022-04-15
+    release: 2022-03-08
+    latestReleaseDate: 2022-04-20
 -   releaseCycle: "8.0"
     cycleShortHand: 800
     eol: 2023-08-10
     latest: 8.0.1
-    release: 2022-01-31
-    latestReleaseDate: 2022-02-24
+    release: 2022-02-10
+    latestReleaseDate: 2022-03-01
 -   releaseCycle: "7.17"
     cycleShortHand: 717
     eol: 2023-08-01
     latest: 7.17.3
-    release: 2022-01-27
-    latestReleaseDate: 2022-04-15
+    release: 2022-02-01
+    latestReleaseDate: 2022-04-20
 -   releaseCycle: "7.16"
     cycleShortHand: 716
     eol: 2023-06-07
     latest: 7.16.3
-    release: 2021-12-02
-    latestReleaseDate: 2022-01-06
+    release: 2021-12-07
+    latestReleaseDate: 2022-01-13
 -   releaseCycle: "7.15"
     cycleShortHand: 715
     eol: 2023-03-22
     latest: 7.15.2
-    release: 2021-09-15
-    latestReleaseDate: 2021-11-03
+    release: 2021-09-22
+    latestReleaseDate: 2021-11-10
 -   releaseCycle: "7.14"
     cycleShortHand: 714
     eol: 2023-02-03
     latest: 7.14.2
-    release: 2021-07-29
-    latestReleaseDate: 2021-09-15
+    release: 2021-08-03
+    latestReleaseDate: 2021-09-21
 -   releaseCycle: "7.13"
     cycleShortHand: 713
     eol: 2022-11-25
     latest: 7.13.4
-    release: 2021-05-19
-    latestReleaseDate: 2021-07-13
+    release: 2021-05-25
+    latestReleaseDate: 2021-07-20
 -   releaseCycle: "7.12"
     cycleShortHand: 712
     eol: 2022-09-23
     latest: 7.12.1
-    release: 2021-03-18
-    latestReleaseDate: 2021-04-20
+    release: 2021-03-23
+    latestReleaseDate: 2021-04-27
 -   releaseCycle: "7.11"
     cycleShortHand: 711
     eol: 2022-08-10
     latest: 7.11.2
-    release: 2021-02-08
-    latestReleaseDate: 2021-03-03
+    release: 2021-02-10
+    latestReleaseDate: 2021-03-10
 -   releaseCycle: "7.10"
     cycleShortHand: 710
     eol: 2022-05-11
     latest: 7.10.2
-    release: 2020-11-05
-    latestReleaseDate: 2021-01-06
+    release: 2020-11-11
+    latestReleaseDate: 2021-01-14
 -   releaseCycle: "7.9"
     cycleShortHand: 709
     eol: 2022-02-18
     latest: 7.9.3
-    release: 2020-08-11
-    latestReleaseDate: 2020-10-16
+    release: 2020-08-18
+    latestReleaseDate: 2020-10-22
 -   releaseCycle: "7.8"
     cycleShortHand: 708
     eol: 2021-12-18
     latest: 7.8.1
-    release: 2020-06-12
-    latestReleaseDate: 2020-07-21
+    release: 2020-06-18
+    latestReleaseDate: 2020-07-27
 -   releaseCycle: "7.7"
     cycleShortHand: 707
     eol: 2021-11-13
     latest: 7.7.1
-    release: 2020-05-08
-    latestReleaseDate: 2020-05-28
+    release: 2020-05-13
+    latestReleaseDate: 2020-06-03
 -   releaseCycle: "7.6"
     cycleShortHand: 706
     eol: 2021-08-11
     latest: 7.6.2
-    release: 2020-02-05
-    latestReleaseDate: 2020-03-25
+    release: 2020-02-11
+    latestReleaseDate: 2020-03-31
 -   releaseCycle: "7.5"
     cycleShortHand: 705
     eol: 2021-06-02
     latest: 7.5.2
-    release: 2019-11-25
-    latestReleaseDate: 2020-01-15
+    release: 2019-12-02
+    latestReleaseDate: 2020-01-21
 -   releaseCycle: "7.4"
     cycleShortHand: 704
     eol: 2021-04-01
     latest: 7.4.2
-    release: 2019-09-27
-    latestReleaseDate: 2019-10-28
+    release: 2019-10-01
+    latestReleaseDate: 2019-10-31
 -   releaseCycle: "7.3"
     cycleShortHand: 703
     eol: 2021-01-31
     latest: 7.3.2
-    release: 2019-07-24
-    latestReleaseDate: 2019-09-06
+    release: 2019-07-31
+    latestReleaseDate: 2019-09-12
 -   releaseCycle: "7.2"
     cycleShortHand: 702
     eol: 2020-12-25
     latest: 7.2.1
-    release: 2019-06-20
-    latestReleaseDate: 2019-07-24
+    release: 2019-06-25
+    latestReleaseDate: 2019-07-30
 -   releaseCycle: "7.1"
     cycleShortHand: 701
     eol: 2020-11-20
     latest: 7.17.3
-    release: 2019-05-15
-    latestReleaseDate: 2022-04-15
+    release: 2019-05-20
+    latestReleaseDate: 2022-04-20
 -   releaseCycle: "7.0"
     cycleShortHand: 700
     eol: 2020-10-10
     latest: 7.0.1
-    release: 2019-04-05
-    latestReleaseDate: 2019-04-29
+    release: 2019-04-10
+    latestReleaseDate: 2019-05-01
 -   releaseCycle: "6.8"
     cycleShortHand: 608
     eol: 2022-02-08
     latest: 6.8.23
-    release: 2019-05-15
-    latestReleaseDate: 2021-12-29
+    release: 2019-05-20
+    latestReleaseDate: 2022-01-13
 -   releaseCycle: "6.7"
     cycleShortHand: 607
     eol: 2020-09-26
     latest: 6.7.2
-    release: 2019-03-21
-    latestReleaseDate: 2019-04-29
+    release: 2019-03-26
+    latestReleaseDate: 2019-05-02
 -   releaseCycle: "6.6"
     cycleShortHand: 606
     eol: 2020-07-29
     latest: 6.6.2
-    release: 2019-01-24
-    latestReleaseDate: 2019-03-06
+    release: 2019-01-29
+    latestReleaseDate: 2019-03-12
 -   releaseCycle: "6.5"
     cycleShortHand: 605
     eol: 2020-05-14
     latest: 6.5.4
-    release: 2018-11-09
-    latestReleaseDate: 2018-12-17
+    release: 2018-11-14
+    latestReleaseDate: 2018-12-25
 -   releaseCycle: "6.4"
     cycleShortHand: 604
     eol: 2020-02-23
     latest: 6.4.3
     release: 2018-08-17
-    latestReleaseDate: 2018-10-30
+    latestReleaseDate: 2018-11-06
 -   releaseCycle: "6.3"
     cycleShortHand: 603
     eol: 2019-12-13
     latest: 6.3.2
-    release: 2018-06-11
-    latestReleaseDate: 2018-07-20
+    release: 2018-06-13
+    latestReleaseDate: 2018-07-24
 -   releaseCycle: "6.2"
     cycleShortHand: 602
     eol: 2019-08-06
     latest: 6.2.4
-    release: 2018-02-01
-    latestReleaseDate: 2018-04-12
+    release: 2018-02-06
+    latestReleaseDate: 2018-04-17
 -   releaseCycle: "6.1"
     cycleShortHand: 601
     eol: 2019-06-13
     latest: 6.1.4
-    release: 2017-12-12
-    latestReleaseDate: 2018-03-14
+    release: 2017-12-14
+    latestReleaseDate: 2018-03-20
 -   releaseCycle: "6.0"
     cycleShortHand: 600
     eol: 2019-05-14
     latest: 6.0.1
-    release: 2017-11-10
-    latestReleaseDate: 2017-12-03
+    release: 2017-11-14
+    latestReleaseDate: 2017-12-07
 -   releaseCycle: "5.6"
     cycleShortHand: 506
     eol: 2019-03-11
     latest: 5.6.16
-    release: 2017-09-07
+    release: 2017-09-12
     latestReleaseDate: 2019-03-19
 -   releaseCycle: "5.5"
     cycleShortHand: 505
     eol: 2019-01-06
     latest: 5.5.3
-    release: 2017-06-30
-    latestReleaseDate: 2017-09-06
+    release: 2017-07-07
+    latestReleaseDate: 2017-09-12
 
 ---
 

--- a/products/elasticsearch.md
+++ b/products/elasticsearch.md
@@ -12,134 +12,198 @@ sortReleasesBy: 'cycleShortHand'
 auto:
 -   git: https://github.com/elastic/elasticsearch.git
 releases:
-  - releaseCycle: "8.2"
+-   releaseCycle: "8.2"
     cycleShortHand: 802
     eol: 2023-10-26
     latest: 8.2.0
-  - releaseCycle: "8.1"
+    release: 2022-04-20
+    latestReleaseDate: 2022-04-20
+-   releaseCycle: "8.1"
     cycleShortHand: 801
     eol: 2023-09-08
     latest: 8.1.3
-  - releaseCycle: "8.0"
+    release: 2022-03-03
+    latestReleaseDate: 2022-04-15
+-   releaseCycle: "8.0"
     cycleShortHand: 800
     eol: 2023-08-10
     latest: 8.0.1
-  - releaseCycle: "7.17"
+    release: 2022-01-31
+    latestReleaseDate: 2022-02-24
+-   releaseCycle: "7.17"
     cycleShortHand: 717
     eol: 2023-08-01
     latest: 7.17.3
-  - releaseCycle: "7.16"
+    release: 2022-01-27
+    latestReleaseDate: 2022-04-15
+-   releaseCycle: "7.16"
     cycleShortHand: 716
     eol: 2023-06-07
     latest: 7.16.3
-  - releaseCycle: "7.15"
+    release: 2021-12-02
+    latestReleaseDate: 2022-01-06
+-   releaseCycle: "7.15"
     cycleShortHand: 715
     eol: 2023-03-22
     latest: 7.15.2
-  - releaseCycle: "7.14"
+    release: 2021-09-15
+    latestReleaseDate: 2021-11-03
+-   releaseCycle: "7.14"
     cycleShortHand: 714
     eol: 2023-02-03
     latest: 7.14.2
-  - releaseCycle: "7.13"
+    release: 2021-07-29
+    latestReleaseDate: 2021-09-15
+-   releaseCycle: "7.13"
     cycleShortHand: 713
     eol: 2022-11-25
     latest: 7.13.4
-  - releaseCycle: "7.12"
+    release: 2021-05-19
+    latestReleaseDate: 2021-07-13
+-   releaseCycle: "7.12"
     cycleShortHand: 712
     eol: 2022-09-23
     latest: 7.12.1
-  - releaseCycle: "7.11"
+    release: 2021-03-18
+    latestReleaseDate: 2021-04-20
+-   releaseCycle: "7.11"
     cycleShortHand: 711
     eol: 2022-08-10
     latest: 7.11.2
-  - releaseCycle: "7.10"
+    release: 2021-02-08
+    latestReleaseDate: 2021-03-03
+-   releaseCycle: "7.10"
     cycleShortHand: 710
     eol: 2022-05-11
     latest: 7.10.2
-  - releaseCycle: "7.9"
+    release: 2020-11-05
+    latestReleaseDate: 2021-01-06
+-   releaseCycle: "7.9"
     cycleShortHand: 709
     eol: 2022-02-18
     latest: 7.9.3
-  - releaseCycle: "7.8"
+    release: 2020-08-11
+    latestReleaseDate: 2020-10-16
+-   releaseCycle: "7.8"
     cycleShortHand: 708
     eol: 2021-12-18
     latest: 7.8.1
-  - releaseCycle: "7.7"
+    release: 2020-06-12
+    latestReleaseDate: 2020-07-21
+-   releaseCycle: "7.7"
     cycleShortHand: 707
     eol: 2021-11-13
     latest: 7.7.1
-  - releaseCycle: "7.6"
+    release: 2020-05-08
+    latestReleaseDate: 2020-05-28
+-   releaseCycle: "7.6"
     cycleShortHand: 706
     eol: 2021-08-11
     latest: 7.6.2
-  - releaseCycle: "7.5"
+    release: 2020-02-05
+    latestReleaseDate: 2020-03-25
+-   releaseCycle: "7.5"
     cycleShortHand: 705
     eol: 2021-06-02
     latest: 7.5.2
-  - releaseCycle: "7.4"
+    release: 2019-11-25
+    latestReleaseDate: 2020-01-15
+-   releaseCycle: "7.4"
     cycleShortHand: 704
     eol: 2021-04-01
     latest: 7.4.2
-  - releaseCycle: "7.3"
+    release: 2019-09-27
+    latestReleaseDate: 2019-10-28
+-   releaseCycle: "7.3"
     cycleShortHand: 703
     eol: 2021-01-31
     latest: 7.3.2
-  - releaseCycle: "7.2"
+    release: 2019-07-24
+    latestReleaseDate: 2019-09-06
+-   releaseCycle: "7.2"
     cycleShortHand: 702
     eol: 2020-12-25
     latest: 7.2.1
-  - releaseCycle: "7.1"
+    release: 2019-06-20
+    latestReleaseDate: 2019-07-24
+-   releaseCycle: "7.1"
     cycleShortHand: 701
     eol: 2020-11-20
-    latest: 7.1.1
-  - releaseCycle: "7.0"
+    latest: 7.17.3
+    release: 2019-05-15
+    latestReleaseDate: 2022-04-15
+-   releaseCycle: "7.0"
     cycleShortHand: 700
     eol: 2020-10-10
     latest: 7.0.1
-  - releaseCycle: "6.8"
+    release: 2019-04-05
+    latestReleaseDate: 2019-04-29
+-   releaseCycle: "6.8"
     cycleShortHand: 608
     eol: 2022-02-08
     latest: 6.8.23
-  - releaseCycle: "6.7"
+    release: 2019-05-15
+    latestReleaseDate: 2021-12-29
+-   releaseCycle: "6.7"
     cycleShortHand: 607
     eol: 2020-09-26
     latest: 6.7.2
-  - releaseCycle: "6.6"
+    release: 2019-03-21
+    latestReleaseDate: 2019-04-29
+-   releaseCycle: "6.6"
     cycleShortHand: 606
     eol: 2020-07-29
     latest: 6.6.2
-  - releaseCycle: "6.5"
+    release: 2019-01-24
+    latestReleaseDate: 2019-03-06
+-   releaseCycle: "6.5"
     cycleShortHand: 605
     eol: 2020-05-14
     latest: 6.5.4
-  - releaseCycle: "6.4"
+    release: 2018-11-09
+    latestReleaseDate: 2018-12-17
+-   releaseCycle: "6.4"
     cycleShortHand: 604
     eol: 2020-02-23
     latest: 6.4.3
-  - releaseCycle: "6.3"
+    release: 2018-08-17
+    latestReleaseDate: 2018-10-30
+-   releaseCycle: "6.3"
     cycleShortHand: 603
     eol: 2019-12-13
     latest: 6.3.2
-  - releaseCycle: "6.2"
+    release: 2018-06-11
+    latestReleaseDate: 2018-07-20
+-   releaseCycle: "6.2"
     cycleShortHand: 602
     eol: 2019-08-06
     latest: 6.2.4
-  - releaseCycle: "6.1"
+    release: 2018-02-01
+    latestReleaseDate: 2018-04-12
+-   releaseCycle: "6.1"
     cycleShortHand: 601
     eol: 2019-06-13
     latest: 6.1.4
-  - releaseCycle: "6.0"
+    release: 2017-12-12
+    latestReleaseDate: 2018-03-14
+-   releaseCycle: "6.0"
     cycleShortHand: 600
     eol: 2019-05-14
     latest: 6.0.1
-  - releaseCycle: "5.6"
+    release: 2017-11-10
+    latestReleaseDate: 2017-12-03
+-   releaseCycle: "5.6"
     cycleShortHand: 506
     eol: 2019-03-11
-    latest: 5.6.15
-  - releaseCycle: "5.5"
+    latest: 5.6.16
+    release: 2017-09-07
+    latestReleaseDate: 2019-03-19
+-   releaseCycle: "5.5"
     cycleShortHand: 505
     eol: 2019-01-06
     latest: 5.5.3
+    release: 2017-06-30
+    latestReleaseDate: 2017-09-06
 
 ---
 

--- a/products/elasticsearch.md
+++ b/products/elasticsearch.md
@@ -129,9 +129,9 @@ releases:
 -   releaseCycle: "7.1"
     cycleShortHand: 701
     eol: 2020-11-20
-    latest: 7.17.3
+    latest: 7.1.1
     release: 2019-05-20
-    latestReleaseDate: 2022-04-20
+    latestReleaseDate: 2019-05-28
 -   releaseCycle: "7.0"
     cycleShortHand: 700
     eol: 2020-10-10
@@ -214,3 +214,4 @@ Each major release of all Elastic products is supported for 18 months from the G
 Major versions, such as 1.0.0, 2.0.0, 5.0.0, 6.0.0, and 7.0.0 will introduce features and break backwards compatibility. Minor versions, such as 7.1.0 and 7.2.0, will only introduce features. Maintenance releases, such as 7.1.1 and 7.1.2, will fix bugs only. Maintenance activity occurs on all releases, but we focus on the minor release stream (e.g., 7.1.x) to define how long we maintain a particular code line. Active maintenance of a minor release implies that we are fixing bugs and backporting some number of fixes into that code branch.
 
 The last minor of the prior major release is always supported. For example, Elasticsearch 6.8.x will be maintained until the GA release of Elasticsearch 8.0.0.
+

--- a/products/electron.md
+++ b/products/electron.md
@@ -19,21 +19,24 @@ releases:
   # but this varies a lot currently due to the cadence change.
 -   releaseCycle: "18"
     eol: false
-    release: 2022-03-29
-    latest: "18.2.4"
-  - releaseCycle: "17"
+    release: 2022-03-28
+    latest: "18.3.0"
+    latestReleaseDate: 2022-05-23
+-   releaseCycle: "17"
     eol: false
-    release: 2022-02-01
+    release: 2022-01-31
     latest: "17.4.5"
-  - releaseCycle: "16"
+    latestReleaseDate: 2022-05-18
+-   releaseCycle: "16"
     eol: false
-    release: 2021-11-16
+    release: 2021-11-15
     latest: "16.2.7"
-  - releaseCycle: "15"
+    latestReleaseDate: 2022-05-18
+-   releaseCycle: "15"
     eol: false
     release: 2021-09-21
-    latest: "15.5.5"
-    latestReleaseDate: 2022-05-11
+    latest: "15.5.6"
+    latestReleaseDate: 2022-05-23
 -   releaseCycle: "14"
     eol: true
     release: 2021-08-30

--- a/products/electron.md
+++ b/products/electron.md
@@ -46,7 +46,7 @@ releases:
     latestReleaseDate: 2022-02-01
 -   releaseCycle: "12"
     eol: true
-    release: 2021-03-02
+    release: 2021-03-01
     latest: "12.2.3"
     latestReleaseDate: 2021-11-15
 -   releaseCycle: "11"
@@ -83,7 +83,7 @@ releases:
     eol: true
     release: 2019-04-23
     latest: "5.0.13"
-    latestReleaseDate: 2019-12-17
+    latestReleaseDate: 2019-12-16
 
 ---
 

--- a/products/electron.md
+++ b/products/electron.md
@@ -17,7 +17,7 @@ sortReleasesBy: releaseCycle
 releases:
   # The approximate EoL going forward will be 8 months for every release
   # but this varies a lot currently due to the cadence change.
-  - releaseCycle: "18"
+-   releaseCycle: "18"
     eol: false
     release: 2022-03-29
     latest: "18.2.4"
@@ -31,48 +31,60 @@ releases:
     latest: "16.2.7"
   - releaseCycle: "15"
     eol: false
-    release: 2021-09-22
+    release: 2021-09-21
     latest: "15.5.5"
-  - releaseCycle: "14"
+    latestReleaseDate: 2022-05-11
+-   releaseCycle: "14"
     eol: true
-    release: 2021-08-31
+    release: 2021-08-30
     latest: "14.2.9"
-  - releaseCycle: "13"
+    latestReleaseDate: 2022-03-29
+-   releaseCycle: "13"
     eol: true
-    release: 2021-05-25
+    release: 2021-05-24
     latest: "13.6.9"
-  - releaseCycle: "12"
+    latestReleaseDate: 2022-02-01
+-   releaseCycle: "12"
     eol: true
     release: 2021-03-02
     latest: "12.2.3"
-  - releaseCycle: "11"
+    latestReleaseDate: 2021-11-15
+-   releaseCycle: "11"
     eol: true
-    release: 2020-11-17
+    release: 2020-11-16
     latest: "11.5.0"
-  - releaseCycle: "10"
+    latestReleaseDate: 2021-08-31
+-   releaseCycle: "10"
     eol: true
-    release: 2020-08-25
+    release: 2020-08-24
     latest: "10.4.7"
-  - releaseCycle: "9"
+    latestReleaseDate: 2021-05-24
+-   releaseCycle: "9"
     eol: true
-    release: 2020-05-19
+    release: 2020-05-18
     latest: "9.4.4"
-  - releaseCycle: "8"
+    latestReleaseDate: 2021-03-03
+-   releaseCycle: "8"
     eol: true
-    release: 2020-02-04
+    release: 2020-02-03
     latest: "8.5.5"
-  - releaseCycle: "7"
+    latestReleaseDate: 2020-11-18
+-   releaseCycle: "7"
     eol: true
-    release: 2019-10-22
+    release: 2019-10-21
     latest: "7.3.3"
-  - releaseCycle: "6"
+    latestReleaseDate: 2020-08-25
+-   releaseCycle: "6"
     eol: true
-    release: 2019-07-30
+    release: 2019-07-29
     latest: "6.1.12"
-  - releaseCycle: "5"
+    latestReleaseDate: 2020-05-18
+-   releaseCycle: "5"
     eol: true
-    release: 2019-04-24
+    release: 2019-04-23
     latest: "5.0.13"
+    latestReleaseDate: 2019-12-17
+
 ---
 
 > [Electron](https://www.electronjs.org/) is a framework for building desktop applications using JavaScript, HTML, and CSS. By embedding Chromium and Node.js into its binary, Electron allows you to maintain one JavaScript codebase and create cross-platform apps that work on Windows, macOS, and Linux.

--- a/products/elixir.md
+++ b/products/elixir.md
@@ -59,7 +59,7 @@ releases:
     eol: 2020-10-06 # release date of 1.11.0
     support: 2018-07-25 # release date of 1.7.0
     latest: "1.6.6"
-    latestReleaseDate: 2018-06-19
+    latestReleaseDate: 2018-06-20
 -   releaseCycle: "1.5"
     release: 2017-07-25
     eol: 2020-01-27 # release date of 1.10.0
@@ -67,7 +67,7 @@ releases:
     latest: "1.5.3"
     latestReleaseDate: 2017-12-19
 -   releaseCycle: "1.4"
-    release: 2017-01-04
+    release: 2017-01-05
     eol: 2019-06-24 # release date of 1.9.0
     support: 2017-07-25 # release date of 1.5.0
     latest: "1.4.5"

--- a/products/elixir.md
+++ b/products/elixir.md
@@ -12,56 +12,67 @@ sortReleasesBy: "release"
 auto:
 -   git: https://github.com/elixir-lang/elixir.git
 releases:
-  - releaseCycle: "1.13"
+-   releaseCycle: "1.13"
     release: 2021-12-03 # https://github.com/elixir-lang/elixir/releases/tag/v1.13.0
     eol: 2024-06-01 # projected release date of 1.18.0
     support: 2022-06-01 # projected release date of 1.14.0
     latest: "1.13.4"
-  - releaseCycle: "1.12"
+    latestReleaseDate: 2022-04-07
+-   releaseCycle: "1.12"
     release: 2021-05-19 # https://github.com/elixir-lang/elixir/releases/tag/v1.12.0
     eol: 2023-12-01 # projected release date of 1.17.0
     support: 2021-12-03 # release date of 1.13.0
     latest: "1.12.3"
-  - releaseCycle: "1.11"
+    latestReleaseDate: 2021-09-05
+-   releaseCycle: "1.11"
     release: 2020-10-06 # https://github.com/elixir-lang/elixir/releases/tag/v1.11.0
     eol: 2023-06-01 # projected release date of 1.16.0
     support: 2021-05-19 # release date of 1.12.0
     latest: "1.11.4"
-  - releaseCycle: "1.10"
+    latestReleaseDate: 2021-03-16
+-   releaseCycle: "1.10"
     release: 2020-01-27
     eol: 2022-12-01 # projected release date of 1.15.0
     support: 2020-10-06 # release date of 1.11.0
     latest: "1.10.4"
-  - releaseCycle: "1.9"
+    latestReleaseDate: 2020-07-04
+-   releaseCycle: "1.9"
     release: 2019-06-24
     eol: 2022-06-01 # projected release date of 1.14.0
     support: 2020-01-27 # release date of 1.10.0
     latest: "1.9.4"
-  - releaseCycle: "1.8"
+    latestReleaseDate: 2019-11-05
+-   releaseCycle: "1.8"
     release: 2019-01-14
     eol: 2021-12-03 # release date of 1.13.0
     support: 2019-06-24 # release date of 1.9.0
     latest: "1.8.2"
-  - releaseCycle: "1.7"
+    latestReleaseDate: 2019-05-11
+-   releaseCycle: "1.7"
     release: 2018-07-25
     eol: 2021-05-19 # release date of 1.12.0
     support: 2019-01-14 # release date of 1.8.0
     latest: "1.7.4"
-  - releaseCycle: "1.6"
+    latestReleaseDate: 2018-10-24
+-   releaseCycle: "1.6"
     release: 2018-01-17
     eol: 2020-10-06 # release date of 1.11.0
     support: 2018-07-25 # release date of 1.7.0
     latest: "1.6.6"
-  - releaseCycle: "1.5"
+    latestReleaseDate: 2018-06-19
+-   releaseCycle: "1.5"
     release: 2017-07-25
     eol: 2020-01-27 # release date of 1.10.0
     support: 2018-01-17 # release date of 1.6.0
     latest: "1.5.3"
-  - releaseCycle: "1.4"
-    release: 2017-01-05
+    latestReleaseDate: 2017-12-19
+-   releaseCycle: "1.4"
+    release: 2017-01-04
     eol: 2019-06-24 # release date of 1.9.0
     support: 2017-07-25 # release date of 1.5.0
     latest: "1.4.5"
+    latestReleaseDate: 2017-06-22
+
 ---
 
 >[Elixir](https://elixir-lang.org/) is a dynamic, functional language designed for building scalable and maintainable applications.

--- a/products/emberjs.md
+++ b/products/emberjs.md
@@ -19,10 +19,10 @@ releases:
     support: true
     eol: false
     latest: "4.4.0"
-    latestReleaseDate: 2022-05-03
+    latestReleaseDate: 2022-05-02
 -   releaseCycle: "3.28"
     lts: true
-    release: 2021-08-10
+    release: 2021-08-09
     support: 2022-08-29
     eol: 2023-01-02
     latest: "3.28.9"

--- a/products/emberjs.md
+++ b/products/emberjs.md
@@ -3,7 +3,7 @@ title: Ember
 permalink: /emberjs
 iconSlug: emberdotjs
 alternate_urls:
-  - /ember
+-   /ember
 layout: post
 category: framework
 sortReleasesBy: 'releaseCycle'
@@ -14,23 +14,27 @@ releaseDateColumn: true
 auto:
 -   git: https://github.com/emberjs/ember.js.git
 releases:
-  - releaseCycle: "4"
-    release: 2021-12-28
+-   releaseCycle: "4"
+    release: 2021-11-15
     support: true
     eol: false
     latest: "4.4.0"
-  - releaseCycle: "3.28"
+    latestReleaseDate: 2022-05-03
+-   releaseCycle: "3.28"
     lts: true
-    release: 2021-12-20
+    release: 2021-08-10
     support: 2022-08-29
     eol: 2023-01-02
     latest: "3.28.9"
-  - releaseCycle: "3.24"
+    latestReleaseDate: 2022-04-19
+-   releaseCycle: "3.24"
     lts: true
-    release: 2021-02-25
+    release: 2020-12-28
     support: 2021-11-04
     eol: 2022-03-10
     latest: "3.24.6"
+
+    latestReleaseDate: 2021-10-18
 
 ---
 
@@ -44,4 +48,4 @@ Once a release of Ember gets promoted to LTS, it receives bugfixes for 36 weeks 
 
 An LTS is declared roughly every 4 minor versions, excluding the x.0 minor version. The last minor version before the next major release is also considered to be an LTS. For example, in Ember 2.x, the following versions were considered LTS's: 2.4, 2.8, 2.12, 2.16, and 2.18 (last version).  
 
-Before a version can be called an "LTS" release, it has to spend at least 6 weeks as a stable release, where it is used and tested by thousands of developers. 
+Before a version can be called an "LTS" release, it has to spend at least 6 weeks as a stable release, where it is used and tested by thousands of developers.

--- a/products/fedora.md
+++ b/products/fedora.md
@@ -5,7 +5,7 @@ layout: post
 releasePolicyLink: https://fedoraproject.org/wiki/End_of_life
 activeSupportColumn: false
 releaseDateColumn: true
-command: cat /etc/fedora-release 
+command: cat /etc/fedora-release
 sortReleasesBy: 'releaseCycle'
 changelogTemplate: https://fedoraproject.org/wiki/Releases/__RELEASE_CYCLE__/ChangeSet?rd=Releases/__RELEASE_CYCLE__
 auto:
@@ -14,42 +14,52 @@ auto:
     template: '{{version}}'
 category: os
 releases:
-  - releaseCycle: "36"
-    release: 2022-05-10
+-   releaseCycle: "36"
+    release: 2022-05-13
     latest: "36"
     eol: 2023-05-16
-  - releaseCycle: "35"
-    release: 2021-11-02
+    latestReleaseDate: 2022-05-13
+-   releaseCycle: "35"
+    release: 2022-03-20
     latest: "35"
     eol: 2022-11-15
-  - releaseCycle: "34"
-    release: 2021-04-27
+    latestReleaseDate: 2022-03-20
+-   releaseCycle: "34"
+    release: 2022-03-20
     latest: "34"
     eol: 2022-06-07
-  - releaseCycle: "33"
-    release: 2020-10-27
+    latestReleaseDate: 2022-03-20
+-   releaseCycle: "33"
+    release: 2021-11-29
     latest: "33"
     eol: 2021-11-30
-  - releaseCycle: "32"
-    release: 2020-04-28
+    latestReleaseDate: 2021-11-29
+-   releaseCycle: "32"
+    release: 2021-07-23
     latest: "32"
     eol: 2021-05-25
-  - releaseCycle: "31"
-    release: 2019-10-29
+    latestReleaseDate: 2021-07-23
+-   releaseCycle: "31"
+    release: 2021-04-01
     latest: "31"
     eol: 2020-11-30
-  - releaseCycle: "30"
-    release: 2019-05-07
+    latestReleaseDate: 2021-04-01
+-   releaseCycle: "30"
+    release: 2020-02-21
     latest: "30"
     eol: 2020-05-26
-  - releaseCycle: "29"
-    release: 2018-10-30
+    latestReleaseDate: 2020-02-21
+-   releaseCycle: "29"
+    release: 2019-06-05
     latest: "29"
     eol: 2019-11-26
-  - releaseCycle: "28"
-    release: 2018-05-01
+    latestReleaseDate: 2019-06-05
+-   releaseCycle: "28"
+    release: 2019-06-05
     latest: "28"
     eol: 2019-05-28
+    latestReleaseDate: 2019-06-05
+
 ---
 
 > [Fedora](https://getfedora.org/) is a Linux distribution developed by the community-supported Fedora Project and sponsored by Red Hat.

--- a/products/ffmpeg.md
+++ b/products/ffmpeg.md
@@ -16,217 +16,241 @@ auto:
     regex: '^n?(?<major>[1-9]\d*)\.(?<minor>0|[1-9]\d*)\.?(?<patch>0|[1-9]\d*)?$'
 releaseLabel: "__RELEASE_CYCLE__ '__CODENAME__'"
 releases:
-  - releaseCycle: "5.0"
+-   releaseCycle: "5.0"
     cycleShortHand: 50
     codename: Lorentz
-    release: 2022-01-17
+    release: 2022-01-14
     eol: false
     latest: "5.0.1"
     lts: true
     link: https://ffmpeg.org/download.html#release_5.0
-  - releaseCycle: "4.4"
+    latestReleaseDate: 2022-04-03
+-   releaseCycle: "4.4"
     cycleShortHand: 44
     codename: Rao
-    release:  2021-04-09
+    release: 2021-04-08
     eol: false
     latest: "4.4.2"
     link: https://ffmpeg.org/download.html#release_4.4
-  - releaseCycle: "4.3"
+    latestReleaseDate: 2022-04-14
+-   releaseCycle: "4.3"
     cycleShortHand: 43
     codename: '4:3'
     release: 2020-06-15
     eol: false
     latest: "4.3.4"
     link: https://ffmpeg.org/download.html#release_4.3
-  - releaseCycle: "4.2"
+    latestReleaseDate: 2022-04-15
+-   releaseCycle: "4.2"
     cycleShortHand: 42
     codename: 'Ada'
-    release: 2019-07-21
+    release: 2019-08-05
     eol: false
     latest: "4.2.7"
     link: https://ffmpeg.org/download.html#release_4.2
-  - releaseCycle: "4.1"
+    latestReleaseDate: 2022-05-09
+-   releaseCycle: "4.1"
     cycleShortHand: 41
     codename: 'al-Khwarizmi'
-    release: 2018-11-02
+    release: 2018-11-05
     eol: false
     latest: "4.1.9"
     link: https://ffmpeg.org/download.html#release_4.1
-  - releaseCycle: "4.0"
+    latestReleaseDate: 2022-04-16
+-   releaseCycle: "4.0"
     cycleShortHand: 40
     codename: 'Wu'
-    release: 2018-04-16
+    release: 2018-04-19
     eol: 2020-07-03
     latest: "4.0.6"
     link: https://ffmpeg.org/olddownload.html#release_4.0
-  - releaseCycle: "3.4"
+    latestReleaseDate: 2020-07-03
+-   releaseCycle: "3.4"
     cycleShortHand: 34
     codename: 'Cantor'
-    release: 2017-10-11
+    release: 2017-10-15
     eol: false
     latest: "3.4.11"
     link: https://ffmpeg.org/download.html#release_3.4
-  - releaseCycle: "3.3"
+    latestReleaseDate: 2022-05-11
+-   releaseCycle: "3.3"
     cycleShortHand: 33
     codename: 'Hilbert'
-    release: 2017-04-02
+    release: 2017-04-13
     eol: 2018-11-18
     latest: "3.3.9"
     link: https://ffmpeg.org/olddownload.html#release_3.3
-  - releaseCycle: "3.2"
+    latestReleaseDate: 2018-11-18
+-   releaseCycle: "3.2"
     cycleShortHand: 32
     codename: 'Hypatia'
-    release: 2016-10-26
+    release: 2016-10-27
     eol: false
     latest: "3.2.18"
     link: https://ffmpeg.org/download.html#release_3.2
-  - releaseCycle: "3.1"
+    latestReleaseDate: 2022-05-11
+-   releaseCycle: "3.1"
     cycleShortHand: 31
     codename: 'Laplace'
     release: 2016-06-26
     eol: 2017-09-25
     latest: "3.1.11"
     link: https://ffmpeg.org/olddownload.html#release_3.1
-  - releaseCycle: "3.0"
+    latestReleaseDate: 2017-09-25
+-   releaseCycle: "3.0"
     cycleShortHand: 30
     codename: 'Einstein'
-    release: 2016-02-14
+    release: 2016-02-15
     eol: 2018-10-28
     latest: "3.0.12"
     link: https://ffmpeg.org/olddownload.html#release_3.0
-  - releaseCycle: "2.8"
+    latestReleaseDate: 2018-10-27
+-   releaseCycle: "2.8"
     cycleShortHand: 28
     codename: 'Feynman'
-    release: 2015-09-05
+    release: 2015-09-08
     eol: false
     latest: "2.8.20"
-    link: https://ffmpeg.org/download.html#release_2.8  
-  - releaseCycle: "2.7"
+    link: https://ffmpeg.org/download.html#release_2.8
+    latestReleaseDate: 2022-05-11
+-   releaseCycle: "2.7"
     cycleShortHand: 27
     codename: 'Nash'
     release: 2015-06-09
     eol: 2016-04-30
     latest: "2.7.7"
     link: https://ffmpeg.org/olddownload.html#release_2.7
-  - releaseCycle: "2.6"
+    latestReleaseDate: 2016-04-30
+-   releaseCycle: "2.6"
     cycleShortHand: 26
     codename: 'Grothendieck'
     release: 2015-03-06
     eol: 2016-05-03
     latest: "2.6.9"
     link: https://ffmpeg.org/olddownload.html#release_2.6
-  - releaseCycle: "2.5"
+    latestReleaseDate: 2016-05-03
+-   releaseCycle: "2.5"
     cycleShortHand: 25
     codename: 'Bohr'
-    release: 2014-12-15
+    release: 2014-12-04
     eol: 2016-02-02
     latest: "2.5.11"
     link: https://ffmpeg.org/olddownload.html#release_2.5
-  - releaseCycle: "2.4"
+    latestReleaseDate: 2016-02-01
+-   releaseCycle: "2.4"
     cycleShortHand: 24
     codename: 'Fresnel'
     release: 2014-09-14
     eol: 2017-12-31
     latest: "2.4.14"
     link: https://ffmpeg.org/olddownload.html#release_2.4
-  - releaseCycle: "2.3"
+    latestReleaseDate: 2017-12-31
+-   releaseCycle: "2.3"
     cycleShortHand: 23
     codename: 'Mandelbrot'
     release: 2014-07-16
     eol: 2015-01-06
     latest: "2.3.6"
     link: https://ffmpeg.org/olddownload.html#release_2.3
-  - releaseCycle: "2.2"
+    latestReleaseDate: 2015-01-06
+-   releaseCycle: "2.2"
     cycleShortHand: 22
     codename: 'Muybridge'
-    release: 2014-03-01
+    release: 2014-03-23
     eol: 2015-06-18
     latest: "2.2.16"
     link: https://ffmpeg.org/olddownload.html#release_2.2
-  - releaseCycle: "2.1"
+    latestReleaseDate: 2015-06-17
+-   releaseCycle: "2.1"
     cycleShortHand: 21
     codename: 'Fourier'
     release: 2013-10-28
     eol: 2015-04-30
     latest: "2.1.8"
     link: https://ffmpeg.org/olddownload.html#release_2.1
-  - releaseCycle: "2.0"
+    latestReleaseDate: 2015-04-30
+-   releaseCycle: "2.0"
     cycleShortHand: 20
     codename: 'Nameless'
     release: 2013-07-10
     eol: 2015-06-10
     latest: "2.0.7"
     link: https://ffmpeg.org/olddownload.html#release_2.0
-  - releaseCycle: "1.2"
+    latestReleaseDate: 2015-06-10
+-   releaseCycle: "1.2"
     cycleShortHand: 12
     codename: 'Magic'
-    release: 2013-03-07
+    release: 2013-03-14
     eol: 2015-02-12
     latest: "1.2.12"
     link: https://ffmpeg.org/olddownload.html#release_1.2
-  - releaseCycle: "1.1"
+    latestReleaseDate: 2015-02-12
+-   releaseCycle: "1.1"
     cycleShortHand: 11
     codename: 'Fire Flower'
     release: 2013-01-06
     eol: 2015-03-13
     latest: "1.1.16"
     link: https://ffmpeg.org/olddownload.html#release_1.1
-  - releaseCycle: "1.0"
+    latestReleaseDate: 2015-03-13
+-   releaseCycle: "1.0"
     cycleShortHand: 10
     codename: 'Angel'
     release: 2012-09-28
     eol: 2014-07-20
     latest: "1.0.10"
     link: https://ffmpeg.org/olddownload.html#release_1.0
-  - releaseCycle: "0.11"
+    latestReleaseDate: 2014-07-20
+-   releaseCycle: "0.11"
     cycleShortHand: 011
     codename: 'Happiness'
     release: 2012-05-25
     eol: 2014-03-10
     latest: "0.11.5"
     link: https://ffmpeg.org/olddownload.html#release_0.11
-  - releaseCycle: "0.10"
+-   releaseCycle: "0.10"
     cycleShortHand: 010
     codename: 'Freedom'
     release: 2012-01-26
     eol: 2015-03-12
     latest: "0.10.16"
     link: https://ffmpeg.org/olddownload.html#release_0.10
-  - releaseCycle: "0.9"
+-   releaseCycle: "0.9"
     cycleShortHand: 09
     codename: 'Harmony'
     release: 2011-12-11
     eol: 2014-03-21
     latest: "0.9.4"
     link: https://ffmpeg.org/olddownload.html#release_0.9
-  - releaseCycle: "0.8"
+-   releaseCycle: "0.8"
     cycleShortHand: 08
     codename: 'Love'
     release: 2011-06-21
     eol: 2013-10-06
     latest: "0.8.15"
     link: https://ffmpeg.org/olddownload.html#release_0.8
-  - releaseCycle: "0.7"
+-   releaseCycle: "0.7"
     cycleShortHand: 07
     codename: 'Peace'
     release: 2011-06-21
     eol: 2015-03-12
     latest: "0.7.17"
     link: https://ffmpeg.org/olddownload.html#release_0.7
-  - releaseCycle: "0.6"
+-   releaseCycle: "0.6"
     cycleShortHand: 06
     codename: 'Works with HTML5'
     release: 2010-05-04
     eol: 2013-09-23
     latest: "0.6.7"
     link: https://ffmpeg.org/olddownload.html#release_0.6
-  - releaseCycle: "0.5"
+-   releaseCycle: "0.5"
     cycleShortHand: 05
     codename: 'half-way to world domination A.K.A. the belligerent blue bike shed'
     release: 2009-03-02
     eol: 2014-11-29
     latest: "0.5.15"
     link: https://ffmpeg.org/olddownload.html#release_0.5
+
 ---
 
 > [FFmpeg](https://ffmpeg.org/) is a free and open-source software project consisting of a suite of libraries and programs for handling video, audio, and other multimedia files and streams. It is the core of software such as VLC, MPV, Blender, Audacity, HandBrake, OBS Studio, and much more. Full list of capabilities are found [in their documentation](https://ffmpeg.org/ffmpeg.html).
@@ -234,4 +258,4 @@ releases:
 
 ## Releases
 
-Starting with the first LTS release FFmpeg 5.0 "Lorentz", FFmpeg is releasing one major release per year, and a LTS every other year.  Note that these releases are intended for distributors and system integrators, not for end users. End users are usually encouraged to use the [latest git snapshots instead](https://ffmpeg.org/download.html). 
+Starting with the first LTS release FFmpeg 5.0 "Lorentz", FFmpeg is releasing one major release per year, and a LTS every other year.  Note that these releases are intended for distributors and system integrators, not for end users. End users are usually encouraged to use the [latest git snapshots instead](https://ffmpeg.org/download.html).

--- a/products/ffmpeg.md
+++ b/products/ffmpeg.md
@@ -24,7 +24,7 @@ releases:
     latest: "5.0.1"
     lts: true
     link: https://ffmpeg.org/download.html#release_5.0
-    latestReleaseDate: 2022-04-03
+    latestReleaseDate: 2022-04-04
 -   releaseCycle: "4.4"
     cycleShortHand: 44
     codename: Rao
@@ -40,7 +40,7 @@ releases:
     eol: false
     latest: "4.3.4"
     link: https://ffmpeg.org/download.html#release_4.3
-    latestReleaseDate: 2022-04-15
+    latestReleaseDate: 2022-04-16
 -   releaseCycle: "4.2"
     cycleShortHand: 42
     codename: 'Ada'
@@ -48,19 +48,19 @@ releases:
     eol: false
     latest: "4.2.7"
     link: https://ffmpeg.org/download.html#release_4.2
-    latestReleaseDate: 2022-05-09
+    latestReleaseDate: 2022-05-14
 -   releaseCycle: "4.1"
     cycleShortHand: 41
     codename: 'al-Khwarizmi'
-    release: 2018-11-05
+    release: 2018-11-06
     eol: false
     latest: "4.1.9"
     link: https://ffmpeg.org/download.html#release_4.1
-    latestReleaseDate: 2022-04-16
+    latestReleaseDate: 2022-04-17
 -   releaseCycle: "4.0"
     cycleShortHand: 40
     codename: 'Wu'
-    release: 2018-04-19
+    release: 2018-04-20
     eol: 2020-07-03
     latest: "4.0.6"
     link: https://ffmpeg.org/olddownload.html#release_4.0
@@ -72,7 +72,7 @@ releases:
     eol: false
     latest: "3.4.11"
     link: https://ffmpeg.org/download.html#release_3.4
-    latestReleaseDate: 2022-05-11
+    latestReleaseDate: 2022-05-14
 -   releaseCycle: "3.3"
     cycleShortHand: 33
     codename: 'Hilbert'
@@ -88,11 +88,11 @@ releases:
     eol: false
     latest: "3.2.18"
     link: https://ffmpeg.org/download.html#release_3.2
-    latestReleaseDate: 2022-05-11
+    latestReleaseDate: 2022-05-14
 -   releaseCycle: "3.1"
     cycleShortHand: 31
     codename: 'Laplace'
-    release: 2016-06-26
+    release: 2016-06-27
     eol: 2017-09-25
     latest: "3.1.11"
     link: https://ffmpeg.org/olddownload.html#release_3.1
@@ -104,19 +104,19 @@ releases:
     eol: 2018-10-28
     latest: "3.0.12"
     link: https://ffmpeg.org/olddownload.html#release_3.0
-    latestReleaseDate: 2018-10-27
+    latestReleaseDate: 2018-10-28
 -   releaseCycle: "2.8"
     cycleShortHand: 28
     codename: 'Feynman'
-    release: 2015-09-08
+    release: 2015-09-09
     eol: false
     latest: "2.8.20"
     link: https://ffmpeg.org/download.html#release_2.8
-    latestReleaseDate: 2022-05-11
+    latestReleaseDate: 2022-05-15
 -   releaseCycle: "2.7"
     cycleShortHand: 27
     codename: 'Nash'
-    release: 2015-06-09
+    release: 2015-06-10
     eol: 2016-04-30
     latest: "2.7.7"
     link: https://ffmpeg.org/olddownload.html#release_2.7
@@ -124,7 +124,7 @@ releases:
 -   releaseCycle: "2.6"
     cycleShortHand: 26
     codename: 'Grothendieck'
-    release: 2015-03-06
+    release: 2015-03-07
     eol: 2016-05-03
     latest: "2.6.9"
     link: https://ffmpeg.org/olddownload.html#release_2.6
@@ -136,7 +136,7 @@ releases:
     eol: 2016-02-02
     latest: "2.5.11"
     link: https://ffmpeg.org/olddownload.html#release_2.5
-    latestReleaseDate: 2016-02-01
+    latestReleaseDate: 2016-02-02
 -   releaseCycle: "2.4"
     cycleShortHand: 24
     codename: 'Fresnel'
@@ -160,7 +160,7 @@ releases:
     eol: 2015-06-18
     latest: "2.2.16"
     link: https://ffmpeg.org/olddownload.html#release_2.2
-    latestReleaseDate: 2015-06-17
+    latestReleaseDate: 2015-06-18
 -   releaseCycle: "2.1"
     cycleShortHand: 21
     codename: 'Fourier'
@@ -180,7 +180,7 @@ releases:
 -   releaseCycle: "1.2"
     cycleShortHand: 12
     codename: 'Magic'
-    release: 2013-03-14
+    release: 2013-03-15
     eol: 2015-02-12
     latest: "1.2.12"
     link: https://ffmpeg.org/olddownload.html#release_1.2

--- a/products/gitlab.md
+++ b/products/gitlab.md
@@ -16,18 +16,20 @@ auto:
 -   regex: '^v?(?<major>[1-9]\d*)\.(?<minor>0|[1-9]\d*)\.(?<patch>0|[1-9]\d*)-ee?$'
     git: https://gitlab.com/gitlab-org/gitlab.git
 releases:
-  - releaseCycle: "15.0"
-    release: 2022-05-22
+-   releaseCycle: "15.0"
+    release: 2022-05-20
     support: 2022-06-22
     eol: 2022-08-22
-    latest: "15.0"
-  - releaseCycle: "14.10"
-    release: 2022-04-22
+    latest: "15.0.0"
+    latestReleaseDate: 2022-05-20
+-   releaseCycle: "14.10"
+    release: 2022-04-21
     support: 2022-05-22
     eol: 2022-07-22
     latest: "14.10.3"
-  - releaseCycle: "14.9"
-    release: 2022-03-22
+    latestReleaseDate: 2022-05-20
+-   releaseCycle: "14.9"
+    release: 2022-03-21
     support: 2022-04-22
     eol: 2022-06-22
     latest: "14.9.4"
@@ -78,8 +80,8 @@ releases:
     release: 2021-07-21
     support: 2021-08-22
     eol: 2021-10-22
-    latest: "14.10.2"
-    latestReleaseDate: 2022-05-04
+    latest: "14.10.3"
+    latestReleaseDate: 2022-05-20
 -   releaseCycle: "14.0"
     release: 2021-06-21
     support: 2021-07-22

--- a/products/gitlab.md
+++ b/products/gitlab.md
@@ -99,7 +99,7 @@ releases:
     latest: "13.11.7"
     latestReleaseDate: 2021-07-07
 -   releaseCycle: "13.10"
-    release: 2021-03-17
+    release: 2021-03-18
     support: 2021-04-22
     eol: 2021-06-22
     latest: "13.10.5"

--- a/products/gitlab.md
+++ b/products/gitlab.md
@@ -80,8 +80,8 @@ releases:
     release: 2021-07-21
     support: 2021-08-22
     eol: 2021-10-22
-    latest: "14.10.3"
-    latestReleaseDate: 2022-05-20
+    latest: "14.1.8"
+    latestReleaseDate: 2021-11-15
 -   releaseCycle: "14.0"
     release: 2021-06-21
     support: 2021-07-22
@@ -119,3 +119,4 @@ GitLab has a well [defined versioning policy](https://docs.gitlab.com/ce/policy/
 | Major        | For significant changes, or when any backward-incompatible changes are introduced to the public API.  |  Yearly. Subsequent major releases will be scheduled for May 22 each year, by default. |
 | Minor        | For when new backward-compatible functionality is introduced to the public API, a minor feature is introduced, or when a set of smaller features is rolled out.  | Monthly on the 22nd.  |
 | Patch        | 	For backward-compatible bug fixes that fix incorrect behavior.  | As needed.  |
+

--- a/products/gitlab.md
+++ b/products/gitlab.md
@@ -31,66 +31,80 @@ releases:
     support: 2022-04-22
     eol: 2022-06-22
     latest: "14.9.4"
-  - releaseCycle: "14.8"
-    release: 2022-02-22
+    latestReleaseDate: 2022-04-29
+-   releaseCycle: "14.8"
+    release: 2022-02-21
     support: 2022-03-22
     eol: 2022-05-22
     latest: "14.8.6"
-  - releaseCycle: "14.7"
-    release: 2022-01-22
+    latestReleaseDate: 2022-04-29
+-   releaseCycle: "14.7"
+    release: 2022-01-21
     support: 2022-02-22
     eol: 2022-04-22
     latest: "14.7.7"
-  - releaseCycle: "14.6"
-    release: 2021-12-22
+    latestReleaseDate: 2022-03-31
+-   releaseCycle: "14.6"
+    release: 2021-12-21
     support: 2022-01-22
     eol: 2022-03-22
     latest: "14.6.7"
-  - releaseCycle: "14.5"
-    release: 2021-11-22
+    latestReleaseDate: 2022-03-31
+-   releaseCycle: "14.5"
+    release: 2021-11-19
     support: 2021-12-22
     eol: 2022-02-22
     latest: "14.5.4"
-  - releaseCycle: "14.4"
-    release: 2021-10-22
+    latestReleaseDate: 2022-02-03
+-   releaseCycle: "14.4"
+    release: 2021-10-21
     support: 2021-11-22
     eol: 2022-01-22
     latest: "14.4.5"
-  - releaseCycle: "14.3"
-    release: 2021-09-22
+    latestReleaseDate: 2022-01-11
+-   releaseCycle: "14.3"
+    release: 2021-09-21
     support: 2021-10-22
     eol: 2021-12-22
     latest: "14.3.6"
-  - releaseCycle: "14.2"
-    release: 2021-08-22
+    latestReleaseDate: 2021-12-03
+-   releaseCycle: "14.2"
+    release: 2021-08-20
     support: 2021-09-22
     eol: 2021-11-22
     latest: "14.2.7"
-  - releaseCycle: "14.1"
-    release: 2021-07-22
+    latestReleaseDate: 2021-11-26
+-   releaseCycle: "14.1"
+    release: 2021-07-21
     support: 2021-08-22
     eol: 2021-10-22
-    latest: "14.1.8"
-  - releaseCycle: "14.0"
-    release: 2021-06-22
+    latest: "14.10.2"
+    latestReleaseDate: 2022-05-04
+-   releaseCycle: "14.0"
+    release: 2021-06-21
     support: 2021-07-22
     eol: 2021-09-22
     latest: "14.0.12"
-  - releaseCycle: "13.12"
-    release: 2021-05-22
+    latestReleaseDate: 2021-11-05
+-   releaseCycle: "13.12"
+    release: 2021-05-21
     support: 2021-06-22
     eol: 2021-08-22
     latest: "13.12.15"
-  - releaseCycle: "13.11"
-    release: 2021-04-22
+    latestReleaseDate: 2021-11-03
+-   releaseCycle: "13.11"
+    release: 2021-04-21
     support: 2021-05-22
     eol: 2021-07-22
     latest: "13.11.7"
-  - releaseCycle: "13.10"
-    release: 2021-03-22
+    latestReleaseDate: 2021-07-07
+-   releaseCycle: "13.10"
+    release: 2021-03-17
     support: 2021-04-22
     eol: 2021-06-22
     latest: "13.10.5"
+
+    latestReleaseDate: 2021-06-01
 
 ---
 

--- a/products/go.md
+++ b/products/go.md
@@ -2,7 +2,7 @@
 title: Go
 permalink: /go
 alternate_urls:
-  - /golang
+-   /golang
 layout: post
 category: lang
 releasePolicyLink: https://golang.org/doc/devel/release.html#policy
@@ -15,51 +15,61 @@ auto:
 -   git: https://github.com/golang/go.git
     regex: ^go(?<major>[1-9]\d*)\.(?<minor>0|[1-9]\d*)\.?(?<patch>0|[1-9]\d*)?$
 releases:
-  - releaseCycle: "1.18"
+-   releaseCycle: "1.18"
     cycleShortHand: 118
     release: 2022-03-15
     eol: false
     latest: "1.18.2"
-  - releaseCycle: "1.17"
+    latestReleaseDate: 2022-05-10
+-   releaseCycle: "1.17"
     cycleShortHand: 117
     release: 2021-08-16
     eol: false
     latest: "1.17.10"
-  - releaseCycle: "1.16"
+    latestReleaseDate: 2022-05-10
+-   releaseCycle: "1.16"
     cycleShortHand: 116
     release: 2021-02-16
     eol: true
     latest: "1.16.15"
-  - releaseCycle: "1.15"
+    latestReleaseDate: 2022-03-03
+-   releaseCycle: "1.15"
     cycleShortHand: 115
     release: 2020-08-11
     eol: true
     latest: "1.15.15"
-  - releaseCycle: "1.14"
+    latestReleaseDate: 2021-08-04
+-   releaseCycle: "1.14"
     cycleShortHand: 114
     release: 2020-02-25
     eol: true
     latest: "1.14.15"
-  - releaseCycle: "1.13"
+    latestReleaseDate: 2021-02-04
+-   releaseCycle: "1.13"
     cycleShortHand: 113
     release: 2019-09-03
     eol: true
     latest: "1.13.15"
-  - releaseCycle: "1.12"
+    latestReleaseDate: 2020-08-06
+-   releaseCycle: "1.12"
     cycleShortHand: 112
     release: 2019-02-25
     eol: true
     latest: "1.12.17"
-  - releaseCycle: "1.11"
+    latestReleaseDate: 2020-02-12
+-   releaseCycle: "1.11"
     cycleShortHand: 111
-    release: 2018-08-04
+    release: 2018-08-24
     eol: true
     latest: "1.11.13"
-  - releaseCycle: "1.10"
+    latestReleaseDate: 2019-08-13
+-   releaseCycle: "1.10"
     cycleShortHand: 110
     release: 2018-02-16
     eol: true
     latest: "1.10.8"
+    latestReleaseDate: 2019-01-23
+
 ---
 
 > [Go](https://golang.org/) is an open source programming language that makes it easy to build simple, reliable, and efficient software.

--- a/products/godot.md
+++ b/products/godot.md
@@ -3,7 +3,7 @@ title: Godot
 permalink: /godot
 category: app
 alternate_urls:
-  - /godotengine
+-   /godotengine
 layout: post
 iconSlug: godotengine
 releasePolicyLink: https://docs.godotengine.org/en/latest/about/release_policy.html
@@ -14,7 +14,9 @@ activeSupportColumn: true
 releaseDateColumn: true
 sortReleasesBy: "releaseCycle"
 auto:
--   dockerhub: barichello/godot-ci
+-   git: https://github.com/godotengine/godot.git
+    regex: ^(?<version>\d+(\.\d+){1,3})-stable$
+    template: "{{version}}"
 releases:
   - releaseCycle: "3.4"
     release: 2021-11-05
@@ -60,6 +62,7 @@ releases:
     eol: true
     support: false
     latest: "1.1"
+
 ---
 
 >[Godot Engine](https://godotengine.org/) is a feature-packed, cross-platform game engine to create 2D and 3D games from a unified interface released under the MIT License. It provides a comprehensive set of common tools, so users can focus on making games without having to reinvent the wheel. Games can be exported in one click to a [number of platforms](https://docs.godotengine.org/en/stable/about/list_of_features.html#platforms).

--- a/products/godot.md
+++ b/products/godot.md
@@ -18,50 +18,56 @@ auto:
     regex: ^(?<version>\d+(\.\d+){1,3})-stable$
     template: "{{version}}"
 releases:
-  - releaseCycle: "3.4"
-    release: 2021-11-05
+-   releaseCycle: "3.4"
+    release: 2021-12-13
     support: true
     eol: false
     latest: "3.4.4"
     link: https://godotengine.org/article/maintenance-release-godot-3-4-2
-  - releaseCycle: "3.3"
-    release: 2021-04-22
+    latestReleaseDate: 2022-03-31
+-   releaseCycle: "3.3"
+    release: 2021-04-21
     support: true
     eol: false
     latest: "3.3.4"
-  - releaseCycle: "3.2"
-    release: 2020-01-01
+    latestReleaseDate: 2021-10-07
+-   releaseCycle: "3.2"
+    release: 2020-04-26
     support: false
     eol: true
     latest: "3.2.3"
-  - releaseCycle: "3.1"
-    release: 2019-03-01
+    latestReleaseDate: 2020-11-15
+-   releaseCycle: "3.1"
+    release: 2019-03-14
     support: false
     eol: false
     latest: "3.1.2"
-  - releaseCycle: "3.0"
-    release: 2018-01-01
+    latestReleaseDate: 2020-01-17
+-   releaseCycle: "3.0"
+    release: 2018-10-24
     support: false
     eol: true
     latest: "3.0.6"
-  - releaseCycle: "2.1"
+    latestReleaseDate: 2018-10-25
+-   releaseCycle: "2.1"
     release: 2016-07-01
     eol: false
     support: false
     latest: "2.1.6"
     lts: true
-  - releaseCycle: "2.0"
+-   releaseCycle: "2.0"
     release: 2016-02-01
     eol: true
     support: false
     latest: "2.0.4.1"
     lts: false
     link: https://godotengine.org/article/maintenance-release-godot-2-0-4
-  - releaseCycle: "1.0"
+-   releaseCycle: "1.0"
     release: 2014-12-01
     eol: true
     support: false
     latest: "1.1"
+
 
 ---
 

--- a/products/haproxy.md
+++ b/products/haproxy.md
@@ -11,51 +11,60 @@ iconSlug: NA
 releaseDateColumn: true
 sortReleasesBy: 'cycleShortHand'
 releases:
-  - releaseCycle: "2.5"
+-   releaseCycle: "2.5"
     cycleShortHand: 205
     release: 2021-11-23
     eol: 2023-01-01
     latest: 2.5.0
-  - releaseCycle: "2.4"
+    latestReleaseDate: 2021-11-23
+-   releaseCycle: "2.4"
     cycleShortHand: 204
     release: 2021-05-14
     eol: 2026-04-01
-    latest: 2.4.9
-  - releaseCycle: "2.3"
+    latest: 2.4.0
+    latestReleaseDate: 2021-05-14
+-   releaseCycle: "2.3"
     cycleShortHand: 203
     release: 2020-11-05
     eol: 2022-01-01
-    latest: 2.3.16
-  - releaseCycle: "2.2"
+    latest: 2.3.0
+    latestReleaseDate: 2020-11-05
+-   releaseCycle: "2.2"
     cycleShortHand: 202
     release: 2020-07-07
     eol: 2025-04-01
-    latest: 2.2.19
-  - releaseCycle: "2.1"
+    latest: 2.2.0
+    latestReleaseDate: 2020-07-07
+-   releaseCycle: "2.1"
     cycleShortHand: 201
     release: 2019-11-25
     eol: 2021-03-18
-    latest: 2.1.12
-  - releaseCycle: "2.0"
+    latest: 2.1.0
+    latestReleaseDate: 2019-11-25
+-   releaseCycle: "2.0"
     cycleShortHand: 200
     release: 2019-06-16
     eol: 2024-04-01
-    latest: 2.0.26
-  - releaseCycle: "1.9"
+    latest: 2.0.0
+    latestReleaseDate: 2019-06-16
+-   releaseCycle: "1.9"
     cycleShortHand: 109
     release: 2018-12-19
     eol: 2020-07-31
-    latest: 1.9.16
-  - releaseCycle: "1.8"
+    latest: 1.9.0
+    latestReleaseDate: 2018-12-19
+-   releaseCycle: "1.8"
     cycleShortHand: 108
     release: 2017-11-26
     eol: 2022-10-01
-    latest: 1.8.30
-  - releaseCycle: "1.7"
+    latest: 1.8.0
+    latestReleaseDate: 2017-11-26
+-   releaseCycle: "1.7"
     cycleShortHand: 107
     release: 2016-11-25
     eol: 2021-10-01
-    latest: 1.7.14
+    latest: 1.7.0
+    latestReleaseDate: 2016-11-25
 
 ---
 

--- a/products/haproxy.md
+++ b/products/haproxy.md
@@ -10,6 +10,9 @@ command: haproxy -v
 iconSlug: NA
 releaseDateColumn: true
 sortReleasesBy: 'cycleShortHand'
+auto:
+  dockerhub: library/haproxy
+  regex: ^(?<major>0|[1-9]\d*)\.(?<minor>0|[1-9]\d*)(\.(?<patch>0|[1-9]\d*))?$
 releases:
 -   releaseCycle: "2.5"
     cycleShortHand: 205

--- a/products/jquery.md
+++ b/products/jquery.md
@@ -6,26 +6,30 @@ sortReleasesBy: "releaseCycle"
 auto:
 -   git: https://github.com/jquery/jquery.git
 releases:
-  - releaseCycle: "3"
+-   releaseCycle: "3"
     eol: false
     release: 2016-06-09
     latest: "3.6.0"
     link: https://blog.jquery.com/2021/03/02/jquery-3-6-0-released/
-  - releaseCycle: "2"
+    latestReleaseDate: 2021-03-02
+-   releaseCycle: "2"
     eol: true
     release: 2013-04-18
     latest: "2.2.4"
     link: https://blog.jquery.com/2016/05/20/jquery-1-12-4-and-2-2-4-released/
-  - releaseCycle: "1"
+    latestReleaseDate: 2016-05-20
+-   releaseCycle: "1"
     eol: true
     release: 2006-08-31
     latest: "1.12.4"
     link: https://blog.jquery.com/2016/05/20/jquery-1-12-4-and-2-2-4-released/
+    latestReleaseDate: 2016-05-20
 iconSlug: jquery
 permalink: /jquery
 activeSupportColumn: false
 releaseColumn: true
 releaseDateColumn: true
+
 ---
 
 > [jQuery](https://jquery.com/) is a widely used JavaScript library making it easier to manipulate HTML documents.

--- a/products/kotlin.md
+++ b/products/kotlin.md
@@ -5,7 +5,7 @@ category: lang
 iconSlug: kotlin
 permalink: /kotlin
 alternate_urls:
-  - /kotlinlang
+-   /kotlinlang
 command: kotlinc-native -version
 releasePolicyLink: https://kotlinlang.org/docs/releases.html
 sortReleasesBy: "cycleShortHand"
@@ -20,33 +20,38 @@ releaseDateColumn: true
 releaseColumn: true
 
 releases:
-  - releaseCycle: "1.6"
+-   releaseCycle: "1.6"
     cycleShortHand: 106
     eol: false #not sure about eol dates of kotlin if you find any information about this please change this part
     support: false
-    release: 2021-11-16
+    release: 2021-11-11
     latest: "1.6.21"
 
-  - releaseCycle: "1.5"
+    latestReleaseDate: 2022-04-18
+-   releaseCycle: "1.5"
     cycleShortHand: 105
     eol: false #not sure about eol dates of kotlin if you find any information about this please change this part
     support: false
-    release: 2021-05-05
+    release: 2021-04-26
     latest: "1.5.32"
 
-  - releaseCycle: "1.4"
+    latestReleaseDate: 2021-11-26
+-   releaseCycle: "1.4"
     cycleShortHand: 104
     eol: false #not sure about eol dates of kotlin if you find any information about this please change this part
     support: false
-    release: 2020-08-17
+    release: 2020-08-13
     latest: "1.4.32"
 
-  - releaseCycle: "1.3"
+    latestReleaseDate: 2021-03-25
+-   releaseCycle: "1.3"
     cycleShortHand: 103
     eol: false #not sure about eol dates of kotlin if you find any information about this please change this part
     support: false
-    release: 2018-10-29
+    release: 2018-10-25
     latest: "1.3.72"
+
+    latestReleaseDate: 2020-04-14
 
 ---
 

--- a/products/kubernetes.md
+++ b/products/kubernetes.md
@@ -15,52 +15,62 @@ auto:
 -   git: https://github.com/kubernetes/kubernetes.git
     regex: ^v(?<major>[1-9]\d*)\.(?<minor>0|[1-9]\d*)\.(?<patch>0|[1-9]\d*)$
 alternate_urls:
-  - /k8s
+-   /k8s
 # The release date for "N" should match the eol date for N-3 release.
 releases:
-  - releaseCycle: "1.24"
+-   releaseCycle: "1.24"
     release: 2022-05-03
-    latest: "1.24"
+    latest: "1.24.0"
     support: 2023-09-29
     eol: 2023-09-29
-  - releaseCycle: "1.23"
+    latestReleaseDate: 2022-05-03
+-   releaseCycle: "1.23"
     release: 2021-12-07
     latest: "1.23.6"
     support: 2022-12-28
     eol: 2023-02-28
-  - releaseCycle: "1.22"
+    latestReleaseDate: 2022-04-14
+-   releaseCycle: "1.22"
     release: 2021-08-04
     latest: "1.22.9"
     support: 2022-08-28
     eol: 2022-10-28
-  - releaseCycle: "1.21"
+    latestReleaseDate: 2022-04-13
+-   releaseCycle: "1.21"
     release: 2021-04-08
     latest: "1.21.12"
     support: 2022-04-28
     eol: 2022-06-28
-  - releaseCycle: "1.20"
-    release: 2020-12-08
+    latestReleaseDate: 2022-04-13
+-   releaseCycle: "1.20"
+    release: 2020-12-04
     latest: "1.20.15"
     support: 2021-12-28
     eol: 2022-02-28
-  - releaseCycle: "1.19"
-    release: 2020-08-27
+    latestReleaseDate: 2022-01-19
+-   releaseCycle: "1.19"
+    release: 2020-08-26
     latest: "1.19.16"
     support: 2021-08-28
     eol: 2021-10-28
-  - releaseCycle: "1.18"
+    latestReleaseDate: 2021-10-27
+-   releaseCycle: "1.18"
     release: 2020-03-25
     latest: "1.18.20"
     support: 2021-04-28
     eol: 2021-06-18
-  - releaseCycle: "1.17"
-    release: 2019-12-09
+    latestReleaseDate: 2021-06-16
+-   releaseCycle: "1.17"
+    release: 2019-12-06
     latest: "1.17.17"
     eol: 2020-12-25
-  - releaseCycle: "1.16"
-    release: 2019-10-22
+    latestReleaseDate: 2021-01-13
+-   releaseCycle: "1.16"
+    release: 2019-09-13
     eol: 2020-08-04
-    latest: "1.16.16"
+    latest: "1.16.15"
+    latestReleaseDate: 2020-09-02
+
 ---
 
 >[Kubernetes](https://kubernetes.io/) is an open-source container-orchestration system for automating computer application deployment, scaling, and management.

--- a/products/kubernetes.md
+++ b/products/kubernetes.md
@@ -43,7 +43,7 @@ releases:
     eol: 2022-06-28
     latestReleaseDate: 2022-04-13
 -   releaseCycle: "1.20"
-    release: 2020-12-04
+    release: 2020-12-08
     latest: "1.20.15"
     support: 2021-12-28
     eol: 2022-02-28
@@ -61,12 +61,12 @@ releases:
     eol: 2021-06-18
     latestReleaseDate: 2021-06-16
 -   releaseCycle: "1.17"
-    release: 2019-12-06
+    release: 2019-12-07
     latest: "1.17.17"
     eol: 2020-12-25
     latestReleaseDate: 2021-01-13
 -   releaseCycle: "1.16"
-    release: 2019-09-13
+    release: 2019-09-18
     eol: 2020-08-04
     latest: "1.16.15"
     latestReleaseDate: 2020-09-02

--- a/products/laravel.md
+++ b/products/laravel.md
@@ -18,14 +18,14 @@ releases:
     eol: 2024-02-08
     latest: 9.13.0
     lts: false
-    latestReleaseDate: 2022-05-11
+    latestReleaseDate: 2022-05-17
 -   releaseCycle: "8"
     release: 2020-09-08
     support: 2022-07-26
     eol: 2023-01-24
     latest: 8.83.13
     lts: false
-    latestReleaseDate: 2022-05-10
+    latestReleaseDate: 2022-05-17
 -   releaseCycle: "7"
     release: 2020-03-03
     support: 2020-10-06

--- a/products/laravel.md
+++ b/products/laravel.md
@@ -12,41 +12,48 @@ sortReleasesBy: 'releaseCycle'
 auto:
 -   git: https://github.com/laravel/framework.git
 releases:
-  - releaseCycle: "9"
+-   releaseCycle: "9"
     release: 2022-02-08
     support: 2023-08-08
     eol: 2024-02-08
     latest: 9.13.0
     lts: false
-  - releaseCycle: "8"
+    latestReleaseDate: 2022-05-11
+-   releaseCycle: "8"
     release: 2020-09-08
     support: 2022-07-26
     eol: 2023-01-24
     latest: 8.83.13
     lts: false
-  - releaseCycle: "7"
+    latestReleaseDate: 2022-05-10
+-   releaseCycle: "7"
     release: 2020-03-03
     support: 2020-10-06
     eol: 2021-03-03
     latest: 7.30.6
     lts: false
-  - releaseCycle: "6"
+    latestReleaseDate: 2021-12-07
+-   releaseCycle: "6"
     release: 2019-09-03
     support: 2022-01-25
     eol: 2022-09-06
     latest: 6.20.44
     lts: true
-  - releaseCycle: "5.8"
+    latestReleaseDate: 2022-01-12
+-   releaseCycle: "5.8"
     release: 2019-02-26
     support: 2019-08-26
     eol: 2020-02-26
     latest: 5.8.38
-  - releaseCycle: "5.5"
+    latestReleaseDate: 2020-04-14
+-   releaseCycle: "5.5"
     release: 2017-08-30
     support: 2019-08-30
     eol: 2020-08-30
     latest: 5.5.50
     lts: true
+    latestReleaseDate: 2020-08-18
+
 ---
 
 > [Laravel](https://laravel.com/) is a free, open-source PHP web framework, created by Taylor Otwell and intended for the development of web applications following the model–view–controller (MVC) architectural pattern and based on Symfony.

--- a/products/linuxkernel.md
+++ b/products/linuxkernel.md
@@ -48,7 +48,7 @@ releases:
     
   - releaseCycle: "5.4"
     cycleShortHand: 504
-    release: 2019-11-25
+    release: 2019-11-24
     eol: 2025-12-01
     lts: true
     latest: "5.4.195"

--- a/products/linuxkernel.md
+++ b/products/linuxkernel.md
@@ -24,8 +24,8 @@ releases:
     release: 2022-03-20
     eol: false
     latest: "5.17.9"
-    
-  - releaseCycle: "5.16"
+    latestReleaseDate: 2022-05-18
+-   releaseCycle: "5.16"
     cycleShortHand: 516
     release: 2022-01-09
     eol: 2022-04-13
@@ -38,42 +38,43 @@ releases:
     eol: 2023-10-31
     lts: true
     latest: "5.15.41"
-        
-  - releaseCycle: "5.10"
+    latestReleaseDate: 2022-05-18
+-   releaseCycle: "5.10"
     cycleShortHand: 510
     release: 2020-12-13
     eol: 2026-12-01
     lts: true
     latest: "5.10.117"
-    
-  - releaseCycle: "5.4"
+    latestReleaseDate: 2022-05-18
+-   releaseCycle: "5.4"
     cycleShortHand: 504
     release: 2019-11-24
     eol: 2025-12-01
     lts: true
     latest: "5.4.195"
-    
-  - releaseCycle: "4.19"
+    latestReleaseDate: 2022-05-18
+-   releaseCycle: "4.19"
     cycleShortHand: 419
     release: 2018-10-22
     eol: 2024-12-01
     lts: true
     latest: "4.19.244"
-    
-  - releaseCycle: "4.14"
+    latestReleaseDate: 2022-05-18
+-   releaseCycle: "4.14"
     cycleShortHand: 414
     release: 2017-11-12
     eol: 2024-01-01
     lts: true
     latest: "4.14.280"
-    
-  - releaseCycle: "4.9"
+    latestReleaseDate: 2022-05-18
+-   releaseCycle: "4.9"
     cycleShortHand: 409
     release: 2016-12-11
     eol: 2023-01-01
     lts: true
     latest: "4.9.315"
-    
+    latestReleaseDate: 2022-05-18
+
 ---
 
 > The Linux kernel is a free and open-source, monolithic, modular, multitasking, Unix-like operating system kernel.

--- a/products/linuxkernel.md
+++ b/products/linuxkernel.md
@@ -19,9 +19,9 @@ auto:
 -   git: https://github.com/gregkh/linux.git
     regex: ^v(?<major>0|[1-9]\d*)\.(?<minor>0|[1-9]\d*)(\.(?<patch>0|[1-9]\d*))?$
 releases:
-  - releaseCycle: "5.17"
+-   releaseCycle: "5.17"
     cycleShortHand: 517
-    release: "5.17"
+    release: 2022-03-20
     eol: false
     latest: "5.17.9"
     
@@ -29,9 +29,10 @@ releases:
     cycleShortHand: 516
     release: 2022-01-09
     eol: 2022-04-13
-    latest: "5.16.20"
+    latest: "5.16"
 
-  - releaseCycle: "5.15"
+    latestReleaseDate: 2022-01-09
+-   releaseCycle: "5.15"
     cycleShortHand: 515
     release: 2021-10-31
     eol: 2023-10-31
@@ -47,7 +48,7 @@ releases:
     
   - releaseCycle: "5.4"
     cycleShortHand: 504
-    release: 2019-11-24
+    release: 2019-11-25
     eol: 2025-12-01
     lts: true
     latest: "5.4.195"
@@ -86,5 +87,4 @@ There are several main categories into which kernel releases may fall:
 
 - **Stable** is labeled after each mainline kernel is released. Any bug fixes for a stable kernel are backported from the mainline tree. There are usually only a few bugfix kernel releases until next mainline kernel becomes available -- unless it is designated a "longterm maintenance kernel". Stable kernel updates are released on as-needed basis, usually once a week.
         
-- **Longterm (LTS)** are usually several longterm maintenance kernel releases provided for the purposes of backporting bugfixes for older kernel trees. By default these are only supported for two years (as opposed to the 4 months of a non-LTS release) [but are usually extended depending on how long companies pledge to back it.](https://lore.kernel.org/lkml/YA%2FE1bHRmZb50MlS@kroah.com/) Only important bugfixes are applied to such kernels and they don't usually see very frequent releases, especially for older trees. 
-
+- **Longterm (LTS)** are usually several longterm maintenance kernel releases provided for the purposes of backporting bugfixes for older kernel trees. By default these are only supported for two years (as opposed to the 4 months of a non-LTS release) [but are usually extended depending on how long companies pledge to back it.](https://lore.kernel.org/lkml/YA%2FE1bHRmZb50MlS@kroah.com/) Only important bugfixes are applied to such kernels and they don't usually see very frequent releases, especially for older trees.

--- a/products/linuxkernel.md
+++ b/products/linuxkernel.md
@@ -29,9 +29,9 @@ releases:
     cycleShortHand: 516
     release: 2022-01-09
     eol: 2022-04-13
-    latest: "5.16"
+    latest: "5.16.20"
 
-    latestReleaseDate: 2022-01-09
+    latestReleaseDate: 2022-04-13
 -   releaseCycle: "5.15"
     cycleShortHand: 515
     release: 2021-10-31

--- a/products/magento.md
+++ b/products/magento.md
@@ -12,119 +12,128 @@ auto:
 releaseDateColumn: true
 sortReleasesBy: 'releaseCycle'
 releases:
-  - releaseCycle: "2.4.3"
+-   releaseCycle: "2.4.3"
     cycleShortHand: 2
-    release: 2020-07-28
+    release: 2021-07-13
     eol: 2022-11-30
     support: 2022-11-30
     link: https://devdocs.magento.com/guides/v2.4/release-notes/open-source-2-4-4.html
-    latest: "2.4.4"
-  - releaseCycle: "2.4.2"
+    latest: "2.4.3"
+    latestReleaseDate: 2021-07-13
+-   releaseCycle: "2.4.2"
     cycleShortHand: 2
-    release: 2020-07-28
+    release: 2021-02-04
     eol: 2022-11-30
     support: 2022-11-30
     link: https://devdocs.magento.com/guides/v2.4/release-notes/open-source-2-4-2.html
-    latest: "2.4.2-p2"
-  - releaseCycle: "2.4.1"
+    latest: "2.4.2"
+    latestReleaseDate: 2021-02-04
+-   releaseCycle: "2.4.1"
     cycleShortHand: 2
-    release: 2020-07-28
+    release: 2020-10-12
     eol: 2022-11-30
     support: 2022-11-30
     link: https://devdocs.magento.com/guides/v2.4/release-notes/open-source-2-4-1.html
     latest: "2.4.1"
-  - releaseCycle: "2.4.0"
+    latestReleaseDate: 2020-10-12
+-   releaseCycle: "2.4.0"
     cycleShortHand: 2
-    release: 2020-07-28
+    release: 2020-07-20
     eol: 2022-11-30
     support: 2022-11-30
     link: https://devdocs.magento.com/guides/v2.4/release-notes/release-notes-2-4-0-open-source.html
     latest: "2.4.0"
-  - releaseCycle: "2.3"
+    latestReleaseDate: 2020-07-20
+-   releaseCycle: "2.3"
     cycleShortHand: 2
-    release: 2018-11-28
+    release: 2018-11-23
     eol: 2022-09-30
     support: 2022-07-31
     link: https://devdocs.magento.com/guides/v2.3/release-notes/open-source-2-3-7.html
-    latest: "2.3.7-p2"
-  - releaseCycle: "2.2"
+    latest: "2.3.7"
+    latestReleaseDate: 2021-05-07
+-   releaseCycle: "2.2"
     cycleShortHand: 2
-    release: 2017-09-01
+    release: 2017-09-22
     eol: 2019-12-01
     support: 2019-12-01
     latest: "2.2.11"
-  - releaseCycle: "2.1"
+    latestReleaseDate: 2020-01-07
+-   releaseCycle: "2.1"
     cycleShortHand: 2
-    release: 2016-06-01
+    release: 2016-06-23
     eol: 2019-06-01
     support: 2019-06-01
     latest: "2.1.18"
-  - releaseCycle: "2.0"
+    latestReleaseDate: 2019-06-06
+-   releaseCycle: "2.0"
     cycleShortHand: 2
-    release: 2015-11-01
+    release: 2015-11-17
     eol: 2018-03-01
     support: 2018-03-01
     latest: "2.0.18"
-  - releaseCycle: "1.9"
+    latestReleaseDate: 2018-02-20
+-   releaseCycle: "1.9"
     cycleShortHand: 1
     release: 2014-05-01
     eol: 2020-06-01
     support: 2020-06-01
     latest: "1.9.4.3"
-  - releaseCycle: "1.8"
+-   releaseCycle: "1.8"
     cycleShortHand: 1
     release: 2013-09-01
     eol: 2020-06-01
     support: 2014-09-01
     latest: "1.8.1.0"
-  - releaseCycle: "1.7"
+-   releaseCycle: "1.7"
     cycleShortHand: 1
     release: 2012-04-01
     eol: 2020-06-01
     support: 2013-04-01
     latest: "1.7.0.2"
-  - releaseCycle: "1.6"
+-   releaseCycle: "1.6"
     cycleShortHand: 1
     release: 2011-08-01
     eol: 2020-06-01
     support: 2012-08-01
     latest: "1.6.2.0"
-  - releaseCycle: "1.5"
+-   releaseCycle: "1.5"
     cycleShortHand: 1
     release: 2011-02-01
     eol: 2020-06-01
     support: 2012-02-01
     latest: "1.5.1.0"
-  - releaseCycle: "1.4"
+-   releaseCycle: "1.4"
     cycleShortHand: 1
     release: 2010-02-01
     eol: 2012-02-01
     support: 2011-02-01
     latest: "1.4.2.0"
-  - releaseCycle: "1.3"
+-   releaseCycle: "1.3"
     cycleShortHand: 1
     release: 2009-03-01
     eol: 2011-03-01
     support: 2010-03-01
     latest: "1.3.3.0"
-  - releaseCycle: "1.2"
+-   releaseCycle: "1.2"
     cycleShortHand: 1
     release: 2008-12-01
     eol: 2010-12-01
     support: 2009-12-01
     latest: "1.2.1.2"
-  - releaseCycle: "1.1"
+-   releaseCycle: "1.1"
     cycleShortHand: 1
     release: 2008-07-01
     eol: 2010-07-01
     support: 2009-07-01
     latest: "1.1.8"
-  - releaseCycle: "1.0"
+-   releaseCycle: "1.0"
     cycleShortHand: 1
     release: 2008-03-01
     eol: 2010-03-01
     support: 2009-03-01
     latest: "1.0.0"
+
 ---
 
 > [Magento](https://magento.com/): Magento is an open-source e-commerce platform written in PHP.

--- a/products/magento.md
+++ b/products/magento.md
@@ -14,12 +14,12 @@ sortReleasesBy: 'releaseCycle'
 releases:
 -   releaseCycle: "2.4.3"
     cycleShortHand: 2
-    release: 2021-07-13
+    release: 2021-08-04
     eol: 2022-11-30
     support: 2022-11-30
     link: https://devdocs.magento.com/guides/v2.4/release-notes/open-source-2-4-4.html
     latest: "2.4.3"
-    latestReleaseDate: 2021-07-13
+    latestReleaseDate: 2021-08-04
 -   releaseCycle: "2.4.2"
     cycleShortHand: 2
     release: 2021-02-04
@@ -30,12 +30,12 @@ releases:
     latestReleaseDate: 2021-02-04
 -   releaseCycle: "2.4.1"
     cycleShortHand: 2
-    release: 2020-10-12
+    release: 2020-10-14
     eol: 2022-11-30
     support: 2022-11-30
     link: https://devdocs.magento.com/guides/v2.4/release-notes/open-source-2-4-1.html
     latest: "2.4.1"
-    latestReleaseDate: 2020-10-12
+    latestReleaseDate: 2020-10-14
 -   releaseCycle: "2.4.0"
     cycleShortHand: 2
     release: 2020-07-20
@@ -68,7 +68,7 @@ releases:
     latestReleaseDate: 2019-06-06
 -   releaseCycle: "2.0"
     cycleShortHand: 2
-    release: 2015-11-17
+    release: 2015-11-16
     eol: 2018-03-01
     support: 2018-03-01
     latest: "2.0.18"
@@ -133,6 +133,7 @@ releases:
     eol: 2010-03-01
     support: 2009-03-01
     latest: "1.0.0"
+
 
 ---
 

--- a/products/mariadb.md
+++ b/products/mariadb.md
@@ -26,57 +26,67 @@ command: mysqld --version
 eolColumn: Support Status
 sortReleasesBy: 'releaseCycle'
 releases:
-  - releaseCycle: "10.8"
+-   releaseCycle: "10.8"
     release: 2022-05-20
     eol: 2023-05-20
     latest: "10.8.3"
     latestShortHand: "1083"
-  - releaseCycle: "10.7"
-    release: 2022-02-14
+-   releaseCycle: "10.7"
+    release: 2022-02-08
     eol: 2023-02-14
     latest: "10.7.4"
     latestShortHand: "1074"
-  - releaseCycle: "10.6"
-    release: 2021-07-06
+    latestReleaseDate: 2022-05-20
+-   releaseCycle: "10.6"
+    release: 2021-07-05
     eol: 2026-07-06
     latest: "10.6.8"
     latestShortHand: "1068"
-  - releaseCycle: "10.5"
-    release: 2020-06-24
+    latestReleaseDate: 2022-05-20
+-   releaseCycle: "10.5"
+    release: 2020-06-23
     eol: 2025-06-24
     latest: "10.5.16"
     latestShortHand: "10516"
-  - releaseCycle: "10.4"
-    release: 2019-06-18
+    latestReleaseDate: 2022-05-20
+-   releaseCycle: "10.4"
+    release: 2019-06-17
     eol: 2024-06-18
     latest: "10.4.25"
     latestShortHand: "10425"
-  - releaseCycle: "10.3"
-    release: 2018-05-25
+    latestReleaseDate: 2022-05-20
+-   releaseCycle: "10.3"
+    release: 2018-05-23
     eol: 2023-05-25
     latest: "10.3.35"
     latestShortHand: "10335"
-  - releaseCycle: "10.2"
-    release: 2017-05-23
+    latestReleaseDate: 2022-05-20
+-   releaseCycle: "10.2"
+    release: 2017-05-15
     eol: 2022-05-23
     latest: "10.2.44"
     latestShortHand: "10244"
-  - releaseCycle: "10.1"
-    release: 2015-10-17
+    latestReleaseDate: 2022-05-20
+-   releaseCycle: "10.1"
+    release: 2016-09-29
     eol: 2020-10-17
     latest: "10.1.48"
     latestShortHand: "10148"
-  - releaseCycle: "10.0"
-    release: 2014-03-31
+    latestReleaseDate: 2020-10-30
+-   releaseCycle: "10.0"
+    release: 2014-06-12
     eol: 2019-03-31
     latest: "10.0.38"
     latestShortHand: "10038"
-  - releaseCycle: "5.5"
-    release: 2012-04-11
+    latestReleaseDate: 2019-01-29
+-   releaseCycle: "5.5"
+    release: 2013-01-29
     eol: 2020-04-11
     latest: "5.5.68"
     latestShortHand: "5568"
     lts: true
+    latestReleaseDate: 2020-05-06
+
 ---
 
 > [MariaDB](https://mariadb.org/about/) is a community-developed, commercially supported fork of the MySQL relational database management system (RDBMS).

--- a/products/mediawiki.md
+++ b/products/mediawiki.md
@@ -13,45 +13,51 @@ releases:
 #    release: 2022-05-01
 #    eol: 2023-05-01
 
-  - releaseCycle: "1.37"
+-   releaseCycle: "1.37"
     lts: false
     release: 2021-11-18
     eol: 2022-11-01
-    latest: "1.37.1"
+    latest: "1.37.2"
 
-  - releaseCycle: "1.36"
+    latestReleaseDate: 2022-03-31
+-   releaseCycle: "1.36"
     lts: false
-    release: 2021-05-28
+    release: 2021-05-27
     eol: 2022-05-01
-    latest: "1.36.3"
-    
-  - releaseCycle: "1.35"
+    latest: "1.36.4"
+    latestReleaseDate: 2022-03-31
+-   releaseCycle: "1.35"
     lts: true
-    release: 2020-09-25
+    release: 2020-09-24
     eol: 2023-09-01
-    latest: "1.35.5"
+    latest: "1.35.6"
 
-  - releaseCycle: "1.34"
+    latestReleaseDate: 2022-03-31
+-   releaseCycle: "1.34"
     release: 2019-12-19
     eol: 2020-11-30
     latest: "1.34.4"
 
-  - releaseCycle: "1.33"
-    release: 2019-06-02
+    latestReleaseDate: 2020-09-24
+-   releaseCycle: "1.33"
+    release: 2019-07-02
     eol: 2020-06-30
     latest: "1.33.4"
 
-  - releaseCycle: "1.32"
-    release: 2019-01-11
+    latestReleaseDate: 2020-06-24
+-   releaseCycle: "1.32"
+    release: 2019-01-10
     eol: 2020-01-24
     latest: "1.32.6"
 
-  - releaseCycle: "1.31"
+    latestReleaseDate: 2019-12-19
+-   releaseCycle: "1.31"
     lts: true
-    release: 2018-06-14
+    release: 2018-06-13
     eol: 2021-09-30
     latest: "1.31.16"
 
+    latestReleaseDate: 2021-09-30
 iconSlug: NA
 permalink: /mediawiki
 releasePolicyLink: https://www.mediawiki.org/wiki/Version_lifecycle
@@ -60,6 +66,7 @@ releaseColumn: true
 releaseDateColumn: true
 eolColumn: End-of-Life
 command: "https://your-server-url/mediawiki/Special:Version"
+
 ---
 
 > [MediaWiki](https://mediawiki.org) is a wiki engine, and mostly known as the software that powers Wikipedia, but it is also frequently used for other wikis.

--- a/products/mediawiki.md
+++ b/products/mediawiki.md
@@ -19,16 +19,16 @@ releases:
     eol: 2022-11-01
     latest: "1.37.2"
 
-    latestReleaseDate: 2022-03-31
+    latestReleaseDate: 2022-04-01
 -   releaseCycle: "1.36"
     lts: false
-    release: 2021-05-27
+    release: 2021-05-28
     eol: 2022-05-01
     latest: "1.36.4"
     latestReleaseDate: 2022-03-31
 -   releaseCycle: "1.35"
     lts: true
-    release: 2020-09-24
+    release: 2020-09-25
     eol: 2023-09-01
     latest: "1.35.6"
 
@@ -66,6 +66,7 @@ releaseColumn: true
 releaseDateColumn: true
 eolColumn: End-of-Life
 command: "https://your-server-url/mediawiki/Special:Version"
+
 
 ---
 

--- a/products/mongodb.md
+++ b/products/mongodb.md
@@ -14,72 +14,98 @@ auto:
 -   git: https://github.com/mongodb/mongo.git
     regex: ^r(?<major>0|[1-9]\d*)\.(?<minor>0|[1-9]\d*)\.(?<patch>0|[1-9]\d*)$
 releases:
-  - releaseCycle: "5.3"
+-   releaseCycle: "5.3"
     codename: "rapid"
     eol: false
-    release: 2022-04-06
+    release: 2022-03-22
     latest: "5.3.1"
-  - releaseCycle: "5.0"
+    latestReleaseDate: 2022-03-30
+-   releaseCycle: "5.0"
     eol: false
-    release: 2021-07-13
+    release: 2021-07-08
     latest: "5.0.8"
-  - releaseCycle: "4.4"
+    latestReleaseDate: 2022-04-20
+-   releaseCycle: "4.4"
     eol: false
-    release: 2020-07-30
+    release: 2020-07-24
     latest: "4.4.14"
-  - releaseCycle: "4.2"
+    latestReleaseDate: 2022-04-18
+-   releaseCycle: "4.2"
     eol: false
-    release: 2019-08-31
+    release: 2019-08-08
     latest: "4.2.20"
-  - releaseCycle: "4.0"
+    latestReleaseDate: 2022-04-12
+-   releaseCycle: "4.0"
     eol: 2022-04-30
-    release: 2018-06-30
-    latest: "4.0.27"
-  - releaseCycle: "3.6"
+    release: 2018-06-21
+    latest: "4.0.28"
+    latestReleaseDate: 2022-01-04
+-   releaseCycle: "3.6"
     eol: 2021-04-30
-    release: 2017-11-30
+    release: 2017-12-01
     latest: "3.6.23"
-  - releaseCycle: "3.4"
+    latestReleaseDate: 2021-02-16
+-   releaseCycle: "3.4"
     eol: 2020-01-31
-    release: 2016-11-30
+    release: 2016-11-26
     latest: "3.4.24"
-  - releaseCycle: "3.2"
+    latestReleaseDate: 2020-01-08
+-   releaseCycle: "3.2"
     eol: 2018-07-31
-    release: 2015-12-31
+    release: 2015-12-02
     latest: "3.2.22"
-  - releaseCycle: "3.0"
+    latestReleaseDate: 2018-12-17
+-   releaseCycle: "3.0"
     eol: 2018-02-28
-    release: 2015-03-31
+    release: 2015-02-27
     latest: "3.0.15"
-  - releaseCycle: "2.6"
+    latestReleaseDate: 2017-05-01
+-   releaseCycle: "2.6"
     eol: 2016-10-31
-    release: 2014-04-30
+    release: 2014-04-07
     latest: "2.6.12"
-  - releaseCycle: "2.4"
+    latestReleaseDate: 2016-03-21
+-   releaseCycle: "2.4"
     eol: 2013-03-31
-    release: 2016-03-31
+    release: 2013-03-15
     latest: "2.4.14"
-  - releaseCycle: "2.2"
+    latestReleaseDate: 2015-04-27
+-   releaseCycle: "2.2"
     eol: 2014-02-28
-    release: 2012-08-31
-  - releaseCycle: "2.0"
+    release: 2012-08-28
+    latestReleaseDate: 2014-01-12
+    latest: 2.2.7
+-   releaseCycle: "2.0"
     eol: 2013-03-31
-    release: 2011-09-30
-  - releaseCycle: "1.8"
+    release: 2011-09-11
+    latestReleaseDate: 2013-03-29
+    latest: 2.0.9
+-   releaseCycle: "1.8"
     eol: 2012-09-30
-    release: 2011-03-31
-  - releaseCycle: "1.6"
+    release: 2011-03-16
+    latestReleaseDate: 2012-02-01
+    latest: 1.8.5
+-   releaseCycle: "1.6"
     eol: 2012-02-28
-    release: 2010-08-31
-  - releaseCycle: "1.4"
+    release: 2010-08-05
+    latestReleaseDate: 2010-12-08
+    latest: 1.6.5
+-   releaseCycle: "1.4"
     eol: 2012-09-30
-    release: 2010-03-31
-  - releaseCycle: "1.2"
+    release: 2010-03-25
+    latestReleaseDate: 2010-08-30
+    latest: 1.4.5
+-   releaseCycle: "1.2"
     eol: 2011-06-30
-    release: 2009-12-31
-  - releaseCycle: "1.0"
+    release: 2009-12-10
+    latestReleaseDate: 2010-04-07
+    latest: 1.2.5
+-   releaseCycle: "1.0"
     eol: 2010-08-31
-    release: 2009-02-28
+    release: 2009-08-27
+    latestReleaseDate: 2009-10-22
+    latest: 1.0.1
+
 ---
 
 > [MongoDB Server](https://www.mongodb.com/) is a general purpose, document-based, distributed database built for modern application developers and for the cloud era.

--- a/products/mongodb.md
+++ b/products/mongodb.md
@@ -19,66 +19,66 @@ releases:
     eol: false
     release: 2022-03-22
     latest: "5.3.1"
-    latestReleaseDate: 2022-03-30
+    latestReleaseDate: 2022-03-31
 -   releaseCycle: "5.0"
     eol: false
     release: 2021-07-08
     latest: "5.0.8"
-    latestReleaseDate: 2022-04-20
+    latestReleaseDate: 2022-04-21
 -   releaseCycle: "4.4"
     eol: false
-    release: 2020-07-24
+    release: 2020-07-25
     latest: "4.4.14"
-    latestReleaseDate: 2022-04-18
+    latestReleaseDate: 2022-05-04
 -   releaseCycle: "4.2"
     eol: false
-    release: 2019-08-08
+    release: 2019-08-09
     latest: "4.2.20"
-    latestReleaseDate: 2022-04-12
+    latestReleaseDate: 2022-05-04
 -   releaseCycle: "4.0"
     eol: 2022-04-30
     release: 2018-06-21
     latest: "4.0.28"
-    latestReleaseDate: 2022-01-04
+    latestReleaseDate: 2022-01-24
 -   releaseCycle: "3.6"
     eol: 2021-04-30
     release: 2017-12-01
     latest: "3.6.23"
-    latestReleaseDate: 2021-02-16
+    latestReleaseDate: 2021-03-16
 -   releaseCycle: "3.4"
     eol: 2020-01-31
     release: 2016-11-26
     latest: "3.4.24"
-    latestReleaseDate: 2020-01-08
+    latestReleaseDate: 2020-01-24
 -   releaseCycle: "3.2"
     eol: 2018-07-31
-    release: 2015-12-02
+    release: 2015-12-04
     latest: "3.2.22"
-    latestReleaseDate: 2018-12-17
+    latestReleaseDate: 2018-12-26
 -   releaseCycle: "3.0"
     eol: 2018-02-28
-    release: 2015-02-27
+    release: 2015-03-03
     latest: "3.0.15"
-    latestReleaseDate: 2017-05-01
+    latestReleaseDate: 2017-05-10
 -   releaseCycle: "2.6"
     eol: 2016-10-31
     release: 2014-04-07
     latest: "2.6.12"
-    latestReleaseDate: 2016-03-21
+    latestReleaseDate: 2016-03-22
 -   releaseCycle: "2.4"
     eol: 2013-03-31
-    release: 2013-03-15
+    release: 2013-03-18
     latest: "2.4.14"
     latestReleaseDate: 2015-04-27
 -   releaseCycle: "2.2"
     eol: 2014-02-28
     release: 2012-08-28
-    latestReleaseDate: 2014-01-12
+    latestReleaseDate: 2014-01-15
     latest: 2.2.7
 -   releaseCycle: "2.0"
     eol: 2013-03-31
     release: 2011-09-11
-    latestReleaseDate: 2013-03-29
+    latestReleaseDate: 2013-04-02
     latest: 2.0.9
 -   releaseCycle: "1.8"
     eol: 2012-09-30
@@ -93,7 +93,7 @@ releases:
 -   releaseCycle: "1.4"
     eol: 2012-09-30
     release: 2010-03-25
-    latestReleaseDate: 2010-08-30
+    latestReleaseDate: 2010-08-31
     latest: 1.4.5
 -   releaseCycle: "1.2"
     eol: 2011-06-30

--- a/products/mysql.md
+++ b/products/mysql.md
@@ -8,9 +8,16 @@ changelogTemplate: "https://dev.mysql.com/doc/relnotes/mysql/__RELEASE_CYCLE__/e
 # support -> GA+5 years = Premier support
 # eol -> GA+8 years = Extended Support
 # We show Extended support dates since that match Community Edition timelines
+
+# Regex takes into account the first GA release in each cycle (in parantheses)
+# https://docs.oracle.com/cd/E17952_01/mysql-5.5-relnotes-en/index.html (5.5.8)
+# https://dev.mysql.com/doc/relnotes/mysql/5.6/en/ (5.6.10)
+# https://docs.oracle.com/cd/E17952_01/mysql-5.7-relnotes-en/ (5.7.9)
+# https://dev.mysql.com/doc/relnotes/mysql/8.0/en/ (8.0.11)
 auto:
 -   git: https://github.com/mysql/mysql-server.git
-    regex: ^mysql-(?<major>0|[1-9]\d*)\.(?<minor>0|[1-9]\d*)\.(?<patch>0|[1-9]\d*)$
+    regex: ^mysql-((?<c>5\.5)\.(?<v>([8-9]|\d{2}))|((?<c>5\.6)\.(?<v>\d{2}))|((?<c>5\.7)\.(?<v>([9]|\d{2})))|((?<c>8\.0)\.(?<v>(1[1-9]|[2-9]\d))))$
+    template: "{{c}}.{{v}}"
 releases:
 -   releaseCycle: "8.0"
     release: 2016-08-25
@@ -39,28 +46,6 @@ releases:
     support: 2015-12-31
     eol: 2018-12-31
     latestReleaseDate: 2018-12-21
--   releaseCycle: "5.1"
-    release: 2005-11-29
-    latest: 5.1.77
-    support: 2013-12-31
-    eol: true
-    latestReleaseDate: 2015-08-17
--   releaseCycle: "5.0"
-    release: 2003-12-22
-    latest: 5.0.96
-    support: 2011-12-31
-    eol: true
-    latestReleaseDate: 2012-03-02
--   releaseCycle: "4.1"
-    release: 2003-04-03
-    eol: 2009-12-31
-    latestReleaseDate: 2008-03-17
-    latest: 4.1.24
--   releaseCycle: "4.0"
-    release: 2001-12-23
-    eol: 2008-12-31
-    latestReleaseDate: 2007-02-16
-    latest: 4.0.30
 permalink: /mysql
 releasePolicyLink: http://www.oracle.com/us/support/library/lifetime-support-technology-069183.pdf
 activeSupportColumn: false

--- a/products/mysql.md
+++ b/products/mysql.md
@@ -12,50 +12,61 @@ auto:
 -   git: https://github.com/mysql/mysql-server.git
     regex: ^mysql-(?<major>0|[1-9]\d*)\.(?<minor>0|[1-9]\d*)\.(?<patch>0|[1-9]\d*)$
 releases:
-  - releaseCycle: "8.0"
-    release: 2018-04-01
+-   releaseCycle: "8.0"
+    release: 2016-08-25
     latest: 8.0.29
     latestShortHand: 8-0-29
     support: 2023-04-30
     eol: 2026-04-30
-  - releaseCycle: "5.7"
-    release: 2015-10-01
+    latestReleaseDate: 2022-04-08
+-   releaseCycle: "5.7"
+    release: 2013-04-03
     latest: 5.7.38
     latestShortHand: 5-7-38
     support: 2020-10-31
     eol: 2023-10-31
-  - releaseCycle: "5.6"
-    release: 2013-02-01
+    latestReleaseDate: 2022-03-07
+-   releaseCycle: "5.6"
+    release: 2011-03-14
     latest: 5.6.51
     latestShortHand: 5-6-51
     support: 2018-02-28
     eol: 2021-02-28
-  - releaseCycle: "5.5"
-    release: 2010-12-01
-    latest: 5.5.62
+    latestReleaseDate: 2021-01-05
+-   releaseCycle: "5.5"
+    release: 2009-12-07
+    latest: 5.5.63
     support: 2015-12-31
     eol: 2018-12-31
-  - releaseCycle: "5.1"
-    release: 2008-12-01
-    latest: 5.1.73
+    latestReleaseDate: 2018-12-21
+-   releaseCycle: "5.1"
+    release: 2005-11-29
+    latest: 5.1.77
     support: 2013-12-31
     eol: true
-  - releaseCycle: "5.0"
-    release: 2005-10-01
+    latestReleaseDate: 2015-08-17
+-   releaseCycle: "5.0"
+    release: 2003-12-22
     latest: 5.0.96
     support: 2011-12-31
     eol: true
-  - releaseCycle: "4.1"
-    release: 2004-10-01
+    latestReleaseDate: 2012-03-02
+-   releaseCycle: "4.1"
+    release: 2003-04-03
     eol: 2009-12-31
-  - releaseCycle: "4.0"
-    release: 2003-03-01
+    latestReleaseDate: 2008-03-17
+    latest: 4.1.24
+-   releaseCycle: "4.0"
+    release: 2001-12-23
     eol: 2008-12-31
+    latestReleaseDate: 2007-02-16
+    latest: 4.0.30
 permalink: /mysql
 releasePolicyLink: http://www.oracle.com/us/support/library/lifetime-support-technology-069183.pdf
 activeSupportColumn: false
 releaseDateColumn: true
 command: mysqld --version
+
 ---
 
 > [MySQL](https://www.mysql.com/about) is an open source database developed by Oracle. With its proven performance, reliability and ease-of-use, MySQL has become the leading database choice for web-based applications, used by high profile web properties including Facebook, Twitter, YouTube, Yahoo! and many more.

--- a/products/nginx.md
+++ b/products/nginx.md
@@ -71,8 +71,8 @@ releases:
 -   releaseCycle: "1.2"
     release: 2012-04-23
     eol: 2013-04-24
-    latest: "1.21.6"
-    latestReleaseDate: 2022-01-25
+    latest: "1.2.9"
+    latestReleaseDate: 2013-05-13
 -   releaseCycle: "1.0"
     release: 2011-04-12
     eol: 2012-04-23
@@ -93,3 +93,4 @@ The open-source NGINX project maintains two branches: mainline and stable.
     Stable receives fixes for high‑severity bugs, but is not updated with new features. It is denoted by an even number in the second part of the version number, for example 1.18.0. The stable branch never receives new functionality during its lifecycle and typically receives just one or two updates, for critical bug fixes.
    
 Every April, the current stable branch is retired, after which no further bug fixes are made. The current mainline branch is forked, to create the next stable branch.
+

--- a/products/nginx.md
+++ b/products/nginx.md
@@ -17,55 +17,68 @@ auto:
     regex: ^release-(?<major>0|[1-9]\d*)\.(?<minor>0|[1-9]\d*)\.(?<patch>0|[1-9]\d*)$
 -   hg: https://hg.nginx.org/nginx
 releases:
-  - releaseCycle: "1.21"
+-   releaseCycle: "1.21"
     release: 2021-05-25
     eol: false
     latest: "1.21.6"
     link: https://nginx.org/en/CHANGES
-  - releaseCycle: "1.20"
+    latestReleaseDate: 2022-01-25
+-   releaseCycle: "1.20"
     release: 2021-04-20
     eol: false
     latest: "1.20.2"
-  - releaseCycle: "1.18"
-    release: 2020-04-20
+    latestReleaseDate: 2021-11-16
+-   releaseCycle: "1.18"
+    release: 2020-04-21
     eol: 2021-04-20
     latest: "1.18.0"
-  - releaseCycle: "1.16"
+    latestReleaseDate: 2020-04-21
+-   releaseCycle: "1.16"
     release: 2019-04-23
     eol: 2020-04-20
     latest: "1.16.1"
-  - releaseCycle: "1.14"
+    latestReleaseDate: 2019-08-13
+-   releaseCycle: "1.14"
     release: 2018-04-17
     eol: 2019-04-23
     latest: "1.14.2"
-  - releaseCycle: "1.12"
+    latestReleaseDate: 2018-12-04
+-   releaseCycle: "1.12"
     release: 2017-04-12
     eol: 2018-04-17
     latest: "1.12.2"
-  - releaseCycle: "1.10"
+    latestReleaseDate: 2017-10-17
+-   releaseCycle: "1.10"
     release: 2016-04-26
     eol: 2017-04-12
     latest: "1.10.3"
-  - releaseCycle: "1.8"
+    latestReleaseDate: 2017-01-31
+-   releaseCycle: "1.8"
     release: 2015-04-21
     eol: 2016-04-26
     latest: "1.8.1"
-  - releaseCycle: "1.6"
+    latestReleaseDate: 2016-01-26
+-   releaseCycle: "1.6"
     release: 2014-04-24
     eol: 2015-04-21
     latest: "1.6.3"
-  - releaseCycle: "1.4"
+    latestReleaseDate: 2015-04-07
+-   releaseCycle: "1.4"
     release: 2013-04-24
     eol: 2014-04-24
     latest: "1.4.7"
-  - releaseCycle: "1.2"
+    latestReleaseDate: 2014-03-18
+-   releaseCycle: "1.2"
     release: 2012-04-23
     eol: 2013-04-24
-    latest: "1.2.9"
-  - releaseCycle: "1.0"
+    latest: "1.21.6"
+    latestReleaseDate: 2022-01-25
+-   releaseCycle: "1.0"
     release: 2011-04-12
     eol: 2012-04-23
     latest: "1.0.15"
+    latestReleaseDate: 2012-04-12
+
 ---
 
 > [NGINX](https://nginx.org/) is an HTTP and reverse proxy server, a mail proxy server, and a generic TCP/UDP proxy server.

--- a/products/nix.md
+++ b/products/nix.md
@@ -5,7 +5,7 @@ category: app
 iconSlug: nixos
 permalink: /nix
 alternate_urls:
-  - /nixlang
+-   /nixlang
 releasePolicyLink: https://nixos.org/blog/announcements.html
 sortReleasesBy: "releaseCycle"
 changelogTemplate: https://nixos.org/manual/nix/stable/release-notes/rl-__RELEASE_CYCLE__.html
@@ -16,46 +16,57 @@ activeSupportColumn: false
 releaseColumn: true
 releaseDateColumn: true
 releases:
-  - releaseCycle: "2.8"
+-   releaseCycle: "2.8"
     latest: "2.8.1"
     release: 2022-04-19
     eol: false
-  - releaseCycle: "2.7"
+    latestReleaseDate: 2022-05-14
+-   releaseCycle: "2.7"
     latest: "2.7.0"
     release: 2022-03-07
     eol: false
-  - releaseCycle: "2.6"
+    latestReleaseDate: 2022-03-07
+-   releaseCycle: "2.6"
     latest: "2.6.1"
     release: 2022-01-24
     eol: true
-  - releaseCycle: "2.5"
+    latestReleaseDate: 2022-02-17
+-   releaseCycle: "2.5"
     latest: "2.5.1"
-    release: 2021-12-17
+    release: 2021-12-13
     eol: true
-  - releaseCycle: "2.4"
+    latestReleaseDate: 2021-12-17
+-   releaseCycle: "2.4"
     latest: "2.4"
     release: 2021-11-01
     eol: true
-  - releaseCycle: "2.3"
+    latestReleaseDate: 2021-11-01
+-   releaseCycle: "2.3"
     latest: "2.3.16"
-    release: 2021-10-07
+    release: 2019-09-04
     eol: false
-  - releaseCycle: "2.2"
+    latestReleaseDate: 2021-09-21
+-   releaseCycle: "2.2"
     latest: "2.2.2"
-    release: 2019-04-15
+    release: 2019-01-10
     eol: true
-  - releaseCycle: "2.1"
+    latestReleaseDate: 2019-04-15
+-   releaseCycle: "2.1"
     latest: "2.1.3"
-    release: 2018-10-02
+    release: 2018-09-02
     eol: true
-  - releaseCycle: "2.0"
+    latestReleaseDate: 2018-10-01
+-   releaseCycle: "2.0"
     latest: "2.0.4"
     release: 2018-02-22
     eol: true
-  - releaseCycle: "1"
+    latestReleaseDate: 2018-05-30
+-   releaseCycle: "1"
     latest: "1.11.16"
-    release: 2017-12-20
+    release: 2012-05-12
     eol: true
+    latestReleaseDate: 2017-12-12
+
 ---
 
 > [nix](https://nixos.org/) is a cross-platform package manager that utilizes a purely functional deployment model where software is installed into unique directories generated through cryptographic hashes. It is also the name of the tool's programming language. A package's hash takes into account the dependencies, which is claimed to eliminate dependency hell. This package management model advertises more reliable, reproducible, and portable packages.

--- a/products/nix.md
+++ b/products/nix.md
@@ -28,7 +28,7 @@ releases:
     latestReleaseDate: 2022-03-07
 -   releaseCycle: "2.6"
     latest: "2.6.1"
-    release: 2022-01-24
+    release: 2022-01-25
     eol: true
     latestReleaseDate: 2022-02-17
 -   releaseCycle: "2.5"
@@ -45,27 +45,27 @@ releases:
     latest: "2.3.16"
     release: 2019-09-04
     eol: false
-    latestReleaseDate: 2021-09-21
+    latestReleaseDate: 2021-10-07
 -   releaseCycle: "2.2"
     latest: "2.2.2"
-    release: 2019-01-10
+    release: 2019-01-11
     eol: true
     latestReleaseDate: 2019-04-15
 -   releaseCycle: "2.1"
     latest: "2.1.3"
-    release: 2018-09-02
+    release: 2018-09-03
     eol: true
-    latestReleaseDate: 2018-10-01
+    latestReleaseDate: 2018-10-02
 -   releaseCycle: "2.0"
     latest: "2.0.4"
     release: 2018-02-22
     eol: true
-    latestReleaseDate: 2018-05-30
+    latestReleaseDate: 2018-05-31
 -   releaseCycle: "1"
     latest: "1.11.16"
-    release: 2012-05-12
+    release: 2012-05-11
     eol: true
-    latestReleaseDate: 2017-12-12
+    latestReleaseDate: 2017-12-20
 
 ---
 

--- a/products/nodejs.md
+++ b/products/nodejs.md
@@ -1,8 +1,8 @@
 ---
 permalink: /nodejs
 alternate_urls:
-  - /node
-  - /node.js
+-   /node
+-   /node.js
 layout: post
 category: lang
 title: Node.js
@@ -17,49 +17,57 @@ command: node --version
 releaseDateColumn: true
 sortReleasesBy: 'releaseCycle'
 releases:
-  - releaseCycle: "18"
+-   releaseCycle: "18"
     release: 2022-04-19
     # Change to true after 2022-10-25
     lts: false
     support: 2023-10-18
     eol: 2025-04-30
     latest: "18.2.0"
-  - releaseCycle: "17"
+    latestReleaseDate: 2022-05-17
+-   releaseCycle: "17"
     release: 2021-10-19
     lts: false
     support: 2022-04-01
     eol: 2022-06-01
     latest: "17.9.0"
-  - releaseCycle: "16"
+    latestReleaseDate: 2022-04-07
+-   releaseCycle: "16"
     release: 2021-04-20
     lts: true
     support: 2022-10-18
     eol: 2024-04-30
     latest: "16.15.0"
-  - releaseCycle: "15"
+    latestReleaseDate: 2022-04-26
+-   releaseCycle: "15"
     release: 2020-10-20
     lts: false
     support: 2021-04-01
     eol: 2021-06-01
     latest: "15.14.0"
-  - releaseCycle: "14"
+    latestReleaseDate: 2021-04-06
+-   releaseCycle: "14"
     release: 2020-04-21
     lts: true
     support: 2021-10-19
     eol: 2023-04-30
     latest: "14.19.3"
-  - releaseCycle: "12"
+    latestReleaseDate: 2022-05-17
+-   releaseCycle: "12"
     release: 2019-04-23
     lts: true
     support: 2020-10-20
     eol: 2022-04-30
     latest: "12.22.12"
-  - releaseCycle: "10"
+    latestReleaseDate: 2022-04-05
+-   releaseCycle: "10"
     release: 2018-04-24
     lts: true
     support: 2020-05-19
     eol: 2021-04-30
     latest: "10.24.1"
+    latestReleaseDate: 2021-04-06
+
 ---
 
 > [Node.js](https://nodejs.org/) is an open-source, cross-platform JavaScript run-time environment built on Chrome's V8 JavaScript engine that executes JavaScript code outside of a browser.

--- a/products/nomad.md
+++ b/products/nomad.md
@@ -17,15 +17,18 @@ releases:
     eol: false
     release: 2022-05-11
     latest: "1.3.1"
-  - releaseCycle: "1.2"
+    latestReleaseDate: 2022-05-19
+-   releaseCycle: "1.2"
     eol: false
     release: 2021-11-15
     latest: "1.2.8"
-  - releaseCycle: "1.1"
+    latestReleaseDate: 2022-05-19
+-   releaseCycle: "1.1"
     eol: false
-    release: 2021-05-18
+    release: 2021-05-17
     latest: "1.1.14"
-  - releaseCycle: "1.0"
+    latestReleaseDate: 2022-05-19
+-   releaseCycle: "1.0"
     eol: true
     release: 2020-12-08
     latest: "1.0.18"
@@ -34,6 +37,7 @@ releases:
     eol: true
     release: 2020-07-09
     latest: "0.12.12"
+
 
 ---
 

--- a/products/nomad.md
+++ b/products/nomad.md
@@ -13,7 +13,7 @@ command: nomad --version
 auto:
 -   git: https://github.com/hashicorp/nomad.git
 releases:
-  - releaseCycle: "1.3"
+-   releaseCycle: "1.3"
     eol: false
     release: 2022-05-11
     latest: "1.3.1"
@@ -29,10 +29,12 @@ releases:
     eol: true
     release: 2020-12-08
     latest: "1.0.18"
-  - releaseCycle: "0.12"
+    latestReleaseDate: 2022-02-10
+-   releaseCycle: "0.12"
     eol: true
     release: 2020-07-09
     latest: "0.12.12"
+
 ---
 
 > [Hashicorp Nomad](https://www.nomadproject.io/) is a simple and flexible workload orchestrator to deploy and manage containers and non-containerized applications across on-prem and clouds at scale.

--- a/products/openzfs.md
+++ b/products/openzfs.md
@@ -25,13 +25,13 @@ releases:
     lts: true
     latest: "2.1.99"
 
-    latestReleaseDate: 2021-03-30
+    latestReleaseDate: 2021-04-19
 -   releaseCycle: "2.0"
     release: 2020-11-30
     eol: 2021-12-23
     latest: "2.0.7"
 
-    latestReleaseDate: 2021-12-22
+    latestReleaseDate: 2021-12-23
 -   releaseCycle: "0.8"
     release: 2019-05-21
     eol: 2020-12-14

--- a/products/openzfs.md
+++ b/products/openzfs.md
@@ -1,7 +1,7 @@
 ---
 permalink: /openzfs
 alternate_urls:
-  - /zfs
+-   /zfs
 layout: post
 title: OpenZFS
 category: app
@@ -19,21 +19,25 @@ eolColumn: Critical bug fixes
 releaseLabel: "OpenZFS __RELEASE_CYCLE__"
 releases:
 
-    - releaseCycle: "2.1"
-      release: 2021-07-02
-      eol: 2023-07-02
-      lts: true
-      latest: "2.1.4"
+-   releaseCycle: "2.1"
+    release: 2021-07-02
+    eol: 2023-07-02
+    lts: true
+    latest: "2.1.99"
 
-    - releaseCycle: "2.0"
-      release: 2020-11-30
-      eol: 2021-12-23
-      latest: "2.0.7"
+    latestReleaseDate: 2021-03-30
+-   releaseCycle: "2.0"
+    release: 2020-11-30
+    eol: 2021-12-23
+    latest: "2.0.7"
 
-    - releaseCycle: "0.8"
-      release: 2019-06-23
-      eol: 2020-12-14
-      latest: "0.8.6"
+    latestReleaseDate: 2021-12-22
+-   releaseCycle: "0.8"
+    release: 2019-05-21
+    eol: 2020-12-14
+    latest: "0.8.6"
+    latestReleaseDate: 2020-12-14
+
 ---
 
 > [OpenZFS](https://openzfs.github.io/openzfs-docs/) is an open-source storage platform that encompasses the functionality of traditional filesystems and volume manager. It includes protection against data corruption, support for high storage capacities, efficient data compression, snapshots and copy-on-write clones, continuous integrity checking and automatic repair, encryption, remote replication with ZFS send and receive, and RAID-Z. Linux and FreeBSD are officially supported, [with plans to support macOS in the future](https://github.com/openzfs/zfs/pull/12110).  

--- a/products/pan-xdr.md
+++ b/products/pan-xdr.md
@@ -69,5 +69,6 @@ releases:
     eol: 2022-12-27
     release: 2022-03-27
 ---
+
 > [Palo Alto Networks](https://www.paloaltonetworks.com/) [Cortex XDR agent](https://docs.paloaltonetworks.com/cortex/cortex-xdr.html) protects endpoints by preventing known and unknown malware from running on those endpoints and by halting any attempts to leverage software exploits and vulnerabilities. The agent can be installed on a variety of operating systems including Windows, macOS, Android, and Linux.
 Software updates are provided as part of a valid support agreement.

--- a/products/perl.md
+++ b/products/perl.md
@@ -34,7 +34,6 @@ releases:
     support: 2019-05-22
     release: 2017-05-30
     latest: "5.26.3"
-
 permalink: /perl
 releasePolicyLink: https://perldoc.perl.org/perlpolicy#MAINTENANCE-AND-SUPPORT
 activeSupportColumn: true

--- a/products/perl.md
+++ b/products/perl.md
@@ -9,31 +9,36 @@ auto:
   # Feel free to file a PR to fix this
 -   git: https://github.com/Perl/perl5.git
 releases:
-  - releaseCycle: "5.34"
+-   releaseCycle: "5.34"
     eol: 2024-05-20
     support: true
     release: 2021-05-20
     latest: "5.34.1"
-  - releaseCycle: "5.32"
+    latestReleaseDate: 2022-03-12
+-   releaseCycle: "5.32"
     eol: 2023-06-20
     support: true
     release: 2020-06-20
     latest: "5.32.1"
-  - releaseCycle: "5.30"
+    latestReleaseDate: 2021-01-23
+-   releaseCycle: "5.30"
     eol: 2022-05-22
     support: true
     release: 2019-05-22
     latest: "5.30.3"
-  - releaseCycle: "5.28"
+    latestReleaseDate: 2020-05-29
+-   releaseCycle: "5.28"
     eol: 2021-06-23
     support: 2020-06-20
-    release: 2018-06-23
+    release: 2018-06-22
     latest: "5.28.3"
-  - releaseCycle: "5.26"
+    latestReleaseDate: 2020-05-29
+-   releaseCycle: "5.26"
     eol: 2020-05-30
     support: 2019-05-22
     release: 2017-05-30
     latest: "5.26.3"
+    latestReleaseDate: 2018-11-28
 permalink: /perl
 releasePolicyLink: https://perldoc.perl.org/perlpolicy#MAINTENANCE-AND-SUPPORT
 activeSupportColumn: true
@@ -41,6 +46,7 @@ releaseColumn: true
 releaseDateColumn: true
 eolColumn: Critical security patches
 command: perl -v
+
 ---
 
 > [Perl](https://www.perl.org/) is a highly capable, feature-rich programming language with over 30 years of development.

--- a/products/php.md
+++ b/products/php.md
@@ -14,103 +14,118 @@ command: php --version
 releaseDateColumn: true
 sortReleasesBy: 'cycleShortHand'
 releases:
-  - releaseCycle: "8.1"
+-   releaseCycle: "8.1"
     cycleShortHand: "801"
-    release: 2021-11-25
+    release: 2021-11-23
     support: 2023-11-25
-    eol:     2024-11-25
-    latest:  "8.1.6"
+    eol: 2024-11-25
+    latest: "8.1.6"
 
-  - releaseCycle: "8.0"
+    latestReleaseDate: 2022-05-11
+-   releaseCycle: "8.0"
     cycleShortHand: "800"
-    release: 2020-11-26
+    release: 2020-11-24
     support: 2022-11-26
-    eol:     2023-11-26
-    latest:  "8.0.19"
+    eol: 2023-11-26
+    latest: "8.0.19"
 
-  - releaseCycle: "7.4"
+    latestReleaseDate: 2022-05-10
+-   releaseCycle: "7.4"
     cycleShortHand: "704"
-    release: 2019-11-28
+    release: 2019-11-26
     support: 2021-11-28
-    eol:     2022-11-28
-    latest:  "7.4.29"
+    eol: 2022-11-28
+    latest: "7.4.29"
 
-  - releaseCycle: "7.3"
+    latestReleaseDate: 2022-04-12
+-   releaseCycle: "7.3"
     cycleShortHand: "703"
-    release: 2018-12-06
+    release: 2018-12-04
     support: 2020-12-06
-    eol:     2021-12-06
-    latest:  "7.3.33"
+    eol: 2021-12-06
+    latest: "7.3.33"
 
-  - releaseCycle: "7.2"
+    latestReleaseDate: 2021-11-16
+-   releaseCycle: "7.2"
     cycleShortHand: "702"
-    release: 2017-11-30
+    release: 2017-11-28
     support: 2019-11-30
-    eol:     2020-11-30
-    latest:  "7.2.34"
+    eol: 2020-11-30
+    latest: "7.2.34"
 
-  - releaseCycle: "7.1"
+    latestReleaseDate: 2020-09-30
+-   releaseCycle: "7.1"
     cycleShortHand: "701"
-    release: 2016-12-01
+    release: 2016-11-30
     support: 2018-12-01
-    eol:     2019-12-01
-    latest:  "7.1.33"
+    eol: 2019-12-01
+    latest: "7.1.33"
 
-  - releaseCycle: "7.0"
+    latestReleaseDate: 2019-10-22
+-   releaseCycle: "7.0"
     cycleShortHand: "700"
-    release: 2015-12-03
+    release: 2015-12-01
     support: 2018-01-04
-    eol:     2019-01-10
-    latest:  "7.0.33"
+    eol: 2019-01-10
+    latest: "7.0.33"
 
-  - releaseCycle: "5.6"
+    latestReleaseDate: 2018-12-04
+-   releaseCycle: "5.6"
     cycleShortHand: "506"
-    release: 2014-08-28
+    release: 2014-08-27
     support: 2017-01-19
-    eol:     2018-12-31
-    latest:  "5.6.40"
+    eol: 2018-12-31
+    latest: "5.6.40"
 
-  - releaseCycle: "5.5"
+    latestReleaseDate: 2019-01-09
+-   releaseCycle: "5.5"
     cycleShortHand: "505"
-    release: 2013-06-20
+    release: 2013-06-19
     support: 2015-07-10
-    eol:     2016-07-21
-    latest:  "5.5.38"
+    eol: 2016-07-21
+    latest: "5.5.38"
 
-  - releaseCycle: "5.4"
+    latestReleaseDate: 2016-07-20
+-   releaseCycle: "5.4"
     cycleShortHand: "504"
-    release: 2012-03-01
+    release: 2012-02-29
     support: 2014-09-14
-    eol:     2015-09-14
-    latest:  "5.4.45"
+    eol: 2015-09-14
+    latest: "5.4.45"
 
-  - releaseCycle: "5.3"
+    latestReleaseDate: 2015-09-01
+-   releaseCycle: "5.3"
     cycleShortHand: "503"
-    release: 2009-06-30
+    release: 2009-06-29
     support: 2011-06-30
-    eol:     2014-08-14
-    latest:  "5.3.29"
+    eol: 2014-08-14
+    latest: "5.3.29"
 
-  - releaseCycle: "5.2"
+    latestReleaseDate: 2014-08-13
+-   releaseCycle: "5.2"
     cycleShortHand: "502"
-    release: 2006-11-02
+    release: 2006-11-01
     support: 2008-11-02
-    eol:     2011-01-06
-    latest:  "5.2.17"
+    eol: 2011-01-06
+    latest: "5.2.17"
 
-  - releaseCycle: "5.1"
+    latestReleaseDate: 2011-01-06
+-   releaseCycle: "5.1"
     cycleShortHand: "501"
-    release: 2005-11-24
+    release: 2005-11-23
     support: 2006-08-24
-    eol:     2006-08-24
-    latest:  "5.1.6"
+    eol: 2006-08-24
+    latest: "5.1.6"
 
-  - releaseCycle: "5.0"
+    latestReleaseDate: 2006-08-23
+-   releaseCycle: "5.0"
     cycleShortHand: "500"
-    release: 2004-07-13
+    release: 2004-07-15
     support: 2005-09-05
-    eol:     2005-09-05
-    latest:  "5.0.5"
+    eol: 2005-09-05
+    latest: "5.0.5"
+    latestReleaseDate: 2005-09-05
+
 ---
 
 > [PHP](https://www.php.net/): Hypertext Preprocessor (or simply PHP) is a general-purpose programming language originally designed for web development.

--- a/products/php.md
+++ b/products/php.md
@@ -21,7 +21,7 @@ releases:
     eol: 2024-11-25
     latest: "8.1.6"
 
-    latestReleaseDate: 2022-05-11
+    latestReleaseDate: 2022-05-10
 -   releaseCycle: "8.0"
     cycleShortHand: "800"
     release: 2020-11-24

--- a/products/postgresql.md
+++ b/products/postgresql.md
@@ -54,7 +54,7 @@ releases:
     latest: "9.5.25"
     latestReleaseDate: 2021-02-08
 -   releaseCycle: "9.4"
-    release: 2014-12-16
+    release: 2014-12-15
     eol: 2020-02-13
     latest: "9.4.26"
     latestReleaseDate: 2020-02-10
@@ -97,7 +97,7 @@ releases:
     release: 2005-11-05
     eol: 2010-11-08
     latest: "8.1.23"
-    latestReleaseDate: 2010-12-14
+    latestReleaseDate: 2010-12-13
 -   releaseCycle: "8.0"
     release: 2005-01-17
     eol: 2010-10-01

--- a/products/postgresql.md
+++ b/products/postgresql.md
@@ -3,8 +3,8 @@ title: PostgreSQL
 layout: post
 permalink: /postgresql
 alternate_urls:
-  - /postgres
-  - /pg
+-   /postgres
+-   /pg
 releasePolicyLink: https://www.postgresql.org/support/versioning/
 category: db
 changelogTemplate: https://www.postgresql.org/docs/release/__LATEST__/
@@ -18,74 +18,92 @@ auto:
   # https://rubular.com/r/KlemgnguNe0e5X
     regex: ^REL_?(?<major>[1-9]\d*)_(?<minor>0|[1-9]\d*)_?(?<patch>\d+)?$
 releases:
-  - releaseCycle: "14"
-    release: 2021-09-30
+-   releaseCycle: "14"
+    release: 2021-09-27
     eol: 2026-09-30
     latest: "14.3"
-  - releaseCycle: "13"
-    release: 2020-09-24
+    latestReleaseDate: 2022-05-09
+-   releaseCycle: "13"
+    release: 2020-09-21
     eol: 2025-11-13
     latest: "13.7"
-  - releaseCycle: "12"
-    release: 2019-10-03
+    latestReleaseDate: 2022-05-09
+-   releaseCycle: "12"
+    release: 2019-09-30
     eol: 2024-11-14
     latest: "12.11"
-  - releaseCycle: "11"
-    release: 2018-10-18
+    latestReleaseDate: 2022-05-09
+-   releaseCycle: "11"
+    release: 2018-10-15
     eol: 2023-11-09
     latest: "11.16"
-  - releaseCycle: "10"
-    release: 2017-10-05
+    latestReleaseDate: 2022-05-09
+-   releaseCycle: "10"
+    release: 2017-10-02
     eol: 2022-11-10
     latest: "10.21"
-  - releaseCycle: "9.6"
-    release: 2016-09-29
+    latestReleaseDate: 2022-05-09
+-   releaseCycle: "9.6"
+    release: 2016-09-26
     eol: 2021-11-11
     latest: "9.6.24"
-  - releaseCycle: "9.5"
-    release: 2016-01-07
+    latestReleaseDate: 2021-11-08
+-   releaseCycle: "9.5"
+    release: 2016-01-04
     eol: 2021-02-11
     latest: "9.5.25"
-  - releaseCycle: "9.4"
-    release: 2014-12-08
+    latestReleaseDate: 2021-02-08
+-   releaseCycle: "9.4"
+    release: 2014-12-16
     eol: 2020-02-13
     latest: "9.4.26"
-  - releaseCycle: "9.3"
-    release: 2013-09-09
+    latestReleaseDate: 2020-02-10
+-   releaseCycle: "9.3"
+    release: 2013-09-02
     eol: 2018-11-08
     latest: "9.3.25"
-  - releaseCycle: "9.2"
-    release: 2012-09-10
+    latestReleaseDate: 2018-11-05
+-   releaseCycle: "9.2"
+    release: 2012-09-06
     eol: 2018-11-09
     latest: "9.2.24"
-  - releaseCycle: "9.1"
-    release: 2011-09-12
+    latestReleaseDate: 2017-11-06
+-   releaseCycle: "9.1"
+    release: 2011-09-08
     eol: 2016-10-27
     latest: "9.1.24"
-  - releaseCycle: "9.0"
-    release: 2010-09-20
+    latestReleaseDate: 2016-10-24
+-   releaseCycle: "9.0"
+    release: 2010-09-17
     eol: 2015-10-08
     latest: "9.0.23"
-  - releaseCycle: "8.4"
-    release: 2009-07-01
+    latestReleaseDate: 2015-10-05
+-   releaseCycle: "8.4"
+    release: 2009-06-27
     eol: 2014-07-24
     latest: "8.4.22"
-  - releaseCycle: "8.3"
-    release: 2008-02-04
+    latestReleaseDate: 2014-07-21
+-   releaseCycle: "8.3"
+    release: 2008-02-01
     eol: 2013-02-07
     latest: "8.3.23"
-  - releaseCycle: "8.2"
-    release: 2006-12-05
+    latestReleaseDate: 2013-02-04
+-   releaseCycle: "8.2"
+    release: 2006-12-02
     eol: 2011-12-05
     latest: "8.2.23"
-  - releaseCycle: "8.1"
-    release: 2005-11-08
+    latestReleaseDate: 2011-12-01
+-   releaseCycle: "8.1"
+    release: 2005-11-05
     eol: 2010-11-08
     latest: "8.1.23"
-  - releaseCycle: "8.0"
-    release: 2005-01-19
+    latestReleaseDate: 2010-12-14
+-   releaseCycle: "8.0"
+    release: 2005-01-17
     eol: 2010-10-01
     latest: "8.0.26"
+    latestReleaseDate: 2010-10-01
+
 ---
 
 > [PostgreSQL](https://www.postgresql.org/), also known as Postgres, is a free and open-source relational database management system (RDBMS) emphasizing extensibility and technical standards compliance.

--- a/products/powershell.md
+++ b/products/powershell.md
@@ -12,37 +12,44 @@ eolColumn: Support Status
 auto:
 -   git: https://github.com/PowerShell/PowerShell.git
 releases:
-  - releaseCycle: "7.2"
+-   releaseCycle: "7.2"
     lts: true
-    release: 2021-11-08
-    eol:     2024-11-30
-    latest:  "7.2.4"
+    release: 2021-11-05
+    eol: 2024-11-30
+    latest: "7.2.4"
 
-  - releaseCycle: "7.1"
+    latestReleaseDate: 2022-05-17
+-   releaseCycle: "7.1"
     release: 2020-11-11
-    eol:     2022-05-31
-    latest:  "7.1.7"
+    eol: 2022-05-31
+    latest: "7.1.7"
 
-  - releaseCycle: "7.0"
+    latestReleaseDate: 2022-04-26
+-   releaseCycle: "7.0"
     lts: true
-    release: 2020-03-04
-    eol:     2022-12-03
-    latest:  "7.0.11"
+    release: 2020-03-03
+    eol: 2022-12-03
+    latest: "7.0.11"
 
-  - releaseCycle: "6.2"
+    latestReleaseDate: 2022-05-17
+-   releaseCycle: "6.2"
     release: 2019-03-28
-    eol:     2020-09-04
-    latest:  "6.2.7"
+    eol: 2020-09-04
+    latest: "6.2.7"
 
-  - releaseCycle: "6.1"
+    latestReleaseDate: 2020-07-16
+-   releaseCycle: "6.1"
     release: 2018-09-13
-    eol:     2019-09-28
-    latest:  "6.1.6"
+    eol: 2019-09-28
+    latest: "6.1.6"
 
-  - releaseCycle: "6.0"
+    latestReleaseDate: 2019-09-12
+-   releaseCycle: "6.0"
     release: 2018-01-10
-    eol:     2019-02-13
-    latest:  "6.0.5"
+    eol: 2019-02-13
+    latest: "6.0.5"
+    latestReleaseDate: 2018-11-13
+
 ---
 
 > [PowerShell](https://aka.ms/powershell)  is a cross-platform automation and configuration tool/framework that is optimized for dealing with structured data (e.g. JSON, CSV, XML, etc.), REST APIs, and object models. It includes a command-line shell, an associated scripting language and a framework for processing cmdlets.

--- a/products/powershell.md
+++ b/products/powershell.md
@@ -17,28 +17,23 @@ releases:
     release: 2021-11-08
     eol:     2024-11-30
     latest:  "7.2.4"
-
   - releaseCycle: "7.1"
     release: 2020-11-11
     eol:     2022-05-31
     latest:  "7.1.7"
-
   - releaseCycle: "7.0"
     lts: true
     release: 2020-03-04
     eol:     2022-12-03
     latest:  "7.0.11"
-
   - releaseCycle: "6.2"
     release: 2019-03-28
     eol:     2020-09-04
     latest:  "6.2.7"
-
   - releaseCycle: "6.1"
     release: 2018-09-13
     eol:     2019-09-28
     latest:  "6.1.6"
-
   - releaseCycle: "6.0"
     release: 2018-01-10
     eol:     2019-02-13

--- a/products/powershell.md
+++ b/products/powershell.md
@@ -17,23 +17,28 @@ releases:
     release: 2021-11-08
     eol:     2024-11-30
     latest:  "7.2.4"
+
   - releaseCycle: "7.1"
     release: 2020-11-11
     eol:     2022-05-31
     latest:  "7.1.7"
+
   - releaseCycle: "7.0"
     lts: true
     release: 2020-03-04
     eol:     2022-12-03
     latest:  "7.0.11"
+
   - releaseCycle: "6.2"
     release: 2019-03-28
     eol:     2020-09-04
     latest:  "6.2.7"
+
   - releaseCycle: "6.1"
     release: 2018-09-13
     eol:     2019-09-28
     latest:  "6.1.6"
+
   - releaseCycle: "6.0"
     release: 2018-01-10
     eol:     2019-02-13

--- a/products/python.md
+++ b/products/python.md
@@ -23,35 +23,35 @@ releases:
 -   releaseCycle: "3.9"
     release: 2020-10-05
     eol: 2025-10-05
-    latest: "3.9.12"
-    latestReleaseDate: 2022-03-23
+    latest: "3.9.13"
+    latestReleaseDate: 2022-05-17
 -   releaseCycle: "3.8"
     release: 2019-10-14
     eol: 2024-10-14
     latest: "3.8.13"
     latestReleaseDate: 2022-03-16
 -   releaseCycle: "3.7"
-    release: 2018-06-27
+    release: 2018-06-26
     eol: 2023-06-27
     latest: "3.7.13"
     latestReleaseDate: 2022-03-16
 -   releaseCycle: "3.6"
-    release: 2021-12-28
+    release: 2021-12-31
     eol: 2021-12-23
     latest: "3.6.15"
-    latestReleaseDate: 2021-09-04
+    latestReleaseDate: 2021-09-03
 -   releaseCycle: "3.5"
-    release: 2020-09-05
+    release: 2020-10-22
     eol: 2020-09-13
     latest: "3.5.10"
     latestReleaseDate: 2020-09-05
 -   releaseCycle: "3.4"
-    release: 2019-05-07
+    release: 2019-05-08
     eol: 2019-03-18
     latest: "3.4.10"
     latestReleaseDate: 2019-03-18
 -   releaseCycle: "3.3"
-    release: 2017-09-19
+    release: 2017-10-06
     eol: 2017-09-29
     latest: "3.3.7"
     latestReleaseDate: 2017-09-19

--- a/products/python.md
+++ b/products/python.md
@@ -36,22 +36,22 @@ releases:
     latest: "3.7.13"
     latestReleaseDate: 2022-03-16
 -   releaseCycle: "3.6"
-    release: 2021-12-31
+    release: 2016-12-22
     eol: 2021-12-23
     latest: "3.6.15"
     latestReleaseDate: 2021-09-03
 -   releaseCycle: "3.5"
-    release: 2020-10-22
+    release: 2015-09-12
     eol: 2020-09-13
     latest: "3.5.10"
     latestReleaseDate: 2020-09-05
 -   releaseCycle: "3.4"
-    release: 2019-05-08
+    release: 2014-03-15
     eol: 2019-03-18
     latest: "3.4.10"
     latestReleaseDate: 2019-03-18
 -   releaseCycle: "3.3"
-    release: 2017-10-06
+    release: 2012-09-29
     eol: 2017-09-29
     latest: "3.3.7"
     latestReleaseDate: 2017-09-19

--- a/products/python.md
+++ b/products/python.md
@@ -15,42 +15,52 @@ auto:
   # eg https://github.com/python/cpython/releases/tag/3.6
     regex: ^v(?<major>[1-9]\d*)\.(?<minor>0|[1-9]\d*)\.?(?<patch>0|[1-9]\d*)?$
 releases:
-    - releaseCycle: "3.10"
-      release: 2021-10-04
-      eol: 2026-10-04
-      latest: "3.10.4"
-    - releaseCycle: "3.9"
-      release: 2020-10-05
-      eol: 2025-10-05
-      latest: "3.9.13"
-    - releaseCycle: "3.8"
-      release: 2019-10-14
-      eol: 2024-10-14
-      latest: "3.8.13"
-    - releaseCycle: "3.7"
-      release: 2018-06-27
-      eol: 2023-06-27
-      latest: "3.7.13"
-    - releaseCycle: "3.6"
-      release: 2016-12-23
-      eol: 2021-12-23
-      latest: "3.6.15"
-    - releaseCycle: "3.5"
-      release: 2015-09-13
-      eol: 2020-09-13
-      latest: "3.5.10"
-    - releaseCycle: "3.4"
-      release: 2014-03-16
-      eol: 2019-03-18
-      latest: "3.4.10"
-    - releaseCycle: "3.3"
-      release: 2012-09-29
-      eol: 2017-09-29
-      latest: "3.3.7"
-    - releaseCycle: "2.7"
-      release: 2010-07-03
-      eol: 2020-01-01
-      latest: "2.7.18"
+-   releaseCycle: "3.10"
+    release: 2021-10-04
+    eol: 2026-10-04
+    latest: "3.10.4"
+    latestReleaseDate: 2022-03-23
+-   releaseCycle: "3.9"
+    release: 2020-10-05
+    eol: 2025-10-05
+    latest: "3.9.12"
+    latestReleaseDate: 2022-03-23
+-   releaseCycle: "3.8"
+    release: 2019-10-14
+    eol: 2024-10-14
+    latest: "3.8.13"
+    latestReleaseDate: 2022-03-16
+-   releaseCycle: "3.7"
+    release: 2018-06-27
+    eol: 2023-06-27
+    latest: "3.7.13"
+    latestReleaseDate: 2022-03-16
+-   releaseCycle: "3.6"
+    release: 2021-12-28
+    eol: 2021-12-23
+    latest: "3.6.15"
+    latestReleaseDate: 2021-09-04
+-   releaseCycle: "3.5"
+    release: 2020-09-05
+    eol: 2020-09-13
+    latest: "3.5.10"
+    latestReleaseDate: 2020-09-05
+-   releaseCycle: "3.4"
+    release: 2019-05-07
+    eol: 2019-03-18
+    latest: "3.4.10"
+    latestReleaseDate: 2019-03-18
+-   releaseCycle: "3.3"
+    release: 2017-09-19
+    eol: 2017-09-29
+    latest: "3.3.7"
+    latestReleaseDate: 2017-09-19
+-   releaseCycle: "2.7"
+    release: 2010-07-03
+    eol: 2020-01-01
+    latest: "2.7.18"
+    latestReleaseDate: 2020-04-19
+
 ---
 
 > [Python](https://www.python.org/) is an interpreted, high-level, general-purpose programming language.

--- a/products/qt.md
+++ b/products/qt.md
@@ -14,79 +14,79 @@ auto:
 releases:
 -   releaseCycle: "6.3"
     cycleShortHand: 603
-    release: 2022-04-06
+    release: 2022-04-11
     eol: 2022-10-12
     latest: "6.3.0"
     lts: false
     link: https://www.qt.io/blog/qt-6.3-released
-    latestReleaseDate: 2022-04-06
+    latestReleaseDate: 2022-04-11
 -   releaseCycle: "6.2"
     cycleShortHand: 602
-    release: 2021-09-25
+    release: 2021-09-30
     eol: 2024-09-30
     latest: "6.2.4"
     lts: true
     link: https://www.qt.io/blog/qt-6.2.4-released
-    latestReleaseDate: 2022-03-10
+    latestReleaseDate: 2022-03-16
 -   releaseCycle: "6.1"
     cycleShortHand: 601
-    release: 2021-05-04
+    release: 2021-05-05
     eol: 2022-05-06
     latest: "6.1.3"
     link: https://www.qt.io/blog/qt-6.1.3-released
-    latestReleaseDate: 2021-08-29
+    latestReleaseDate: 2021-08-31
 -   releaseCycle: "6.0"
     cycleShortHand: 600
-    release: 2020-12-05
+    release: 2020-12-08
     eol: 2021-12-08
     latest: "6.0.4"
     link: https://www.qt.io/blog/qt-6.0.4-released
-    latestReleaseDate: 2021-04-28
+    latestReleaseDate: 2021-05-03
 -   releaseCycle: "5.15"
     cycleShortHand: 515
-    release: 2020-05-12
+    release: 2020-05-25
     eol: 2023-05-26
     latest: "5.15.2"
     lts: true
     link: https://www.qt.io/blog/qt-5.15-released
-    latestReleaseDate: 2020-11-12
+    latestReleaseDate: 2020-11-13
 -   releaseCycle: "5.14"
     cycleShortHand: 514
-    release: 2019-12-08
+    release: 2019-12-11
     eol: 2020-12-12
     latest: "5.14.2"
     link: https://www.qt.io/blog/qt-5.14-has-released
-    latestReleaseDate: 2020-03-28
+    latestReleaseDate: 2020-03-30
 -   releaseCycle: "5.13"
     cycleShortHand: 513
-    release: 2019-06-13
+    release: 2019-06-18
     eol: 2020-06-19
     latest: "5.13.2"
     link: https://blog.qt.io/blog/2019/06/19/qt-5-13-released
     latestReleaseDate: 2019-10-28
 -   releaseCycle: "5.12"
     cycleShortHand: 512
-    release: 2018-12-03
+    release: 2018-12-04
     eol: 2021-12-05
     latest: "5.12.12"
     lts: true
     link: https://www.qt.io/blog/qt-5.12.12-released
-    latestReleaseDate: 2021-11-22
+    latestReleaseDate: 2021-11-25
 -   releaseCycle: "5.9"
     cycleShortHand: 509
-    release: 2017-05-27
+    release: 2017-05-29
     eol: 2020-05-31
     latest: "5.9.9"
     link: https://www.qt.io/blog/qt-5.9.9-released
-    latestReleaseDate: 2019-12-08
+    latestReleaseDate: 2019-12-16
 -   releaseCycle: "5.6"
     cycleShortHand: 506
-    release: 2016-03-08
+    release: 2016-03-15
     eol: 2019-03-16
     latest: "5.6.3"
     lts: true
     link: https://www.qt.io/blog/2017/09/21/qt-5-6-3-released
-    latestReleaseDate: 2017-09-15
+    latestReleaseDate: 2017-09-20
 -   releaseCycle: "4.8"
     cycleShortHand: 408
     release: 2011-12-15

--- a/products/qt.md
+++ b/products/qt.md
@@ -12,78 +12,88 @@ auto:
   # Upstream does not support filtering https://code.qt.io/qt/qt5.git
 -   git: https://github.com/qt/qt5.git
 releases:
-    - releaseCycle: "6.3"
-      cycleShortHand: 603
-      release: 2022-04-12
-      eol: 2022-10-12
-      latest: "6.3"
-      lts: false
-      link: https://www.qt.io/blog/qt-6.3-released
-    - releaseCycle: "6.2"
-      cycleShortHand: 602
-      release: 2021-09-30
-      eol: 2024-09-30
-      latest: "6.2.4"
-      lts: true
-      link: https://www.qt.io/blog/qt-6.2.4-released
-    - releaseCycle: "6.1"
-      cycleShortHand: 601
-      release: 2021-05-06
-      eol: 2022-05-06
-      latest: "6.1.3"
-      link: https://www.qt.io/blog/qt-6.1.3-released
-    - releaseCycle: "6.0"
-      cycleShortHand: 600
-      release: 2020-12-08
-      eol: 2021-12-08
-      latest: "6.0.4"
-      link: https://www.qt.io/blog/qt-6.0.4-released
-    - releaseCycle: "5.15"
-      cycleShortHand: 515
-      release: 2020-05-26
-      eol: 2023-05-26
-      latest: "5.15.8"
-      lts: true
-      link: https://www.qt.io/blog/qt-5.15-released
-    - releaseCycle: "5.14"
-      cycleShortHand: 514
-      release: 2019-12-12
-      eol: 2020-12-12
-      latest: "5.14.2"
-      link: https://www.qt.io/blog/qt-5.14-has-released
-    - releaseCycle: "5.13"
-      cycleShortHand: 513
-      release: 2019-06-19
-      eol: 2020-06-19
-      latest: "5.13.2"
-      link: https://blog.qt.io/blog/2019/06/19/qt-5-13-released
-    - releaseCycle: "5.12"
-      cycleShortHand: 512
-      release: 2018-12-06
-      eol: 2021-12-05
-      latest: "5.12.12"
-      lts: true
-      link: https://www.qt.io/blog/qt-5.12.12-released
-    - releaseCycle: "5.9"
-      cycleShortHand: 509
-      release: 2017-05-31
-      eol: 2020-05-31
-      latest: "5.9.9"
-      link: https://www.qt.io/blog/qt-5.9.9-released
-    - releaseCycle: "5.6"
-      cycleShortHand: 506
-      release: 2016-03-16
-      eol: 2019-03-16
-      latest: "5.6.3"
-      lts: true
-      link: https://www.qt.io/blog/2017/09/21/qt-5-6-3-released
-    - releaseCycle: "4.8"
-      cycleShortHand: 408
-      release: 2011-12-15
-      eol: 2015-12-31
-      latest: "4.8.7"
-      lts: true
-      link: https://www.qt.io/blog/2015/05/26/qt-4-8-7-released
+-   releaseCycle: "6.3"
+    cycleShortHand: 603
+    release: 2022-04-06
+    eol: 2022-10-12
+    latest: "6.3.0"
+    lts: false
+    link: https://www.qt.io/blog/qt-6.3-released
+    latestReleaseDate: 2022-04-06
+-   releaseCycle: "6.2"
+    cycleShortHand: 602
+    release: 2021-09-25
+    eol: 2024-09-30
+    latest: "6.2.4"
+    lts: true
+    link: https://www.qt.io/blog/qt-6.2.4-released
+    latestReleaseDate: 2022-03-10
+-   releaseCycle: "6.1"
+    cycleShortHand: 601
+    release: 2021-05-04
+    eol: 2022-05-06
+    latest: "6.1.3"
+    link: https://www.qt.io/blog/qt-6.1.3-released
+    latestReleaseDate: 2021-08-29
+-   releaseCycle: "6.0"
+    cycleShortHand: 600
+    release: 2020-12-05
+    eol: 2021-12-08
+    latest: "6.0.4"
+    link: https://www.qt.io/blog/qt-6.0.4-released
+    latestReleaseDate: 2021-04-28
+-   releaseCycle: "5.15"
+    cycleShortHand: 515
+    release: 2020-05-12
+    eol: 2023-05-26
+    latest: "5.15.2"
+    lts: true
+    link: https://www.qt.io/blog/qt-5.15-released
+    latestReleaseDate: 2020-11-12
+-   releaseCycle: "5.14"
+    cycleShortHand: 514
+    release: 2019-12-08
+    eol: 2020-12-12
+    latest: "5.14.2"
+    link: https://www.qt.io/blog/qt-5.14-has-released
+    latestReleaseDate: 2020-03-28
+-   releaseCycle: "5.13"
+    cycleShortHand: 513
+    release: 2019-06-13
+    eol: 2020-06-19
+    latest: "5.13.2"
+    link: https://blog.qt.io/blog/2019/06/19/qt-5-13-released
+    latestReleaseDate: 2019-10-28
+-   releaseCycle: "5.12"
+    cycleShortHand: 512
+    release: 2018-12-03
+    eol: 2021-12-05
+    latest: "5.12.12"
+    lts: true
+    link: https://www.qt.io/blog/qt-5.12.12-released
+    latestReleaseDate: 2021-11-22
+-   releaseCycle: "5.9"
+    cycleShortHand: 509
+    release: 2017-05-27
+    eol: 2020-05-31
+    latest: "5.9.9"
+    link: https://www.qt.io/blog/qt-5.9.9-released
+    latestReleaseDate: 2019-12-08
+-   releaseCycle: "5.6"
+    cycleShortHand: 506
+    release: 2016-03-08
+    eol: 2019-03-16
+    latest: "5.6.3"
+    lts: true
+    link: https://www.qt.io/blog/2017/09/21/qt-5-6-3-released
+    latestReleaseDate: 2017-09-15
+-   releaseCycle: "4.8"
+    cycleShortHand: 408
+    release: 2011-12-15
+    eol: 2015-12-31
+    latest: "4.8.7"
+    lts: true
+    link: https://www.qt.io/blog/2015/05/26/qt-4-8-7-released
 
 ---
 

--- a/products/rabbitmq.md
+++ b/products/rabbitmq.md
@@ -13,7 +13,7 @@ auto:
 -   git: https://github.com/rabbitmq/rabbitmq-server.git
     regex: ^(rabbitmq_v(?<major>[1-9]\d*)_(?<minor>0|[1-9]\d*)_(?<patch>0|[1-9]\d*)|v(?<major>[1-9]\d*)\.(?<minor>0|[1-9]\d*)\.(?<patch>0|[1-9]\d*))$
 releases:
-  - releaseCycle: "3.10"
+-   releaseCycle: "3.10"
     eol: false
     release: 2022-05-03
     latest: "3.10.2"
@@ -29,34 +29,43 @@ releases:
     eol: 2020-09-30
     release: 2017-11-28
     latest: "3.7.28"
-  - releaseCycle: "3.6"
+    latestReleaseDate: 2020-07-22
+-   releaseCycle: "3.6"
     eol: 2018-05-31
     release: 2015-12-22
     latest: "3.6.16"
-  - releaseCycle: "3.5"
+    latestReleaseDate: 2018-05-28
+-   releaseCycle: "3.5"
     eol: 2016-10-31
     release: 2015-03-11
     latest: "3.5.8"
-  - releaseCycle: "3.4"
+    latestReleaseDate: 2016-11-03
+-   releaseCycle: "3.4"
     eol: 2015-10-31
     release: 2014-10-21
     latest: "3.4.4"
-  - releaseCycle: "3.3"
+    latestReleaseDate: 2015-02-11
+-   releaseCycle: "3.3"
     eol: 2015-03-31
     release: 2014-04-02
     latest: "3.3.5"
-  - releaseCycle: "3.2"
+    latestReleaseDate: 2014-08-11
+-   releaseCycle: "3.2"
     eol: 2014-10-31
     release: 2013-10-23
     latest: "3.2.4"
-  - releaseCycle: "3.1"
+    latestReleaseDate: 2014-03-04
+-   releaseCycle: "3.1"
     eol: 2014-04-30
     release: 2013-05-01
-    latest: "3.1.5"
-  - releaseCycle: "3.0"
+    latest: "3.10.1"
+    latestReleaseDate: 2022-05-10
+-   releaseCycle: "3.0"
     eol: 2013-11-30
     release: 2012-11-19
     latest: "3.0.4"
+    latestReleaseDate: 2013-03-06
+
 ---
 
 > [RabbitMQ](https://www.rabbitmq.com/) is an open source message broker.

--- a/products/rabbitmq.md
+++ b/products/rabbitmq.md
@@ -17,15 +17,18 @@ releases:
     eol: false
     release: 2022-05-03
     latest: "3.10.2"
-  - releaseCycle: "3.9"
+    latestReleaseDate: 2022-05-20
+-   releaseCycle: "3.9"
     eol: false
-    release: 2021-07-26
+    release: 2021-07-23
     latest: "3.9.18"
-  - releaseCycle: "3.8"
+    latestReleaseDate: 2022-05-20
+-   releaseCycle: "3.8"
     eol: 2022-01-31
     release: 2019-10-01
     latest: "3.8.32"
-  - releaseCycle: "3.7"
+    latestReleaseDate: 2022-05-20
+-   releaseCycle: "3.7"
     eol: 2020-09-30
     release: 2017-11-28
     latest: "3.7.28"
@@ -58,8 +61,8 @@ releases:
 -   releaseCycle: "3.1"
     eol: 2014-04-30
     release: 2013-05-01
-    latest: "3.10.1"
-    latestReleaseDate: 2022-05-10
+    latest: "3.10.2"
+    latestReleaseDate: 2022-05-20
 -   releaseCycle: "3.0"
     eol: 2013-11-30
     release: 2012-11-19

--- a/products/rabbitmq.md
+++ b/products/rabbitmq.md
@@ -61,8 +61,8 @@ releases:
 -   releaseCycle: "3.1"
     eol: 2014-04-30
     release: 2013-05-01
-    latest: "3.10.2"
-    latestReleaseDate: 2022-05-20
+    latest: "3.1.5"
+    latestReleaseDate: 2013-08-15
 -   releaseCycle: "3.0"
     eol: 2013-11-30
     release: 2012-11-19
@@ -72,3 +72,4 @@ releases:
 ---
 
 > [RabbitMQ](https://www.rabbitmq.com/) is an open source message broker.
+

--- a/products/rabbitmq.md
+++ b/products/rabbitmq.md
@@ -29,12 +29,12 @@ releases:
     eol: 2020-09-30
     release: 2017-11-28
     latest: "3.7.28"
-    latestReleaseDate: 2020-07-22
+    latestReleaseDate: 2020-08-17
 -   releaseCycle: "3.6"
     eol: 2018-05-31
     release: 2015-12-22
     latest: "3.6.16"
-    latestReleaseDate: 2018-05-28
+    latestReleaseDate: 2018-06-13
 -   releaseCycle: "3.5"
     eol: 2016-10-31
     release: 2015-03-11

--- a/products/react.md
+++ b/products/react.md
@@ -12,17 +12,20 @@ releaseDateColumn: true
 auto:
 -   git: https://github.com/facebook/react.git
 releases:
-  - releaseCycle: "18"
+-   releaseCycle: "18"
     release: 2022-03-29
     support: true
     eol: false
     latest: "18.1.0"
-  - releaseCycle: "17"
+    latestReleaseDate: 2022-04-26
+-   releaseCycle: "17"
     lts: false
     release: 2020-10-20
     eol: 2021-03-22
     support: false
     latest: "17.0.2"
+
+    latestReleaseDate: 2021-03-22
 
 ---
 

--- a/products/redis.md
+++ b/products/redis.md
@@ -12,18 +12,27 @@ sortReleasesBy: 'releaseCycle'
 auto:
 -   git: https://github.com/redis/redis.git
 releases:
-  - releaseCycle: "7.0"
+-   releaseCycle: "7.0"
     eol: false
     latest: '7.0.0'
-  - releaseCycle: "6.2"
+    release: 2022-04-27
+    latestReleaseDate: 2022-04-27
+-   releaseCycle: "6.2"
     eol: false
     latest: '6.2.7'
-  - releaseCycle: "6.0"
+    release: 2021-02-22
+    latestReleaseDate: 2022-04-27
+-   releaseCycle: "6.0"
     eol: false
     latest: '6.0.16'
-  - releaseCycle: "5.0"
+    release: 2020-04-30
+    latestReleaseDate: 2021-10-04
+-   releaseCycle: "5.0"
     eol: true
     latest: '5.0.14'
+    release: 2018-10-17
+    latestReleaseDate: 2021-10-04
+
 ---
 
 > [Redis](https://redis.io/) is an open source (BSD licensed), in-memory data structure store, used as a database, cache and message broker. It supports data structures such as strings, hashes, lists, sets, sorted sets with range queries, bitmaps, hyperloglogs, geospatial indexes with radius queries and streams. Redis has built-in replication, Lua scripting, LRU eviction, transactions and different levels of on-disk persistence, and provides high availability via [Redis Sentinel](https://redis.io/topics/sentinel) and automatic partitioning with [Redis Cluster](https://docs.redislabs.com/latest/rc/concepts/clustering/).

--- a/products/roundcube.md
+++ b/products/roundcube.md
@@ -9,46 +9,53 @@ changelogTemplate: https://github.com/roundcube/roundcubemail/releases/tag/__LAT
 auto:
 -   git: https://github.com/roundcube/roundcubemail.git
 releases:
-  - releaseCycle: "1.5"
+-   releaseCycle: "1.5"
     latest: "1.5.2"
-    release: 2021-10-18
+    release: 2021-10-17
     eol: false
     support: true
-    
-  - releaseCycle: "1.4"
+
+    latestReleaseDate: 2021-12-29
+-   releaseCycle: "1.4"
     latest: "1.4.13"
     release: 2019-11-09
     eol: false
     support: false
-    
-  - releaseCycle: "1.3"
+
+    latestReleaseDate: 2021-12-29
+-   releaseCycle: "1.3"
     latest: "1.3.17"
     release: 2017-06-26
     eol: false
     support: false
-    
-  - releaseCycle: "1.2"
+
+    latestReleaseDate: 2021-11-12
+-   releaseCycle: "1.2"
     latest: "1.2.13"
-    release: 2016-05-22
+    release: 2016-05-21
     eol: 2021-10-18
     support: false
-    
-  - releaseCycle: "1.1"
+
+    latestReleaseDate: 2020-12-27
+-   releaseCycle: "1.1"
     latest: "1.1.12"
-    release: 2015-02-10
+    release: 2015-02-07
     eol: true
     support: false
-    
-  - releaseCycle: "1.0"
-    latest: "1.0.9"
-    release: 2014-04-07
+
+    latestReleaseDate: 2018-04-29
+-   releaseCycle: "1.0"
+    latest: "1.0.12"
+    release: 2014-04-05
     eol: true
     support: false
-    
+
+    latestReleaseDate: 2017-11-08
 releasePolicyLink: https://roundcube.net/news/2021/10/18/roundcube-1.5.0-released
 releaseDateColumn: true
 eolColumn: Security Support
 iconSlug: roundcube
+
 ---
 
 > [Roundcube Webmail](https://roundcube.net/) is a browser-based multilingual IMAP client with an application-like user interface. 

--- a/products/roundcube.md
+++ b/products/roundcube.md
@@ -11,7 +11,7 @@ auto:
 releases:
 -   releaseCycle: "1.5"
     latest: "1.5.2"
-    release: 2021-10-17
+    release: 2021-10-18
     eol: false
     support: true
 

--- a/products/ruby-on-rails.md
+++ b/products/ruby-on-rails.md
@@ -1,9 +1,9 @@
 ---
 permalink: /rails
 alternate_urls:
-  - /rubyonrails
-  - /ruby-on-rails
-  - /roro
+-   /rubyonrails
+-   /ruby-on-rails
+-   /roro
 layout: post
 iconSlug: rubyonrails
 title: Ruby on Rails
@@ -17,39 +17,47 @@ auto:
     regex: v(?<major>[1-9]\d*)\.(?<minor>0|[1-9]\d*)\.(?<patch>0|[1-9]\d*)(\.(?<tiny>0|[1-9]\d*))?$
     template: "{{major}}.{{minor}}.{{patch}}{%if tiny %}.{{tiny}}{%endif%}"
 releases:
-  - releaseCycle: "7.0"
+-   releaseCycle: "7.0"
     release: 2021-12-15
     eol: false
     latest: "7.0.3"
-  - releaseCycle: "6.1"
+    latestReleaseDate: 2022-05-09
+-   releaseCycle: "6.1"
     release: 2020-12-09
     eol: false
     latest: "6.1.6"
-  - releaseCycle: "6.0"
+    latestReleaseDate: 2022-05-09
+-   releaseCycle: "6.0"
     release: 2019-08-16
     eol: 2023-06-01
     support: 2021-12-15
     latest: "6.0.5"
-  - releaseCycle: "5.2"
+    latestReleaseDate: 2022-05-09
+-   releaseCycle: "5.2"
     release: 2018-04-09
     eol: 2022-06-01
     support: 2021-12-15
     latest: "5.2.8"
-  - releaseCycle: "5.1"
+    latestReleaseDate: 2022-05-09
+-   releaseCycle: "5.1"
     release: 2017-04-27
     eol: 2019-08-25
     support: 2018-04-09
     latest: "5.1.7"
-  - releaseCycle: "5.0"
+    latestReleaseDate: 2019-03-28
+-   releaseCycle: "5.0"
     release: 2016-06-30
     eol: 2018-04-09
     support: 2018-04-09
     latest: "5.0.7.2"
-  - releaseCycle: "4.2"
+    latestReleaseDate: 2019-03-11
+-   releaseCycle: "4.2"
     release: 2014-12-20
     eol: 2017-04-27
     support: 2016-06-30
     latest: "4.2.11.3"
+    latestReleaseDate: 2020-05-15
+
 ---
 
 >[Ruby on Rails](https://rubyonrails.org/), or Rails, is a server-side web application framework written in Ruby.

--- a/products/ruby-on-rails.md
+++ b/products/ruby-on-rails.md
@@ -44,15 +44,15 @@ releases:
     eol: 2019-08-25
     support: 2018-04-09
     latest: "5.1.7"
-    latestReleaseDate: 2019-03-28
+    latestReleaseDate: 2019-03-27
 -   releaseCycle: "5.0"
     release: 2016-06-30
     eol: 2018-04-09
     support: 2018-04-09
     latest: "5.0.7.2"
-    latestReleaseDate: 2019-03-11
+    latestReleaseDate: 2019-03-13
 -   releaseCycle: "4.2"
-    release: 2014-12-20
+    release: 2014-12-19
     eol: 2017-04-27
     support: 2016-06-30
     latest: "4.2.11.3"

--- a/products/ruby.md
+++ b/products/ruby.md
@@ -18,62 +18,74 @@ releaseDateColumn: true
 eolColumn: Support Status
 sortReleasesBy: 'release'
 releases:
-  - releaseCycle: "3.1"
+-   releaseCycle: "3.1"
     release: 2021-12-25
     eol: 2025-12-25
     latest: "3.1.2"
 
-  - releaseCycle: "3.0"
+    latestReleaseDate: 2022-04-12
+-   releaseCycle: "3.0"
     release: 2020-12-25
     eol: 2024-03-31
     latest: "3.0.4"
 
-  - releaseCycle: "2.7"
+    latestReleaseDate: 2022-04-12
+-   releaseCycle: "2.7"
     release: 2019-12-25
     eol: 2023-03-31
     latest: "2.7.6"
 
-  - releaseCycle: "2.6"
+    latestReleaseDate: 2022-04-12
+-   releaseCycle: "2.6"
     release: 2018-12-25
     eol: 2022-03-31
     latest: "2.6.10"
 
-  - releaseCycle: "2.5"
+    latestReleaseDate: 2022-04-12
+-   releaseCycle: "2.5"
     release: 2017-12-25
     eol: 2021-03-31
     latest: "2.5.9"
 
-  - releaseCycle: "2.4"
-    release: 2016-12-25
+    latestReleaseDate: 2021-04-05
+-   releaseCycle: "2.4"
+    release: 2016-12-23
     eol: 2020-03-31
     latest: "2.4.10"
 
-  - releaseCycle: "2.3"
-    release: 2015-12-25
+    latestReleaseDate: 2020-03-31
+-   releaseCycle: "2.3"
+    release: 2015-12-24
     eol: 2019-03-31
     latest: "2.3.8"
 
-  - releaseCycle: "2.2"
+    latestReleaseDate: 2018-10-17
+-   releaseCycle: "2.2"
     release: 2014-12-25
     eol: 2018-03-31
     latest: "2.2.10"
 
-  - releaseCycle: "2.1"
+    latestReleaseDate: 2018-03-28
+-   releaseCycle: "2.1"
     release: 2013-12-25
     eol: 2017-03-31
     latest: "2.1.10"
 
-  - releaseCycle: "2.0.0"
+    latestReleaseDate: 2016-03-31
+-   releaseCycle: "2.0.0"
     release: 2013-02-24
     eol: 2016-02-24
     # Keep this pinned
-    latest: "2.0.0-p648"
+    latest: "2.0.0p648"
 
-  - releaseCycle: "1.9.3"
-    release: 2011-10-31
+    latestReleaseDate: 2015-12-16
+-   releaseCycle: "1.9.3"
+    release: 2011-10-30
     eol: 2015-02-23
     # Keep this pinned
-    latest: "1.9.3-p551"
+    latest: "1.9.3p551"
+
+    latestReleaseDate: 2014-11-13
 
 ---
 

--- a/products/spring-framework.md
+++ b/products/spring-framework.md
@@ -1,7 +1,7 @@
 ---
 title: Spring Framework
 alternate_urls:
-  - /spring
+-   /spring
 layout: post
 category: framework
 sortReleasesBy: "releaseCycle"
@@ -11,36 +11,42 @@ auto:
   # See https://rubular.com/r/XQUdQN2MHdmmCD for reference
     regex: '^v?(?<major>[1-9]\d*)\.(?<minor>0|[1-9]\d*)\.(?<patch>0|[1-9]\d*)(\.RELEASE)?$'
 releases:
-  - releaseCycle: "5.3"
+-   releaseCycle: "5.3"
     eol: false
     support: true
-    release: 2020-12-09
+    release: 2020-10-27
     latest: "5.3.20"
-  - releaseCycle: "5.2"
+    latestReleaseDate: 2022-05-11
+-   releaseCycle: "5.2"
     eol: 2021-12-31
     support: true
-    release: 2021-02-16
+    release: 2019-09-30
     latest: "5.2.22"
-  - releaseCycle: "5.1"
+    latestReleaseDate: 2022-05-11
+-   releaseCycle: "5.1"
     eol: 2020-12-09
     support: false
-    release: 2020-12-09
+    release: 2018-09-21
     latest: "5.1.20"
-  - releaseCycle: "5.0"
+    latestReleaseDate: 2020-12-09
+-   releaseCycle: "5.0"
     eol: 2020-12-09
     support: false
-    release: 2020-12-09
+    release: 2017-09-28
     latest: "5.0.20"
-  - releaseCycle: "4.3"
+    latestReleaseDate: 2020-12-09
+-   releaseCycle: "4.3"
     eol: 2020-12-31
     support: false
-    release: 2020-12-09
+    release: 2016-06-10
     latest: "4.3.30"
-  - releaseCycle: "3.2"
+    latestReleaseDate: 2020-12-09
+-   releaseCycle: "3.2"
     eol: 2016-12-31
     support: false
-    release: 2019-01-17
+    release: 2012-12-13
     latest: "3.2.18"
+    latestReleaseDate: 2016-12-21
 permalink: /spring-framework
 releasePolicyLink: https://github.com/spring-projects/spring-framework/wiki/Spring-Framework-Versions
 activeSupportColumn: true

--- a/products/symfony.md
+++ b/products/symfony.md
@@ -126,7 +126,7 @@ releases:
     eol: 2017-07-01
     latest: "3.1.10"
 
-    latestReleaseDate: 2017-01-28
+    latestReleaseDate: 2017-01-27
 -   releaseCycle: "3.0"
     release: 2015-11-30
     support: 2016-07-01

--- a/products/symfony.md
+++ b/products/symfony.md
@@ -19,125 +19,144 @@ releases:
 #    eol: 2023-01-XX
 #    latest: "6.1.0"
 
-  - releaseCycle: "6.0"
+-   releaseCycle: "6.0"
     release: 2021-11-29
     support: 2023-01-31
     eol: 2023-01-31
     latest: "6.0.8"
 
-  - releaseCycle: "5.4"
+    latestReleaseDate: 2022-04-27
+-   releaseCycle: "5.4"
     release: 2021-11-29
     support: 2024-11-30
     eol: 2025-11-30
     latest: "5.4.8"
     lts: true
 
-  - releaseCycle: "5.3"
+    latestReleaseDate: 2022-04-27
+-   releaseCycle: "5.3"
     release: 2021-05-31
     support: 2022-01-01
     eol: 2022-01-01
-    latest: "5.3.15"
+    latest: "5.3.16"
 
-  - releaseCycle: "5.2"
+    latestReleaseDate: 2022-03-01
+-   releaseCycle: "5.2"
     release: 2020-11-30
     support: 2021-07-21
     eol: 2021-07-21
     latest: "5.2.14"
 
-  - releaseCycle: "5.1"
+    latestReleaseDate: 2021-07-29
+-   releaseCycle: "5.1"
     release: 2020-05-31
     support: 2021-01-21
     eol: 2021-01-21
     latest: "5.1.11"
 
-  - releaseCycle: "5.0"
+    latestReleaseDate: 2021-01-27
+-   releaseCycle: "5.0"
     release: 2019-11-21
     support: 2020-07-21
     eol: 2020-07-21
     latest: "5.0.11"
 
-  - releaseCycle: "4.4"
+    latestReleaseDate: 2020-07-24
+-   releaseCycle: "4.4"
     release: 2019-11-21
     support: 2022-11-21
     eol: 2023-11-21
     latest: "4.4.41"
     lts: true
 
-  - releaseCycle: "4.3"
-    release: 2019-05-01
+    latestReleaseDate: 2022-04-27
+-   releaseCycle: "4.3"
+    release: 2019-05-30
     support: 2020-01-01
     eol: 2020-07-01
     latest: "4.3.11"
 
-  - releaseCycle: "4.2"
-    release: 2018-11-01
+    latestReleaseDate: 2020-01-31
+-   releaseCycle: "4.2"
+    release: 2018-11-30
     support: 2019-07-01
     eol: 2020-01-01
     latest: "4.2.12"
 
-  - releaseCycle: "4.1"
-    release: 2018-05-01
+    latestReleaseDate: 2019-11-13
+-   releaseCycle: "4.1"
+    release: 2018-05-30
     support: 2019-01-01
     eol: 2019-07-01
     latest: "4.1.13"
 
-  - releaseCycle: "4.0"
-    release: 2017-11-01
+    latestReleaseDate: 2019-04-17
+-   releaseCycle: "4.0"
+    release: 2017-11-30
     support: 2018-07-01
     eol: 2019-01-01
     latest: "4.0.15"
 
-  - releaseCycle: "3.4"
-    release: 2017-11-01
+    latestReleaseDate: 2018-12-06
+-   releaseCycle: "3.4"
+    release: 2017-11-30
     support: 2020-11-01
     eol: 2021-11-01
     latest: "3.4.49"
     lts: true
 
-  - releaseCycle: "3.3"
-    release: 2017-05-01
+    latestReleaseDate: 2021-05-19
+-   releaseCycle: "3.3"
+    release: 2017-05-29
     support: 2018-01-01
     eol: 2018-07-01
     latest: "3.3.18"
 
-  - releaseCycle: "3.2"
-    release: 2016-11-01
+    latestReleaseDate: 2018-08-01
+-   releaseCycle: "3.2"
+    release: 2016-11-30
     support: 2017-07-01
     eol: 2018-01-01
     latest: "3.2.14"
 
-  - releaseCycle: "3.1"
-    release: 2016-05-01
+    latestReleaseDate: 2017-11-16
+-   releaseCycle: "3.1"
+    release: 2016-05-30
     support: 2017-01-01
     eol: 2017-07-01
     latest: "3.1.10"
 
-  - releaseCycle: "3.0"
-    release: 2015-11-01
+    latestReleaseDate: 2017-01-28
+-   releaseCycle: "3.0"
+    release: 2015-11-30
     support: 2016-07-01
     eol: 2017-01-01
     latest: "3.0.9"
 
-  - releaseCycle: "2.8"
-    release: 2015-11-01
+    latestReleaseDate: 2016-07-30
+-   releaseCycle: "2.8"
+    release: 2015-11-30
     support: 2018-11-01
     eol: 2019-11-01
     latest: "2.8.52"
     lts: true
 
-  - releaseCycle: "2.7"
-    release: 2015-05-01
+    latestReleaseDate: 2019-11-13
+-   releaseCycle: "2.7"
+    release: 2015-05-30
     support: 2018-05-01
     eol: 2019-05-01
     latest: "2.7.52"
     lts: true
- 
-  - releaseCycle: "2.3"
-    release: 2013-05-01
+
+    latestReleaseDate: 2019-04-17
+-   releaseCycle: "2.3"
+    release: 2013-06-03
     support: 2016-05-01
     eol: 2017-05-01
     latest: "2.3.42"
     lts: true
+    latestReleaseDate: 2016-05-30
 
 ---
 

--- a/products/tarantool.md
+++ b/products/tarantool.md
@@ -5,9 +5,7 @@ title: Tarantool
 command: $ tarantool --version
 releaseImage: https://hb.bizmrg.com/tarantool-io/doc-builds/tarantool/latest/images_en/releases_calendar.svg
 releasePolicyLink: https://www.tarantool.io/en/doc/latest/release/policy/
-# This is a comment
-changelogTemplate: |
-  https://github.com/tarantool/tarantool/releases/tag/__LATEST__
+changelogTemplate: https://github.com/tarantool/tarantool/releases/tag/__LATEST__
 auto:
 -   git: https://github.com/tarantool/tarantool.git
 category: db

--- a/products/tarantool.md
+++ b/products/tarantool.md
@@ -14,51 +14,61 @@ eolColumn: Support Status
 releaseDateColumn: false
 sortReleasesBy: 'releaseCycle'
 releases:
-  - releaseCycle: "2.10"
+-   releaseCycle: "2.10"
     release: 2022-05-22
     eol: false
     latest: "2.10.0"
 
-  - releaseCycle: "2.8"
-    release: 2021-12-22
+    latestReleaseDate: 2022-05-22
+-   releaseCycle: "2.8"
+    release: 2020-12-30
     eol: false
     latest: "2.8.4"
 
-  - releaseCycle: "2.7"
-    release: 2021-08-19
+    latestReleaseDate: 2022-04-25
+-   releaseCycle: "2.7"
+    release: 2020-10-23
     eol: 2021-08-19
     latest: "2.7.3"
 
-  - releaseCycle: "2.6"
-    release: 2021-04-21
+    latestReleaseDate: 2021-08-19
+-   releaseCycle: "2.6"
+    release: 2020-07-17
     eol: 2021-04-21
     latest: "2.6.3"
 
-  - releaseCycle: "2.5"
-    release: 2020-12-30
+    latestReleaseDate: 2021-04-21
+-   releaseCycle: "2.5"
+    release: 2020-04-20
     eol: 2020-12-30
     latest: "2.5.3"
 
-  - releaseCycle: "2.4"
-    release: 2020-10-22
+    latestReleaseDate: 2020-12-30
+-   releaseCycle: "2.4"
+    release: 2020-01-10
     eol: 2020-10-22
     latest: "2.4.3"
 
-  - releaseCycle: "2.3"
-    release: 2020-07-17
+    latestReleaseDate: 2020-10-23
+-   releaseCycle: "2.3"
+    release: 2019-08-02
     eol: 2020-07-17
     latest: "2.3.3"
 
-  - releaseCycle: "2.2"
-    release: 2019-12-31
+    latestReleaseDate: 2020-07-17
+-   releaseCycle: "2.2"
+    release: 2019-03-22
     eol: 2020-04-20
     latest: "2.2.3"
 
-  - releaseCycle: "1.10"
-    release: 2021-12-22
+    latestReleaseDate: 2020-04-20
+-   releaseCycle: "1.10"
+    release: 2018-03-07
     eol: false
     lts: true
     latest: "1.10.13"
+
+    latestReleaseDate: 2022-04-26
 
 ---
 

--- a/products/unrealircd.md
+++ b/products/unrealircd.md
@@ -8,36 +8,42 @@ permalink: /unrealircd
 releasePolicyLink: https://www.unrealircd.org/docs/UnrealIRCd_releases
 releaseDateColumn: true
 command: ./unrealircd version
-changelogTemplate: "https://github.com/unrealircd/unrealircd/blob/__CYCLE_SHORT_HAND__/doc/RELEASE-NOTES.md#unrealircd-{{'__LATEST__' | replace:'.',''}}"
+changelogTemplate: "https://github.com/unrealircd/unrealircd/blob/__CYCLE_SHORT_HAND__/doc/RELEASE-NOTES.md#unrealircd-{{'__LATEST__'\
+  \ | replace:'.',''}}"
 iconSlug: NA
 
 # A list of releases, supported or not
 # Newer releases go on top of the list, in order
 releases:
-  - releaseCycle: "6"
+-   releaseCycle: "6"
     cycleShortHand: "unreal60_dev"
     release: 2021-12-17
     support: true
     eol: false
     latest: "6.0.3"
-  - releaseCycle: "5"
+    latestReleaseDate: 2022-04-02
+-   releaseCycle: "5"
     cycleShortHand: "unreal52"
     release: 2019-12-13
     support: 2022-07-01
     eol: 2023-07-01
     latest: "5.2.4"
-  - releaseCycle: "4"
+    latestReleaseDate: 2022-01-28
+-   releaseCycle: "4"
     cycleShortHand: "unreal42"
     release: 2015-12-24
     support: 2019-05-20
     eol: 2020-12-31
     latest: "4.2.4.1"
-  - releaseCycle: "3.2"
+    latestReleaseDate: 2019-07-07
+-   releaseCycle: "3.2"
     cycleShortHand: "unreal3_2_fixes"
     release: 2004-04-25
     support: 2015-12-11
     eol: 2016-12-31
     latest: "3.2.10.7"
+    latestReleaseDate: 2016-09-03
+
 ---
 
 > [UnrealIRCd](https://www.unrealircd.org) is an Open Source IRC Server since 1999. It implements almost all IRCv3 features.

--- a/products/vue.md
+++ b/products/vue.md
@@ -21,7 +21,7 @@ releases:
     eol: false
     latest: "3.2.36"
     lts: false
-    latestReleaseDate: 2022-04-14
+    latestReleaseDate: 2022-05-23
 -   releaseCycle: "2"
     release: 2016-09-30
     support: 2022-03-18

--- a/products/vue.md
+++ b/products/vue.md
@@ -28,12 +28,14 @@ releases:
     eol: 2023-09-23
     latest: "2.6.14"
     lts: false
+    latestReleaseDate: 2021-06-07
 -   releaseCycle: "1"
-    release: 2015-10-27
+    release: 2015-10-26
     support: false
     eol: true
     latest: "1.0.28"
     lts: false
+    latestReleaseDate: 2016-09-27
 
 ---
 

--- a/products/vue.md
+++ b/products/vue.md
@@ -3,7 +3,7 @@ title: Vue
 layout: post
 permalink: /vue
 alternate_urls:
-  - /vuejs
+-   /vuejs
 category: framework
 releasePolicyLink: https://vuejs.org/about/releases.html
 activeSupportColumn: true
@@ -15,24 +15,26 @@ auto:
 -   git: https://github.com/vuejs/core.git
 -   git: https://github.com/vuejs/vue.git
 releases:
-  - releaseCycle: "3"
+-   releaseCycle: "3"
     release: 2020-09-18
     support: true
     eol: false
     latest: "3.2.36"
     lts: false
-  - releaseCycle: "2"
+    latestReleaseDate: 2022-04-14
+-   releaseCycle: "2"
     release: 2016-09-30
     support: 2022-03-18
-    eol: 2023-09-23 
+    eol: 2023-09-23
     latest: "2.6.14"
-    lts: false 
-  - releaseCycle: "1"
+    lts: false
+-   releaseCycle: "1"
     release: 2015-10-27
     support: false
     eol: true
     latest: "1.0.28"
     lts: false
+
 ---
 
 > [Vue](https://vuejs.org/) is a JavaScript framework for building user interfaces. It builds on top of standard HTML, CSS and JavaScript, and provides a declarative and component-based programming model to efficiently develop user interfaces.

--- a/products/wagtail.md
+++ b/products/wagtail.md
@@ -12,72 +12,84 @@ auto:
 -   git: https://github.com/wagtail/wagtail.git
 sortReleasesBy: "release"
 releases:
-  - releaseCycle: "3.0"
+-   releaseCycle: "3.0"
     support: 2022-08-01
     release: 2022-05-16
     lts: false
     eol: false
     latest: "3.0"
-  - releaseCycle: "2.16"
+    latestReleaseDate: 2022-05-16
+-   releaseCycle: "2.16"
     support: 2022-05-01
     release: 2022-02-07
     lts: false
     eol: 2022-05-16
     latest: "2.16.2"
-  - releaseCycle: "2.15"
+    latestReleaseDate: 2022-04-11
+-   releaseCycle: "2.15"
     support: 2023-02-01
     release: 2021-11-04
     lts: true
     eol: false
     latest: "2.15.5"
-  - releaseCycle: "2.14"
+    latestReleaseDate: 2022-04-11
+-   releaseCycle: "2.14"
     eol: 2022-02-07
     support: 2021-11-04
-    release: 2021-08-01
+    release: 2021-08-02
     lts: false
     latest: "2.14.2"
-  - releaseCycle: "2.13"
+    latestReleaseDate: 2021-10-14
+-   releaseCycle: "2.13"
     eol: 2022-02-01
     support: 2021-08-01
     release: 2021-05-12
     lts: false
     latest: "2.13.5"
-  - releaseCycle: "2.12"
+    latestReleaseDate: 2021-10-14
+-   releaseCycle: "2.12"
     eol: 2021-08-01
     support: 2021-05-12
     release: 2021-02-02
     lts: false
     latest: "2.12.6"
-  - releaseCycle: "2.11"
+    latestReleaseDate: 2021-07-13
+-   releaseCycle: "2.11"
     eol: 2022-02-07
     support: 2021-02-02
     release: 2020-11-02
     lts: true
     latest: "2.11.9"
-  - releaseCycle: "2.10"
+    latestReleaseDate: 2022-01-24
+-   releaseCycle: "2.10"
     eol: 2021-02-02
     support: 2020-11-02
     release: 2020-08-11
     lts: false
     latest: "2.10.2"
-  - releaseCycle: "2.9"
+    latestReleaseDate: 2020-09-25
+-   releaseCycle: "2.9"
     eol: 2020-11-02
     support: 2020-08-11
     release: 2020-05-04
     lts: false
     latest: "2.9.3"
-  - releaseCycle: "2.8"
+    latestReleaseDate: 2020-07-20
+-   releaseCycle: "2.8"
     eol: 2020-08-11
     support: 2020-05-04
     release: 2020-02-03
     lts: false
     latest: "2.8.2"
-  - releaseCycle: "2.7"
+    latestReleaseDate: 2020-05-04
+-   releaseCycle: "2.7"
     eol: 2021-02-02
     support: 2020-02-03
     release: 2019-11-06
     lts: true
     latest: "2.7.4"
+
+    latestReleaseDate: 2020-07-20
 
 ---
 

--- a/products/zabbix.md
+++ b/products/zabbix.md
@@ -19,29 +19,33 @@ releases:
 #    release: 2022-05-30
 #    support: 2022-11-30
 #    eol:     2022-12-31
-  - releaseCycle: "6.0"
-    release: 2022-02-08
+-   releaseCycle: "6.0"
+    release: 2022-02-14
     support: 2025-02-28
-    eol:     2027-02-28
+    eol: 2027-02-28
     lts: true
     latest: "6.0.4"
-  - releaseCycle: "5.4"
+    latestReleaseDate: 2022-05-03
+-   releaseCycle: "5.4"
     release: 2021-05-17
     support: 2022-02-28
-    eol:     2022-03-31
+    eol: 2022-03-31
     latest: "5.4.12"
-  - releaseCycle: "5.0"
-    release: 2020-05-12
+-   releaseCycle: "5.0"
+    release: 2020-05-11
     support: 2023-05-31
-    eol:     2025-05-31
+    eol: 2025-05-31
     lts: true
     latest: "5.0.23"
-  - releaseCycle: "4.0"
+    latestReleaseDate: 2022-05-02
+-   releaseCycle: "4.0"
     release: 2018-10-01
     support: 2021-10-31
-    eol:     2023-10-31
+    eol: 2023-10-31
     lts: true
     latest: "4.0.40"
+
+    latestReleaseDate: 2022-05-02
 
 ---
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+ruamel.yaml==0.17.21
+ruamel.yaml.clib==0.2.6
+semver==2.13.0


### PR DESCRIPTION
Works for all the pages with a `auto` configuration. The data was already commited in the repo [`_data/release-data` subdirectory ](https://github.com/endoflife-date/endoflife.date/tree/master/_data), this PR adds a script to update the product files against this data.

To avoid confusions, this script will only run when the underlying data is updated (so not on regular contributions) in the dependabot PRs. I've run it once locally and committed the results in this PR for a first check.

- This information is getting picked up from the release-data repository
- This should (hopefully, untested so far) get auto-updated along with every dependabot
  PR that is raised in the repo by itself. We should still review those to make sure there aren't any bugs
- Some dates are off by 1 or 2 days - mainly because our earlier
  information comes from blog posts and news pages, while this is coming
  from the tag information which are usually published slightly earlier. Adding timezone confusion (we calculate
  dates on UTC for now) makes the drift slightly larger in some cases -
  I think it's acceptable, but open to discussion.

The update script uses `py:ruamel`, which treats newlines in lists as
belonging to the previous element, which causes some weird newlines. Don't have a solution for this yet, except for not adding spurious newlines within the YAML. But this makes no difference, so not a big issue. (Had to use Python:Ruamel, since that's the only package I could find that supports reading and writing YAML comments back)

One quirk with this is that ruamel needs a clean newline after the `---` in the markdown file or it breaks. Will add a test for that somewhere - we just have to worry about this in contributions for now.

Haven't made any changes in the layouts in this PR, will tackle them separately, but notes on plans:

1. Add some label/text to denote a page as auto-updating. Auto-updating only works within a releaseCycle, since we don't have EOL information for the new release.
2. Start using `latestReleaseDate` in the layout where we have it. We can use this information for proper release RSS feeds as well. We might consider maintaining it for other pages manually as well (too much overhead imo, but we'll see)

Note on update schedule: The [release-data](https://github.com/endoflife-date/release-data/) repo itself is updated 4 times a day, which then syncs back here once a day. So new releases in a product should show up usually within a day in a PR here (Worst case would be 30 hours). 