### PR TITLE
[linux] Switch to the stable tree mirror

### DIFF
--- a/products/linuxkernel.md
+++ b/products/linuxkernel.md
@@ -14,9 +14,11 @@ releaseColumn: true
 sortReleasesBy: 'cycleShortHand'
 command: uname -r
 auto:
-  # Upstream is https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git
+  # Upstream is https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
   # But does not support filtering
-  git: https://github.com/torvalds/linux.git
+  # Note that we're tracking the linux kernel stable tree, not torvalds' tree
+  # which doesn't contain all tags
+  git: https://github.com/gregkh/linux.git
   regex: ^v(?<major>0|[1-9]\d*)\.(?<minor>0|[1-9]\d*)(\.(?<patch>0|[1-9]\d*))?$
 releases:
   - releaseCycle: "5.17"


### PR DESCRIPTION
https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/refs/tags only contains the first tag in each release. So we instead use [The Linux Kernel Stable Tree](https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/refs/tags).

However, since Kernel.org doesn't support blob filtering, so we use the GitHub mirror instead.
