### PR TITLE
[react] update security support for react 17

### DIFF
--- a/products/react.md
+++ b/products/react.md
@@ -18,9 +18,8 @@ releases:
     latestReleaseDate: 2022-06-14
     releaseDate: 2022-03-29
 -   releaseCycle: "17"
-    lts: 2022-03-29
     eol: false
-    support: true
+    support: 2022-03-29
     latest: "17.0.2"
 
     latestReleaseDate: 2021-03-22

--- a/products/react.md
+++ b/products/react.md
@@ -19,8 +19,8 @@ releases:
     releaseDate: 2022-03-29
 -   releaseCycle: "17"
     lts: false
-    eol: 2021-03-22
-    support: false
+    eol: 2022-03-29
+    support: true
     latest: "17.0.2"
 
     latestReleaseDate: 2021-03-22

--- a/products/react.md
+++ b/products/react.md
@@ -18,8 +18,8 @@ releases:
     latestReleaseDate: 2022-06-14
     releaseDate: 2022-03-29
 -   releaseCycle: "17"
-    lts: false
-    eol: 2022-03-29
+    lts: 2022-03-29
+    eol: false
     support: true
     latest: "17.0.2"
 


### PR DESCRIPTION
React does not have an EoL policy. While they stop making fixes to previous majors soon as a new major version is released, all major versions will receive an update for critical security fixes.

- https://github.com/reactjs/reactjs.org/issues/1745
- https://www.reddit.com/r/reactjs/comments/a2ifz4/do_react_versions_have_an_end_of_life_like_other/

Also updated the "Active Support" date of react 17 to the release date of react 18 as noted in https://github.com/endoflife-date/endoflife.date/pull/993#discussion_r840790750