### PR TITLE
[electron] Add 19, Update 18.3.0, 16.2.8, 15.5.7, EoL 16, 15

### DIFF
--- a/products/electron.md
+++ b/products/electron.md
@@ -14,30 +14,30 @@ auto:
 -   git: https://github.com/electron/electron.git
 releaseDateColumn: true
 sortReleasesBy: releaseCycle
-releases:
-  # The approximate EoL going forward will be 8 months for every release
-  # but this varies a lot currently due to the cadence change.
-  - releaseCycle: "19"
+# The approximate EoL going forward will be 8 months for every release
+# but this varies a lot currently due to the cadence change.
+releases:  
+-   releaseCycle: "19"
     eol: false
     release: 2022-05-24
     latest: "19.0.0"
-  - releaseCycle: "18"
+-   releaseCycle: "18"
     eol: false
     release: 2022-03-29
     latest: "18.3.0"
-  - releaseCycle: "17"
+-   releaseCycle: "17"
     eol: false
     release: 2022-01-31
     latest: "17.4.5"
-  - releaseCycle: "16"
+-   releaseCycle: "16"
     eol: 2022-05-24
     release: 2021-11-16
     latest: "16.2.8"
-  - releaseCycle: "15"
+-   releaseCycle: "15"
     eol: 2022-05-24
     release: 2021-09-22
     latest: "15.5.7"
-  - releaseCycle: "14"
+-   releaseCycle: "14"
     eol: true
     release: 2021-08-30
     latest: "14.2.9"

--- a/products/electron.md
+++ b/products/electron.md
@@ -32,11 +32,11 @@ releases:
   - releaseCycle: "16"
     eol: 2022-05-24
     release: 2021-11-16
-    latest: "16.2.7"
+    latest: "16.2.8"
   - releaseCycle: "15"
     eol: 2022-05-24
     release: 2021-09-22
-    latest: "15.5.6"
+    latest: "15.5.7"
   - releaseCycle: "14"
     eol: true
     release: 2021-08-31

--- a/products/electron.md
+++ b/products/electron.md
@@ -19,7 +19,7 @@ releases:
   # but this varies a lot currently due to the cadence change.
   - releaseCycle: "19"
     eol: false
-    release: 2022-05-23
+    release: 2022-05-24
     latest: "19.0.0"
   - releaseCycle: "18"
     eol: false

--- a/products/electron.md
+++ b/products/electron.md
@@ -30,11 +30,11 @@ releases:
     release: 2022-02-01
     latest: "17.4.5"
   - releaseCycle: "16"
-    eol: true
+    eol: 2022-05-24
     release: 2021-11-16
     latest: "16.2.7"
   - releaseCycle: "15"
-    eol: true
+    eol: 2022-05-24
     release: 2021-09-22
     latest: "15.5.6"
   - releaseCycle: "14"

--- a/products/electron.md
+++ b/products/electron.md
@@ -17,22 +17,26 @@ sortReleasesBy: releaseCycle
 releases:
   # The approximate EoL going forward will be 8 months for every release
   # but this varies a lot currently due to the cadence change.
+  - releaseCycle: "19"
+    eol: false
+    release: 2022-05-23
+    latest: "19.0.0"
   - releaseCycle: "18"
     eol: false
     release: 2022-03-29
-    latest: "18.2.4"
+    latest: "18.3.0"
   - releaseCycle: "17"
     eol: false
     release: 2022-02-01
     latest: "17.4.5"
   - releaseCycle: "16"
-    eol: false
+    eol: true
     release: 2021-11-16
     latest: "16.2.7"
   - releaseCycle: "15"
-    eol: false
+    eol: true
     release: 2021-09-22
-    latest: "15.5.5"
+    latest: "15.5.6"
   - releaseCycle: "14"
     eol: true
     release: 2021-08-31


### PR DESCRIPTION
https://github.com/electron/electron/releases/tag/v19.0.0
https://github.com/electron/electron/releases/tag/v18.3.0
https://github.com/electron/electron/releases/tag/v16.2.8
https://github.com/electron/electron/releases/tag/v15.5.7
With the release of 19 in May 2022 only 19, 18, 17 are supported see https://www.electronjs.org/blog/8-week-cadence#-will-electron-extend-the-number-of-supported-versions