### PR TITLE
[CentOS] Add EOL date for Stream 9

### DIFF
--- a/products/centos.md
+++ b/products/centos.md
@@ -36,8 +36,8 @@ releases:
     
   - releaseCycle: "CentOS Stream 9"
     release: 2021-09-15
-    support: true
-    eol: false
+    support: 2027-05-31
+    eol: 2027-05-31
     latest: "9"
     link: https://wiki.centos.org/Manuals/ReleaseNotes/CentOSStream
 

--- a/products/centos.md
+++ b/products/centos.md
@@ -31,10 +31,11 @@ releases:
     eol: 2021-12-31
     latest: "8 (2111)"
     link:  https://wiki.centos.org/Manuals/ReleaseNotes/CentOS8.2111
-  - releaseCycle: "8"
+  - releaseCycle: "stream-8"
     release: 2019-09-24
     support: 2024-05-31
     eol: 2024-05-31
+    releaseLabel: "CentOS Stream 8"
     latest: "8"
     link: https://wiki.centos.org/Manuals/ReleaseNotes/CentOSStream
   - releaseCycle: "9"

--- a/products/centos.md
+++ b/products/centos.md
@@ -8,38 +8,40 @@ releasePolicyLink: https://wiki.centos.org/About/Product
 activeSupportColumn: true
 releaseDateColumn: true
 sortReleasesBy: 'release'
+releaseLabel: "CentOS Stream __RELEASE_CYCLE__"
 releases:
-  - releaseCycle: "CentOS 6"
+  - releaseCycle: "6"
     release: 2011-07-10
+    releaseLabel: "CentOS 6"
     support: 2017-05-10
     eol: 2020-11-30
     latest: "6.10"
     link: https://wiki.centos.org/Manuals/ReleaseNotes/CentOS6.10
-  - releaseCycle: "CentOS Linux 7"
+  - releaseCycle: "7"
     release: 2014-07-07
+    releaseLabel: "CentOS Linux 7"
     support: 2020-08-06
     eol: 2024-06-30
     latest: "7 (2009)"
     link: https://wiki.centos.org/Manuals/ReleaseNotes/CentOS7.2009
-  - releaseCycle: "CentOS Linux 8"
+  - releaseCycle: "8"
     release: 2019-09-24
+    releaseLabel: "CentOS Linux 8"
     support: 2021-12-31
     eol: 2021-12-31
     latest: "8 (2111)"
     link:  https://wiki.centos.org/Manuals/ReleaseNotes/CentOS8.2111
-  - releaseCycle: "CentOS Stream 8"
+  - releaseCycle: "8"
     release: 2019-09-24
     support: 2024-05-31
     eol: 2024-05-31
     latest: "8"
     link: https://wiki.centos.org/Manuals/ReleaseNotes/CentOSStream
-    
-  - releaseCycle: "CentOS Stream 9"
+  - releaseCycle: "9"
     release: 2021-09-15
     support: 2027-05-31
     eol: 2027-05-31
     latest: "9"
-    link: https://wiki.centos.org/Manuals/ReleaseNotes/CentOSStream
 
 ---
 

--- a/products/centos.md
+++ b/products/centos.md
@@ -51,6 +51,6 @@ CentOS Linux currently has 2 major released branches that are active: CentOS Lin
 
 Since minor versions of CentOS are point in time releases of a major branch, starting with CentOS Linux 7, CentOS Linux uses a date code as the minor version. As an example, `CentOS Linux 7 (1406)` means June 2014 and `CentOS Linux 7 (1503)` means March 2015. For releases before CentOS 7 - minor versions are incremental (6.0, 6.1, 6.2, etc.).
 
-CentOS Stream only has major versions, no minor versions.
+CentOS Stream only has major versions, no minor versions. Its support ends when its corresponding RHEL release leaves full support.
 
 The project has [announced](https://blog.centos.org/2020/12/future-is-centos-stream/) that work on CentOS Linux 8 will cease at the end of 2021.


### PR DESCRIPTION
As mentioned on the CentOS Stream page ( https://www.centos.org/centos-stream/ ), the end of life of Stream 9 is the full support of RHEL 9.