### PR TITLE
[NewProduct] Motorola Mobility

### DIFF
--- a/products/motorola.md
+++ b/products/motorola.md
@@ -9,267 +9,334 @@ releaseDateColumn: true
 releaseColumn: false
 sortReleasesBy: releaseDate
 releases:
--   releaseCycle: "moto g pro"
+-   releaseCycle: "moto-g-pro"
+    releaseLabel: "moto g pro"
     releaseDate: 2020-06-01
     eol: 2023-06-01
     link: https://www.motorola.com/we/smartphones-moto-g-pro/p
--   releaseCycle: "motorola one action"
+-   releaseCycle: "motorola-one-action"
+    releaseLabel: "motorola one action"
     releaseDate: 2019-08-01
     eol: 2022-08-01
     link: https://www.motorola.com/we/smartphones-motorola-one-action/p
--   releaseCycle: "moto g stylus 5g (2022)"
+-   releaseCycle: "moto-g-stylus-5g-2022"
+    releaseLabel: "moto g stylus 5g (2022)"
     releaseDate: 2022-04-01
     eol: 2025-04-01
     link: https://www.motorola.com/us/smartphones-moto-g-stylus-5g-gen-2/p
--   releaseCycle: "moto g 5g (2022)"
+-   releaseCycle: "moto-g-5g-2022"
+    releaseLabel: "moto g 5g (2022)"
     releaseDate: 2022-04-01
     eol: 2025-04-01
     link: https://www.motorola.com/we/smartphones-moto-g-5g/p
--   releaseCycle: "moto g stylus (2022)"
+-   releaseCycle: "moto-g-stylus-2022"
+    releaseLabel: "moto g stylus (2022)"
     releaseDate: 2022-02-01
     eol: 2024-02-01
     link: https://www.motorola.com/us/smartphones-moto-g-stylus/p
--   releaseCycle: "moto g stylus 5g (2022)"
+-   releaseCycle: "moto-g-stylus-5g-2022"
+    releaseLabel: "moto g stylus 5g (2022)"
     releaseDate: 2022-04-01
     eol: 2025-04-01
     link: https://www.motorola.com/us/smartphones-moto-g-stylus-5g-gen-2/p
--   releaseCycle: "moto g power (2022)"
+-   releaseCycle: "moto-g-power-2022"
+    releaseLabel: "moto g power (2022)"
     releaseDate: 2021-11-01
     eol: 2023-11-01
     link: https://www.motorola.com/us/smartphones-moto-g-power-gen-3/p
--   releaseCycle: "moto g pure"
+-   releaseCycle: "moto-g-pure"
+    releaseLabel: "moto g pure"
     releaseDate: 2021-09-01
     eol: 2023-09-01
     link: https://www.motorola.com/us/smartphones-moto-g-pure/p
--   releaseCycle: "moto g stylus 5g"
+-   releaseCycle: "moto-g-stylus-5g"
+    releaseLabel: "moto g stylus 5g"
     releaseDate: 2021-06-01
     eol: 2023-06-01
     link: https://www.motorola.com/us/smartphones-moto-g-stylus-5g/p
--   releaseCycle: "moto g200 5g"
+-   releaseCycle: "moto-g200-5g"
+    releaseLabel: "moto g200 5g"
     releaseDate: 2021-11-01
     eol: 2023-11-01
     link: https://www.motorola.com/we/smartphones-moto-g-200-5g/p
--   releaseCycle: "moto g100"
+-   releaseCycle: "moto-g100"
+    releaseLabel: "moto g100"
     releaseDate: 2021-03-01
     eol: 2023-03-01
     link: https://www.motorola.com/we/smartphones-moto-g-100/p
--   releaseCycle: "moto g82 5g"
+-   releaseCycle: "moto-g82-5g"
+    releaseLabel: "moto g82 5g"
     releaseDate: 2022-05-01
     eol: 2025-05-01
     link: https://www.motorola.com/we/smartphones-moto-g-82-5g/p
--   releaseCycle: "moto g71 5g"
+-   releaseCycle: "moto-g71-5g"
+    releaseLabel: "moto g71 5g"
     releaseDate: 2021-11-01
     eol: 2023-11-01
     link: https://www.motorola.com/we/smartphones-moto-g-71-5g/p
--   releaseCycle: "moto g62 5g"
+-   releaseCycle: "moto-g62-5g"
+    releaseLabel: "moto g62 5g"
     releaseDate: 2022-06-01
     eol: 2025-06-01
     link: https://www.motorola.com/we/smartphones-moto-g-62-5g/p
--   releaseCycle: "moto g60s"
+-   releaseCycle: "moto-g60s"
+    releaseLabel: "moto g60s"
     releaseDate: 2021-06-01
     eol: 2023-06-01
     link: https://www.motorola.com/we/smartphones-moto-g-60-s/p
--   releaseCycle: "moto g60"
+-   releaseCycle: "moto-g60"
+    releaseLabel: "moto g60"
     releaseDate: 2021-05-01
     eol: 2023-05-01
     link: https://www.motorola.com/be/fr/smartphones-moto-g-60/p
