### PR TITLE
[mysql] Remove 'latestShortHand', create links from 'latest'

### DIFF
--- a/products/mysql.md
+++ b/products/mysql.md
@@ -2,7 +2,7 @@
 title: MySQL
 category: db
 sortReleasesBy: "releaseCycle"
-changelogTemplate: "https://dev.mysql.com/doc/relnotes/mysql/__RELEASE_CYCLE__/en/news-__LATEST_SHORT_HAND__.html"
+changelogTemplate: "https://dev.mysql.com/doc/relnotes/mysql/__RELEASE_CYCLE__/en/news-{{"__LATEST__" | replace:'.','-'}}.html"
 # dates below are for:
 # support -> GA+5 years = Premier support
 # eol -> GA+8 years = Extended Support
@@ -20,21 +20,18 @@ auto:
 releases:
 -   releaseCycle: "8.0"
     latest: 8.0.30
-    latestShortHand: 8-0-29
     support: 2023-04-30
     eol: 2026-04-30
     latestReleaseDate: 2022-07-06
     releaseDate: 2018-04-08
 -   releaseCycle: "5.7"
     latest: 5.7.39
-    latestShortHand: 5-7-38
     support: 2020-10-31
     eol: 2023-10-31
     latestReleaseDate: 2022-06-06
     releaseDate: 2015-10-09
 -   releaseCycle: "5.6"
     latest: 5.6.51
-    latestShortHand: 5-6-51
     support: 2018-02-28
     eol: 2021-02-28
     latestReleaseDate: 2021-01-05

--- a/products/mysql.md
+++ b/products/mysql.md
@@ -2,7 +2,7 @@
 title: MySQL
 category: db
 sortReleasesBy: "releaseCycle"
-changelogTemplate: "https://dev.mysql.com/doc/relnotes/mysql/__RELEASE_CYCLE__/en/news-{{"__LATEST__" | replace:'.','-'}}.html"
+changelogTemplate: https://dev.mysql.com/doc/relnotes/mysql/__RELEASE_CYCLE__/en/news-{{"__LATEST__" | replace:'.','-'}}.html
 # dates below are for:
 # support -> GA+5 years = Premier support
 # eol -> GA+8 years = Extended Support


### PR DESCRIPTION
Just blatantly following the pattern seen in https://github.com/endoflife-date/endoflife.date/pull/1503. Let me actually quote @usta from https://github.com/endoflife-date/endoflife.date/pull/1503#issue-1344282903:

> Also it was not updated by our bots thus links were always lagged

This is exactly what happened here for MySQL as well - the bot updated two `latest` versions so far, but "forgot" to update the `latestReleaseDate`, which were left linking to the old version:

- ~5.7.38~ &xrarr; **5.7.39** ([`2311a42`](https://github.com/endoflife-date/endoflife.date/commit/2311a4286aeaad503ccc4197f1d0dad0e429bde3#diff-c970884c4fedb53957ab777d67859b37deb2d88c30d25a6bb14a9b5ab957b545)), but the link target is still [https://dev.mysql.com/doc/relnotes/mysql/5.7/en/news-~~**5-7-38**~~.html](https://dev.mysql.com/doc/relnotes/mysql/5.7/en/news-5-7-38.html)
- ~8.0.29~ &xrarr; **8.0.30** ([`0cf0d04`](https://github.com/endoflife-date/endoflife.date/commit/0cf0d048de82bbfb240397308a28669636cc25b1#diff-c970884c4fedb53957ab777d67859b37deb2d88c30d25a6bb14a9b5ab957b545)), but the link target is still [https://dev.mysql.com/doc/relnotes/mysql/8.0/en/news-~~**8-0-29**~~.html](https://dev.mysql.com/doc/relnotes/mysql/8.0/en/news-8-0-29.html)