### PR TITLE
[java] Use openjdk icon for java

### DIFF
--- a/products/java.md
+++ b/products/java.md
@@ -5,7 +5,7 @@ alternate_urls:
 -   /jdk
 title: Java/OpenJDK
 category: lang
-iconSlug: NA
+iconSlug: openjdk
 versionCommand: java -version
 activeSupportColumn: true
 releasePolicyLink: https://www.oracle.com/technetwork/java/java-se-support-roadmap.html

--- a/products/java.md
+++ b/products/java.md
@@ -5,6 +5,7 @@ alternate_urls:
 -   /jdk
 title: Java/OpenJDK
 category: lang
+iconSlug: NA
 versionCommand: java -version
 activeSupportColumn: true
 releasePolicyLink: https://www.oracle.com/technetwork/java/java-se-support-roadmap.html


### PR DESCRIPTION
simple icons removed its logo probably because of Copyright things thus it looks like error on our page.
We will use openjdk ( thank you @Evernow for this idea )