### PR TITLE
[log4j] Rename log4j to Apache log4j

### DIFF
--- a/products/log4j.md
+++ b/products/log4j.md
@@ -1,6 +1,9 @@
 ---
 title: Apache Log4j
 permalink: /log4j
+alternate_urls:
+-   /apache_log4j
+-   /apache-log4j
 category: framework
 releasePolicyLink: https://logging.apache.org/log4j/2.x/security.html
 changelogTemplate: https://logging.apache.org/log4j/2.x/changes-report.html#a{{"__LATEST__"}}
@@ -46,7 +49,7 @@ Log4j 1 reached End-Of-Life on [August 2015](https://blogs.apache.org/foundation
 
 The only supported Java version is Java 8 and above.
 
-- Log4j 2.13.0 and greater require Java 8.
-- Log4j (2.4 - 2.12.2) require Java 7.
+- Log4j 2.13.0 and greater require Java 8 or above.
+- Log4j (2.4 - 2.12.2) require Java 7 or above.
 - Log4j 2.12.2 was released as an emergency release (to fix CVE-2021-45046 and CVE-2021-44228) and is the last 2.x release to support Java 7. The Log4j team no longer supports Java 7, so this release (while fixing the vulnerability) is no longer supported.
 - Log4j 2.3 was the last 2.x release to support Java 6.

--- a/products/log4j.md
+++ b/products/log4j.md
@@ -1,5 +1,5 @@
 ---
-title: Log4j
+title: Apache Log4j
 permalink: /log4j
 category: framework
 releasePolicyLink: https://logging.apache.org/log4j/2.x/security.html


### PR DESCRIPTION
Proposing that log4j be fully named and thus listed under the Apache section of the page.