### PR TITLE
[mssqlserver] Use releaseLabel

### DIFF
--- a/products/mssqlserver.md
+++ b/products/mssqlserver.md
@@ -9,32 +9,37 @@ versionCommand: select @@version
 releaseDateColumn: true
 sortReleasesBy: 'latest'
 releases:
--   releaseCycle: "2019 CU16"
+-   releaseCycle: "2019"
     support: 2025-01-07
+    releaseLabel:  2019 CU16
     eol: 2030-01-08
     latest: "15.0.4236.7"
     releaseDate: 2019-11-04
--   releaseCycle: "2017 CU29"
+-   releaseCycle: "2017"
     support: 2022-10-11
+    releaseLabel: 2017-CU29
     eol: 2027-10-12
     latest: "14.0.3445.2"
     releaseDate: 2017-09-29
--   releaseCycle: "2016 SP3"
+-   releaseCycle: "2016"
     support: 2021-07-13
+    releaseLabel: 2016 SP3
     eol: 2026-07-14
     latest: "13.0.6419.1"
     releaseDate: 2018-04-24
--   releaseCycle: "2014 SP3 CU4"
+-   releaseCycle: "2014"
     support: 2019-07-09
+    releaseLabel: 2014 SP3 CU4
     eol: 2024-07-09
     latest: "12.0.6439.10"
     releaseDate: 2018-10-30
--   releaseCycle: "2012 SP4"
+-   releaseCycle: "2012"
     support: 2017-07-11
+    releaseLabel: 2012 SP4
     eol: 2022-07-12
     latest: "11.0.7507.2"
     releaseDate: 2017-10-05
--   releaseCycle: "2008 R2 SP3"
+-   releaseCycle: "2008"
     support: 2014-07-08
     eol: 2019-07-09
     latest: "10.50.6560.0"


### PR DESCRIPTION
This improves the API URLs, without changing any of the text. The service-pack isn't really a relevant part releaseCycle, imo - so excluding it from the releaseCycle makes sense. (What we're trying to show is "latest service pack or CU number per release cycle), and maybe there is a better way for that.

For now, this fixes the API URLs from `https://endoflife.date/api/mssqlserver/2014%20SP3.json` to `https://endoflife.date/api/mssqlserver/2014.json`