### PR TITLE
[mariadb] remove not used latestShortHand and fix changelogtemplate

### DIFF
--- a/products/mariadb.md
+++ b/products/mariadb.md
@@ -3,7 +3,7 @@ title: MariaDB
 permalink: /mariadb
 category: db
 releasePolicyLink: https://mariadb.org/about/maintenance-policy/
-changelogTemplate: https://mariadb.com/kb/en/mariadb-__LATEST_SHORT_HAND__-changelog/
+changelogTemplate: https://mariadb.com/kb/en/mariadb-{{"__LATEST__" | replace:'.',''}}-changelog/
 activeSupportColumn: false
 releaseDateColumn: true
 auto:

--- a/products/mariadb.md
+++ b/products/mariadb.md
@@ -28,62 +28,52 @@ releases:
 -   releaseCycle: "10.8"
     eol: 2023-05-20
     latest: "10.8.4"
-    latestShortHand: "1083"
     releaseDate: 2022-05-20
     latestReleaseDate: 2022-08-15
 -   releaseCycle: "10.7"
     eol: 2023-02-14
     latest: "10.7.5"
-    latestShortHand: "1074"
     latestReleaseDate: 2022-08-15
     releaseDate: 2022-02-08
 -   releaseCycle: "10.6"
     eol: 2026-07-06
     latest: "10.6.9"
-    latestShortHand: "1068"
     lts: true
     latestReleaseDate: 2022-08-14
     releaseDate: 2021-07-05
 -   releaseCycle: "10.5"
     eol: 2025-06-24
     latest: "10.5.17"
-    latestShortHand: "10516"
     latestReleaseDate: 2022-08-14
     releaseDate: 2020-06-23
 -   releaseCycle: "10.4"
     eol: 2024-06-18
     latest: "10.4.26"
-    latestShortHand: "10425"
     latestReleaseDate: 2022-08-14
     releaseDate: 2019-06-17
 -   releaseCycle: "10.3"
     eol: 2023-05-25
     latest: "10.3.36"
-    latestShortHand: "10335"
     latestReleaseDate: 2022-08-14
     releaseDate: 2018-05-23
 -   releaseCycle: "10.2"
     eol: 2022-05-23
     latest: "10.2.44"
-    latestShortHand: "10244"
     latestReleaseDate: 2022-05-20
     releaseDate: 2017-05-15
 -   releaseCycle: "10.1"
     eol: 2020-10-17
     latest: "10.1.48"
-    latestShortHand: "10148"
     latestReleaseDate: 2020-10-30
     releaseDate: 2016-09-29
 -   releaseCycle: "10.0"
     eol: 2019-03-31
     latest: "10.0.38"
-    latestShortHand: "10038"
     latestReleaseDate: 2019-01-29
     releaseDate: 2014-06-12
 -   releaseCycle: "5.5"
     eol: 2020-04-11
     latest: "5.5.68"
-    latestShortHand: "5568"
     lts: true
     latestReleaseDate: 2020-05-06
     releaseDate: 2013-01-29


### PR DESCRIPTION
latestShortHand is not needed and also not used in sorting so removing those ones to 
pervent possible to misunderstand by following contributors
Also it was not updated by our bots thus links were always lagged
Thanks @hebbet to let me see that part