--   releaseCycle: "moto g52j 5g"
+-   releaseCycle: "moto-g52j-5g"
+    releaseLabel: "moto g52j 5g"
     releaseDate: 2022-05-01
     eol: 2024-05-01
     link: https://www.motorola.co.jp/smartphone-motorola-moto-g52j/p
--   releaseCycle: "moto g52"
+-   releaseCycle: "moto-g52"
+    releaseLabel: "moto g52"
     releaseDate: 2022-04-01
     eol: 2025-04-01
     link: https://www.motorola.com/we/smartphones-moto-g-52/p
--   releaseCycle: "moto g51 5g"
+-   releaseCycle: "moto-g51-5g"
+    releaseLabel: "moto g51 5g"
     releaseDate: 2021-11-01
     eol: 2023-11-01
     link: https://www.motorola.com/we/smartphones-moto-g-51-5g/p
--   releaseCycle: "moto g50 5g"
+-   releaseCycle: "moto-g50-5g"
+    releaseLabel: "moto g50 5g"
     releaseDate: 2021-08-01
     eol: 2023-08-01
     link: https://nz.motorola.com/smartphones-motorola-g50-5g/p
--   releaseCycle: "moto g50"
+-   releaseCycle: "moto-g50"
+    releaseLabel: "moto g50"
     releaseDate: 2021-03-01
     eol: 2023-03-01
     link: https://www.motorola.com/we/smartphones-moto-g-50/p
--   releaseCycle: "moto g42"
+-   releaseCycle: "moto-g42"
+    releaseLabel: "moto g42"
     releaseDate: 2022-06-01
     eol: 2025-06-01
     link: https://www.motorola.com/we/smartphones-moto-g-42/p
--   releaseCycle: "moto g41"
+-   releaseCycle: "moto-g41"
+    releaseLabel: "moto g41"
     releaseDate: 2021-11-01
     eol: 2023-11-01
     link: https://www.motorola.com/we/smartphones-moto-g-41/p
--   releaseCycle: "moto g40 FUSION"
+-   releaseCycle: "moto-g40-fusion"
+    releaseLabel: "moto g40 FUSION"
     releaseDate: 2021-05-01
     eol: 2023-05-01
     link: https://www.motorola.in/smartphones-moto-g40-fusion/p
--   releaseCycle: "moto g31"
+-   releaseCycle: "moto-g31"
+    releaseLabel: "moto g31"
     releaseDate: 2021-11-01
     eol: 2023-11-01
     link: https://www.motorola.com/we/smartphones-moto-g-31/p
--   releaseCycle: "moto g30"
+-   releaseCycle: "moto-g30"
+    releaseLabel: "moto g30"
     releaseDate: 2021-02-01
     eol: 2023-02-01
     link: https://www.motorola.com/we/smartphones-moto-g-30/p
--   releaseCycle: "moto g22"
+-   releaseCycle: "moto-g22"
+    releaseLabel: "moto g22"
     releaseDate: 2022-03-01
     eol: 2025-03-01
     link: https://www.motorola.com/we/smartphones-moto-g-22/p
--   releaseCycle: "moto g20"
+-   releaseCycle: "moto-g20"
+    releaseLabel: "moto g20"
     releaseDate: 2021-05-01
     eol: 2023-05-01
     link: https://www.motorola.com/we/smartphones-moto-g-20/p
--   releaseCycle: "moto g10 power"
+-   releaseCycle: "moto-g10-power"
+    releaseLabel: "moto g10 power"
     releaseDate: 2021-03-01
     eol: 2023-03-01
     link: https://www.motorola.in/smartphones-moto-g-10-power/p
--   releaseCycle: "moto g10"
+-   releaseCycle: "moto-g10"
+    releaseLabel: "moto g10"
     releaseDate: 2021-03-01
     eol: 2023-03-01
     link: https://www.motorola.com/we/smartphones-moto-g-10/p
--   releaseCycle: "moto g stylus (2021)"
+-   releaseCycle: "moto-g-stylus-2021"
+    releaseLabel: "moto g stylus (2021)"
     releaseDate: 2021-01-01
     eol: 2023-01-01
     link: https://www.motorola.com/us/smartphones-moto-g-stylus-gen-2/p
--   releaseCycle: "moto g pure (2021)"
+-   releaseCycle: "moto-g-pure-2021"
+    releaseLabel: "moto g pure (2021)"
     releaseDate: 2021-11-01
     eol: 2023-11-01
     link: https://www.motorola.com/us/smartphones-moto-g-pure/p
--   releaseCycle: "moto g power (2021)"
+-   releaseCycle: "moto-g-power-2021"
+    releaseLabel: "moto g power (2021)"
     releaseDate: 2021-01-01
     eol: 2023-01-01
     link: https://www.motorola.com/us/smartphones-moto-g-power/p
--   releaseCycle: "moto g play (2021)"
+-   releaseCycle: "moto-g-play-2021"
+    releaseLabel: "moto g play (2021)"
     releaseDate: 2021-01-01
     eol: 2023-01-01
     link: https://www.motorola.com/we/smartphones-moto-g-play/p
