### PR TITLE
[blender] Fix changelogTemplate

### DIFF
--- a/products/blender.md
+++ b/products/blender.md
@@ -9,7 +9,7 @@ releaseImage: https://code.blender.org/wp-content/uploads/2020/05/release_cadenc
 auto:
   # https://git.blender.org/blender.git does not support partialClone
 -   git: https://github.com/blender/blender.git
-changelogTemplate: https://www.blender.org/download/releases/{{"__LATEST__" | replace:'.','-'}}/
+changelogTemplate: https://www.blender.org/download/releases/{{"__RELEASE_CYCLE__" | replace:'.','-'}}/
 sortReleasesBy: releaseDate
 eolColumn: Critical bug fixes
 activeSupportColumn: true


### PR DESCRIPTION
The current changelogTemplate generates the following links:
https://www.blender.org/download/releases/3-2-0/
https://www.blender.org/download/releases/2-93-9/
They both give 404 errors.

The correct links are:
https://www.blender.org/download/releases/3-2/
https://www.blender.org/download/releases/2-93/

With the change in the template to release cycle it works again.