### PR TITLE
[Feature] Better icon support

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -156,12 +156,21 @@ releases:
     # Also returned as-as in the API.
     codename: firebolt
 
-# Set an icon for the product from https://simpleicons.org/
-# If the icon is not available on simpleicons, set it to "NA"
-# As an example, https://simpleicons.org/?q=opensuse links to
-# https://simpleicons.org/icons/opensuse.svg and https://simpleicons.org/icons/opensuse.pdf
-# So the slug is `opensuse` (the SVG filename without extension).
-iconSlug: ministryofmagic
+# Search on https://logosear.ch/search.html, and pick one of the below icon sets
+# SimpleIcons is preferred, since it has good coverage, and looks consistent.
+# Set an icon for the product from various sources. Only the first icon will be used.
+# Examples for the following URLS:
+# - https://simpleicons.org/icons/suse.svg
+# - https://cdn.jsdelivr.net/gh/devicons/devicon/icons/moodle/moodle-original.svg
+# - https://www.vectorlogo.zone/logos/zabbix/zabbix-icon.svg
+# - https://cdn.svgporn.com/logos/nomad.svg
+# - https://raw.githubusercontent.com/get-icon/geticon/master/icons/mediawiki.svg
+icon:
+  simpleicons: suse
+  devicons: moodle
+  vectorlogozone: zabbix
+  svgporn: nomad
+  geticon: mediawiki
 
 # A few extra fields define overall page behaviour
 

--- a/_layouts/product.html
+++ b/_layouts/product.html
@@ -169,10 +169,10 @@ or +1 (EoL is in the future)
 {% endfor %}
 </table>
 
-{% if page.iconSlug and page.iconSlug != "NA" %}
-<img alt="{{page.title}} Logo" class=productlogo width=50 height=50 src="https://simpleicons.org/icons/{{page.iconSlug}}.svg" >
-{% elsif page.iconSlug != "NA" %}
-<img alt="{{page.title}} Logo" class=productlogo width=50 height=50 src="https://simpleicons.org/icons{{page.permalink}}.svg" >
+{% assign product_logo_url = page.icon | icon_url %}
+
+{% if product_logo_url %}
+<img alt="{{page.title}} Logo" class=productlogo width=50 height=50 src="{{product_logo_url}}" >
 {% endif %}
 
 <div class="maincontent">{{content}}</div>

--- a/_plugins/create-json-files.rb
+++ b/_plugins/create-json-files.rb
@@ -55,6 +55,7 @@ end
 
 # each file is something like 'products/foo.md'
 def process_all_files()
+  t = Time.now
   all_products = []
   Dir['products/*.md'].each do |file|
     product = Product.new(file)
@@ -63,6 +64,7 @@ def process_all_files()
   end
   output_file = json_filename(API_DIR, 'all')
   File.open(output_file, 'w') { |f| f.puts all_products.sort.to_json }
+  puts "API/JSON files generated in #{Time.now - t} seconds"
 end
 
 ############################################################

--- a/_plugins/liquify.rb
+++ b/_plugins/liquify.rb
@@ -1,5 +1,6 @@
 # https://fettblog.eu/snippets/jekyll/liquid-in-frontmatter/
 # This lets use use Liquid templating in front matter
+
 module LiquidFilter
   def liquify(input)
     Liquid::Template.parse(input).render(@context)

--- a/_plugins/parse_release.rb
+++ b/_plugins/parse_release.rb
@@ -1,0 +1,20 @@
+URL_TEMPLATES = {
+  "simpleicons" => "https://simpleicons.org/icons/%s.svg",
+  "devicons" => "https://cdn.jsdelivr.net/gh/devicons/devicon/icons/%s/%s-original.svg",
+  "vectorlogozone" => "https://www.vectorlogo.zone/logos/%s/%s-icon.svg",
+  "svgporn" => "https://cdn.svgporn.com/logos/%s.svg",
+  "geticon" => "https://raw.githubusercontent.com/get-icon/geticon/master/icons/%s.svg"
+}
+
+module EOL
+  module ProductFilter
+    def icon_url(icon)
+      return false unless icon
+      key = icon.keys[0]
+      v = icon[key]
+      sprintf(URL_TEMPLATES[key], v, v)
+    end
+  end
+end
+
+Liquid::Template.register_filter(EOL::ProductFilter)

--- a/_plugins/validate-releases.rb
+++ b/_plugins/validate-releases.rb
@@ -10,6 +10,7 @@ STRING_KEYS = ['latest', 'releaseCycle']
 
 def process_files
   success = true
+  t = Time.now
   Dir['products/*.md'].each do |markdown_file|
     hash = YAML.load_file(markdown_file)
     hash['releases'].each do |r|
@@ -23,7 +24,9 @@ def process_files
       end
     end
   end
+  puts "Validated products in #{Time.now - t} seconds"
   success
+
 end
 
 exit(1) unless process_files

--- a/_sass/custom/custom.scss
+++ b/_sass/custom/custom.scss
@@ -15,6 +15,7 @@
 }
 .productlogo {
   float: left;
+  filter: grayscale(100%);
 }
 .bg-light {
   background-color: #f8f9fa !important;

--- a/products/almalinux.md
+++ b/products/almalinux.md
@@ -7,7 +7,6 @@ releasePolicyLink: https://blog.cloudlinux.com/announcing-open-sourced-community
 activeSupportColumn: true
 releaseDateColumn: true
 sortReleasesBy: releaseDate
-iconSlug: NA
 changelogTemplate: https://wiki.almalinux.org/release-notes/__LATEST__.html
 auto:
 -   dockerhub: almalinux/9-init
@@ -26,6 +25,8 @@ releases:
     latest: "8.6"
 
     latestReleaseDate: 2022-05-31
+icon:
+  simpleicons: almalinux
 
 ---
 

--- a/products/alpinelinux.md
+++ b/products/alpinelinux.md
@@ -5,7 +5,6 @@ alternate_urls:
 title: Alpine Linux
 category: os
 releasePolicyLink: https://alpinelinux.org/releases/
-iconSlug: alpinelinux
 changelogTemplate: https://alpinelinux.org/posts/Alpine-__LATEST__-released.html
 activeSupportColumn: false
 versionCommand: cat /etc/alpine-release
@@ -78,6 +77,8 @@ releases:
     link: https://git.alpinelinux.org/aports/log/?h=3.7-stable
     latestReleaseDate: 2019-03-06
     releaseDate: 2017-11-30
+icon:
+  simpleicons: alpinelinux
 
 ---
 

--- a/products/amazon-linux.md
+++ b/products/amazon-linux.md
@@ -1,7 +1,6 @@
 ---
 permalink: /amazon-linux
 title: Amazon Linux
-iconSlug: amazonaws
 category: os
 releasePolicyLink: https://aws.amazon.com/amazon-linux-2/release-notes/
 activeSupportColumn: false
@@ -28,6 +27,8 @@ releases:
     latest: "2.0.20220426.0"
     latestReleaseDate: 2022-05-03
     releaseDate: 2018-06-26
+icon:
+  simpleicons: amazonaws
 
 ---
 

--- a/products/android.md
+++ b/products/android.md
@@ -118,6 +118,8 @@ releases:
     releaseLabel: "Android __RELEASE_CYCLE__"
     eol: true
     releaseDate: 2008-09-23
+icon:
+  simpleicons: android
 
 ---
 

--- a/products/angular.md
+++ b/products/angular.md
@@ -52,6 +52,8 @@ releases:
     latest: "9.1.13"
     latestReleaseDate: 2020-12-16
     releaseDate: 2020-02-06
+icon:
+  simpleicons: angular
 
 ---
 

--- a/products/ansible.md
+++ b/products/ansible.md
@@ -8,7 +8,6 @@ releaseDateColumn: true
 sortReleasesBy: "releaseCycle"
 activeSupportColumn: false
 eolColumn: Supported
-iconSlug: ansible
 auto:
 -   git: https://github.com/ansible-community/ansible-build-data.git
 releases:
@@ -33,6 +32,8 @@ releases:
 
     latestReleaseDate: 2021-02-09
     releaseDate: 2020-09-22
+icon:
+  simpleicons: ansible
 
 ---
 

--- a/products/apache-http-server.md
+++ b/products/apache-http-server.md
@@ -3,7 +3,6 @@ title: Apache HTTP Server
 permalink: /apache
 alternate_urls:
 -   /httpd
-iconSlug: apache
 releasePolicyLink: https://httpd.apache.org/
 category: server-app
 activeSupportColumn: false
@@ -29,6 +28,8 @@ releases:
     eol: 2010-02-03
     latest: "1.3.42"
     releaseDate: 1998-06-06
+icon:
+  simpleicons: apache
 
 ---
 

--- a/products/api-platform.md
+++ b/products/api-platform.md
@@ -1,7 +1,6 @@
 ---
 title: API Platform
 permalink: /api-platform
-iconSlug: "NA"
 releasePolicyLink: https://api-platform.com/docs/extra/releases/
 activeSupportColumn: true
 versionCommand: composer show api-platform/core | grep versions

--- a/products/azure-devops.md
+++ b/products/azure-devops.md
@@ -4,7 +4,6 @@ permalink: /azure-devops
 alternate_urls:
 -   /tfs
 -   /team-foundation-server
-iconSlug: azuredevops
 category: server-app
 releasePolicyLink: https://docs.microsoft.com/lifecycle/products/?terms=Azure%20DevOps
 activeSupportColumn: true
@@ -63,6 +62,8 @@ releases:
     eol: 2016-07-12
     latest: "2005.SP2"
     releaseDate: 2006-06-17
+icon:
+  simpleicons: azuredevops
 
 ---
 

--- a/products/blender.md
+++ b/products/blender.md
@@ -4,12 +4,12 @@ title: Blender
 releasePolicyLink: https://www.blender.org
 releaseDateColumn: true
 releaseColumn: true
-iconSlug: blender
 releaseImage: https://code.blender.org/wp-content/uploads/2020/05/release_cadence_4th_wall-1-1024x224.png
 auto:
   # https://git.blender.org/blender.git does not support partialClone
 -   git: https://github.com/blender/blender.git
-changelogTemplate: https://www.blender.org/download/releases/{{"__RELEASE_CYCLE__" | replace:'.','-'}}/
+changelogTemplate: https://www.blender.org/download/releases/{{"__RELEASE_CYCLE__"
+  | replace:'.','-'}}/
 sortReleasesBy: releaseDate
 eolColumn: Critical bug fixes
 activeSupportColumn: true
