### PR TITLE
Update humans.txt

### DIFF
--- a/humans.txt
+++ b/humans.txt
@@ -1,16 +1,8 @@
 /* TEAM */
 
-Name: John Michael Ferraris
-GitHub: @jhnferraris
-
-Name: Nemo
-Contact: endoflife.date [at] captnemo.in
-GitHub: @captn3m0
-
-Name: BiNZGi
-GitHub: @BiNZGi
-
-More: https://github.com/endoflife-date/endoflife.date/graphs/contributors
+Team: https://github.com/orgs/endoflife-date/people
+Contributors: https://github.com/endoflife-date/endoflife.date/graphs/contributors
 
 /* SITE */
-Tools: Jekyll, Netlify, GitHub, Ruby
+Software: Jekyll, Netlify, GitHub, Ruby, GitHub Actions
+Components: Just the Docs Jekyll Theme, Stoplight Elements


### PR DESCRIPTION
Instead of linking to individual profiles, linking to the team and contributor pages instead.

If your name isn't visible in the team link, you can change your GitHub team membership to public, and it will show up.