### PR TITLE
iPhone - Mark as unsupported

### DIFF
--- a/products/iphone.md
+++ b/products/iphone.md
@@ -50,11 +50,11 @@ releases:
     eol: false
     releaseDate: 2018-09-21
 -   releaseCycle: "iPhone XR"
-    discontinued: true
+    discontinued: 2021-09-07
     eol: false
     releaseDate: 2018-10-26
 -   releaseCycle: "iPhone 11"
-    discontinued: false
+    discontinued: 2022-09-07
     eol: false
     releaseDate: 2019-09-20
 -   releaseCycle: "iPhone 11 Pro / 11 Pro Max"
@@ -62,7 +62,7 @@ releases:
     eol: false
     releaseDate: 2019-09-20
 -   releaseCycle: "iPhone SE (2nd generation)"
-    discontinued: false
+    discontinued: 2022-03-08
     eol: false
     releaseDate: 2020-04-24
 -   releaseCycle: "iPhone 12"
@@ -70,19 +70,22 @@ releases:
     eol: false
     releaseDate: 2020-10-23
 -   releaseCycle: "iPhone 12 Mini"
-    discontinued: false
+    discontinued: 2022-09-07
     eol: false
     releaseDate: 2020-11-13
 -   releaseCycle: "iPhone 12 Pro"
-    discontinued: true
+    discontinued: 2021-09-14
     eol: false
     releaseDate: 2020-10-23
 -   releaseCycle: "iPhone 12 Pro Max"
-    discontinued: true
+    discontinued: 2021-09-14
     eol: false
     releaseDate: 2020-11-13
--   releaseCycle: "iPhone 13 / 13 Mini / 13 Pro / 13 Pro Max"
+-   releaseCycle: "iPhone 13 / 13 Mini"
     discontinued: false
+    eol: false
+-   releaseCycle: "iPhone 13 Pro / 13 Pro Max"
+    discontinued: 2022-09-07
     eol: false
     releaseDate: 2021-09-24
 -   releaseCycle: "iPhone SE (3rd generation)"

--- a/products/iphone.md
+++ b/products/iphone.md
@@ -19,11 +19,11 @@ releases:
     releaseDate: 2013-09-20
 -   releaseCycle: "iPhone 5S"
     discontinued: 2016-03-21
-    eol: 2019-09-19
+    eol: 2022-08-31
     releaseDate: 2013-09-20
 -   releaseCycle: "iPhone 6 / 6 Plus"
     discontinued: 2016-09-07
-    eol: 2019-09-19
+    eol: 2022-08-31
     releaseDate: 2014-09-25
 -   releaseCycle: "iPhone 6S / 6S Plus"
     discontinued: 2018-09-12
@@ -107,5 +107,7 @@ releases:
 > The iPhone is a line of smartphones designed and marketed by Apple Inc. that use Apple's iOS mobile operating system.
 
 Most likely, new iPhone models will come out in September every year (with a few possible exceptions). iPhone support (supported devices gets the latest iOS updates) is quite long. Apple occasionally releases security updates for much older devices, such as [this security fix in iOS 12.5.6](https://support.apple.com/HT213428) which was pushed to iPhone 6 and iPhone 5S.
+
+On new iOS releases, the [previous iOS version is supported for a few months](https://www.zdnet.com/article/still-running-ios-14-on-your-iphone-apple-brings-support-to-an-end/) as a stop-gap to allow users time to update.
 
 Apple maintains a list of Supported iPhone models at <https://support.apple.com/guide/iphone/iphe3fa5df43>.

--- a/products/iphone.md
+++ b/products/iphone.md
@@ -15,27 +15,27 @@ sortReleasesBy: releaseDate
 releases:
 -   releaseCycle: "iPhone 5C"
     discontinued: 2015-09-09
-    eol: true
+    eol: 2017-09-19
     releaseDate: 2013-09-20
 -   releaseCycle: "iPhone 5S"
     discontinued: 2016-03-21
-    eol: true
+    eol: 2019-09-19
     releaseDate: 2013-09-20
 -   releaseCycle: "iPhone 6 / 6 Plus"
     discontinued: 2016-09-07
-    eol: true
+    eol: 2019-09-19
     releaseDate: 2014-09-25
 -   releaseCycle: "iPhone 6S / 6S Plus"
     discontinued: 2018-09-12
-    eol: false
+    eol: 2022-09-12
     releaseDate: 2015-09-25
 -   releaseCycle: "iPhone SE (1st generation)"
     discontinued: 2018-09-12
-    eol: false
+    eol: 2022-09-12
     releaseDate: 2016-03-31
 -   releaseCycle: "iPhone 7 / 7 Plus"
     discontinued: 2019-09-10
-    eol: false
+    eol: 2022-09-12
     releaseDate: 2016-09-16
 -   releaseCycle: "iPhone 8 / 8 Plus"
     discontinued: 2020-04-15

--- a/products/iphone.md
+++ b/products/iphone.md
@@ -84,6 +84,7 @@ releases:
 -   releaseCycle: "iPhone 13 / 13 Mini"
     discontinued: false
     eol: false
+    releaseDate: 2021-09-24
 -   releaseCycle: "iPhone 13 Pro / 13 Pro Max"
     discontinued: 2022-09-07
     eol: false


### PR DESCRIPTION
Mark old iPhones as unsupported.
Correct discontinued dates