--   releaseCycle: "moto g 5g PLUS"
+-   releaseCycle: "moto-g-5g-plus"
+    releaseLabel: "moto g 5g PLUS"
     releaseDate: 2020-07-01
     eol: 2022-07-01
     link: https://www.motorola.com/we/smartphones-moto-g-5g-plus/p
--   releaseCycle: "moto g 5g"
+-   releaseCycle: "moto-g-5g"
+    releaseLabel: "moto g 5g"
     releaseDate: 2020-11-01
     eol: 2022-11-01
     link: https://www.motorola.com/we/smartphones-moto-g-5g/p
--   releaseCycle: "moto g9 power"
+-   releaseCycle: "moto-g9-power"
+    releaseLabel: "moto g9 power"
     releaseDate: 2020-12-01
     eol: 2022-12-01
     link: https://www.motorola.com/we/smartphones-moto-g-power-gen-9/p
--   releaseCycle: "moto g9 plus"
+-   releaseCycle: "moto-g9-plus"
+    releaseLabel: "moto g9 plus"
     releaseDate: 2020-08-01
     eol: 2022-08-01
     link: https://www.motorola.com/nz/smartphones-moto-g-plus-gen-9/p
--   releaseCycle: "moto g9 play"
+-   releaseCycle: "moto-g9-play"
+    releaseLabel: "moto g9 play"
     releaseDate: 2020-08-01
     eol: 2022-08-01
     link: https://www.motorola.com/we/smartphones-moto-g-play-gen-9/p
--   releaseCycle: "moto g9"
+-   releaseCycle: "moto-g9"
+    releaseLabel: "moto g9"
     releaseDate: 2020-08-01
     eol: 2022-08-01
--   releaseCycle: "moto g fast"
+-   releaseCycle: "moto-g-fast"
+    releaseLabel: "moto g fast"
     releaseDate: 2020-06-01
     eol: 2022-06-01
     link: https://www.motorola.com/us/smartphones-moto-g-fast/p
--   releaseCycle: "moto g stylus"
+-   releaseCycle: "moto-g-stylus"
+    releaseLabel: "moto g stylus"
     releaseDate: 2020-04-01
     eol: 2022-04-01
     link: https://www.motorola.com/us/smartphones-moto-g-stylus/p
--   releaseCycle: "moto e40"
+-   releaseCycle: "moto-e40"
+    releaseLabel: "moto e40"
     releaseDate: 2021-09-01
     eol: 2023-09-01
     link: https://www.motorola.com/we/smartphones-moto-e-40/p
--   releaseCycle: "moto e32s"
+-   releaseCycle: "moto-e32s"
+    releaseLabel: "moto e32s"
     releaseDate: 2022-06-01
     eol: 2025-06-01
     link: https://www.motorola.com/we/smartphones-moto-e-32-s/p
--   releaseCycle: "moto e32"
+-   releaseCycle: "moto-e32"
+    releaseLabel: "moto e32"
     releaseDate: 2022-05-01
     eol: 2024-05-01
     link: https://www.motorola.com/we/smartphones-moto-e-32/p
--   releaseCycle: "moto e30"
+-   releaseCycle: "moto-e30"
+    releaseLabel: "moto e30"
     releaseDate: 2021-09-01
     eol: 2023-09-01
     link: https://www.motorola.com/we/smartphones-moto-e-30/p
--   releaseCycle: "moto e20"
+-   releaseCycle: "moto-e20"
+    releaseLabel: "moto e20"
     releaseDate: 2021-09-01
     eol: 2023-09-01
     link: https://www.motorola.com/we/smartphones-moto-e-20/p
--   releaseCycle: "moto e7i power"
+-   releaseCycle: "moto-e7i-power"
+    releaseLabel: "moto e7i power"
     releaseDate: 2021-03-01
     eol: 2023-03-01
     link: https://www.motorola.com/ph/smartphones-moto-e7i-power/p
--   releaseCycle: "moto e7 power"
+-   releaseCycle: "moto-e7-power"
+    releaseLabel: "moto e7 power"
     releaseDate: 2021-01-01
     eol: 2023-01-01
     link: https://www.motorola.com/we/smartphones-moto-e-power-gen-7/p
--   releaseCycle: "moto e7 plus"
+-   releaseCycle: "moto-e7-plus"
+    releaseLabel: "moto e7 plus"
     releaseDate: 2020-09-01
     eol: 2022-09-01
     link: https://np.motorola.com/smartphones-moto-e-plus-gen-7/p
--   releaseCycle: "moto e7"
+-   releaseCycle: "moto-e7"
+    releaseLabel: "moto e7"
     releaseDate: 2020-11-01
     eol: 2022-11-01
     link: https://www.motorola.com/we/smartphones-moto-e-gen-7/p
--   releaseCycle: "moto e (2020)"
+-   releaseCycle: "moto-e-2020"
+    releaseLabel: "moto e (2020)"
     releaseDate: 2020-06-01
     eol: 2022-06-01
