### PR TITLE
[fedora] Fix URLs

### DIFF
--- a/products/fedora.md
+++ b/products/fedora.md
@@ -7,7 +7,7 @@ activeSupportColumn: false
 releaseDateColumn: true
 command: cat /etc/fedora-release 
 sortReleasesBy: 'releaseCycle'
-changelogTemplate: https://fedoraproject.org/wiki/Releases/__LATEST__
+changelogTemplate: https://fedoraproject.org/wiki/Releases/__RELEASE_CYCLE__/ChangeSet?rd=Releases/__RELEASE_CYCLE__
 auto:
   oci: https://index.docker.io/v2/_library/fedora
 category: os


### PR DESCRIPTION
The new docs page seems empty: https://docs.fedoraproject.org/en-US/fedora/f35/release-notes/

Ref: #1206