### PR TITLE
fix: Angular 14 LTS eol date

### DIFF
--- a/products/angular.md
+++ b/products/angular.md
@@ -12,7 +12,7 @@ auto:
 releases:
 -   releaseCycle: "14"
     support: 2022-12-02
-    eol: 2022-12-02
+    eol: 2023-12-02
     latest: "14.1.2"
     releaseDate: 2022-06-02
     lts: 2022-12-02


### PR DESCRIPTION
The "Security Support" end date for Angular 14 is shown wrong:
https://endoflife.date/angular

<img width="786" alt="Screenshot 2022-08-16 at 12 36 59 PM" src="https://user-images.githubusercontent.com/29686866/184818572-adaa393f-1a3f-4a24-b3db-79cd5367a0f2.png">

Correct date can be found in the official docs:
https://angular.io/guide/releases#support-policy-and-schedule

<img width="575" alt="Screenshot 2022-08-16 at 12 38 25 PM" src="https://user-images.githubusercontent.com/29686866/184818832-58a31546-d252-4d94-93f8-ff61c2d3c7cc.png">
