### PR TITLE
Add Ansible 6.0

### DIFF
--- a/products/ansible.md
+++ b/products/ansible.md
@@ -16,7 +16,7 @@ releases:
     eol: false
     latest: "6.0.0"
     latestReleaseDate: 2022-06-21
-    releaseDate: 2021-06-21
+    releaseDate: 2022-06-21
 -   releaseCycle: "5"
     eol: false
     latest: "5.9.0"

--- a/products/ansible.md
+++ b/products/ansible.md
@@ -12,6 +12,11 @@ iconSlug: ansible
 auto:
 -   git: https://github.com/ansible-community/ansible-build-data.git
 releases:
+-   releaseCycle: "6"
+    eol: false
+    latest: "6.0.0"
+    latestReleaseDate: 2022-06-21
+    releaseDate: 2021-06-21
 -   releaseCycle: "5"
     eol: false
     latest: "5.9.0"


### PR DESCRIPTION
Ansible 6.0 release announcement https://groups.google.com/g/ansible-announce/c/yprrt94l22w

Ansible 5.0 has one more release to go before it reaches EOL. Couldn't find an exact date for it so leaving it as it is for now https://docs.ansible.com/ansible/latest/reference_appendices/release_and_maintenance.html#ansible-community-changelogs