--   releaseCycle: "moto e6i"
+-   releaseCycle: "moto-e6i"
+    releaseLabel: "moto e6i"
     releaseDate: 2021-02-01
     eol: 2023-02-01
     link: https://www.motorola.com/we/smartphones-moto-e-i-gen-6/p
--   releaseCycle: "motorola edge 30 pro"
+-   releaseCycle: "motorola-edge-30-pro"
+    releaseLabel: "motorola edge 30 pro"
     releaseDate: 2022-02-01
     eol: 2025-02-01
     link: https://www.motorola.com/we/smartphones-motorola-edge-30-pro/p
--   releaseCycle: "motorola edge 30"
+-   releaseCycle: "motorola-edge-30"
+    releaseLabel: "motorola edge 30"
     releaseDate: 2022-05-01
     eol: 2025-05-01
     link: https://www.motorola.com/we/smartphones-motorola-edge-30/p
--   releaseCycle: "motorola edge+ (2022)"
+-   releaseCycle: "motorola-edge-plus-2022"
+    releaseLabel: "motorola edge+ (2022)"
     releaseDate: 2022-02-01
     eol: 2025-02-01
     link: https://www.motorola.com/us/smartphones-motorola-edge-plus-gen-2/p
--   releaseCycle: "motorola edge20 pro"
+-   releaseCycle: "motorola-edge20-pro"
+    releaseLabel: "motorola edge20 pro"
     releaseDate: 2021-08-01
     eol: 2023-08-01
     link: https://www.motorola.com/we/smartphones-motorola-edge-20-pro/p
--   releaseCycle: "motorola edge20 lite"
+-   releaseCycle: "motorola-edge20-lite"
+    releaseLabel: "motorola edge20 lite"
     releaseDate: 2021-08-01
     eol: 2023-08-01
     link: https://www.motorola.com/we/smartphones-motorola-edge-20-lite/p
--   releaseCycle: "motorola edge20 fusion"
+-   releaseCycle: "motorola-edge20-fusion"
+    releaseLabel: "motorola edge20 fusion"
     releaseDate: 2021-08-01
     eol: 2023-08-01
     link: https://www.motorola.com/nz/smartphones-motorola-edge-20-fusion/p
--   releaseCycle: "motorola edge20"
+-   releaseCycle: "motorola-edge20"
+    releaseLabel: "motorola edge20"
     releaseDate: 2021-08-01
     eol: 2023-08-01
     link: https://www.motorola.com/we/smartphones-motorola-edge-20/p
--   releaseCycle: "motorola one 5G UW ACE"
+-   releaseCycle: "motorola-one-5g-uw-ace"
+    releaseLabel: "motorola one 5G UW ACE"
     releaseDate: 2021-07-01
     eol: 2023-07-01
--   releaseCycle: "motorola one 5G ACE"
+-   releaseCycle: "motorola-one-5g-ace"
+    releaseLabel: "motorola one 5G ACE"
     releaseDate: 2021-01-01
     eol: 2023-01-01
     link: https://www.motorola.com/us/smartphones-motorola-one-5g-ace/p
--   releaseCycle: "motorola one 5G"
+-   releaseCycle: "motorola-one-5g"
+    releaseLabel: "motorola one 5G"
     releaseDate: 2021-08-01
     eol: 2023-08-01
     link: https://www.motorola.com/us/smartphones-motorola-one-5g/p
--   releaseCycle: "motorola one fusion+"
+-   releaseCycle: "motorola-one-fusion-plus"
+    releaseLabel: "motorola one fusion+"
     releaseDate: 2020-06-01
     eol: 2022-06-01
     link: https://www.motorola.com/we/smartphones-motorola-one-fusion-plus/p
--   releaseCycle: "motorola one fusion"
+-   releaseCycle: "motorola-one-fusion"
+    releaseLabel: "motorola one fusion"
     releaseDate: 2020-06-01
     eol: 2022-06-01
--   releaseCycle: "motorola razr 5g"
+-   releaseCycle: "motorola-razr-5g"
+    releaseLabel: "motorola razr 5g"
     releaseDate: 2020-09-01
     eol: 2022-09-01
     link: https://www.motorola.com/we/smartphones-razr-5g
--   releaseCycle: "motorola razr (2020)"
+-   releaseCycle: "motorola-razr-2020"
+    releaseLabel: "motorola razr (2020)"
     releaseDate: 2020-09-01
     eol: 2022-09-01
     link: https://www.motorola.com/us/smartphones-razr-gen-2/p

--- a/products/motorola.md
+++ b/products/motorola.md
@@ -4,10 +4,9 @@ permalink: /motorola
 category: device
 iconSlug: motorola
 releasePolicyLink: https://motorola-global-en-roe.custhelp.com/app/software-upgrade/
-activeSupportColumn: false
+activeSupportColumn: true
 releaseDateColumn: true
 releaseColumn: false
-sortReleasesBy: releaseDate
 releases:
 -   releaseCycle: "moto-g-pro"
     releaseLabel: "moto g pro"
@@ -21,11 +20,13 @@ releases:
     link: https://www.motorola.com/we/smartphones-motorola-one-action/p
 -   releaseCycle: "moto-g-stylus-5g-2022"
     releaseLabel: "moto g stylus 5g (2022)"
