### PR TITLE
[es] Switch page to use major versions

### DIFF
--- a/products/elasticsearch.md
+++ b/products/elasticsearch.md
@@ -4,212 +4,34 @@ permalink: /elasticsearch
 category: db
 releasePolicyLink: https://www.elastic.co/support/eol
 changelogTemplate: https://www.elastic.co/guide/en/elasticsearch/reference/__RELEASE_CYCLE__/release-notes-__LATEST__.html
-activeSupportColumn: false
 versionCommand: $ES_HOME/bin/elasticsearch -v
-releaseDateColumn: false
-sortReleasesBy: 'cycleShortHand'
+sortReleasesBy: releaseDate
 auto:
 -   git: https://github.com/elastic/elasticsearch.git
 releases:
--   releaseCycle: "8.2"
-    cycleShortHand: 802
+# The EOL will update on minor 8.x releases
+-   releaseCycle: "8"
     eol: 2023-10-26
-    latest: 8.2.2
+    latest: "8.2.2"
     latestReleaseDate: 2022-05-26
-    releaseDate: 2022-05-03
--   releaseCycle: "8.1"
-    cycleShortHand: 801
-    eol: 2023-09-08
-    latest: 8.1.3
-    latestReleaseDate: 2022-04-20
-    releaseDate: 2022-03-08
--   releaseCycle: "8.0"
-    cycleShortHand: 800
-    eol: 2023-08-10
-    latest: 8.0.1
-    latestReleaseDate: 2022-03-01
     releaseDate: 2022-02-10
--   releaseCycle: "7.17"
-    cycleShortHand: 717
+-   releaseCycle: "7"
     eol: 2023-08-01
-    latest: 7.17.4
+    latest: "7.17.4"
     latestReleaseDate: 2022-05-24
-    releaseDate: 2022-02-01
--   releaseCycle: "7.16"
-    cycleShortHand: 716
-    eol: 2023-06-07
-    latest: 7.16.3
-    latestReleaseDate: 2022-01-13
-    releaseDate: 2021-12-07
--   releaseCycle: "7.15"
-    cycleShortHand: 715
-    eol: 2023-03-22
-    latest: 7.15.2
-    latestReleaseDate: 2021-11-10
-    releaseDate: 2021-09-22
--   releaseCycle: "7.14"
-    cycleShortHand: 714
-    eol: 2023-02-03
-    latest: 7.14.2
-    latestReleaseDate: 2021-09-21
-    releaseDate: 2021-08-03
--   releaseCycle: "7.13"
-    cycleShortHand: 713
-    eol: 2022-11-25
-    latest: 7.13.4
-    latestReleaseDate: 2021-07-20
-    releaseDate: 2021-05-25
--   releaseCycle: "7.12"
-    cycleShortHand: 712
-    eol: 2022-09-23
-    latest: 7.12.1
-    latestReleaseDate: 2021-04-27
-    releaseDate: 2021-03-23
--   releaseCycle: "7.11"
-    cycleShortHand: 711
-    eol: 2022-08-10
-    latest: 7.11.2
-    latestReleaseDate: 2021-03-10
-    releaseDate: 2021-02-10
--   releaseCycle: "7.10"
-    cycleShortHand: 710
-    eol: 2022-05-11
-    latest: 7.10.2
-    latestReleaseDate: 2021-01-14
-    releaseDate: 2020-11-11
--   releaseCycle: "7.9"
-    cycleShortHand: 709
-    eol: 2022-02-18
-    latest: 7.9.3
-    latestReleaseDate: 2020-10-22
-    releaseDate: 2020-08-18
--   releaseCycle: "7.8"
-    cycleShortHand: 708
-    eol: 2021-12-18
-    latest: 7.8.1
-    latestReleaseDate: 2020-07-27
-    releaseDate: 2020-06-18
--   releaseCycle: "7.7"
-    cycleShortHand: 707
-    eol: 2021-11-13
-    latest: 7.7.1
-    latestReleaseDate: 2020-06-03
-    releaseDate: 2020-05-13
--   releaseCycle: "7.6"
-    cycleShortHand: 706
-    eol: 2021-08-11
-    latest: 7.6.2
-    latestReleaseDate: 2020-03-31
-    releaseDate: 2020-02-11
--   releaseCycle: "7.5"
-    cycleShortHand: 705
-    eol: 2021-06-02
-    latest: 7.5.2
-    latestReleaseDate: 2020-01-21
-    releaseDate: 2019-12-02
--   releaseCycle: "7.4"
-    cycleShortHand: 704
-    eol: 2021-04-01
-    latest: 7.4.2
-    latestReleaseDate: 2019-10-31
-    releaseDate: 2019-10-01
--   releaseCycle: "7.3"
-    cycleShortHand: 703
-    eol: 2021-01-31
-    latest: 7.3.2
-    latestReleaseDate: 2019-09-12
-    releaseDate: 2019-07-31
--   releaseCycle: "7.2"
-    cycleShortHand: 702
-    eol: 2020-12-25
-    latest: 7.2.1
-    latestReleaseDate: 2019-07-30
-    releaseDate: 2019-06-25
--   releaseCycle: "7.1"
-    cycleShortHand: 701
-    eol: 2020-11-20
-    latest: 7.1.1
-    latestReleaseDate: 2019-05-28
-    releaseDate: 2019-05-20
--   releaseCycle: "7.0"
-    cycleShortHand: 700
-    eol: 2020-10-10
-    latest: 7.0.1
-    latestReleaseDate: 2019-05-01
     releaseDate: 2019-04-10
