### PR TITLE
Update elasticsearch.md cycle 6

### DIFF
--- a/products/elasticsearch.md
+++ b/products/elasticsearch.md
@@ -22,10 +22,10 @@ releases:
     latest: "7.17.4"
     latestReleaseDate: 2022-05-24
     releaseDate: 2019-04-10
--   releaseCycle: "6.0"
-    eol: 2019-05-14
-    latest: "6.0.1"
-    latestReleaseDate: 2017-12-07
+-   releaseCycle: "6"
+    eol: 2022-02-10
+    latest: "6.8.23"
+    latestReleaseDate: 2020-12-29
     releaseDate: 2017-11-14
 
 ---

--- a/products/elasticsearch.md
+++ b/products/elasticsearch.md
@@ -25,7 +25,7 @@ releases:
 -   releaseCycle: "6"
     eol: 2022-02-10
     latest: "6.8.23"
-    latestReleaseDate: 2020-12-29
+    latestReleaseDate: 2022-01-13
     releaseDate: 2017-11-14
 
 ---


### PR DESCRIPTION
Update the elasticsearch cycle 6 to include last release 6.8.23
The cycle 6.0 should be 6 as major release cycle.