+    support: true
     releaseDate: 2022-04-01
     eol: 2025-04-01
     link: https://www.motorola.com/us/smartphones-moto-g-stylus-5g-gen-2/p
 -   releaseCycle: "moto-g-5g-2022"
     releaseLabel: "moto g 5g (2022)"
+    support: true
     releaseDate: 2022-04-01
     eol: 2025-04-01
     link: https://www.motorola.com/we/smartphones-moto-g-5g/p
@@ -34,8 +35,8 @@ releases:
     releaseDate: 2022-02-01
     eol: 2024-02-01
     link: https://www.motorola.com/us/smartphones-moto-g-stylus/p
--   releaseCycle: "moto-g-stylus-5g-2022"
-    releaseLabel: "moto g stylus 5g (2022)"
+-   releaseCycle: "moto-g-stylus"
+    releaseLabel: "moto g stylus"
     releaseDate: 2022-04-01
     eol: 2025-04-01
     link: https://www.motorola.com/us/smartphones-moto-g-stylus-5g-gen-2/p
@@ -66,6 +67,7 @@ releases:
     link: https://www.motorola.com/we/smartphones-moto-g-100/p
 -   releaseCycle: "moto-g82-5g"
     releaseLabel: "moto g82 5g"
+    support: true
     releaseDate: 2022-05-01
     eol: 2025-05-01
     link: https://www.motorola.com/we/smartphones-moto-g-82-5g/p
@@ -76,6 +78,7 @@ releases:
     link: https://www.motorola.com/we/smartphones-moto-g-71-5g/p
 -   releaseCycle: "moto-g62-5g"
     releaseLabel: "moto g62 5g"
+    support: true
     releaseDate: 2022-06-01
     eol: 2025-06-01
     link: https://www.motorola.com/we/smartphones-moto-g-62-5g/p
@@ -116,6 +119,7 @@ releases:
     link: https://www.motorola.com/we/smartphones-moto-g-50/p
 -   releaseCycle: "moto-g42"
     releaseLabel: "moto g42"
+    support: true
     releaseDate: 2022-06-01
     eol: 2025-06-01
     link: https://www.motorola.com/we/smartphones-moto-g-42/p
@@ -129,6 +133,11 @@ releases:
     releaseDate: 2021-05-01
     eol: 2023-05-01
     link: https://www.motorola.in/smartphones-moto-g40-fusion/p
+-   releaseCycle: "moto-g32"
+    releaseDate: 2022-08-01
+    eol: 2025-08-01
+    support: true
+    link: https://www.motorola.in/smartphones-moto-g32/p
 -   releaseCycle: "moto-g31"
     releaseLabel: "moto g31"
     releaseDate: 2021-11-01
@@ -272,18 +281,27 @@ releases:
     releaseDate: 2021-02-01
     eol: 2023-02-01
     link: https://www.motorola.com/we/smartphones-moto-e-i-gen-6/p
+-   releaseCycle: "motorola-edge-30-ultra"
+    releaseLabel: "motorola edge 30 ultra"
+    releaseDate: 2022-09-01
+    eol: 2025-09-01
+    support: true
+    link: https://www.motorola.com/we/smartphones-motorola-edge-30-ultra/p
 -   releaseCycle: "motorola-edge-30-pro"
     releaseLabel: "motorola edge 30 pro"
     releaseDate: 2022-02-01
     eol: 2025-02-01
+    support: true
     link: https://www.motorola.com/we/smartphones-motorola-edge-30-pro/p
 -   releaseCycle: "motorola-edge-30"
     releaseLabel: "motorola edge 30"
     releaseDate: 2022-05-01
     eol: 2025-05-01
+    support: true
     link: https://www.motorola.com/we/smartphones-motorola-edge-30/p
 -   releaseCycle: "motorola-edge-plus-2022"
     releaseLabel: "motorola edge+ (2022)"
+    support: true
     releaseDate: 2022-02-01
     eol: 2025-02-01
     link: https://www.motorola.com/us/smartphones-motorola-edge-plus-gen-2/p

--- a/products/motorola.md
+++ b/products/motorola.md
@@ -275,6 +275,6 @@ releases:
     link: https://www.motorola.com/us/smartphones-razr-gen-2/p
 ---
 