--   releaseCycle: "6.8"
-    cycleShortHand: 608
-    eol: 2022-02-08
-    latest: 6.8.23
-    latestReleaseDate: 2022-01-13
-    releaseDate: 2019-05-20
--   releaseCycle: "6.7"
-    cycleShortHand: 607
-    eol: 2020-09-26
-    latest: 6.7.2
-    latestReleaseDate: 2019-05-02
-    releaseDate: 2019-03-26
--   releaseCycle: "6.6"
-    cycleShortHand: 606
-    eol: 2020-07-29
-    latest: 6.6.2
-    latestReleaseDate: 2019-03-12
-    releaseDate: 2019-01-29
--   releaseCycle: "6.5"
-    cycleShortHand: 605
-    eol: 2020-05-14
-    latest: 6.5.4
-    latestReleaseDate: 2018-12-25
-    releaseDate: 2018-11-14
--   releaseCycle: "6.4"
-    cycleShortHand: 604
-    eol: 2020-02-23
-    latest: 6.4.3
-    latestReleaseDate: 2018-11-06
-    releaseDate: 2018-08-17
--   releaseCycle: "6.3"
-    cycleShortHand: 603
-    eol: 2019-12-13
-    latest: 6.3.2
-    latestReleaseDate: 2018-07-24
-    releaseDate: 2018-06-13
--   releaseCycle: "6.2"
-    cycleShortHand: 602
-    eol: 2019-08-06
-    latest: 6.2.4
-    latestReleaseDate: 2018-04-17
-    releaseDate: 2018-02-06
--   releaseCycle: "6.1"
-    cycleShortHand: 601
-    eol: 2019-06-13
-    latest: 6.1.4
-    latestReleaseDate: 2018-03-20
-    releaseDate: 2017-12-14
 -   releaseCycle: "6.0"
-    cycleShortHand: 600
     eol: 2019-05-14
-    latest: 6.0.1
-    latestReleaseDate: 2017-12-07
+    latest: "6.8.9"
+    latestReleaseDate: 2020-05-13
     releaseDate: 2017-11-14
