### PR TITLE
[tarantool] Mark 2.8 series as EOL

### DIFF
--- a/products/tarantool.md
+++ b/products/tarantool.md
@@ -20,7 +20,7 @@ releases:
 
     releaseDate: 2022-05-22
 -   releaseCycle: "2.8"
-    eol: false
+    eol: 2022-04-25
     latest: "2.8.4"
     latestReleaseDate: 2022-04-25
 


### PR DESCRIPTION
See the release lifetime information on the website:

https://www.tarantool.io/en/doc/latest/release/calendar/