### PR TITLE
[auto] Distrowatch configuration changes

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -91,9 +91,11 @@ auto:
     # Use named capturing groups
     # Default value should work for most releases of the form a.b or a.b.c
     # default also skips over any special releases (nightly,beta,pre,rc etc)
+    # The default values can be found here: https://github.com/endoflife-date/release-data/blob/main/update.rb#L19-L20
     regex: ^v(?<major>0|[1-9]\d*)_(?<minor>0|[1-9]\d*)_(?<patch>\d{1,3})_?(?<tiny>\d+)?$
     # A liquid template using the captured variables from the regex above that renders the final version
     # You can use liquid templating here
+    # The default values can be found here: https://github.com/endoflife-date/release-data/blob/main/update.rb#L19-L20
     template: '{{major}}.{{minor}}.{{patch}}{%if tiny %}p{{tiny}}{%endif%}'
 
   # owner/repo combination for a docker hub public image
@@ -103,8 +105,19 @@ auto:
   # Link to package on NPM
   - npm: https://www.npmjs.com/package/abc
 
+  # Use distrowatch page for a given release. (such as https://distrowatch.com/index.php?distribution=debian)
+  - distrowatch: quibbler #distribution ID from the URL
+    # A mandatory regex that is used to parse headlines.
+    # Parse into major/minor/patch named groups
+    # You can also pass a list of regexes here, and matches for any of those will be considered
+    regex: 'Distribution Release: (?P<version>\d+.\d+)'
+    # A template to render default value is same as in `git` above
+    # https://github.com/endoflife-date/release-data/blob/main/src/distrowatch.py
+    template: '{{version}}'
+
   # Use this if the product has a custom script updating releases
-  # in release-data repository
+  # in release-data repository. This will enable the footer note
+  # informing users that releases are automated
   - custom: true
 
 # A list of releases, supported or not

--- a/products/almalinux.md
+++ b/products/almalinux.md
@@ -10,8 +10,8 @@ sortReleasesBy: releaseDate
 iconSlug: NA
 changelogTemplate: https://wiki.almalinux.org/release-notes/__LATEST__.html
 auto:
--   dockerhub: almalinux/9-init
--   dockerhub: almalinux/8-init
+-   distrowatch: alma
+    regex: '^Distribution Release: AlmaLinux OS (?P<major>\d).(?P<minor>\d)$'
 releases:
 -   releaseCycle: "9"
     releaseDate: 2022-07-07

--- a/products/debian.md
+++ b/products/debian.md
@@ -9,6 +9,15 @@ releaseColumn: true
 releaseDateColumn: true
 sortReleasesBy: releaseDate
 releaseLabel: "__RELEASE_CYCLE__ (__CODENAME__)"
+# We have 2 regexes, because there are two variations for headlines
+auto:
+-   distrowatch: debian
+    regex:
+      # https://regex101.com/r/d6SeC6/2
+      - '^Distribution Release: Debian (GNU\/Linux )?(?P<major>\d+)(\.?(?P<minor>\d+)(r(?P<patch>\d))?)?$'
+      # https://regex101.com/r/WQWhwH/1
+      - 'Debian GNU\/Linux (?P<major>\d+)\.(?P<minor>\d+) [Uu]pdated \(r(?P<patch>\d+)\)$'
+    template: "{{major}}{% if minor %}.{{minor}}{% if patch %}.{{patch}}{%endif%}{%endif%}"
 releases:
 -   releaseCycle: "11"
     codename: "Bullseye"

--- a/products/oraclelinux.md
+++ b/products/oraclelinux.md
@@ -10,6 +10,10 @@ eolColumn: Extended Support
 sortReleasesBy: releaseDate
 iconSlug: oracle
 changelogTemplate: https://docs.oracle.com/en/operating-systems/oracle-linux/__RELEASE_CYCLE__/relnotes__LATEST__/
+# https://regex101.com/r/fRdw9L/1
+auto:
+-   distrowatch: oracle
+    regex: '^Distribution Release: Oracle( Enterprise| Unbreakable)? Linux R?(?P<major>\d)(-U|\.| Update )?(?P<minor>\d+)?$'
 releases:
 -   releaseCycle: "9"
     releaseDate: 2022-06-30

--- a/products/rockylinux.md
+++ b/products/rockylinux.md
@@ -13,6 +13,9 @@ activeSupportColumn: true
 releaseDateColumn: true
 sortReleasesBy: releaseDate
 releaseLabel: "Rocky Linux __RELEASE_CYCLE__"
+auto:
+-   distrowatch: rocky
+    regex: '^Distribution Release: Rocky Linux (?P<major>\d)\.(?P<minor>\d)$'
 releases:
 -   releaseCycle: "8"
     support: 2024-05-31

--- a/products/ubuntu.md
+++ b/products/ubuntu.md
@@ -6,7 +6,13 @@ category: os
 releasePolicyLink: https://wiki.ubuntu.com/Releases
 changelogTemplate: |
   https://wiki.ubuntu.com/{{"__CODENAME__"|replace:' ',''}}/ReleaseNotes/ChangeSummary/__LATEST__/
-
+# https://regex101.com/r/Fzt9US/1
+# We return v1 and v2 separated by newline in case 2 releases were marked
+# under the same headline
+auto:
+-   distrowatch: ubuntu
+    regex: '^Distribution Releases?: Ubuntu( Linux)? (?P<v1>\d+\.\d+\.?\d+)(, (?P<v2>\d+\.\d+\.?\d+))?( LTS|, Kubuntu.*)?$'
+    template: "{{v1}}{%if v2%}\n{{v2}}{%endif%}"
 activeSupportColumn: true
 releaseDateColumn: true
 releaseImage: https://user-images.githubusercontent.com/44484725/135176160-a1d5dd88-fc56-44ee-9ce8-98d52a41da2b.png


### PR DESCRIPTION
Release Data is here: https://github.com/endoflife-date/release-data/pull/7

This would fix #1280 and provide automatic release updates for Debian, Ubuntu, Oracle Linux, Rocky, Ubuntu, and Alma Linux

We can track Fedora, Redhat, CentOS, SLES, SUSE, and Mint later, if needed.