### PR TITLE
[auto] switch label to dockerhub

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -95,9 +95,9 @@ auto:
     # You can use liquid templating here
     template: '{{major}}.{{minor}}.{{patch}}{%if tiny %}p{{tiny}}{%endif%}'
 
-  # The following are currently not supported, but support is planned
-  # Valid OCI Image Registry URL
-  - oci: https://index.docker.io/v2/_library/image
+  # owner/repo combination for a docker hub public image
+  # Use "library" as the owner name for a official docker/community image
+  - dockerhub: ministryofmagic/timeturner
 
   # Link to package on NPM
   - npm: https://www.npmjs.com/package/abc

--- a/products/amazon-linux.md
+++ b/products/amazon-linux.md
@@ -11,7 +11,9 @@ eolColumn: Support
 releaseDateColumn: true
 sortReleasesBy: 'release'
 auto:
--   oci: https://index.docker.io/v2/_library/amazonlinux
+-   dockerhub: library/amazonlinux
+    regex: ^(?<version>\d+(\.\d+){2,4})$
+    template: "{{version}}"
 changelogTemplate: 'https://docs.aws.amazon.com/AL2/latest/relnotes/relnotes-{{"__LATEST__"| slice:4,8 }}.html'
 releases:
   - releaseCycle: '1'
@@ -19,7 +21,6 @@ releases:
     release: "2010-09-14"
     eol: 2020-12-31
     latest: "2018.03"
-    auto: false
   - releaseCycle: '2'
     releaseLabel: 'Amazon Linux 2'
     release: 2017-12-19

--- a/products/couchbase-server.md
+++ b/products/couchbase-server.md
@@ -10,7 +10,8 @@ releasePolicyLink: https://www.couchbase.com/support-policy/enterprise-software
 sortReleasesBy: "releaseCycle"
 changelogTemplate: https://docs.couchbase.com/server/__RELEASE_CYCLE__/release-notes/relnotes.html
 auto:
--   oci: https://index.docker.io/v2/_library/couchbase
+-   dockerhub: library/couchbase
+    regex: ^(?<major>[1-9]\d*)\.(?<minor>0|[1-9]\d*)\.?(?<patch>0|[1-9]\d*)?$
 activeSupportColumn: false
 releaseDateColumn: true
 command: cat /opt/couchbase/VERSION.txt

--- a/products/fedora.md
+++ b/products/fedora.md
@@ -9,7 +9,9 @@ command: cat /etc/fedora-release
 sortReleasesBy: 'releaseCycle'
 changelogTemplate: https://fedoraproject.org/wiki/Releases/__RELEASE_CYCLE__/ChangeSet?rd=Releases/__RELEASE_CYCLE__
 auto:
--   oci: https://index.docker.io/v2/_library/fedora
+-   dockerhub: library/fedora
+    regex: ^(?<version>\d+)$
+    template: '{{version}}'
 category: os
 releases:
   - releaseCycle: "36"

--- a/products/godot.md
+++ b/products/godot.md
@@ -14,7 +14,7 @@ activeSupportColumn: true
 releaseDateColumn: true
 sortReleasesBy: "releaseCycle"
 auto:
--   oci: https://index.docker.io/v2/barichello/godot-ci
+-   dockerhub: barichello/godot-ci
 releases:
   - releaseCycle: "3.4"
     release: 2021-11-05


### PR DESCRIPTION
Using the Docker Hub API for listing tags is better than the OCI Registry API because the former readily provides datetime of the tag creation.

So switching to dockerhub, but also changing the label so we can do proper OCI later if needed.