### PR TITLE
[couchbase] Add 7.1

### DIFF
--- a/products/couchbase-server.md
+++ b/products/couchbase-server.md
@@ -17,7 +17,7 @@ versionCommand: cat /opt/couchbase/VERSION.txt
 
 releases:
 -   releaseCycle: "7.1"
-    eol: no
+    eol: false
     latest: "7.1.1"
     latestReleaseDate: 2022-07-07
     releaseDate: 2022-06-07

--- a/products/couchbase-server.md
+++ b/products/couchbase-server.md
@@ -16,6 +16,11 @@ releaseDateColumn: true
 versionCommand: cat /opt/couchbase/VERSION.txt
 
 releases:
+-   releaseCycle: "7.1"
+    eol: no
+    latest: "7.1.1"
+    latestReleaseDate: 2022-07-07
+    releaseDate: 2022-06-07
 -   releaseCycle: "7.0"
     eol: 2023-01-01
     latest: "7.0.3"


### PR DESCRIPTION
https://docs.couchbase.com/server/current/release-notes/relnotes.html#release-710
releaseDate from https://hub.docker.com/layers/couchbase/library/couchbase/7.1.0/images/sha256-7d39eec7f4b690434d612729e20696704b35af5c65a7452384f7f2ccb4e2e3cf?context=explore
eol listed as TBC No earlier than Jan 2024 on https://www.couchbase.com/support-policy/enterprise-software