-> [Motorola Mobility LLC](https://en.wikipedia.org/wiki/Motorola_Mobility), marketed as **Motorola**, is an American consumer electronics and telecommunications company, and a subsidiary of Chinese multinational technology company [Lenovo](https://en.wikipedia.org/wiki/Lenovo). Motorola primarily manufactures smartphones and other mobile devices running the Android operating system developed by Google.
+> [Motorola](https://motorola.com) manufactures smartphones and other mobile devices running the Android operating system.
 
 Phones are supported for 2 to 3 years.

--- a/products/motorola.md
+++ b/products/motorola.md
@@ -277,4 +277,4 @@ releases:
 
 > [Motorola](https://motorola.com) manufactures smartphones and other mobile devices running the Android operating system.
 
-Phones are supported for 2 to 3 years.
+Phones are supported for 2 to 3 years, with upgrades pending partner approval in some cases.

--- a/products/motorola.md
+++ b/products/motorola.md
@@ -1,0 +1,280 @@
+---
+title: Motorola
+permalink: /motorola
+category: device
+iconSlug: motorola
+releasePolicyLink: https://motorola-global-en-roe.custhelp.com/app/software-upgrade/
+activeSupportColumn: false
+releaseDateColumn: true
+releaseColumn: false
+sortReleasesBy: releaseDate
+releases:
+-   releaseCycle: "moto g pro"
+    releaseDate: 2020-06-01
+    eol: 2023-06-01
+    link: https://www.motorola.com/we/smartphones-moto-g-pro/p
+-   releaseCycle: "motorola one action"
+    releaseDate: 2019-08-01
+    eol: 2022-08-01
+    link: https://www.motorola.com/we/smartphones-motorola-one-action/p
+-   releaseCycle: "moto g stylus 5g (2022)"
+    releaseDate: 2022-04-01
+    eol: 2025-04-01
+    link: https://www.motorola.com/us/smartphones-moto-g-stylus-5g-gen-2/p
+-   releaseCycle: "moto g 5g (2022)"
+    releaseDate: 2022-04-01
+    eol: 2025-04-01
+    link: https://www.motorola.com/we/smartphones-moto-g-5g/p
+-   releaseCycle: "moto g stylus (2022)"
+    releaseDate: 2022-02-01
+    eol: 2024-02-01
+    link: https://www.motorola.com/us/smartphones-moto-g-stylus/p
+-   releaseCycle: "moto g stylus 5g (2022)"
+    releaseDate: 2022-04-01
+    eol: 2025-04-01
+    link: https://www.motorola.com/us/smartphones-moto-g-stylus-5g-gen-2/p
+-   releaseCycle: "moto g power (2022)"
+    releaseDate: 2021-11-01
+    eol: 2023-11-01
+    link: https://www.motorola.com/us/smartphones-moto-g-power-gen-3/p
+-   releaseCycle: "moto g pure"
+    releaseDate: 2021-09-01
+    eol: 2023-09-01
+    link: https://www.motorola.com/us/smartphones-moto-g-pure/p
+-   releaseCycle: "moto g stylus 5g"
+    releaseDate: 2021-06-01
+    eol: 2023-06-01
+    link: https://www.motorola.com/us/smartphones-moto-g-stylus-5g/p
+-   releaseCycle: "moto g200 5g"
+    releaseDate: 2021-11-01
+    eol: 2023-11-01
+    link: https://www.motorola.com/we/smartphones-moto-g-200-5g/p
+-   releaseCycle: "moto g100"
+    releaseDate: 2021-03-01
+    eol: 2023-03-01
+    link: https://www.motorola.com/we/smartphones-moto-g-100/p
+-   releaseCycle: "moto g82 5g"
+    releaseDate: 2022-05-01
+    eol: 2025-05-01
+    link: https://www.motorola.com/we/smartphones-moto-g-82-5g/p
+-   releaseCycle: "moto g71 5g"
+    releaseDate: 2021-11-01
+    eol: 2023-11-01
+    link: https://www.motorola.com/we/smartphones-moto-g-71-5g/p
+-   releaseCycle: "moto g62 5g"
+    releaseDate: 2022-06-01
+    eol: 2025-06-01
+    link: https://www.motorola.com/we/smartphones-moto-g-62-5g/p
+-   releaseCycle: "moto g60s"
+    releaseDate: 2021-06-01
+    eol: 2023-06-01
+    link: https://www.motorola.com/we/smartphones-moto-g-60-s/p
+-   releaseCycle: "moto g60"
+    releaseDate: 2021-05-01
+    eol: 2023-05-01
+    link: https://www.motorola.com/be/fr/smartphones-moto-g-60/p
+-   releaseCycle: "moto g52j 5g"
+    releaseDate: 2022-05-01
+    eol: 2024-05-01
+    link: https://www.motorola.co.jp/smartphone-motorola-moto-g52j/p
+-   releaseCycle: "moto g52"
+    releaseDate: 2022-04-01
+    eol: 2025-04-01
+    link: https://www.motorola.com/we/smartphones-moto-g-52/p
+-   releaseCycle: "moto g51 5g"
+    releaseDate: 2021-11-01
+    eol: 2023-11-01
+    link: https://www.motorola.com/we/smartphones-moto-g-51-5g/p
+-   releaseCycle: "moto g50 5g"
+    releaseDate: 2021-08-01
+    eol: 2023-08-01
+    link: https://nz.motorola.com/smartphones-motorola-g50-5g/p
+-   releaseCycle: "moto g50"
+    releaseDate: 2021-03-01
+    eol: 2023-03-01
+    link: https://www.motorola.com/we/smartphones-moto-g-50/p
+-   releaseCycle: "moto g42"
+    releaseDate: 2022-06-01
+    eol: 2025-06-01
+    link: https://www.motorola.com/we/smartphones-moto-g-42/p
+-   releaseCycle: "moto g41"
+    releaseDate: 2021-11-01
+    eol: 2023-11-01
+    link: https://www.motorola.com/we/smartphones-moto-g-41/p
+-   releaseCycle: "moto g40 FUSION"
+    releaseDate: 2021-05-01
+    eol: 2023-05-01
+    link: https://www.motorola.in/smartphones-moto-g40-fusion/p
+-   releaseCycle: "moto g31"
+    releaseDate: 2021-11-01
+    eol: 2023-11-01
+    link: https://www.motorola.com/we/smartphones-moto-g-31/p
+-   releaseCycle: "moto g30"
+    releaseDate: 2021-02-01
+    eol: 2023-02-01
+    link: https://www.motorola.com/we/smartphones-moto-g-30/p
+-   releaseCycle: "moto g22"
+    releaseDate: 2022-03-01
+    eol: 2025-03-01
+    link: https://www.motorola.com/we/smartphones-moto-g-22/p
+-   releaseCycle: "moto g20"
+    releaseDate: 2021-05-01
+    eol: 2023-05-01
+    link: https://www.motorola.com/we/smartphones-moto-g-20/p
+-   releaseCycle: "moto g10 power"
+    releaseDate: 2021-03-01
+    eol: 2023-03-01
+    link: https://www.motorola.in/smartphones-moto-g-10-power/p
+-   releaseCycle: "moto g10"
+    releaseDate: 2021-03-01
+    eol: 2023-03-01
+    link: https://www.motorola.com/we/smartphones-moto-g-10/p
+-   releaseCycle: "moto g stylus (2021)"
+    releaseDate: 2021-01-01
+    eol: 2023-01-01
+    link: https://www.motorola.com/us/smartphones-moto-g-stylus-gen-2/p
+-   releaseCycle: "moto g pure (2021)"
+    releaseDate: 2021-11-01
+    eol: 2023-11-01
+    link: https://www.motorola.com/us/smartphones-moto-g-pure/p
+-   releaseCycle: "moto g power (2021)"
+    releaseDate: 2021-01-01
+    eol: 2023-01-01
+    link: https://www.motorola.com/us/smartphones-moto-g-power/p
+-   releaseCycle: "moto g play (2021)"
+    releaseDate: 2021-01-01
+    eol: 2023-01-01
+    link: https://www.motorola.com/we/smartphones-moto-g-play/p
+-   releaseCycle: "moto g 5g PLUS"
+    releaseDate: 2020-07-01
+    eol: 2022-07-01
+    link: https://www.motorola.com/we/smartphones-moto-g-5g-plus/p
+-   releaseCycle: "moto g 5g"
+    releaseDate: 2020-11-01
+    eol: 2022-11-01
+    link: https://www.motorola.com/we/smartphones-moto-g-5g/p
+-   releaseCycle: "moto g9 power"
+    releaseDate: 2020-12-01
+    eol: 2022-12-01
+    link: https://www.motorola.com/we/smartphones-moto-g-power-gen-9/p
+-   releaseCycle: "moto g9 plus"
+    releaseDate: 2020-08-01
+    eol: 2022-08-01
+    link: https://www.motorola.com/nz/smartphones-moto-g-plus-gen-9/p
+-   releaseCycle: "moto g9 play"
+    releaseDate: 2020-08-01
+    eol: 2022-08-01
+    link: https://www.motorola.com/we/smartphones-moto-g-play-gen-9/p
+-   releaseCycle: "moto g9"
+    releaseDate: 2020-08-01
+    eol: 2022-08-01
+-   releaseCycle: "moto g fast"
+    releaseDate: 2020-06-01
+    eol: 2022-06-01
+    link: https://www.motorola.com/us/smartphones-moto-g-fast/p
+-   releaseCycle: "moto g stylus"
+    releaseDate: 2020-04-01
+    eol: 2022-04-01
+    link: https://www.motorola.com/us/smartphones-moto-g-stylus/p
+-   releaseCycle: "moto e40"
+    releaseDate: 2021-09-01
+    eol: 2023-09-01
+    link: https://www.motorola.com/we/smartphones-moto-e-40/p
+-   releaseCycle: "moto e32s"
+    releaseDate: 2022-06-01
+    eol: 2025-06-01
+    link: https://www.motorola.com/we/smartphones-moto-e-32-s/p
+-   releaseCycle: "moto e32"
+    releaseDate: 2022-05-01
+    eol: 2024-05-01
+    link: https://www.motorola.com/we/smartphones-moto-e-32/p
+-   releaseCycle: "moto e30"
+    releaseDate: 2021-09-01
+    eol: 2023-09-01
+    link: https://www.motorola.com/we/smartphones-moto-e-30/p
+-   releaseCycle: "moto e20"
+    releaseDate: 2021-09-01
+    eol: 2023-09-01
+    link: https://www.motorola.com/we/smartphones-moto-e-20/p
+-   releaseCycle: "moto e7i power"
+    releaseDate: 2021-03-01
+    eol: 2023-03-01
+    link: https://www.motorola.com/ph/smartphones-moto-e7i-power/p
+-   releaseCycle: "moto e7 power"
+    releaseDate: 2021-01-01
+    eol: 2023-01-01
+    link: https://www.motorola.com/we/smartphones-moto-e-power-gen-7/p
+-   releaseCycle: "moto e7 plus"
+    releaseDate: 2020-09-01
+    eol: 2022-09-01
+    link: https://np.motorola.com/smartphones-moto-e-plus-gen-7/p
+-   releaseCycle: "moto e7"
+    releaseDate: 2020-11-01
+    eol: 2022-11-01
+    link: https://www.motorola.com/we/smartphones-moto-e-gen-7/p
+-   releaseCycle: "moto e (2020)"
+    releaseDate: 2020-06-01
+    eol: 2022-06-01
+-   releaseCycle: "moto e6i"
+    releaseDate: 2021-02-01
+    eol: 2023-02-01
+    link: https://www.motorola.com/we/smartphones-moto-e-i-gen-6/p
+-   releaseCycle: "motorola edge 30 pro"
+    releaseDate: 2022-02-01
+    eol: 2025-02-01
+    link: https://www.motorola.com/we/smartphones-motorola-edge-30-pro/p
+-   releaseCycle: "motorola edge 30"
+    releaseDate: 2022-05-01
+    eol: 2025-05-01
+    link: https://www.motorola.com/we/smartphones-motorola-edge-30/p
+-   releaseCycle: "motorola edge+ (2022)"
+    releaseDate: 2022-02-01
+    eol: 2025-02-01
+    link: https://www.motorola.com/us/smartphones-motorola-edge-plus-gen-2/p
+-   releaseCycle: "motorola edge20 pro"
+    releaseDate: 2021-08-01
+    eol: 2023-08-01
+    link: https://www.motorola.com/we/smartphones-motorola-edge-20-pro/p
+-   releaseCycle: "motorola edge20 lite"
+    releaseDate: 2021-08-01
+    eol: 2023-08-01
+    link: https://www.motorola.com/we/smartphones-motorola-edge-20-lite/p
+-   releaseCycle: "motorola edge20 fusion"
+    releaseDate: 2021-08-01
+    eol: 2023-08-01
+    link: https://www.motorola.com/nz/smartphones-motorola-edge-20-fusion/p
+-   releaseCycle: "motorola edge20"
+    releaseDate: 2021-08-01
+    eol: 2023-08-01
+    link: https://www.motorola.com/we/smartphones-motorola-edge-20/p
+-   releaseCycle: "motorola one 5G UW ACE"
+    releaseDate: 2021-07-01
+    eol: 2023-07-01
+-   releaseCycle: "motorola one 5G ACE"
+    releaseDate: 2021-01-01
+    eol: 2023-01-01
+    link: https://www.motorola.com/us/smartphones-motorola-one-5g-ace/p
+-   releaseCycle: "motorola one 5G"
+    releaseDate: 2021-08-01
+    eol: 2023-08-01
+    link: https://www.motorola.com/us/smartphones-motorola-one-5g/p
+-   releaseCycle: "motorola one fusion+"
+    releaseDate: 2020-06-01
+    eol: 2022-06-01
+    link: https://www.motorola.com/we/smartphones-motorola-one-fusion-plus/p
+-   releaseCycle: "motorola one fusion"
+    releaseDate: 2020-06-01
+    eol: 2022-06-01
+-   releaseCycle: "motorola razr 5g"
+    releaseDate: 2020-09-01
+    eol: 2022-09-01
+    link: https://www.motorola.com/we/smartphones-razr-5g
+-   releaseCycle: "motorola razr (2020)"
+    releaseDate: 2020-09-01
+    eol: 2022-09-01
+    link: https://www.motorola.com/us/smartphones-razr-gen-2/p
+---
+
+> [Motorola Mobility LLC](https://en.wikipedia.org/wiki/Motorola_Mobility), marketed as **Motorola**, is an American consumer electronics and telecommunications company, and a subsidiary of Chinese multinational technology company [Lenovo](https://en.wikipedia.org/wiki/Lenovo). Motorola primarily manufactures smartphones and other mobile devices running the Android operating system developed by Google.
+
+Phones are supported for 2 to 3 years.

--- a/products/motorola.md
+++ b/products/motorola.md
@@ -358,6 +358,7 @@ releases:
     releaseDate: 2020-09-01
     eol: 2022-09-01
     link: https://www.motorola.com/us/smartphones-razr-gen-2/p
+
 ---
 
 > [Motorola](https://motorola.com) manufactures smartphones and other mobile devices running the Android operating system.

--- a/products/motorola.md
+++ b/products/motorola.md
@@ -1,5 +1,5 @@
 ---
-title: Motorola
+title: Motorola Mobility
 permalink: /motorola
 category: device
 iconSlug: motorola


### PR DESCRIPTION
Used the /we/ pages where available ("Rest of Europe"); /us/ otherwise; and if still that fails, anything goes.
No link for "moto g9", "moto e (2020)", "motorola one 5G UW ACE", "motorola one fusion"