### PR TITLE
[windows] add LTS versions for windows EOL [fixes #1425]

### DIFF
--- a/products/windows.md
+++ b/products/windows.md
@@ -9,6 +9,11 @@ releaseDateColumn: true
 versionCommand: winver
 sortReleasesBy: releaseDate
 releases:
+-   releaseCycle: "Windows 10, version 21H2 (LTS)"
+    cycleShortHand: 10.0.19044
+    support: 2027-01-12
+    eol: 2032-01-13
+    releaseDate: 2021-11-16
 -   releaseCycle: "Windows 10, version 21H2 (E)"
     cycleShortHand: 10.0.19044
     support: 2024-06-11
@@ -64,6 +69,11 @@ releases:
     support: 2020-12-08
     eol: 2020-12-08
     releaseDate: 2019-08-29
+-   releaseCycle: "Windows 10, version 1809 (LTS)"
+    cycleShortHand: 10.0.17763
+    support: 2024-01-09
+    eol: 2029-01-09
+    releaseDate: 2018-11-13
 -   releaseCycle: "Windows 10, version 1809 (E)"
     cycleShortHand: 10.0.17763
     support: 2021-05-11
@@ -104,6 +114,11 @@ releases:
     support: 2018-10-09
     eol: 2018-10-09
     releaseDate: 2017-04-11
+-   releaseCycle: "Windows 10, version 1607 (LTS)"
+    cycleShortHand: 10.0.14393
+    support: 2021-10-12
+    eol: 2026-10-13
+    releaseDate: 2016-08-02
 -   releaseCycle: "Windows 10, version 1607 (E)"
     cycleShortHand: 10.0.14393
     support: 2019-04-09
@@ -119,6 +134,11 @@ releases:
     support: 2017-10-10
     eol: 2017-10-10
     releaseDate: 2015-11-10
+-   releaseCycle: "Windows 10, version 1507 (LTS)"
+    cycleShortHand: 10.0.10240
+    support: 2020-10-13
+    eol: 2025-10-14
+    releaseDate: 2015-07-29
 -   releaseCycle: "Windows 10, version 1507 (E)(W)"
     cycleShortHand: 10.0.10240
     support: 2017-05-09

--- a/products/windows.md
+++ b/products/windows.md
@@ -9,7 +9,8 @@ releaseDateColumn: true
 versionCommand: winver
 sortReleasesBy: releaseDate
 releases:
--   releaseCycle: "Windows 10, version 21H2 (LTS)"
+-   releaseCycle: "Windows 10, version 21H2"
+    lts: true
     cycleShortHand: 10.0.19044
     support: 2027-01-12
     eol: 2032-01-13
@@ -69,7 +70,8 @@ releases:
     support: 2020-12-08
     eol: 2020-12-08
     releaseDate: 2019-08-29
--   releaseCycle: "Windows 10, version 1809 (LTS)"
+-   releaseCycle: "Windows 10, version 1809"
+    lts: true
     cycleShortHand: 10.0.17763
     support: 2024-01-09
     eol: 2029-01-09
@@ -114,7 +116,8 @@ releases:
     support: 2018-10-09
     eol: 2018-10-09
     releaseDate: 2017-04-11
--   releaseCycle: "Windows 10, version 1607 (LTS)"
+-   releaseCycle: "Windows 10, version 1607"
+    lts: true
     cycleShortHand: 10.0.14393
     support: 2021-10-12
     eol: 2026-10-13
@@ -134,7 +137,8 @@ releases:
     support: 2017-10-10
     eol: 2017-10-10
     releaseDate: 2015-11-10
--   releaseCycle: "Windows 10, version 1507 (LTS)"
+-   releaseCycle: "Windows 10, version 1507"
+    lts: true
     cycleShortHand: 10.0.10240
     support: 2020-10-13
     eol: 2025-10-14

--- a/products/windows.md
+++ b/products/windows.md
@@ -176,6 +176,8 @@ releases:
 
 ---
 
+> [Microsoft Windows](https://www.microsoft.com/windows) is the operating system developed by Microsoft Corporation to run on personal computers.
+
 | Note | Comment                                                    |
 | ---- | ---------------------------------------------------------- |
 | (E)  | Enterprise, Education and IoT Enterprise editions          |


### PR DESCRIPTION
- changes
add LTS versions

- reasons
already described (E),(W), and LTS version, but there is no eol of LTS versions in the current API.

- others
ref: https://microsoft.fandom.com/wiki/Windows_10_version_history
ref: https://docs.microsoft.com/en-us/windows/release-health/release-information
ref: https://ja.wikipedia.org/wiki/Microsoft_Windows_10%E3%81%AE%E3%83%90%E3%83%BC%E3%82%B8%E3%83%A7%E3%83%B3%E5%B1%A5%E6%AD%B4#cite_note-Windows_1507_CBB_Support_postponed-6