### PR TITLE
[dotnet] Update git url

### DIFF
--- a/products/dotnet.md
+++ b/products/dotnet.md
@@ -13,7 +13,7 @@ releaseDateColumn: true
 sortReleasesBy: releaseDate
 eolColumn: Support Status
 auto:
--   git: https://github.com/dotnet/runtime.git
+-   git: https://github.com/dotnet/core.git
 releases:
 -   releaseCycle: "6.0"
     cycleShortHand: "6.0"


### PR DESCRIPTION
According to comments in https://github.com/dotnet/runtime/issues/70774 the runtime repo is only for .NET 5 and higher. For .NET 3.1 Core we have to use the repo at https://github.com/dotnet/core/

Looking at https://github.com/dotnet/core/releases/ there is also the release of 6.0.6 there. I think we can change the auto git url to: `https://github.com/dotnet/core.git`

Should resolve #1321