### PR TITLE
Support future LTS.

### DIFF
--- a/_includes/ltslabel.html
+++ b/_includes/ltslabel.html
@@ -1,0 +1,11 @@
+{% if include.lts == true %}
+    ({{include.label}})
+{% elsif include.lts %}
+  {% assign diff = include.lts | date: '%s' | plus:0 | minus:now %}
+  {% comment %}Diff is number of seconds from today when LTS starts. This is <=0 if the LTS has started{% endcomment %}
+  {% if diff <= 0 %}
+    ({{include.label}})
+  {% else %}
+    (<span title="{{include.lts|date_to_string}}">Upcoming</span> {{include.label}})
+  {% endif %}
+{% endif %}

--- a/_layouts/product.html
+++ b/_layouts/product.html
@@ -46,7 +46,7 @@ or +1 (EoL is in the future)
 {% assign LTSLabel = page.LTSLabel | default: '<abbr title="Long Term Support">LTS</abbr>' %}
 
 {% if r.releaseLabel %}{% assign t=r.releaseLabel%}{%else%}{%assign t=page.releaseLabel | default: '__RELEASE_CYCLE__' %}{%endif%}
-{% capture releaseCycleText %}{{t | replace: '__RELEASE_CYCLE__',r.releaseCycle  | replace: '__LATEST__',latestVersionNumber | replace: '__LATEST_SHORT_HAND__',r.latestShortHand | replace: '__CYCLE_SHORT_HAND__',r.cycleShortHand | replace: '__CODENAME__',r.codename | liquify }}{% if r.lts %} ({{LTSLabel}}){% endif %}{% endcapture %}
+{% capture releaseCycleText %}{{t | replace: '__RELEASE_CYCLE__',r.releaseCycle  | replace: '__LATEST__',latestVersionNumber | replace: '__LATEST_SHORT_HAND__',r.latestShortHand | replace: '__CYCLE_SHORT_HAND__',r.cycleShortHand | replace: '__CODENAME__',r.codename | liquify }}{% include ltslabel.html lts=r.lts label=LTSLabel %}{% endcapture %}
 
 {% capture releaseLink %}
 {% if r.link and diff > 0 %}
@@ -62,7 +62,7 @@ or +1 (EoL is in the future)
   <td>
     {% comment %}Only put a link in the version column if the release column is not shown{% endcomment %}
     {% if releaseLink != "" and page.releaseColumn == false %}
-      <a href="{{releaseLink}}" title="Release Notes / Changelog for {{releaseCycleText}}">{{releaseCycleText}}</a>
+      <a href="{{releaseLink}}" title="Release Notes / Changelog for {{releaseCycleText | strip_html}}">{{releaseCycleText}}</a>
     {% else %}
       {{releaseCycleText}}
     {% endif %}

--- a/assets/openapi.yml
+++ b/assets/openapi.yml
@@ -309,8 +309,12 @@ components:
           minLength: 1
           description: 'Link to changelog for the latest release, if available'
         lts:
-          type: boolean
-          description: Whether this release cycle has long-term-support (LTS)
+          type:
+            - boolean
+            - string
+          description: >
+            Whether this release cycle has long-term-support (LTS). Can be a date instead in YYYY-MM-DD format as well
+            if the release enters LTS status on a given date.
         support:
           type:
             - string

--- a/products/debian.md
+++ b/products/debian.md
@@ -16,30 +16,32 @@ releases:
     latest: "11.3"
     link: https://www.debian.org/News/2022/20220326
     releaseDate: 2021-08-14
+    lts: 2024-07-01
 -   releaseCycle: "10"
     codename: "Buster"
     eol: 2024-06-01
     latest: "10.12"
     link: https://www.debian.org/News/2022/2022032602
+    lts: 2022-07-01
     releaseDate: 2019-07-06
 -   releaseCycle: "9"
     codename: "Stretch"
     eol: 2022-06-30
-    lts: true
+    lts: 2020-06-06
     latest: "9.13"
     link: https://lists.debian.org/debian-announce/2020/msg00004.html
     releaseDate: 2017-06-17
 -   releaseCycle: "8"
     codename: "Jessie"
     eol: 2020-06-30
-    lts: true
+    lts: 2018-06-17
     latest: "8.11"
     link: https://www.debian.org/News/2015/20150426
     releaseDate: 2015-04-26
 -   releaseCycle: "7"
     codename: "Wheezy"
     eol: 2018-05-31
-    lts: true
+    lts: 2016-04-26
     latest: "7.11"
     link: https://www.debian.org/News/2013/20130504
     releaseDate: 2013-05-04
