### PR TITLE
[python] Fix Python regex

### DIFF
--- a/products/python.md
+++ b/products/python.md
@@ -11,6 +11,9 @@ releaseDateColumn: true
 sortReleasesBy: 'release'
 auto:
   git: https://github.com/python/cpython.git
+  # The v is mandatory here because each branch EOL is tagged:
+  # eg https://github.com/python/cpython/releases/tag/3.6
+  regex: ^v(?<major>[1-9]\d*)\.(?<minor>0|[1-9]\d*)\.?(?<patch>0|[1-9]\d*)?$
 releases:
     - releaseCycle: "3.10"
       release: 2021-10-04


### PR DESCRIPTION
Some tags like https://github.com/python/cpython/tree/3.6 denote the last commit
in a EOL branch, and thus should not be treated as a new release.