### PR TITLE
[Oracle Linux] Add Oracle Linux 9

### DIFF
--- a/products/oraclelinux.md
+++ b/products/oraclelinux.md
@@ -11,6 +11,12 @@ sortReleasesBy: releaseDate
 iconSlug: oracle
 changelogTemplate: https://docs.oracle.com/en/operating-systems/oracle-linux/__RELEASE_CYCLE__/relnotes__LATEST__/
 releases:
+-   releaseCycle: "9"
+    releaseDate: 2022-06-30
+    support: true
+    eol: false
+    latest: "9.0"
+
 -   releaseCycle: "8"
     releaseDate: 2019-07-18
     support: 2029-07-01


### PR DESCRIPTION
Release details here: https://blogs.oracle.com/linux/post/announcing-oracle-linux-9-general-availability

As far as I can see Oracle has not yet published their support dates, and while it is safe to assume they're similar to RedHat's, sometimes they have different structuring for their Extended Support branch. For now I believe it's safer to simply mark it as true/false respectably.