--   releaseCycle: "5.6"
-    cycleShortHand: 506
-    eol: 2019-03-11
-    latest: 5.6.16
-    latestReleaseDate: 2019-03-19
-    releaseDate: 2017-09-12
--   releaseCycle: "5.5"
-    cycleShortHand: 505
-    eol: 2019-01-06
-    latest: 5.5.3
-    latestReleaseDate: 2017-09-12
-    releaseDate: 2017-07-07
 
 ---
 
 > Elasticsearch is a search engine that provides a distributed, multitenant-capable full-text search engine with an HTTP web interface and schema-free JSON documents.
 
-Each major release of all Elastic products is supported for 18 months from the General Availability date. The last minor release of the two most recent major branches of Elasticsearch (and compatible releases of Kibana, Beats, and Logstash) is maintained.
+Each major release of all Elastic products is supported for at least 18 months from the General Availability date. The last minor release of the two most recent major branches of Elasticsearch (and compatible releases of Kibana, Beats, and Logstash) is maintained. The EOL date of a major release is usually bumped over time as additional minor versions are released.
 
-Major versions, such as 1.0.0, 2.0.0, 5.0.0, 6.0.0, and 7.0.0 will introduce features and break backwards compatibility. Minor versions, such as 7.1.0 and 7.2.0, will only introduce features. Maintenance releases, such as 7.1.1 and 7.1.2, will fix bugs only. Maintenance activity occurs on all releases, but we focus on the minor release stream (e.g., 7.1.x) to define how long we maintain a particular code line. Active maintenance of a minor release implies that we are fixing bugs and backporting some number of fixes into that code branch.
+Major versions will introduce features and break backwards compatibility. Minor versions, such as 7.1.0 and 7.2.0, will only introduce features. Maintenance releases, such as 7.1.1 and 7.1.2, will fix bugs only.
 
-The last minor of the prior major release is always supported. For example, Elasticsearch 6.8.x will be maintained until the GA release of Elasticsearch 8.0.0.
+Elasticsearch maintains the most recent minor release from the current major release stream and the most recent minor release from the prior major release stream. For example, Elasticsearch 6.8.x was maintained until the GA release of Elasticsearch 8.0.0.

--- a/products/elasticsearch.md
+++ b/products/elasticsearch.md
@@ -3,7 +3,9 @@ title: Elasticsearch
 permalink: /elasticsearch
 category: db
 releasePolicyLink: https://www.elastic.co/support/eol
-changelogTemplate: https://www.elastic.co/guide/en/elasticsearch/reference/__RELEASE_CYCLE__/release-notes-__LATEST__.html
+# Take the latest version, and drop the patch version to get MAJOR.MINOR
+changelogTemplate: >
+  https://www.elastic.co/guide/en/elasticsearch/reference/{{"__LATEST__"|split:"."|pop|join:'.'}}/release-notes-__LATEST__.html
 versionCommand: $ES_HOME/bin/elasticsearch -v
 sortReleasesBy: releaseDate
 auto:


### PR DESCRIPTION
The ES documentation, legalese, past behaviour, as well as discussion
on customer Slack all points to the fact that:

1. Only the latest minor release will get regular updates
2. Only major releases will break compatibility
3. Thus, customers should always be running the latest minor+patch
   release of a supported major version to be covered under support.

ES calls "support" as vendor support, which is to say that if you open a
ticket against 8.0.x, it will not be closed, but you will only be asked
to upgrade to the latest 8.x release (8.2.2 as of now).

In this sense, ES considers older minor releases (such as 7.1, 7.2) as
supported. So for example, 7.16.x is marked as EOL on 2023-06-07, even
though it will never get a fix (security or otherwise), because users
are expected to upgrade to the latest minor release (7.17).

With all this in consideration, it makes sense to only showcase the
major releases instead, which is what this PR does. The latest release
is what a user should be running, and the EOL date is what ES documents
for the latest minor release. This will unfortunately need to be updated
on every ES minor release.

This will finally close #883 (cc @zr2d2)