### PR TITLE
[CFEngine] Add 3.20 series and missing latestReleaseDate tags

### DIFF
--- a/products/cfengine.md
+++ b/products/cfengine.md
@@ -29,6 +29,7 @@ releases:
     lts: true
     latest: "3.18.2"
     support: 2023-06-24
+    link: https://github.com/cfengine/core/blob/3.18.2/ChangeLog
     eol: false
     releaseDate: 2021-06-24
     latestReleaseDate: 2022-06-29
@@ -36,11 +37,13 @@ releases:
     latest: "3.17.0"
     eol: true
     support: false
+    link: https://github.com/cfengine/core/blob/3.17.0/ChangeLog
     releaseDate: 2020-11-18
     latestReleaseDate: 2020-11-18
 -   releaseCycle: "3.16"
     latest: "3.16.0"
     support: false
+    link: https://github.com/cfengine/core/blob/3.16.0/ChangeLog
     eol: true
     releaseDate: 2020-06-25
     latestReleaseDate: 2020-06-25
@@ -49,6 +52,7 @@ releases:
     latest: "3.15.6"
     eol: false
     support: 2022-12-18
+    link: https://github.com/cfengine/core/blob/3.15.6/ChangeLog
     releaseDate: 2019-12-18
     latestReleaseDate: 2022-06-29
 

--- a/products/cfengine.md
+++ b/products/cfengine.md
@@ -11,10 +11,16 @@ permalink: /cfengine
 releasePolicyLink: https://cfengine.com
 
 releases:
--   releaseCycle: "3.19"
-    latest: "3.19.0"
+-   releaseCycle: "3.20"
+    latest: "3.20.0"
     eol: false
     support: true
+    link: https://github.com/cfengine/core/blob/3.20.0/ChangeLog
+    releaseDate: 2022-07-01
+-   releaseCycle: "3.19"
+    latest: "3.19.0"
+    eol: true
+    support: false
     link: https://github.com/cfengine/core/blob/3.19.0/ChangeLog
     releaseDate: 2021-12-10
 -   releaseCycle: "3.18"

--- a/products/cfengine.md
+++ b/products/cfengine.md
@@ -17,34 +17,40 @@ releases:
     support: true
     link: https://github.com/cfengine/core/blob/3.20.0/ChangeLog
     releaseDate: 2022-07-01
+    latestReleaseDate: 2022-07-01
 -   releaseCycle: "3.19"
     latest: "3.19.0"
     eol: true
     support: false
     link: https://github.com/cfengine/core/blob/3.19.0/ChangeLog
     releaseDate: 2021-12-10
+    latestReleaseDate: 2021-12-10
 -   releaseCycle: "3.18"
     lts: true
     latest: "3.18.2"
     support: 2023-06-24
     eol: false
     releaseDate: 2021-06-24
+    latestReleaseDate: 2022-06-29
 -   releaseCycle: "3.17"
     latest: "3.17.0"
     eol: true
     support: false
     releaseDate: 2020-11-18
+    latestReleaseDate: 2020-11-18
 -   releaseCycle: "3.16"
     latest: "3.16.0"
     support: false
     eol: true
     releaseDate: 2020-06-25
+    latestReleaseDate: 2020-06-25
 -   releaseCycle: "3.15"
     lts: true
     latest: "3.15.6"
     eol: false
     support: 2022-12-18
     releaseDate: 2019-12-18
+    latestReleaseDate: 2022-06-29
 
 ---
 


### PR DESCRIPTION
https://cfengine.com/blog/2022/cfengine-3-20-released-modularity/