### PR TITLE
[vue] Release ver 2.7.0 and fixed EoL date of v2.x

### DIFF
--- a/products/vue.md
+++ b/products/vue.md
@@ -23,10 +23,10 @@ releases:
     releaseDate: 2020-09-18
 -   releaseCycle: "2"
     support: 2022-03-18
-    eol: 2023-09-23
-    latest: "2.6.14"
+    eol: 2023-12-31
+    latest: "2.7.0"
     lts: false
-    latestReleaseDate: 2021-06-07
+    latestReleaseDate: 2022-07-01
     releaseDate: 2016-09-30
 -   releaseCycle: "1"
     support: false


### PR DESCRIPTION
Updated the release date of vue 2.7.0 and vue v2.x EoL date.

https://github.com/vuejs/vue/releases/tag/v2.7.0

### Related URL
- Vue 2.7 "Naruto" Released | The Vue Point
  - https://blog.vuejs.org/posts/vue-2-7-naruto.html

> ## Implications of the 2.7 Release
> As stated before, 2.7 is the final minor release of Vue 2.x. After this release, Vue 2 has entered LTS (long-term support) which lasts for 18 months from now, and will no longer receive new features.
> 
> This means Vue 2 will reach End of Life by the end of 2023
