### PR TITLE
Add nginx 1.23, set eol for 1.21 and 1.20

### DIFF
--- a/products/nginx.md
+++ b/products/nginx.md
@@ -34,7 +34,7 @@ releases:
     latestReleaseDate: 2022-01-25
     releaseDate: 2021-05-25
 -   releaseCycle: "1.20"
-    eol: true
+    eol: 2022-05-24
     latest: "1.20.2"
     latestReleaseDate: 2021-11-16
     releaseDate: 2021-04-20

--- a/products/nginx.md
+++ b/products/nginx.md
@@ -16,13 +16,19 @@ auto:
     regex: ^release-(?<major>0|[1-9]\d*)\.(?<minor>0|[1-9]\d*)\.(?<patch>0|[1-9]\d*)$
 -   hg: https://hg.nginx.org/nginx
 releases:
+-   releaseCycle: "1.23"
+    eol: false
+    latest: "1.23.0"
+    link: https://nginx.org/en/CHANGES
+    latestReleaseDate: 2022-06-22
+    releaseDate: 2022-06-21
 -   releaseCycle: "1.22"
     eol: false
     latest: "1.22.0"
     latestReleaseDate: 2022-05-24
     releaseDate: 2022-05-24
 -   releaseCycle: "1.21"
-    eol: false
+    eol: 2022-05-24
     latest: "1.21.6"
     link: https://nginx.org/en/CHANGES
     latestReleaseDate: 2022-01-25


### PR DESCRIPTION
https://nginx.org/en/CHANGES

as 1.23 is the new mainline, the old 1.21 is end of life.

as i understand the linked blog post 1.20 reached its end of life with the new version 1.22