@@ -49,6 +49,8 @@ releases:
     lts: true
     latestReleaseDate: 2022-04-20
     releaseDate: 2020-06-03
+icon:
+  simpleicons: blender
 
 ---
 

--- a/products/bootstrap.md
+++ b/products/bootstrap.md
@@ -37,6 +37,8 @@ releases:
 releasePolicyLink: https://github.com/twbs/release
 releaseDateColumn: true
 eolColumn: Critical Support
+icon:
+  simpleicons: bootstrap
 
 ---
 

--- a/products/centos.md
+++ b/products/centos.md
@@ -43,6 +43,8 @@ releases:
     latest: "9"
 
     releaseDate: 2021-09-15
+icon:
+  simpleicons: centos
 
 ---
 

--- a/products/cfengine.md
+++ b/products/cfengine.md
@@ -6,7 +6,6 @@ releaseDateColumn: true
 sortReleasesBy: "releaseCycle"
 activeSupportColumn: true
 eolColumn: Supported
-iconSlug: NA
 permalink: /cfengine
 releasePolicyLink: https://cfengine.com
 
@@ -39,7 +38,8 @@ releases:
     eol: false
     support: 2022-12-18
     releaseDate: 2019-12-18
-
+icon:
+  vectorlogozone: cfengine
 ---
 
 > [CFEngine](https://cfengine.com) is an open-source configuration management, automation and knowledge management tool enabling infrastructure as code. It runs on many Unix-like systems, and can configure both Unix-like systems as well as Microsoft Windows.
@@ -49,3 +49,4 @@ CFEngine typically has releases once every 6 months. LTS releases occur every 1.
 See the [CFEngine blog][blog] for recent announcements.
 
 [blog]: https://cfengine.com/blog
+ine.com/blog

--- a/products/citrix-apps-desktops.md
+++ b/products/citrix-apps-desktops.md
@@ -6,7 +6,6 @@ alternate_urls:
 -   /cvad
   # This can be removed if we add more citrix products
 -   /citrix
-iconSlug: citrix
 category: app
 releasePolicyLink: https://www.citrix.com/support/product-lifecycle/product-matrix
 activeSupportColumn: true
@@ -62,6 +61,8 @@ releases:
     eol: 2022-08-15
     lts: true
     releaseDate: 2017-08-15
+icon:
+  simpleicons: citrix
 
 ---
 

--- a/products/coldfusion.md
+++ b/products/coldfusion.md
@@ -3,7 +3,6 @@ title: Adobe ColdFusion
 category: server-app
 permalink: /coldfusion
 releasePolicyLink: https://helpx.adobe.com/support/programs/eol-matrix.html
-iconSlug: adobe
 activeSupportColumn: false
 releaseColumn: false
 releaseDateColumn: true
@@ -27,6 +26,8 @@ releases:
 -   releaseCycle: "10"
     eol: 2017-05-16
     releaseDate: 2012-05-15
+icon:
+  simpleicons: adobe
 
 ---
 

--- a/products/composer.md
+++ b/products/composer.md
@@ -26,12 +26,13 @@ releases:
     eol: 2020-10-24
 
     releaseDate: 2016-04-05
-iconSlug: composer
 permalink: /composer
 activeSupportColumn: false
 releaseColumn: true
 releaseDateColumn: true
 versionCommand: composer --version
+icon:
+  simpleicons: composer
 
 ---
 

--- a/products/consul.md
+++ b/products/consul.md
@@ -2,7 +2,6 @@
 title: Consul
 permalink: /consul
 category: server-app
-iconSlug: consul
 releasePolicyLink: https://support.hashicorp.com/hc/articles/360021185113
 sortReleasesBy: releaseDate
 changelogTemplate: https://github.com/hashicorp/consul/blob/v__LATEST__/CHANGELOG.md
@@ -38,6 +37,8 @@ releases:
     latest: "1.8.19"
     latestReleaseDate: 2021-12-15
     releaseDate: 2020-06-18
+icon:
+  simpleicons: consul
 
 ---
 

--- a/products/couchbase-server.md
+++ b/products/couchbase-server.md
@@ -4,7 +4,6 @@ permalink: /couchbase-server
 alternate_urls:
 -   /couchbase
 category: db
-iconSlug: couchbase
 releasePolicyLink: https://www.couchbase.com/support-policy/enterprise-software
 sortReleasesBy: "releaseCycle"
 changelogTemplate: https://docs.couchbase.com/server/__RELEASE_CYCLE__/release-notes/relnotes.html
@@ -36,6 +35,8 @@ releases:
     latest: "6.0.5"
     latestReleaseDate: 2022-04-30
     releaseDate: 2019-01-23
+icon:
+  simpleicons: couchbase
 
 ---
 

--- a/products/debian.md
+++ b/products/debian.md
@@ -52,6 +52,8 @@ releases:
     latest: "6.0.10"
     link: https://www.debian.org/News/2011/20110205a
     releaseDate: 2011-02-06
+icon:
+  simpleicons: debian
 
 ---
 

--- a/products/django.md
+++ b/products/django.md
@@ -71,6 +71,8 @@ releases:
 
     latestReleaseDate: 2020-03-04
     releaseDate: 2017-04-04
+icon:
+  simpleicons: django
 
 ---
 

--- a/products/docker-engine.md
+++ b/products/docker-engine.md
@@ -6,7 +6,6 @@ sortReleasesBy: "releaseCycle"
 releasePolicyLink: https://docs.docker.com/engine/release-notes/
 changelogTemplate: |
   https://docs.docker.com/engine/release-notes/#{{"__LATEST__" | replace:'.',''}}
-iconSlug: docker
 activeSupportColumn: false
 releaseColumn: true
 releaseDateColumn: true
@@ -126,6 +125,8 @@ releases:
 
     latestReleaseDate: 2017-06-27
     releaseDate: 2017-02-23
+icon:
+  simpleicons: docker
 
 ---
 

--- a/products/dotnet.md
+++ b/products/dotnet.md
@@ -67,6 +67,8 @@ releases:
     latest: "1.0.16"
 
     releaseDate: 2016-06-27
+icon:
+  simpleicons: dotnet
 
 ---
 

--- a/products/dotnetfx.md
+++ b/products/dotnetfx.md
@@ -3,7 +3,6 @@ permalink: /dotnetfx
 alternative_urls:
 -   /.netfx
 -   /dotnetframework
-iconSlug: dotnet
 category: framework
 title: .NET Framework
 versionCommand: reg query "HKLM\SOFTWARE\Microsoft\Net Framework Setup\NDP" /s
@@ -49,6 +48,8 @@ releases:
 -   releaseCycle: "3.5 SP1"
     eol: 2029-01-09
     releaseDate: 2007-11-19
+icon:
+  simpleicons: dotnet
 
 ---
 

--- a/products/drupal.md
+++ b/products/drupal.md
@@ -55,6 +55,8 @@ releases:
     latest: "7.89"
     lts: true
     releaseDate: 2011-01-05
+icon:
+  simpleicons: drupal
 
 ---
 

--- a/products/eks.md
+++ b/products/eks.md
@@ -34,8 +34,6 @@ releases:
     latest: "1.16.15"
 
     releaseDate: 2020-04-30
-iconSlug: kubernetes
-
 permalink: /amazon-eks
 alternate_urls:
 -   /eks
@@ -47,6 +45,8 @@ releaseColumn: true
 releaseDateColumn: true
 eolColumn: End of Support
 versionCommand: eksctl get cluster --name=cluster-name
+icon:
+  simpleicons: kubernetes
 
 ---
 

--- a/products/elasticsearch.md
+++ b/products/elasticsearch.md
@@ -27,6 +27,8 @@ releases:
     latest: "6.0.1"
     latestReleaseDate: 2017-12-07
     releaseDate: 2017-11-14
+icon:
+  simpleicons: elasticsearch
 
 ---
 

--- a/products/electron.md
+++ b/products/electron.md
@@ -3,7 +3,6 @@ title: Electron
 category: framework
 changelogTemplate: |
   https://www.electronjs.org/releases/stable?version={{"__LATEST__" | split:'.' | first}}#__LATEST__
-iconSlug: electron
 permalink: /electron
 releasePolicyLink: https://www.electronjs.org/docs/latest/tutorial/support
 eolColumn: Supported
@@ -91,6 +90,8 @@ releases:
     latest: "5.0.13"
     latestReleaseDate: 2019-12-16
     releaseDate: 2019-04-23
+icon:
+  simpleicons: electron
 
 ---
 

--- a/products/elixir.md
+++ b/products/elixir.md
@@ -71,6 +71,8 @@ releases:
     latest: "1.4.5"
     latestReleaseDate: 2017-06-22
     releaseDate: 2017-01-05
+icon:
+  simpleicons: elixir
 
 ---
 

--- a/products/emberjs.md
+++ b/products/emberjs.md
@@ -1,7 +1,6 @@
 ---
 title: Ember
 permalink: /emberjs
-iconSlug: emberdotjs
 alternate_urls:
 -   /ember
 category: framework
@@ -34,6 +33,8 @@ releases:
 
     latestReleaseDate: 2021-10-18
     releaseDate: 2020-12-28
+icon:
+  simpleicons: emberdotjs
 
 ---
 

--- a/products/fedora.md
+++ b/products/fedora.md
@@ -58,6 +58,8 @@ releases:
     eol: 2019-05-28
     latestReleaseDate: 2019-06-05
     releaseDate: 2019-06-05
+icon:
+  simpleicons: fedora
 
 ---
 

--- a/products/ffmpeg.md
+++ b/products/ffmpeg.md
@@ -2,7 +2,8 @@
 title: FFmpeg
 permalink: /ffmpeg
 category: framework
-icon: FFmpeg
+icon:
+  simpleicons: ffmpeg
 releasePolicyLink: https://ffmpeg.org/
 versionCommand: ffmpeg -version
 activeSupportColumn: false

--- a/products/filemaker.md
+++ b/products/filemaker.md
@@ -3,7 +3,6 @@ title: FileMaker
 category: app
 permalink: /filemaker
 releasePolicyLink: https://www.filemaker.com/support/product-availability.html
-iconSlug: "NA"
 activeSupportColumn: false
 releaseColumn: false
 eolColumn: Support Status
@@ -49,9 +48,11 @@ releases:
 -   releaseCycle: "7"
     eol: 2008-09-26
     releaseDate: 2004-03-01
-
+icon:
+  vectorlogozone: filemaker
 ---
 
 FileMaker has recently adopted a yearly release cycle, in May. Previously there was an 18-month release cycle.
 
 Source for release dates only gives month and year, so 1st of month assumed.
+month assumed.

--- a/products/firefox.md
+++ b/products/firefox.md
@@ -5,7 +5,6 @@ title: Firefox
 releasePolicyLink: https://www.mozilla.org/firefox/
 releaseDateColumn: true
 releaseColumn: true
-iconSlug: firefox
 LTSLabel: "<abbr title='Extended Support Release'>ESR</abbr>"
 changelogTemplate: |
   https://www.mozilla.org/firefox/__LATEST__/releasenotes/
@@ -16,18 +15,20 @@ releases:
     eol: false
     latest: "101.0"
     releaseDate: 2022-05-31
-    
+
 -   releaseCycle: "91"
     eol: 2022-09-20
     latest: "91.10.0"
     lts: true
     releaseDate: 2021-08-10
-    
+
 -   releaseCycle: "78"
     eol: 2021-11-02
     latest: "78.15.0"
     lts: true
     releaseDate: 2020-06-30
+icon:
+  simpleicons: firefox
 
 ---
 

--- a/products/freebsd.md
+++ b/products/freebsd.md
@@ -215,6 +215,8 @@ releases:
 -   releaseCycle: "stable/4"
     cycleShortHand: "4"
     eol: 2007-01-31
+icon:
+  simpleicons: freebsd
 
 ---
 

--- a/products/gitlab.md
+++ b/products/gitlab.md
@@ -9,7 +9,6 @@ releaseDateColumn: true
 sortReleasesBy: releaseDate
 activeSupportColumn: true
 eolColumn: Maintenance Support
-iconSlug: gitlab
 auto:
   # Reference: https://rubular.com/r/mFfxB8FgXXERX4
 -   regex: '^v?(?<major>[1-9]\d*)\.(?<minor>0|[1-9]\d*)\.(?<patch>0|[1-9]\d*)-ee?$'
@@ -106,6 +105,8 @@ releases:
 
     latestReleaseDate: 2021-06-01
     releaseDate: 2021-03-18
+icon:
+  simpleicons: gitlab
 
 ---
 

--- a/products/gke.md
+++ b/products/gke.md
@@ -13,55 +13,57 @@ releases:
   # The latest data is coming from the _data/gke.{json|yml} file
   # The file is generated at build-time
   # See #314 for an explanation
-  - releaseCycle: "Rapid"
+-   releaseCycle: "Rapid"
     eol: false
     support: true
     latest: '{{ site.data.gke.channels.RAPID" }}'
     link: https://cloud.google.com/kubernetes-engine/docs/release-notes-rapid
-  - releaseCycle: "Regular"
+-   releaseCycle: "Regular"
     eol: false
     support: true
     latest: '{{ site.data.gke.channels.REGULAR" }}'
     link: https://cloud.google.com/kubernetes-engine/docs/release-notes-regular
-  - releaseCycle: "Stable"
+-   releaseCycle: "Stable"
     eol: false
     support: true
     latest: '{{ site.data.gke.channels.STABLE" }}'
     link: https://cloud.google.com/kubernetes-engine/docs/release-notes-stable
-  - releaseCycle: "1.22"
+-   releaseCycle: "1.22"
     eol: 2023-04-01
     support: 2023-02-01
     latest: '{{ site.data.gke.versions["1.22"] }}'
-  - releaseCycle: "1.21"
+-   releaseCycle: "1.21"
     eol: 2023-03-01
     support: 2023-01-01
     latest: '{{ site.data.gke.versions["1.21"] }}'
-  - releaseCycle: "1.20"
+-   releaseCycle: "1.20"
     eol: 2022-08-01
     support: 2021-12-01
     latest: '{{ site.data.gke.versions["1.20"] }}'
-  - releaseCycle: "1.19"
+-   releaseCycle: "1.19"
     eol: 2022-06-01
     support: 2021-10-01
     latest: '{{ site.data.gke.versions["1.19"] }}'
-  - releaseCycle: "1.18"
+-   releaseCycle: "1.18"
     eol: 2022-03-01
     support: 2021-08-01
     latest: '{{ site.data.gke.versions["1.18"] }}'
-  - releaseCycle: "1.17"
+-   releaseCycle: "1.17"
     eol: 2021-11-01
     support: 2021-07-01
     latest: '{{ site.data.gke.versions["1.17"] }}'
-iconSlug: kubernetes
 permalink: /google-kubernetes-engine
 alternate_urls:
-  - gke
+-   gke
 releasePolicyLink: https://cloud.google.com/kubernetes-engine/docs/release-schedule
 activeSupportColumn: true
 releaseColumn: true
 releaseDateColumn: false
 eolColumn: Maintenance Support
 versionCommand: kubectl version
+icon:
+  simpleicons: kubernetes
+
 ---
 
 > [Google Kubernetes Engine][gke] is the fully managed Kubernetes service from Google.

--- a/products/go.md
+++ b/products/go.md
@@ -68,6 +68,8 @@ releases:
     latest: "1.10.8"
     latestReleaseDate: 2019-01-23
     releaseDate: 2018-02-16
+icon:
+  simpleicons: go
 
 ---
 

--- a/products/godot.md
+++ b/products/godot.md
@@ -4,7 +4,6 @@ permalink: /godot
 category: app
 alternate_urls:
 -   /godotengine
-iconSlug: godotengine
 releasePolicyLink: https://docs.godotengine.org/en/latest/about/release_policy.html
 changelogTemplate: |
   https://godotengine.org/article/maintenance-release-godot-{{"__LATEST__" | replace:'.','-'}}
@@ -71,6 +70,8 @@ releases:
 
     latestReleaseDate: 2014-12-15
     releaseDate: 2014-12-15
+icon:
+  simpleicons: godotengine
 
 ---
 

--- a/products/haproxy.md
+++ b/products/haproxy.md
@@ -6,7 +6,6 @@ releasePolicyLink: https://haproxy.org
 changelogTemplate: https://www.haproxy.org/download/__RELEASE_CYCLE__/src/CHANGELOG
 activeSupportColumn: false
 versionCommand: haproxy -v
-iconSlug: NA
 releaseDateColumn: true
 auto:
 -   custom: true
@@ -75,7 +74,8 @@ releases:
     latest: "1.7.14"
     latestReleaseDate: 2021-03-31
     releaseDate: 2016-11-25
-
+icon:
+  vectorlogozone: haproxy
 ---
 
 >[HAProxy](https://www.haproxy.org/) is a free, very fast and reliable reverse-proxy offering high availability, load balancing, and proxying for TCP and HTTP-based applications. It is particularly suited for very high traffic web sites and powers a significant portion of the world's most visited ones.
@@ -87,3 +87,4 @@ The core team deploys a lot of efforts backporting fixes to older releases while
 Branches with an even number are called "LTS" (for "long term support") and are maintained for 5 years after their release. During this time they will receive fixes for bugs that are discovered after the release. These branches are aimed at general users who seek extreme stability and do not want to qualify a new version too often but still want to receive fixes.
 
 Branches with an odd number are only called "stable", they're aimed at highly skilled users who prefer to upgrade often to benefit from modern features, and who are also able to roll back in case of problem. These versions are maintained between 12 and 18 months. The duration is short and purposely not strict so that the maintenance cycle is decided with users based on feedback, and so that these versions do not end up in embedded products. It may happen that a few features are backported to these version if there is some reasonable demand and the operation is considered riskless enough.
+less enough.

--- a/products/iphone.md
+++ b/products/iphone.md
@@ -4,7 +4,6 @@ alternate_urls:
 -   /ios
 title: iPhone
 category: device
-iconSlug: apple
 releasePolicyLink: https://wikipedia.org/wiki/List_of_iOS_devices#In_production_and_supported
 discontinuedColumn: true
 activeSupportColumn: false
@@ -89,6 +88,8 @@ releases:
     discontinued: false
     eol: false
     releaseDate: 2022-03-18
+icon:
+  simpleicons: apple
 
 ---
 

--- a/products/java.md
+++ b/products/java.md
@@ -79,6 +79,8 @@ releases:
     eol: 2018-12-31
     latest: "6u211"
     releaseDate: 2006-12-11
+icon:
+  simpleicons: java
 
 ---
 

--- a/products/jquery.md
+++ b/products/jquery.md
@@ -23,11 +23,12 @@ releases:
     link: https://blog.jquery.com/2016/05/20/jquery-1-12-4-and-2-2-4-released/
     latestReleaseDate: 2016-05-20
     releaseDate: 2006-08-31
-iconSlug: jquery
 permalink: /jquery
 activeSupportColumn: false
 releaseColumn: true
 releaseDateColumn: true
+icon:
+  simpleicons: jquery
 
 ---
 

--- a/products/kdeplasma.md
+++ b/products/kdeplasma.md
@@ -10,7 +10,6 @@ versionCommand: plasmashell -v
 sortReleasesBy: 'releaseCycle'
 changelogTemplate: https://kde.org/announcements/plasma/5/__LATEST__/
 category: os
-iconSlug: kde
 eolColumn: Critical bug fixes
 releases:
 -   releaseCycle: "5.24"
@@ -33,6 +32,8 @@ releases:
     eol: 2022-02-11
     lts: true
     releaseDate: 2020-02-11
+icon:
+  simpleicons: kde
 
 ---
 

--- a/products/kindle.md
+++ b/products/kindle.md
@@ -1,6 +1,5 @@
 ---
 title: Amazon Kindle
-iconSlug: amazon
 category: device
 sortReleasesBy: releaseDate
 releases:
@@ -63,6 +62,8 @@ activeSupportColumn: false
 releaseColumn: true
 releaseDateColumn: true
 eolColumn: Service Status
+icon:
+  simpleicons: amazon
 
 ---
 

--- a/products/kotlin.md
+++ b/products/kotlin.md
@@ -1,7 +1,6 @@
 ---
 title: Kotlin
 category: lang
-iconSlug: kotlin
 permalink: /kotlin
 alternate_urls:
 -   /kotlinlang
@@ -51,6 +50,8 @@ releases:
 
     latestReleaseDate: 2020-04-14
     releaseDate: 2018-10-25
+icon:
+  simpleicons: kotlin
 
 ---
 

--- a/products/kubernetes.md
+++ b/products/kubernetes.md
@@ -69,6 +69,8 @@ releases:
     latest: "1.16.15"
     latestReleaseDate: 2020-09-02
     releaseDate: 2019-09-18
+icon:
+  simpleicons: kubernetes
 
 ---
 

--- a/products/laravel.md
+++ b/products/laravel.md
@@ -52,6 +52,8 @@ releases:
     lts: true
     latestReleaseDate: 2020-08-18
     releaseDate: 2017-08-30
+icon:
+  simpleicons: laravel
 
 ---
 

--- a/products/lineageos.md
+++ b/products/lineageos.md
@@ -18,7 +18,6 @@ releases:
 -   releaseCycle: "16.0"
     eol: 2021-02-16
     releaseDate: 2019-03-01
-iconSlug: lineageos
 permalink: /lineageos
 alternate_urls:
 -   /lineage
@@ -26,6 +25,8 @@ activeSupportColumn: false
 releaseColumn: false
 releaseDateColumn: true
 discontinuedColumn: false
+icon:
+  simpleicons: lineageos
 
 ---
 

--- a/products/linuxkernel.md
+++ b/products/linuxkernel.md
@@ -2,7 +2,6 @@
 title: Linux Kernel
 permalink: /linux
 category: os
-iconSlug: linux
 releasePolicyLink: https://www.kernel.org/
 releaseImage: https://upload.wikimedia.org/wikipedia/en/timeline/ebiqfbdzyuxdbre7104smcbs2skj37k.png
 changelogTemplate: |
@@ -87,6 +86,8 @@ releases:
     latest: "4.9.317"
     latestReleaseDate: 2022-06-06
     releaseDate: 2016-12-11
+icon:
+  simpleicons: linux
 
 ---
 

--- a/products/linuxmint.md
+++ b/products/linuxmint.md
@@ -6,7 +6,6 @@ category: os
 releasePolicyLink: https://linuxmint.com/download_all.php
 activeSupportColumn: true
 releaseDateColumn: true
-iconSlug: linuxmint
 sortReleasesBy: "releaseCycle"
 releaseLabel: "__RELEASE_CYCLE__ '__CODENAME__'"
 releases:
@@ -99,6 +98,8 @@ releases:
     latest: "18.3"
     link: https://blog.linuxmint.com/?p=3457
     releaseDate: 2017-11-27
+icon:
+  simpleicons: linuxmint
 
 ---
 

--- a/products/log4j.md
+++ b/products/log4j.md
@@ -6,7 +6,6 @@ releasePolicyLink: https://logging.apache.org/log4j/2.x/security.html
 changelogTemplate: https://logging.apache.org/log4j/2.x/changes-report.html#a{{"__LATEST__"}}
 activeSupportColumn: false
 releaseDateColumn: true
-iconSlug: apache
 eolColumn: Supported
 sortReleasesBy: cycleShortHand
 releases:
@@ -30,6 +29,8 @@ releases:
     eol: 2015-10-15
     latest: "1.2.17"
     releaseDate: 2001-01-08
+icon:
+  simpleicons: apache
 
 ---
 

--- a/products/looker.md
+++ b/products/looker.md
@@ -2,7 +2,6 @@
 title: Looker
 permalink: /looker
 category: server-app
-iconSlug: looker
 releasePolicyLink: https://docs.looker.com/relnotes/release-overview
 changelogTemplate: |
   https://docs.looker.com/relnotes/v{{"__RELEASE_CYCLE__" | split:'.' | first}}-changelog#{{"__RELEASE_CYCLE__"}}
@@ -94,6 +93,8 @@ releases:
     cycleShortHand: 716
     eol: true
     releaseDate: 2020-09-17
+icon:
+  simpleicons: looker
 
 ---
 

--- a/products/macos.md
+++ b/products/macos.md
@@ -76,6 +76,8 @@ releaseColumn: true
 releaseDateColumn: true
 eolColumn: Service Status
 versionCommand: sw_vers
+icon:
+  simpleicons: macos
 
 ---
 

--- a/products/magento.md
+++ b/products/magento.md
@@ -134,6 +134,8 @@ releases:
 
 
     releaseDate: 2008-03-01
+icon:
+  simpleicons: magento
 
 ---
 

--- a/products/mariadb.md
+++ b/products/mariadb.md
@@ -85,6 +85,8 @@ releases:
     lts: true
     latestReleaseDate: 2020-05-06
     releaseDate: 2013-01-29
+icon:
+  simpleicons: mariadb
 
 ---
 

--- a/products/mediawiki.md
+++ b/products/mediawiki.md
@@ -4,7 +4,6 @@ category: server-app
 sortReleasesBy: "releaseCycle"
 changelogTemplate: "https://www.mediawiki.org/wiki/Release_notes/__RELEASE_CYCLE__"
 releaseImage: https://upload.wikimedia.org/wikipedia/mediawiki/timeline/bxn2hc9b02nf015vxy4zlq7sdr9cs6u.png
-iconSlug: NA
 permalink: /mediawiki
 releasePolicyLink: https://www.mediawiki.org/wiki/Version_lifecycle
 activeSupportColumn: false
@@ -57,7 +56,8 @@ releases:
     latest: "1.31.16"
     latestReleaseDate: 2021-09-30
     releaseDate: 2018-06-13
-
+icon:
+  geticon: mediawiki
 ---
 
 > [MediaWiki](https://mediawiki.org) is a wiki engine, and mostly known as the software that powers Wikipedia, but it is also frequently used for other wikis.

--- a/products/mongodb.md
+++ b/products/mongodb.md
@@ -104,6 +104,8 @@ releases:
     latestReleaseDate: 2009-10-22
     latest: 1.0.1
     releaseDate: 2009-08-27
+icon:
+  simpleicons: mongodb
 
 ---
 

--- a/products/moodle.md
+++ b/products/moodle.md
@@ -1,7 +1,6 @@
 ---
 title: Moodle
 category: server-app
-
 sortReleasesBy: "support"
 changelogTemplate: "https://docs.moodle.org/dev/Moodle___LATEST___release_notes"
 
@@ -11,38 +10,31 @@ releases:
     support: 2023-05-08
     latest: "4.0.1"
     lts: false
-
     releaseDate: 2022-04-19
 -   releaseCycle: "3.11"
     eol: 2022-11-14
     support: 2022-05-09
     latest: "3.11.7"
     lts: false
-
     releaseDate: 2021-05-17
 -   releaseCycle: "3.10"
     eol: 2022-05-09
     support: 2021-11-08
     latest: "3.10.11"
     lts: false
-
     releaseDate: 2020-11-09
 -   releaseCycle: "3.9"
     eol: 2023-05-08
     support: 2021-05-10
     latest: "3.9.14"
     lts: true
-
     releaseDate: 2020-06-15
 -   releaseCycle: "3.8"
     eol: 2021-05-10
     support: 2020-11-09
     latest: "3.8.9"
     lts: false
-
-
     releaseDate: 2019-11-18
-iconSlug: NA
 permalink: /moodle
 releasePolicyLink: https://docs.moodle.org/dev/Releases
 activeSupportColumn: true
@@ -50,7 +42,9 @@ releaseColumn: true
 releaseDateColumn: true
 discontinuedColumn: false
 releaseImage: https://docs.moodle.org/dev/images_dev/7/7e/releasescurrent.png
-
+# https://github.com/simple-icons/simple-icons/issues/6270
+icon:
+  devicons: moodle
 ---
 
 > [Moodle](https://moodle.org/) is a Learning Platform or course management system (CMS) - a free Open Source software package designed to help educators create effective online courses based on sound pedagogical principles.

--- a/products/msexchange.md
+++ b/products/msexchange.md
@@ -1,7 +1,6 @@
 ---
 title: Microsoft Exchange
 permalink: /msexchange
-iconSlug: microsoftexchange
 category: server-app
 releasePolicyLink: https://docs.microsoft.com/lifecycle/products/?terms=Exchange%20Server
 activeSupportColumn: true
@@ -39,6 +38,8 @@ releases:
     eol: 2014-04-08
     latest: "6.5.7654.4"
     releaseDate: 2003-09-28
+icon:
+  simpleicons: microsoftexchange
 
 ---
 

--- a/products/mssharepoint.md
+++ b/products/mssharepoint.md
@@ -3,7 +3,6 @@ title: Microsoft SharePoint
 permalink: /sharepoint
 alternate_urls:
 -   /mssharepoint
-iconSlug: microsoftsharepoint
 category: server-app
 releasePolicyLink: https://docs.microsoft.com/en-us/lifecycle/products/?terms=SharePoint%20Server
 activeSupportColumn: true
@@ -35,6 +34,8 @@ releases:
     eol: 2017-10-10
     latest: "12.0.6690.5000"
     releaseDate: 2007-01-27
+icon:
+  simpleicons: microsoftsharepoint
 
 ---
 

--- a/products/mssqlserver.md
+++ b/products/mssqlserver.md
@@ -1,7 +1,6 @@
 ---
 title: Microsoft SQL Server
 permalink: /mssqlserver
-iconSlug: microsoftsqlserver
 category: db
 releasePolicyLink: https://docs.microsoft.com/lifecycle/products/?terms=SQL%20Server
 activeSupportColumn: true
@@ -39,6 +38,8 @@ releases:
     eol: 2019-07-09
     latest: "10.50.6560.0 SP3 GDR"
     releaseDate: 2014-09-26
+icon:
+  simpleicons: microsoftsqlserver
 
 ---
 

--- a/products/mysql.md
+++ b/products/mysql.md
@@ -50,6 +50,8 @@ releasePolicyLink: https://www.oracle.com/us/support/library/lifetime-support-te
 activeSupportColumn: false
 releaseDateColumn: true
 versionCommand: mysqld --version
+icon:
+  simpleicons: mysql
 
 ---
 

--- a/products/nginx.md
+++ b/products/nginx.md
@@ -1,7 +1,6 @@
 ---
 title: nginx
 permalink: /nginx
-iconSlug: nginx
 releasePolicyLink: https://www.nginx.com/blog/nginx-1-18-1-19-released/#NGINX-Versioning-Explained
 category: server-app
 activeSupportColumn: false
@@ -82,6 +81,8 @@ releases:
     latest: "1.0.15"
     latestReleaseDate: 2012-04-12
     releaseDate: 2011-04-12
+icon:
+  simpleicons: nginx
 
 ---
 

--- a/products/nix.md
+++ b/products/nix.md
@@ -1,7 +1,6 @@
 ---
 title: nix
 category: app
-iconSlug: nixos
 permalink: /nix
 alternate_urls:
 -   /nixlang
@@ -70,6 +69,8 @@ releases:
     eol: true
     latestReleaseDate: 2017-12-20
     releaseDate: 2012-05-11
+icon:
+  simpleicons: nixos
 
 ---
 

--- a/products/nixos.md
+++ b/products/nixos.md
@@ -1,7 +1,6 @@
 ---
 title: NixOS
 category: os
-iconSlug: nixos
 permalink: /nixos
 alternate_urls:
 -   /nixoslinux
@@ -99,6 +98,8 @@ releases:
     latest: "13.10"
     eol: 2014-05-31
     releaseDate: 2013-10-31
+icon:
+  simpleicons: nixos
 
 ---
 

--- a/products/nodejs.md
+++ b/products/nodejs.md
@@ -5,7 +5,6 @@ alternate_urls:
 -   /node.js
 category: lang
 title: Node.js
-iconSlug: nodedotjs
 releasePolicyLink: https://nodejs.org/about/releases/
 releaseImage: https://raw.githubusercontent.com/nodejs/Release/master/schedule.svg?sanitize=true
 changelogTemplate: https://github.com/nodejs/node/blob/master/doc/changelogs/CHANGELOG_V__RELEASE_CYCLE__.md#__LATEST__
@@ -132,6 +131,8 @@ releases:
     latest: "1.8.4"
     releaseDate: 2015-01-20
     latestReleaseDate: 2015-07-09
+icon:
+  simpleicons: nodedotjs
 
 ---
 

--- a/products/nomad.md
+++ b/products/nomad.md
@@ -1,7 +1,6 @@
 ---
 title: Nomad
 permalink: /nomad
-iconSlug: "NA"
 category: server-app
 releasePolicyLink: https://support.hashicorp.com/hc/articles/360021185113
 sortReleasesBy: "releaseCycle"
@@ -35,10 +34,9 @@ releases:
 -   releaseCycle: "0.12"
     eol: true
     latest: "0.12.12"
-
-
     releaseDate: 2020-07-09
-
+icon:
+  svgporn: nomad
 ---
 
 > [Hashicorp Nomad](https://www.nomadproject.io/) is a simple and flexible workload orchestrator to deploy and manage containers and non-containerized applications across on-prem and clouds at scale.
@@ -48,3 +46,4 @@ Generally Available (GA) releases of active products are supported for up to two
 A major release is identified by a change in the first (X) or second (Y) digit in the following versioning nomenclature: `Version X.Y.Z.`
 
 Hashicorp uses the same support period and EoL Policy for all its products.
+ its products.

--- a/products/nvidiadriver.md
+++ b/products/nvidiadriver.md
@@ -3,7 +3,6 @@ releaseImage: https://docs.nvidia.com/datacenter/tesla/drivers/graphics/driver-b
 title: NVIDIA Driver
 permalink: /nvidia
 category: app
-iconSlug: nvidia
 releasePolicyLink: https://www.nvidia.com/Download/index.aspx
 activeSupportColumn: true
 releaseDateColumn: true
@@ -131,6 +130,8 @@ releases:
     link: https://www.nvidia.com/download/driverResults.aspx/187162/en-us
     cycleShortHand: 13
     releaseDate: 2022-01-11
+icon:
+  simpleicons: nvidia
 
 ---
 

--- a/products/nvidiaproducts.md
+++ b/products/nvidiaproducts.md
@@ -5,7 +5,6 @@ alternate_urls:
 -   /nvidia-products
 -   /nvidia-gpus
 category: device
-iconSlug: nvidia
 releasePolicyLink: https://www.nvidia.com/en-us/geforce/graphics-cards/
 activeSupportColumn: true
 releaseDateColumn: true
@@ -186,6 +185,8 @@ releases:
     eol: false
     discontinued: false
     releaseDate: 2021-01-12
+icon:
+  simpleicons: nvidia
 
 ---
 

--- a/products/office.md
+++ b/products/office.md
@@ -3,7 +3,6 @@ title: Microsoft Office
 permalink: /office
 alternate_urls:
 -   /msoffice
-iconSlug: microsoftoffice
 category: app
 releasePolicyLink: https://docs.microsoft.com/lifecycle/products/?terms=Office
 activeSupportColumn: true
@@ -43,6 +42,8 @@ releases:
     support: 2012-10-09
     eol: 2017-10-10
     releaseDate: 2011-10-25
+icon:
+  simpleicons: microsoftoffice
 
 ---
 

--- a/products/openbsd.md
+++ b/products/openbsd.md
@@ -267,6 +267,8 @@ releases:
     eol: 1998-05-19
     releaseCycle: "2.1"
     link: https://www.openbsd.org/21.html
+icon:
+  simpleicons: openbsd
 
 ---
 

--- a/products/openssl.md
+++ b/products/openssl.md
@@ -1,7 +1,6 @@
 ---
 title: OpenSSL
 category: framework
-iconSlug: openssl
 permalink: /openssl
 releasePolicyLink: https://www.openssl.org/policies/releasestrat.html
 changelogTemplate: |
@@ -31,6 +30,8 @@ releases:
     latest: "1.0.2u"
     lts: true
     releaseDate: 2015-01-22
+icon:
+  simpleicons: openssl
 
 ---
 

--- a/products/opensuse.md
+++ b/products/opensuse.md
@@ -88,8 +88,6 @@ releases:
     eol: 2010-07-26
 
     releaseDate: 2008-06-19
-iconSlug: opensuse
-
 permalink: /opensuse
 alternate_urls:
 -   /opensuseleap
@@ -107,6 +105,8 @@ releaseDateColumn: true
 eolColumn: End of Life
 # Command that can be used to check the current version. (optional)
 versionCommand: cat /usr/lib/os-release
+icon:
+  simpleicons: opensuse
 
 ---
 

--- a/products/openzfs.md
+++ b/products/openzfs.md
@@ -13,7 +13,6 @@ auto:
     regex: ^zfs-(?<major>0|[1-9]\d*)\.(?<minor>0|[1-9]\d*)\.(?<patch>0|[1-9]\d*)$
 releaseDateColumn: true
 sortReleasesBy: 'releaseCycle'
-iconSlug: openzfs
 eolColumn: Critical bug fixes
 releaseLabel: "OpenZFS __RELEASE_CYCLE__"
 releases:
@@ -36,6 +35,8 @@ releases:
     latest: "0.8.6"
     latestReleaseDate: 2020-12-14
     releaseDate: 2019-05-21
+icon:
+  simpleicons: openzfs
 
 ---
 

--- a/products/pan-gp.md
+++ b/products/pan-gp.md
@@ -3,7 +3,6 @@ title: Palo Alto Networks GlobalProtect App
 category: app
 permalink: /pangp
 releasePolicyLink: https://www.paloaltonetworks.com/services/support/end-of-life-announcements/end-of-life-summary
-iconSlug: NA
 activeSupportColumn: true
 releaseColumn: false
 releaseDateColumn: true

--- a/products/pan-os.md
+++ b/products/pan-os.md
@@ -3,7 +3,6 @@ title: Palo Alto Networks PAN-OS
 category: os
 permalink: /panos
 releasePolicyLink: https://www.paloaltonetworks.com/services/support/end-of-life-announcements/end-of-life-summary
-iconSlug: NA
 activeSupportColumn: false
 releaseColumn: false
 releaseDateColumn: true

--- a/products/pan-xdr.md
+++ b/products/pan-xdr.md
@@ -3,7 +3,6 @@ title: Palo Alto Networks Cortex XDR agent
 category: app
 permalink: /cortexxdr
 releasePolicyLink: https://www.paloaltonetworks.com/services/support/end-of-life-announcements/end-of-life-summary
-iconSlug: NA
 activeSupportColumn: false
 releaseColumn: false
 releaseDateColumn: true

--- a/products/perl.md
+++ b/products/perl.md
@@ -45,6 +45,8 @@ releaseColumn: true
 releaseDateColumn: true
 eolColumn: Critical security patches
 versionCommand: perl -v
+icon:
+  simpleicons: perl
 
 ---
 

--- a/products/php.md
+++ b/products/php.md
@@ -124,6 +124,8 @@ releases:
     latest: "5.0.5"
     latestReleaseDate: 2005-09-05
     releaseDate: 2004-07-15
+icon:
+  simpleicons: php
 
 ---
 

--- a/products/pixel.md
+++ b/products/pixel.md
@@ -1,7 +1,6 @@
 ---
 permalink: /pixel
 title: Google Pixel
-iconSlug: google
 category: device
 versionCommand: "Settings -> About Phone -> Regulatory labels"
 releasePolicyLink: https://support.google.com/nexus/answer/4457705
@@ -79,6 +78,8 @@ releases:
     eol: 2018-10-31
     support: 2015-11-19
     releaseDate: 2016-10-04
+icon:
+  simpleicons: google
 
 ---
 

--- a/products/postgresql.md
+++ b/products/postgresql.md
@@ -102,6 +102,8 @@ releases:
     latest: "8.0.26"
     latestReleaseDate: 2010-10-01
     releaseDate: 2005-01-17
+icon:
+  simpleicons: postgresql
 
 ---
 

--- a/products/powershell.md
+++ b/products/powershell.md
@@ -48,6 +48,8 @@ releases:
     latest: "6.0.5"
     latestReleaseDate: 2018-11-13
     releaseDate: 2018-01-10
+icon:
+  simpleicons: powershell
 
 ---
 

--- a/products/python.md
+++ b/products/python.md
@@ -59,6 +59,8 @@ releases:
     latest: "2.7.18"
     latestReleaseDate: 2020-04-19
     releaseDate: 2010-07-03
+icon:
+  simpleicons: python
 
 ---
 

--- a/products/qt.md
+++ b/products/qt.md
@@ -93,6 +93,8 @@ releases:
     lts: true
     link: https://www.qt.io/blog/2015/05/26/qt-4-8-7-released
     releaseDate: 2011-12-15
+icon:
+  simpleicons: qt
 
 ---
 

--- a/products/rabbitmq.md
+++ b/products/rabbitmq.md
@@ -67,6 +67,8 @@ releases:
     latest: "3.0.4"
     latestReleaseDate: 2013-03-06
     releaseDate: 2012-11-19
+icon:
+  simpleicons: rabbitmq
 
 ---
 

--- a/products/react.md
+++ b/products/react.md
@@ -1,7 +1,6 @@
 ---
 title: React
 permalink: /react
-iconSlug: react
 category: framework
 sortReleasesBy: 'releaseCycle'
 releasePolicyLink: https://reactjs.org/docs/release-channels.html
@@ -25,6 +24,8 @@ releases:
 
     latestReleaseDate: 2021-03-22
     releaseDate: 2020-10-20
+icon:
+  simpleicons: react
 
 ---
 

--- a/products/readynas.md
+++ b/products/readynas.md
@@ -4,67 +4,67 @@ category: device
 sortReleasesBy: "releaseCycle"
 changelogTemplate: "https://www.netgear.com/support/product/__RELEASE_CYCLE__.aspx"
 releases:
-- releaseCycle: "RN102"
-  eol: true
-- releaseCycle: "RN104"
-  eol: true
-- releaseCycle: "RN202"
-  eol: true
-- releaseCycle: "RN204"
-  eol: true
-- releaseCycle: "RN212"
-  eol: false
-- releaseCycle: "RN214"
-  eol: false
-- releaseCycle: "RN2120"
-  eol: true
-- releaseCycle: "RN312"
-  eol: true
-- releaseCycle: "RN314"
-  eol: true
-- releaseCycle: "RN316"
-  eol: true
-- releaseCycle: "RN422"
-  eol: false
-- releaseCycle: "RN424"
-  eol: false
-- releaseCycle: "RN426"
-  eol: false
-- releaseCycle: "RN516"
-  eol: true
-- releaseCycle: "RN524X"
-  eol: false
-- releaseCycle: "RN526X"
-  eol: false
-- releaseCycle: "RN528X"
-  eol: false
-- releaseCycle: "RN626X"
-  eol: false
-- releaseCycle: "RN628X"
-  eol: false
-- releaseCycle: "RN716X"
-  eol: true
-- releaseCycle: "RR2304"
-  eol: false
-- releaseCycle: "RN3130"
-  eol: false
-- releaseCycle: "RN3138"
-  eol: false
-- releaseCycle: "RN3220"
-  eol: true
-- releaseCycle: "RR3312"
-  eol: false
-- releaseCycle: "RR4312X"
-  eol: false
-- releaseCycle: "RR4360X"
-  eol: false
-- releaseCycle: "RR4360S"
-  eol: false
-iconSlug: NA
+-   releaseCycle: "RN102"
+    eol: true
+-   releaseCycle: "RN104"
+    eol: true
+-   releaseCycle: "RN202"
+    eol: true
+-   releaseCycle: "RN204"
+    eol: true
+-   releaseCycle: "RN212"
+    eol: false
+-   releaseCycle: "RN214"
+    eol: false
+-   releaseCycle: "RN2120"
+    eol: true
+-   releaseCycle: "RN312"
+    eol: true
+-   releaseCycle: "RN314"
+    eol: true
+-   releaseCycle: "RN316"
+    eol: true
+-   releaseCycle: "RN422"
+    eol: false
+-   releaseCycle: "RN424"
+    eol: false
+-   releaseCycle: "RN426"
+    eol: false
+-   releaseCycle: "RN516"
+    eol: true
+-   releaseCycle: "RN524X"
+    eol: false
+-   releaseCycle: "RN526X"
+    eol: false
+-   releaseCycle: "RN528X"
+    eol: false
+-   releaseCycle: "RN626X"
+    eol: false
+-   releaseCycle: "RN628X"
+    eol: false
+-   releaseCycle: "RN716X"
+    eol: true
+-   releaseCycle: "RR2304"
+    eol: false
+-   releaseCycle: "RN3130"
+    eol: false
+-   releaseCycle: "RN3138"
+    eol: false
+-   releaseCycle: "RN3220"
+    eol: true
+-   releaseCycle: "RR3312"
+    eol: false
+-   releaseCycle: "RR4312X"
+    eol: false
+-   releaseCycle: "RR4360X"
+    eol: false
+-   releaseCycle: "RR4360S"
+    eol: false
 permalink: /readynas
 activeSupportColumn: false
 releaseColumn: false
 releaseDateColumn: false
+
 ---
 
 > ReadyNAS is a line of network-attached storages sold by [Netgear](https://www.netgear.com/).

--- a/products/redhat.md
+++ b/products/redhat.md
@@ -2,7 +2,6 @@
 title: Red Hat Enterprise Linux
 permalink: /rhel
 category: os
-iconSlug: redhat
 alternate_urls:
 -   /redhat
 -   /redhatlinux
@@ -46,6 +45,8 @@ releases:
     support: 2009-03-31
     eol: 2012-02-29
     releaseDate: 2005-02-14
+icon:
+  simpleicons: redhat
 
 ---
 

--- a/products/redis.md
+++ b/products/redis.md
@@ -31,6 +31,8 @@ releases:
     latest: '5.0.14'
     latestReleaseDate: 2021-10-04
     releaseDate: 2018-10-17
+icon:
+  simpleicons: redis
 
 ---
 

--- a/products/rockylinux.md
+++ b/products/rockylinux.md
@@ -4,7 +4,6 @@ title: Rocky Linux
 permalink: /rocky-linux
 category: os
 versionCommand: cat /etc/os-release
-iconSlug: rockylinux
 alternate_urls:
 -   /rocky
 -   /rockylinux
@@ -20,6 +19,8 @@ releases:
     latest: "8.6"
     link: https://rockylinux.org/news/rocky-linux-8-6-ga-release/
     releaseDate: 2021-06-21
+icon:
+  simpleicons: rockylinux
 
 ---
 

--- a/products/ros.md
+++ b/products/ros.md
@@ -28,6 +28,8 @@ releases:
     codename: 'Kinetic Kame'
     eol: 2021-05-01
     releaseDate: 2016-04-23
+icon:
+  simpleicons: ros
 
 ---
 

--- a/products/roundcube.md
+++ b/products/roundcube.md
@@ -53,7 +53,8 @@ releases:
 releasePolicyLink: https://roundcube.net/news/2021/10/18/roundcube-1.5.0-released
 releaseDateColumn: true
 eolColumn: Security Support
-iconSlug: roundcube
+icon:
+  simpleicons: roundcube
 
 ---
 

--- a/products/ruby-on-rails.md
+++ b/products/ruby-on-rails.md
@@ -4,7 +4,6 @@ alternate_urls:
 -   /rubyonrails
 -   /ruby-on-rails
 -   /roro
-iconSlug: rubyonrails
 title: Ruby on Rails
 releasePolicyLink: https://guides.rubyonrails.org/maintenance_policy.html
 changelogTemplate: https://github.com/rails/rails/releases/tag/v__LATEST__
@@ -56,6 +55,8 @@ releases:
     latest: "4.2.11.3"
     latestReleaseDate: 2020-05-15
     releaseDate: 2014-12-19
+icon:
+  simpleicons: rubyonrails
 
 ---
 

--- a/products/ruby.md
+++ b/products/ruby.md
@@ -85,6 +85,8 @@ releases:
 
     latestReleaseDate: 2014-11-13
     releaseDate: 2011-10-30
+icon:
+  simpleicons: ruby
 
 ---
 

--- a/products/samsungmobile.md
+++ b/products/samsungmobile.md
@@ -2,7 +2,6 @@
 permalink: /samsung-mobile
 title: Samsung Mobile
 category: device
-iconSlug: samsung
 releasePolicyLink: https://security.samsungmobile.com/workScope.smsb
 discontinuedColumn: false
 activeSupportColumn: true
@@ -910,6 +909,8 @@ releases:
     support: false
     eol: false
     releaseDate: 2019-04-01
+icon:
+  simpleicons: samsung
 
 ---
 

--- a/products/sles.md
+++ b/products/sles.md
@@ -32,9 +32,6 @@ releases:
     cycleShortHand: 10-SP4
 
     releaseDate: 2006-07-17
-iconSlug: suse
-
-# URL for the page
 permalink: /sles
 alternate_urls:
 -   /suseenterpriseserver
@@ -51,6 +48,8 @@ releaseColumn: true
 releaseDateColumn: true
 LTSLabel: "<abbr title='Long Term Service Pack Support'>LTSS</abbr>"
 versionCommand: cat /etc/os-release
+icon:
+  simpleicons: suse
 
 ---
 
@@ -59,3 +58,4 @@ versionCommand: cat /etc/os-release
 SLES has a thirteen year product lifecycle. The current support model consists of 10 years of general support, followed by 3 years of Long Term Service Pack Support (LTSS). Major versions are released at an interval of 3–4 years, while minor versions (called "Service Packs") are released about every 12 months. SLES receives more intense testing than the upstream openSUSE community product.
 
 SLES 13 and SLES 14 version numbers were skipped. Advisories are published at <https://www.suse.com/support/update/>.
+pdate/>.

--- a/products/splunk.md
+++ b/products/splunk.md
@@ -2,7 +2,6 @@
 title: Splunk
 permalink: /splunk
 category: server-app
-iconSlug: splunk
 releasePolicyLink: https://www.splunk.com/en_us/legal/splunk-software-support-policy.html
 sortReleasesBy: "releaseCycle"
 changelogTemplate: https://docs.splunk.com/Documentation/Splunk/__LATEST__/ReleaseNotes/MeetSplunk
@@ -30,6 +29,8 @@ releases:
     eol: 2021-10-22
     latest: "7.3.9"
     releaseDate: 2021-02-24
+icon:
+  simpleicons: splunk
 
 ---
 

--- a/products/spring-framework.md
+++ b/products/spring-framework.md
@@ -52,7 +52,8 @@ activeSupportColumn: true
 releaseColumn: true
 releaseDateColumn: true
 eolColumn: Security Support
-iconSlug: spring
+icon:
+  simpleicons: spring
 
 ---
 

--- a/products/surface.md
+++ b/products/surface.md
@@ -1,6 +1,5 @@
 ---
 permalink: /surface
-iconSlug: windows
 title: Microsoft Surface
 category: device
 releasePolicyLink: https://docs.microsoft.com/surface/surface-driver-firmware-lifecycle-support
@@ -116,6 +115,8 @@ releases:
 -   releaseCycle: Surface Hub 2S 85"
     eol: 2025-01-11
     releaseDate: 2021-01-11
+icon:
+  simpleicons: windows
 
 ---
 

--- a/products/symfony.md
+++ b/products/symfony.md
@@ -138,6 +138,8 @@ releases:
     lts: true
     latestReleaseDate: 2016-05-30
     releaseDate: 2013-06-03
+icon:
+  simpleicons: symfony
 
 ---
 

--- a/products/tarantool.md
+++ b/products/tarantool.md
@@ -8,7 +8,6 @@ changelogTemplate: https://github.com/tarantool/tarantool/releases/tag/__LATEST_
 auto:
 -   git: https://github.com/tarantool/tarantool.git
 category: db
-iconSlug: NA
 eolColumn: Support Status
 releaseDateColumn: false
 sortReleasesBy: releaseDate
@@ -67,6 +66,8 @@ releases:
     latest: "1.10.13"
     latestReleaseDate: 2022-04-26
     releaseDate: 2018-03-07
+icon:
+  simpleicons: tarantool
 
 ---
 
@@ -80,3 +81,4 @@ Here are the most significant changes from the legacy release policy:
 
 - The third number in the version label doesn’t distinguish between pre-release (alpha and beta) and release versions. Instead, it is used for patch (bugfix-only) releases. Pre-release versions have suffixes, like `3.0.0-alpha1`.
 - In the legacy release policy, `1.10` was a long-term support (LTS) series, while `2.x.y` had stable releases, but wasn’t an LTS series. Now both series are long-term supported.
+m supported.

--- a/products/tomcat.md
+++ b/products/tomcat.md
@@ -1,7 +1,6 @@
 ---
 title: Apache Tomcat
 permalink: /tomcat
-iconSlug: apachetomcat
 releasePolicyLink: https://tomcat.apache.org/whichversion.html
 changelogTemplate: https://dlcdn.apache.org/tomcat/tomcat-__RELEASE_CYCLE__/v__LATEST__/RELEASE-NOTES
 category: server-app
@@ -38,6 +37,8 @@ releases:
     eol: 2012-09-30
     latest: "5.5.36"
     releaseDate: 2003-09-06
+icon:
+  simpleicons: apachetomcat
 
 ---
 

--- a/products/ubuntu.md
+++ b/products/ubuntu.md
@@ -84,6 +84,8 @@ releases:
     eol: 2024-04-01
     latest: "14.04.6"
     releaseDate: 2014-04-17
+icon:
+  simpleicons: ubuntu
 
 ---
 

--- a/products/unity.md
+++ b/products/unity.md
@@ -6,7 +6,6 @@ alternate_urls:
 releasePolicyLink: https://unity3d.com/unity/qa/lts-releases
 releaseDateColumn: true
 releaseColumn: true
-iconSlug: unity
 changelogTemplate: |
   https://unity3d.com/unity/whats-new/__LATEST__
 releaseImage: https://blog-api.unity.com/sites/default/files/2022-04/Unity-2021-LTS-Timeline.jpg
@@ -52,6 +51,8 @@ releases:
     latest: "2017.4.40"
 
     releaseDate: 2017-03-20
+icon:
+  simpleicons: unity
 
 ---
 

--- a/products/unrealircd.md
+++ b/products/unrealircd.md
@@ -9,7 +9,6 @@ releaseDateColumn: true
 versionCommand: ./unrealircd version
 changelogTemplate: "https://github.com/unrealircd/unrealircd/blob/__CYCLE_SHORT_HAND__/doc/RELEASE-NOTES.md#unrealircd-{{'__LATEST__'\
   \ | replace:'.',''}}"
-iconSlug: NA
 auto:
 -   custom: true
 # A list of releases, supported or not
@@ -53,3 +52,4 @@ When a new major version is released, the EOL dates of the previous major versio
 The previous major version is guaranteed to be supported for at least 12 months.
 The final support period starts with a period where bugs are still being fixed (but no new
 features are being implemented), followed by a "security fixes only" period.
+nly" period.

--- a/products/visualstudio.md
+++ b/products/visualstudio.md
@@ -91,13 +91,14 @@ releases:
     cycleShortHand: 2010
 
     releaseDate: 2010-06-29
-iconSlug: visualstudio
 permalink: /visualstudio
 releasePolicyLink: https://docs.microsoft.com/visualstudio/productinfo/vs-servicing
 activeSupportColumn: false
 releaseColumn: false
 releaseDateColumn: false
 eolColumn: Active Support
+icon:
+  simpleicons: visualstudio
 
 ---
 

--- a/products/vmware-esxi.md
+++ b/products/vmware-esxi.md
@@ -1,7 +1,6 @@
 ---
 title: VMware ESXi
 category: os
-iconSlug: vmware
 permalink: /esxi
 alternate_urls:
 -   /esx
@@ -49,6 +48,8 @@ releases:
 
 
     releaseDate: 2013-09-19
+icon:
+  simpleicons: vmware
 
 ---
 

--- a/products/vmware-horizon.md
+++ b/products/vmware-horizon.md
@@ -4,7 +4,6 @@ permalink: /horizon
 alternate_urls:
 -   /vmwarehorizon
 -   /vmware-horizon
-iconSlug: vmware
 category: app
 releasePolicyLink: https://lifecycle.vmware.com/
 activeSupportColumn: true
@@ -57,6 +56,8 @@ releases:
     support: 2021-03-22
     eol: 2023-03-22
     releaseDate: 2016-03-22
+icon:
+  simpleicons: vmware
 
 ---
 

--- a/products/vue.md
+++ b/products/vue.md
@@ -9,7 +9,6 @@ activeSupportColumn: true
 versionCommand: npm list vue
 releaseDateColumn: true
 sortReleasesBy: 'releaseCycle'
-iconSlug: vuedotjs
 auto:
 -   git: https://github.com/vuejs/core.git
 -   git: https://github.com/vuejs/vue.git
@@ -35,6 +34,8 @@ releases:
     lts: false
     latestReleaseDate: 2016-09-27
     releaseDate: 2015-10-26
+icon:
+  simpleicons: vuedotjs
 
 ---
 

--- a/products/wagtail.md
+++ b/products/wagtail.md
@@ -89,6 +89,8 @@ releases:
 
     latestReleaseDate: 2020-07-20
     releaseDate: 2019-11-06
+icon:
+  simpleicons: wagtail
 
 ---
 

--- a/products/windows.md
+++ b/products/windows.md
@@ -149,6 +149,8 @@ releases:
     support: 2009-04-14
     eol: 2014-04-08
     releaseDate: 2008-04-21
+icon:
+  simpleicons: windows
 
 ---
 

--- a/products/windowsEmbedded.md
+++ b/products/windowsEmbedded.md
@@ -1,7 +1,6 @@
 ---
 title: Windows Embedded
 permalink: /windowsembedded
-iconSlug: windows
 releasePolicyLink: https://docs.microsoft.com/lifecycle/products/?terms=Windows%20Embedded
 category: os
 activeSupportColumn: true
@@ -35,6 +34,8 @@ releases:
     support: 2015-10-13
     eol: 2020-10-13
     releaseDate: 2011-02-28
+icon:
+  simpleicons: windows
 
 ---
 

--- a/products/windowsServer.md
+++ b/products/windowsServer.md
@@ -1,7 +1,6 @@
 ---
 title: Windows Server
 permalink: /windowsserver
-iconSlug: windows
 releasePolicyLink: https://docs.microsoft.com/lifecycle/products/?terms=Windows%20Server
 category: os
 activeSupportColumn: true
@@ -97,6 +96,8 @@ releases:
     support: 2005-06-30
     eol: 2010-07-13
     releaseDate: 2000-02-17
+icon:
+  simpleicons: windows
 
 ---
 

--- a/products/wordpress.md
+++ b/products/wordpress.md
@@ -18,13 +18,14 @@ releases:
     link: https://wordpress.org/support/wordpress-version/version-5-9-3/
 auto:
 -   git: https://github.com/WordPress/wordpress-develop.git
-iconSlug: wordpress
 permalink: /wordpress
 activeSupportColumn: false
 releaseColumn: true
 releaseDateColumn: true
 discontinuedColumn: false
 versionCommand: wp core version
+icon:
+  simpleicons: wordpress
 
 ---
 

--- a/products/yocto.md
+++ b/products/yocto.md
@@ -4,7 +4,6 @@ category: os
 sortReleasesBy: "cycleShortHand"
 changelogTemplate: |
   https://docs.yoctoproject.org/migration-guides/migration-{{"__RELEASE_CYCLE__"| split: " " | first}}.html
-iconSlug: NA
 releaseLabel: "__RELEASE_CYCLE__ '__CODENAME__'"
 releases:
 #  - releaseCycle: "4.1"
@@ -88,4 +87,3 @@ A release enters End-of-Life status if no community maintainer steps up, or when
 
 Yocto stable releases (e.g. 3.0, 3.1, 3.2, 3.3…) are made about every 6 months, usually in April and October.
 Stable releases are maintained seven months after the initial release.
-ase.

--- a/products/zabbix.md
+++ b/products/zabbix.md
@@ -11,7 +11,6 @@ releaseDateColumn: true
 sortReleasesBy: "releaseCycle"
 activeSupportColumn: true
 eolColumn: Security Support
-iconSlug: NA
 releases:
 # Uncomment once 6.2 is released
 #  - releaseCycle: "6.2"
@@ -42,10 +41,10 @@ releases:
     eol: 2023-10-31
     lts: true
     latest: "4.0.41"
-
     latestReleaseDate: 2022-05-30
     releaseDate: 2018-10-01
-
+icon:
+  vectorlogozone: zabbix
 ---
 
 > [Zabbix](https://www.zabbix.com/) is an open-source software tool to monitor IT infrastructure such as networks, servers, virtual machines, and cloud services.


### PR DESCRIPTION
This creates a new release filter to help parse the releases in code.
Using Liquid for generating the actual product page is good for simple
prose, but gets too complicated for the remaining part. This can help us
move to a simpler codebase, where the complicated parts are handled by
the code, and the Liquid parts have very little logic.

This would help us make progress on getting API to parity with the HTML (The goal being to have a Release filter that actually parses the page into something both the API and HTML can consume)
