### PR TITLE
[firefox] Update 104.0.2 and add missing latestReleaseDate infos

### DIFF
--- a/products/firefox.md
+++ b/products/firefox.md
@@ -15,12 +15,14 @@ releases:
 -   releaseCycle: "104"
     eol: false
     latest: "104.0.2"
+    latestReleaseDate: 2022-09-06
     lts: false
     releaseDate: 2022-08-24
 
 -   releaseCycle: "102"
     eol: false
     latest: "102.2.0"
+    latestReleaseDate: 2022-08-23
     lts: true
     releaseDate: 2022-06-28
     link: https://www.mozilla.org/firefox/102.0esr/releasenotes/
@@ -28,12 +30,14 @@ releases:
 -   releaseCycle: "91"
     eol: 2022-09-20
     latest: "91.13.0"
+    latestReleaseDate: 2022-08-23
     lts: true
     releaseDate: 2021-08-10
     
 -   releaseCycle: "78"
     eol: 2021-11-02
     latest: "78.15.0"
+    latestReleaseDate: 2021-10-05
     lts: true
     releaseDate: 2020-06-30
 

--- a/products/firefox.md
+++ b/products/firefox.md
@@ -14,7 +14,7 @@ releases:
 
 -   releaseCycle: "104"
     eol: false
-    latest: "104.0.1"
+    latest: "104.0.2"
     lts: false
     releaseDate: 2022-08-24
 


### PR DESCRIPTION
See
- https://www.mozilla.org/en-US/firefox/releases/
- https://www.mozilla.org/en-US/firefox/104.0.2/releasenotes/