### PR TITLE
[dotnet] Fix eol dates and add 3.1.26

### DIFF
--- a/products/dotnet.md
+++ b/products/dotnet.md
@@ -18,7 +18,7 @@ releases:
 -   releaseCycle: "6.0"
     cycleShortHand: "6.0"
     lts: true
-    eol: 2024-11-08
+    eol: 2024-11-12
     latest: "6.0.6"
     latestReleaseDate: 2022-06-14
     releaseDate: 2021-11-08
@@ -32,8 +32,9 @@ releases:
 -   releaseCycle: "Core 3.1"
     cycleShortHand: "3.1"
     lts: true
-    latest: "3.1.25"
-    eol: 2022-12-03
+    latest: "3.1.26"
+    latestReleaseDate: 2022-06-14
+    eol: 2022-12-13
     releaseDate: 2019-12-03
 -   releaseCycle: "Core 3.0"
     cycleShortHand: "3.0"
@@ -65,7 +66,6 @@ releases:
     cycleShortHand: "1.0"
     eol: 2019-06-27
     latest: "1.0.16"
-
     releaseDate: 2016-06-27
 
 ---


### PR DESCRIPTION
* Fix eol dates with help of https://github.com/dotnet/core/tree/main/release-notes
* Add 3.1.26 version