@@ -57,6 +59,6 @@ releases:
 
 At any given time, there is one stable release of Debian, which has the support of the Debian security team. When a new stable version is released, the security team will usually cover the previous version for a year or so, while they also cover the new/current version. Only stable is recommended for production use.
 
-[Debian Long Term Support (LTS)](https://wiki.debian.org/LTS) is a project to extend the lifetime of all Debian stable releases to (at least) 5 years. Debian LTS will not be handled by the Debian security team, but by a separate group of volunteers and companies interested in making it a success. Not all packages of the Debian archive are supported by LTS, the [debian-security-support](https://wiki.debian.org/LTS/Using#Check_for_unsupported_packages) package can check for unsupported packages.
+[Debian Long Term Support (LTS)](https://wiki.debian.org/LTS) is a project to extend the lifetime of all Debian stable releases to (at least) 5 years. Debian LTS will not be handled by the Debian security team, but by a separate group of volunteers and companies. Not all packages of the Debian archive are supported by LTS, the [debian-security-support](https://wiki.debian.org/LTS/Using#Check_for_unsupported_packages) package can check for unsupported packages.
 
 A commercial offering for [Extended Long Term Support](https://wiki.debian.org/LTS/Extended) is available.

--- a/products/looker.md
+++ b/products/looker.md
@@ -12,16 +12,40 @@ activeSupportColumn: false
 releaseDateColumn: true
 releaseColumn: false
 sortReleasesBy: "cycleShortHand"
-releaseImage: https://docs.looker.com/assets/images/2021-std-supp-releases.png
+releaseImage: https://docs.looker.com/assets/images/2022-std-supp-releases.png
 releases:
+-   releaseCycle: "22.8"
+    cycleShortHand: 2208
+    releaseDate: 2022-05-06
+    # Update once 22.14 is released
+    eol: 2022-08-15
+-   releaseCycle: "22.6"
+    cycleShortHand: 2206
+    releaseDate: 2022-04-18
+    lts: 2022-06-01
+    eol: 2022-08-31
+-   releaseCycle: "22.4"
+    cycleShortHand: 2204
+    releaseDate: 2022-03-14
+    # Update once 22.10 is released
+    eol: 2022-06-15
+-   releaseCycle: "22.2"
+    cycleShortHand: 2202
+    releaseDate: 2022-02-15
+    eol: 2022-05-16
+-   releaseCycle: "22.0"
+    cycleShortHand: 2200
+    releaseDate: 2022-01-18
+    eol: 2022-05-31
+    lts: 2022-03-01
 -   releaseCycle: "21.20"
     cycleShortHand: 2120
-    eol: false
+    eol: 2022-03-15
     releaseDate: 2021-11-16
 -   releaseCycle: "21.18"
     cycleShortHand: 2118
     eol: 2022-02-28
-    lts: true
+    lts: 2021-12-01
     releaseDate: 2021-10-19
 -   releaseCycle: "21.16"
     cycleShortHand: 2116
@@ -34,7 +58,7 @@ releases:
 -   releaseCycle: "21.12"
     cycleShortHand: 2112
     eol: 2021-11-30
-    lts: true
+    lts: 2021-09-01
     releaseDate: 2021-07-15
 -   releaseCycle: "21.10"
     cycleShortHand: 2110
@@ -47,7 +71,7 @@ releases:
 -   releaseCycle: "21.6"
     cycleShortHand: 2106
     eol: 2021-08-31
-    lts: true
+    lts: 2021-06-01
     releaseDate: 2021-04-15
 -   releaseCycle: "21.4"
     cycleShortHand: 2104
@@ -56,7 +80,7 @@ releases:
 -   releaseCycle: "21.0"
     cycleShortHand: 2100
     eol: 2021-05-31
-    lts: true
+    lts: 2021-03-01
     releaseDate: 2021-01-20
 -   releaseCycle: "7.20"
     cycleShortHand: 720
@@ -87,7 +111,7 @@ When a new release is ready for installation, any Looker user listed as a Techni
 
 ESR releases are quarterly instead of monthly, and get 3 months of support. Issues deemed S1 and S2 will be patched back to the currently supported ESR releases. Participants in the ESR program are required to pair production instances with staging instances. A ESR release is kept in "ESR-staging" for a month, where it is considered "pre-stable".
 
-![ESR release schedule image](https://docs.looker.com/assets/images/2021-std-esr-supp-releases.png)
+![ESR release schedule image](https://docs.looker.com/assets/images/2022-std-esr-supp-releases.png)
 
 ## [Notifications][emails]
 

--- a/products/nodejs.md
+++ b/products/nodejs.md
@@ -17,49 +17,47 @@ releaseDateColumn: true
 sortReleasesBy: 'releaseCycle'
 releases:
 -   releaseCycle: "18"
-    lts: false
+    lts: 2022-10-25
     support: 2023-10-18
     eol: 2025-04-30
     latest: "18.2.0"
     latestReleaseDate: 2022-05-17
     releaseDate: 2022-04-19
 -   releaseCycle: "17"
-    lts: false
     support: 2022-04-01
     eol: 2022-06-01
     latest: "17.9.0"
     latestReleaseDate: 2022-04-07
     releaseDate: 2021-10-19
 -   releaseCycle: "16"
-    lts: true
+    lts: 2021-10-26
     support: 2022-10-18
     eol: 2024-04-30
     latest: "16.15.0"
     latestReleaseDate: 2022-04-26
     releaseDate: 2021-04-20
 -   releaseCycle: "15"
-    lts: false
     support: 2021-04-01
     eol: 2021-06-01
     latest: "15.14.0"
     latestReleaseDate: 2021-04-06
     releaseDate: 2020-10-20
 -   releaseCycle: "14"
-    lts: true
+    lts: 2020-10-27
     support: 2021-10-19
     eol: 2023-04-30
     latest: "14.19.3"
     latestReleaseDate: 2022-05-17
     releaseDate: 2020-04-21
 -   releaseCycle: "12"
-    lts: true
+    lts: 2019-10-21
     support: 2020-10-20
     eol: 2022-04-30
     latest: "12.22.12"
     latestReleaseDate: 2022-04-05
     releaseDate: 2019-04-23
 -   releaseCycle: "10"
-    lts: true
+    lts: 2018-10-30
     support: 2020-05-19
     eol: 2021-04-30
     latest: "10.24.1"
@@ -73,6 +71,3 @@ releases:
 Major Node.js versions enter Current release status for six months, which gives library authors time to add support for them. After six months, odd-numbered releases (9, 11, etc.) become unsupported, and even-numbered releases (10, 12, etc.) move to Active LTS status and are ready for general use. LTS release status is "long-term support", which typically guarantees that critical bugs will be fixed for a total of 30 months. Production applications should only use Active LTS or Maintenance LTS releases.
 
 If a even-numbered release above is _not marked as LTS_, then it has not entered "Active LTS" and is not recommended for Production use.
-
-The Active LTS start date is used as the release date for the table.
-he table.

--- a/products/redhat.md
+++ b/products/redhat.md
@@ -7,6 +7,7 @@ alternate_urls:
 -   /redhat
 -   /redhatlinux
 releasePolicyLink: https://access.redhat.com/support/policy/updates/errata
+LTSLabel: "<abbr title='Extended Life Cycle Support'>ELS</abbr>"
 activeSupportColumn: true
 releaseDateColumn: true
 releaseColumn: false
@@ -18,24 +19,29 @@ releases:
     eol: 2032-05-31
     latest: "9.0"
     releaseDate: 2022-05-18
+    lts: 2032-05-31
 -   releaseCycle: "8"
     support: 2024-05-31
     eol: 2029-05-31
     latest: "8.6"
     releaseDate: 2019-05-01
+    lts: 2029-05-31
 -   releaseCycle: "7"
     support: 2019-12-31
     eol: 2024-06-30
     latest: "7.9"
     releaseDate: 2014-06-10
+    lts: 2024-06-30
 -   releaseCycle: "6"
     support: 2016-05-10
     eol: 2020-11-30
     releaseDate: 2010-11-10
+    lts: 2020-11-30
 -   releaseCycle: "5"
     support: 2013-01-08
     eol: 2017-03-31
     releaseDate: 2007-03-15
+    lts: 2017-03-31
 -   releaseCycle: "4"
     support: 2009-03-31
     eol: 2012-02-29
@@ -48,3 +54,5 @@ releases:
 Red Hat Enterprise Linux versions 5, 6, and 7 each deliver ten years of support in Full Support, Maintenance Support 1 and Maintenance Support 2 Phases followed by an Extended Life Phase. In addition, for Red Hat Enterprise Linux 5 and 6, customers may purchase annual Add-on subscriptions called Extended Life-cycle Support (ELS) to extend limited subscription services beyond the Maintenance Support 2 Phase.
 
 With the introduction of Red Hat Enterprise Linux version 8, Red Hat is simplifying the RHEL product phases from four to three: Full Support, Maintenance Support, and Extended Life Phase.
+
+The Security Support dates in the above table use "Maintenance Support" as the end of security support.


### PR DESCRIPTION
Closes #156.

Instead of setting `lts: true`, you can now set `lts: YYYY-MM-DD` and
the release will be marked as lts: true beyond that date. In case the
date is in the future, the release will be marked as an upcoming LTS.

Updated dates for 4 products to comply with these changes:
- Debian
- Looker
- Nodejs
- RHEL