### PR TITLE
Update macos.md

### DIFF
--- a/products/macos.md
+++ b/products/macos.md
@@ -16,8 +16,8 @@ releases:
     eol: false
     link: https://support.apple.com/HT212585
     releaseDate: 2021-10-25
-    latestReleaseDate: 2022-07-20
-    latest: '12.5'
+    latestReleaseDate: 2022-08-17
+    latest: '12.5.1'
 -   releaseCycle: "11"
     codename: "Big Sur"
     eol: false


### PR DESCRIPTION
Added latest update of macOS 12.5.1, which was released on 8-17-2022.