### PR TITLE
[fix] Fix LTS date diff being considered as EOL diff

### DIFF
--- a/_includes/ltslabel.html
+++ b/_includes/ltslabel.html
@@ -1,9 +1,9 @@
 {% if include.lts == true %}
     ({{include.label}})
 {% elsif include.lts %}
-  {% assign diff = include.lts | date: '%s' | plus:0 | minus:now %}
+  {% assign ltsdiff = include.lts | date: '%s' | plus:0 | minus:now %}
   {% comment %}Diff is number of seconds from today when LTS starts. This is <=0 if the LTS has started{% endcomment %}
-  {% if diff <= 0 %}
+  {% if ltsdiff <= 0 %}
     ({{include.label}})
   {% else %}
     (<span title="{{include.lts|date_to_string}}">Upcoming</span> {{include.label}})


### PR DESCRIPTION
Fixes #1283

TIL variables in Jekyll are all global while rendering. Always thought includes would have some sort of scope. 