### PR TITLE
Extend amazon linux 2 EOL

### DIFF
--- a/products/amazon-linux.md
+++ b/products/amazon-linux.md
@@ -24,7 +24,7 @@ releases:
     releaseDate: "2010-09-14"
 -   releaseCycle: '2'
     releaseLabel: 'Amazon Linux 2'
-    eol: 2023-06-30
+    eol: 2024-06-30
     latest: "2.0.20220606.1"
     latestReleaseDate: 2022-06-21
     releaseDate: 2018-06-26


### PR DESCRIPTION
Amazon [FAQs](https://aws.amazon.com/amazon-linux-2/faqs/) says Amazon Linux 2 EOL is extended to 2024-06-30.

> **Q. When will support for Amazon Linux 2 end?**
> 
> Amazon Linux 2 end of support date (End of Life, or EOL) has been extended by one year from 2023-06-30 to 2024-06-30 to provide customers with ample time to migrate to [Amazon Linux 2022](https://aws.amazon.com/linux/amazon-linux-2022/). Amazon Linux 2022 Generally Available release is scheduled for later this year, and will be supported for five years.