### PR TITLE
[magento] Update Magento release information.

### DIFF
--- a/products/magento.md
+++ b/products/magento.md
@@ -11,34 +11,50 @@ auto:
 releaseDateColumn: true
 sortReleasesBy: 'releaseCycle'
 releases:
+-   releaseCycle: "2.4.5"
+    cycleShortHand: 2
+    eol: 2024-11-25
+    support: 2024-11-25
+    link: https://devdocs.magento.com/guides/v2.4/release-notes/open-source-2-4-5.html
+    latest: "2.4.5"
+    latestReleaseDate: 2022-08-09
+    releaseDate: 2022-08-09
+-   releaseCycle: "2.4.4"
+    cycleShortHand: 2
+    eol: 2024-11-25
+    support: 2024-11-25
+    link: https://devdocs.magento.com/guides/v2.4/release-notes/open-source-2-4-4.html
+    latest: "2.4.4"
+    latestReleaseDate: 2022-04-12
+    releaseDate: 2022-04-12
 -   releaseCycle: "2.4.3"
     cycleShortHand: 2
-    eol: 2022-11-30
-    support: 2022-11-30
-    link: https://devdocs.magento.com/guides/v2.4/release-notes/open-source-2-4-4.html
+    eol: 2022-11-28
+    support: 2022-11-28
+    link: https://devdocs.magento.com/guides/v2.4/release-notes/open-source-2-4-3.html
     latest: "2.4.3"
     latestReleaseDate: 2021-08-04
     releaseDate: 2021-08-04
 -   releaseCycle: "2.4.2"
     cycleShortHand: 2
-    eol: 2022-11-30
-    support: 2022-11-30
+    eol: 2022-11-28
+    support: 2022-11-28
     link: https://devdocs.magento.com/guides/v2.4/release-notes/open-source-2-4-2.html
     latest: "2.4.2"
     latestReleaseDate: 2021-02-04
     releaseDate: 2021-02-04
 -   releaseCycle: "2.4.1"
     cycleShortHand: 2
-    eol: 2022-11-30
-    support: 2022-11-30
+    eol: 2022-11-28
+    support: 2022-11-28
     link: https://devdocs.magento.com/guides/v2.4/release-notes/open-source-2-4-1.html
     latest: "2.4.1"
     latestReleaseDate: 2020-10-14
     releaseDate: 2020-10-14
 -   releaseCycle: "2.4.0"
     cycleShortHand: 2
-    eol: 2022-11-30
-    support: 2022-11-30
+    eol: 2022-11-28
+    support: 2022-11-28
     link: https://devdocs.magento.com/guides/v2.4/release-notes/release-notes-2-4-0-open-source.html
     latest: "2.4.0"
     latestReleaseDate: 2020-07-20

--- a/products/magento.md
+++ b/products/magento.md
@@ -160,6 +160,19 @@ For Magento Commerce 2.3 and subsequent releases, Magento will provide software 
 * Magento will provide security patches for a minor release for a minimum of 18 months from the general availability announcement date of the next minor software release.
 * Quality and security fixes will be made available via cumulative patch releases for the currently supported minor release versions only. They will not be backported to previous minor releases, nor to previous patch releases within supported minor releases. For example, while 2.2 and 2.3 are currently supported minor releases, quality and security fixes will be released as 2.2.X and 2.3.Y, where X and Y represent the next incremental patch release cumulative of all prior patches. They will not be released for prior minor releases out of support (e.g. 2.1.Z), or as patches to prior patch releases (e.g. 2.2.1.X).
 
+## PHP Compatibility
+
+Magento | PHP
+--------|---------
+2.3     | 7.3, 7.4
+2.4     | 7.4
+2.4.1   | 7.4
+2.4.2   | 7.4
+2.4.3   | 7.4
+2.4.4   | 8.1
+2.4.5   | 8.1
+2.4.6   | 8.1
+
 [Magento Semantic Versioning Release Policy](https://devdocs.magento.com/release/policy/)
 
 [Magento Security Patch-Only Releases](https://community.magento.com/t5/Magento-DevBlog/Introducing-the-New-Security-only-Patch-Release/ba-p/141287)


### PR DESCRIPTION
Add Magento 2.4.4 and 2.4.5 and also update EOL for previous versions.
Release information: https://devdocs.magento.com/release/
EOL: https://devdocs.magento.com/release/lifecycle-policy.html