### PR TITLE
[tarantool] Fix releases sorting and add 2.10 series

### DIFF
--- a/products/tarantool.md
+++ b/products/tarantool.md
@@ -14,7 +14,7 @@ eolColumn: Support Status
 releaseDateColumn: false
 sortReleasesBy: 'release'
 releases:
-  - releaseCycle: "2.10"
+-   releaseCycle: "2.10"
     release: 2022-05-22
     eol: false
     latest: "2.10.0"

--- a/products/tarantool.md
+++ b/products/tarantool.md
@@ -14,7 +14,7 @@ category: db
 iconSlug: NA
 eolColumn: Support Status
 releaseDateColumn: false
-sortReleasesBy: 'cycleShortHand'
+sortReleasesBy: 'release'
 releases:
   - releaseCycle: "2.8"
     release: 2021-12-22

--- a/products/tarantool.md
+++ b/products/tarantool.md
@@ -16,6 +16,11 @@ eolColumn: Support Status
 releaseDateColumn: false
 sortReleasesBy: 'release'
 releases:
+  - releaseCycle: "2.10"
+    release: 2022-05-22
+    eol: false
+    latest: "2.10.0"
+
   - releaseCycle: "2.8"
     release: 2021-12-22
     eol: false

--- a/products/tarantool.md
+++ b/products/tarantool.md
@@ -14,7 +14,7 @@ category: db
 iconSlug: NA
 eolColumn: Support Status
 releaseDateColumn: false
-sortReleasesBy: 'releaseCycle'
+sortReleasesBy: 'cycleShortHand'
 releases:
   - releaseCycle: "2.8"
     release: 2021-12-22


### PR DESCRIPTION
Current [sorting](https://endoflife.date/tarantool) is wrong:

![image](https://user-images.githubusercontent.com/1151557/170251188-0a423c78-417e-4c20-b30d-321684783523.png)


Part of #199