### PR TITLE
[Firefox] Add Firefox 102 release

### DIFF
--- a/products/firefox.md
+++ b/products/firefox.md
@@ -14,9 +14,15 @@ releases:
 
 -   releaseCycle: "102"
     eol: false
-    latest: "102.0.0"
+    lts: false
+    releaseDate: 2022-06-28
+
+-   releaseCycle: "102"
+    eol: false
+    latest: "102.0"
     lts: true
     releaseDate: 2022-06-28
+    link: https://www.mozilla.org/firefox/102.0esr/releasenotes/
     
 -   releaseCycle: "91"
     eol: 2022-09-20

--- a/products/firefox.md
+++ b/products/firefox.md
@@ -14,6 +14,7 @@ releases:
 
 -   releaseCycle: "102"
     eol: false
+    latest: "102.0"
     lts: false
     releaseDate: 2022-06-28
 


### PR DESCRIPTION
Add explicit Firefox 102 release after a discussion in #1358 , fix invalid Firefox 102 ESR version and add explizit Firefox 102 ESR link, since the automatically computed one does not resolve correctly.