### PR TITLE
[ubuntu] Fix link

### DIFF
--- a/products/ubuntu.md
+++ b/products/ubuntu.md
@@ -68,6 +68,7 @@ releases:
     support: 2023-04-02
     eol:     2028-04-01
     latest: "18.04.6"
+    link: https://wiki.ubuntu.com/BionicBeaver/ReleaseNotes
 
   - releaseCycle: "16.04"
     codename: "Xenial Xerus"


### PR DESCRIPTION
There's apparently no actual release notes for 18.04.6 available. 
The announcement mentions BootHole: https://lists.ubuntu.com/archives/ubuntu-announce/2021-September/000272.html

and links to https://wiki.ubuntu.com/BionicBeaver/ReleaseNotes as the release notes, but that was barely updated for the 18.04.6 release: https://wiki.ubuntu.com/BionicBeaver/ReleaseNotes?action=diff&rev2=143&rev1=141

¯\\\_(ツ)\_/¯

Ref #1206