### PR TITLE
[eks] Upcoming 1.24 release - WIP

### DIFF
--- a/products/eks.md
+++ b/products/eks.md
@@ -11,9 +11,9 @@ auto:
 releases:
 -   releaseCycle: "1.24"
     eol: 2024-01-01
-    latestReleaseDate: 2022-11-01
-    releaseDate: 2022-11-01
-    latest: "1.24-eks-1"
+    latest: "1.24-eks-2"
+    latestReleaseDate: 2022-11-15
+    releaseDate: 2022-11-07
 -   releaseCycle: "1.23"
     eol: 2023-10-01
     latest: "1.23-eks-1"

--- a/products/eks.md
+++ b/products/eks.md
@@ -9,6 +9,10 @@ changelogTemplate: "https://docs.aws.amazon.com/eks/latest/userguide/kubernetes-
 auto:
 -   custom: true
 releases:
+-   releaseCycle: "1.24"
+    eol: 2024-01-01
+    latestReleaseDate: 2022-11-01
+    releaseDate: 2022-11-01
 -   releaseCycle: "1.23"
     eol: 2023-10-01
     latest: "1.23.7"

--- a/products/eks.md
+++ b/products/eks.md
@@ -13,6 +13,7 @@ releases:
     eol: 2024-01-01
     latestReleaseDate: 2022-11-01
     releaseDate: 2022-11-01
+    latest: "1.24-eks-1"
 -   releaseCycle: "1.23"
     eol: 2023-10-01
     latest: "1.23-eks-1"


### PR DESCRIPTION
Not yet released, but mentioned on the upstream table.

WIP - Let's not merge till 1.24 is released on EKS List: https://docs.aws.amazon.com/eks/latest/userguide/kubernetes-versions.html#available-versions