### PR TITLE
Replace docs.microsoft with learn.microsoft in Microsoft links

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ _data/gke.json
 .ionide
 .vscode/*.code-snippets
 *.code-workspace
+node_modules

--- a/products/azure-devops.md
+++ b/products/azure-devops.md
@@ -6,7 +6,7 @@ alternate_urls:
 -   /team-foundation-server
 iconSlug: azuredevops
 category: server-app
-releasePolicyLink: https://docs.microsoft.com/lifecycle/products/?terms=Azure%20DevOps
+releasePolicyLink: https://learn.microsoft.com/lifecycle/products/?terms=Azure%20DevOps
 activeSupportColumn: true
 releaseDateColumn: true
 sortReleasesBy: releaseDate
@@ -15,43 +15,43 @@ releases:
     support: 2025-10-14
     eol: 2030-10-08
     latest: "2020.1.1patch4"
-    link: https://docs.microsoft.com/en-us/azure/devops/server/release-notes/azuredevops2020u1?view=azure-devops-2020#azure-devops-server-202011-patch-4-release-date-january-26-2022
+    link: https://learn.microsoft.com/azure/devops/server/release-notes/azuredevops2020u1?view=azure-devops-2020#azure-devops-server-202011-patch-4-release-date-january-26-2022
     releaseDate: 2020-08-25
 -   releaseCycle: "2019"
     support: 2024-04-09
     eol: 2029-04-10
     latest: "2019.1.1patch13"
-    link: https://docs.microsoft.com/en-us/azure/devops/server/release-notes/azuredevops2019u1?view=azure-devops-2020#azure-devops-server-2019-update-11-patch-13-release-date-january-26-2022
+    link: https://learn.microsoft.com/azure/devops/server/release-notes/azuredevops2019u1?view=azure-devops-2020#azure-devops-server-2019-update-11-patch-13-release-date-january-26-2022
     releaseDate: 2019-03-05
 -   releaseCycle: "2018"
     support: 2023-01-10
     eol: 2028-01-11
     latest: "2018.3.2patch16"
-    link: https://docs.microsoft.com/en-us/visualstudio/releasenotes/tfs2018-update3#team-foundation-server-2018-update-32-patch-16
+    link: https://learn.microsoft.com/visualstudio/releasenotes/tfs2018-update3#team-foundation-server-2018-update-32-patch-16
     releaseDate: 2017-11-15
 -   releaseCycle: "2017"
     support: 2022-01-11
     eol: 2027-01-11
     latest: "2017.3.1patch13"
-    link: https://docs.microsoft.com/en-us/visualstudio/releasenotes/tfs2017-update3#details-of-whats-new-in-team-foundation-server-2017-update-31-patch-13
+    link: https://learn.microsoft.com/visualstudio/releasenotes/tfs2017-update3#details-of-whats-new-in-team-foundation-server-2017-update-31-patch-13
     releaseDate: 2016-11-16
 -   releaseCycle: "2015"
     support: 2020-10-13
     eol: 2025-10-14
     latest: "2015.4.2patch6"
-    link: https://docs.microsoft.com/en-us/visualstudio/releasenotes/tfs2015-update4-vs#details-of-whats-new-in-team-foundation-server-2015-update-42-patch-6
+    link: https://learn.microsoft.com/visualstudio/releasenotes/tfs2015-update4-vs#details-of-whats-new-in-team-foundation-server-2015-update-42-patch-6
     releaseDate: 2015-07-30
 -   releaseCycle: "2013"
     support: 2019-04-09
     eol: 2024-04-09
     latest: "2013.5"
-    link: https://docs.microsoft.com/en-us/visualstudio/releasenotes/vs2013-update5-vs
+    link: https://learn.microsoft.com/visualstudio/releasenotes/vs2013-update5-vs
     releaseDate: 2014-01-15
 -   releaseCycle: "2012"
     support: 2019-01-09
     eol: 2023-01-10
     latest: "2012.4"
-    link: https://docs.microsoft.com/en-us/troubleshoot/developer/visualstudio/install/general/visual-studio-2012-update-4
+    link: https://learn.microsoft.com/troubleshoot/developer/visualstudio/installation/visual-studio-2012-update-4
     releaseDate: 2012-10-31
 -   releaseCycle: "2010"
     support: 2015-07-14
@@ -68,4 +68,4 @@ releases:
 
 > [Azure DevOps Server](https://azure.microsoft.com/services/devops/), is a set of collaborative software development tools, hosted on-premises.
 
-Prior to 2019, Azure DevOps was known as [Team Foundation Server (TFS)](https://docs.microsoft.com/lifecycle/products/?terms=Team%20Foundation%20Server)
+Prior to 2019, Azure DevOps was known as [Team Foundation Server (TFS)](https://learn.microsoft.com/lifecycle/products/?terms=Team%20Foundation%20Server)

--- a/products/dotnetfx.md
+++ b/products/dotnetfx.md
@@ -57,4 +57,4 @@ releases:
 
 > [.NET Framework](https://dotnet.microsoft.com/) is a software framework developed by Microsoft that runs primarily on Microsoft Windows. It includes a large class library called Framework Class Library (FCL) and provides language interoperability across several programming languages.
 
-On operating systems prior to Windows 10 version 1809 and Windows Server 2019, .NET 3.5 SP1 [assumes the same lifecycle policy](https://docs.microsoft.com/lifecycle/faq/dotnet-framework) as the underlying OS on which it is installed.
+On operating systems prior to Windows 10 version 1809 and Windows Server 2019, .NET 3.5 SP1 [assumes the same lifecycle policy](https://learn.microsoft.com/lifecycle/faq/dotnet-framework) as the underlying OS on which it is installed.

--- a/products/internetexplorer.md
+++ b/products/internetexplorer.md
@@ -1,7 +1,7 @@
 ---
 permalink: /internet-explorer
 title: Internet Explorer
-releasePolicyLink: https://docs.microsoft.com/en-us/lifecycle/faq/internet-explorer-microsoft-edge#what-is-the-lifecycle-policy-for-internet-explorer-
+releasePolicyLink: https://learn.microsoft.com/lifecycle/faq/internet-explorer-microsoft-edge#what-is-the-lifecycle-policy-for-internet-explorer-
 releaseDateColumn: true
 releaseColumn: false
 iconSlug: internetexplorer
@@ -10,7 +10,7 @@ eolColumn: Security and technical support
 sortReleasesBy: releaseDate
 releases:
 
--   releaseCycle: "7" 
+-   releaseCycle: "7"
     eol: 2023-10-10
     releaseDate: 2006-10-18
 
@@ -18,7 +18,7 @@ releases:
     eol: 2016-01-12
     releaseDate: 2009-06-17
 
-    
+
 -   releaseCycle: "9"
     eol: 2016-01-12
     releaseDate: 2011-03-15
@@ -31,7 +31,7 @@ releases:
     eol: 2022-06-14
     releaseDate: 2013-11-13
 
-    
+
 -   releaseCycle: "11-ltsb"
     releaseLabel: "11 LTSB/LTSC/Server/Embedded"
     eol: 2031-10-14
@@ -40,12 +40,12 @@ releases:
 
 ---
 
-> [Internet Explorer](https://www.microsoft.com/en-us/download/internet-explorer.aspx), is a proprietary and no longer recommended web browser developed by Microsoft. Internet Explorer has been included with a variety of devices throughout its lifespan such as Windows, Windows Phone, Mac OS, Xbox 360, Xbox One and others.
+> [Internet Explorer](https://www.microsoft.com/download/internet-explorer.aspx), is a proprietary and no longer recommended web browser developed by Microsoft. Internet Explorer has been included with a variety of devices throughout its lifespan such as Windows, Windows Phone, Mac OS, Xbox 360, Xbox One and others.
 
-Microsoft recommends users to transition to [Microsoft Edge](https://www.microsoft.com/en-us/edge), there is an [Internet Explorer mode](https://docs.microsoft.com/en-us/deployedge/edge-ie-mode) included and supported till 2029.
+Microsoft recommends users to transition to [Microsoft Edge](https://www.microsoft.com/edge), there is an [Internet Explorer mode](https://learn.microsoft.com/deployedge/edge-ie-mode) included and supported till 2029.
 
 ## Special notes
 
 - Internet Explorer is end of life on June 14, 2022 for Semi-Annual channel Windows installs (Home, Pro, Education, Enterprise, Workstations editions), regardless of their accompanying operating system's life cycle.
-- Internet Explorer 11 is supported on LTSB, LTSC and Server for their appropiate operating system's life cycle, including ESU. For exceptions to this see [Microsoft's documentation.](https://docs.microsoft.com/en-us/lifecycle/faq/internet-explorer-microsoft-edge#what-is-the-lifecycle-policy-for-internet-explorer-)
-- End of life date for Internet Explorer 11 on non semi-annual channel Windows installs is based on the end of life date of [Windows Server 2022's extended end date](https://docs.microsoft.com/en-us/lifecycle/products/windows-server-2022). But if the operating system that Internet Explorer 11 is installed on loses support prior to this then your installation is unsupported.
+- Internet Explorer 11 is supported on LTSB, LTSC and Server for their appropiate operating system's life cycle, including ESU. For exceptions to this see [Microsoft's documentation.](https://learn.microsoft.com/lifecycle/faq/internet-explorer-microsoft-edge#what-is-the-lifecycle-policy-for-internet-explorer-)
+- End of life date for Internet Explorer 11 on non semi-annual channel Windows installs is based on the end of life date of [Windows Server 2022's extended end date](https://learn.microsoft.com/lifecycle/products/windows-server-2022). But if the operating system that Internet Explorer 11 is installed on loses support prior to this then your installation is unsupported.

--- a/products/msexchange.md
+++ b/products/msexchange.md
@@ -3,7 +3,7 @@ title: Microsoft Exchange
 permalink: /msexchange
 iconSlug: microsoftexchange
 category: server-app
-releasePolicyLink: https://docs.microsoft.com/lifecycle/products/?terms=Exchange%20Server
+releasePolicyLink: https://learn.microsoft.com/lifecycle/products/?terms=Exchange%20Server
 activeSupportColumn: true
 versionCommand: Get-ExchangeServer | Format-List Name,Edition,AdminDisplayVersion
 releaseDateColumn: true
@@ -84,7 +84,7 @@ releases:
 
 > [Microsoft Exchange Server](https://en.wikipedia.org/wiki/Microsoft_Exchange_Server) is a mail server and calendaring server developed by Microsoft.
 
-[Exchange Server build numbers and release dates](https://docs.microsoft.com/exchange/new-features/build-numbers-and-release-dates)
+[Exchange Server build numbers and release dates](https://learn.microsoft.com/exchange/new-features/build-numbers-and-release-dates)
 
 CU: Cumulative Update
 SU: Security Update

--- a/products/mssharepoint.md
+++ b/products/mssharepoint.md
@@ -5,7 +5,7 @@ alternate_urls:
 -   /mssharepoint
 iconSlug: microsoftsharepoint
 category: server-app
-releasePolicyLink: https://docs.microsoft.com/en-us/lifecycle/products/?terms=SharePoint%20Server
+releasePolicyLink: https://learn.microsoft.com/lifecycle/products/?terms=SharePoint%20Server
 activeSupportColumn: true
 releaseDateColumn: true
 sortReleasesBy: releaseDate
@@ -48,6 +48,6 @@ releases:
 
 > [Microsoft SharePoint Server](https://en.wikipedia.org/wiki/SharePoint) is a web-based collaborative platform that integrates with Microsoft Office, developed by Microsoft.
 
-Microsoft publishes tables for each release [detailing the build numbers, versions, and release dates](https://docs.microsoft.com/en-us/officeupdates/sharepoint-updates).
+Microsoft publishes tables for each release [detailing the build numbers, versions, and release dates](https://learn.microsoft.com/officeupdates/sharepoint-updates).
 
 The 2013 version was the last to which Service Pack (SP) appeared. As of 2016 onwards, only security updates are released for the product.

--- a/products/mssqlserver.md
+++ b/products/mssqlserver.md
@@ -3,7 +3,7 @@ title: Microsoft SQL Server
 permalink: /mssqlserver
 iconSlug: microsoftsqlserver
 category: db
-releasePolicyLink: https://docs.microsoft.com/lifecycle/products/?terms=SQL%20Server
+releasePolicyLink: https://learn.microsoft.com/lifecycle/products/?terms=SQL%20Server
 activeSupportColumn: true
 versionCommand: select @@version
 releaseDateColumn: true
@@ -50,7 +50,7 @@ releases:
 
 >[SQLServer](https://www.microsoft.com/sql-server/): Microsoft SQL Server is a relational database management system developed by Microsoft.
 
-[Latest updates for Microsoft SQL Server](https://docs.microsoft.com/sql/database-engine/install-windows/latest-updates-for-microsoft-sql-server)
+[Latest updates for Microsoft SQL Server](https://learn.microsoft.com/sql/database-engine/install-windows/latest-updates-for-microsoft-sql-server)
 
 Each of the products has its own Technical Support Policy, which determine the lifetime and scope of product support.
 

--- a/products/office.md
+++ b/products/office.md
@@ -5,7 +5,7 @@ alternate_urls:
 -   /msoffice
 iconSlug: microsoftoffice
 category: app
-releasePolicyLink: https://docs.microsoft.com/lifecycle/products/?terms=Office
+releasePolicyLink: https://learn.microsoft.com/lifecycle/products/?terms=Office
 activeSupportColumn: true
 releaseColumn: false
 releaseDateColumn: true
@@ -48,4 +48,4 @@ releases:
 
 > Microsoft Office, or simply Office, is a family of client software, server software, and services developed by Microsoft.
 
-Note that Microsoft Office 2019 for Mac is [only supported until 2023-10-10](https://docs.microsoft.com/lifecycle/products/microsoft-office-2019-for-mac).
+Note that Microsoft Office 2019 for Mac is [only supported until 2023-10-10](https://learn.microsoft.com/lifecycle/products/microsoft-office-2019-for-mac).

--- a/products/powershell.md
+++ b/products/powershell.md
@@ -3,7 +3,7 @@ permalink: /powershell
 category: app
 title: PowerShell
 versionCommand: pwsh -v
-releasePolicyLink: https://docs.microsoft.com/lifecycle/products/powershell
+releasePolicyLink: https://learn.microsoft.com/lifecycle/products/powershell
 changelogTemplate: https://github.com/PowerShell/PowerShell/blob/master/CHANGELOG/__RELEASE_CYCLE__.md
 releaseDateColumn: true
 sortReleasesBy: releaseDate
@@ -53,4 +53,4 @@ releases:
 
 > [PowerShell](https://aka.ms/powershell)  is a cross-platform automation and configuration tool/framework that is optimized for dealing with structured data (e.g. JSON, CSV, XML, etc.), REST APIs, and object models. It includes a command-line shell, an associated scripting language and a framework for processing cmdlets.
 
-PowerShell follows the [Modern Lifecycle Policy](https://docs.microsoft.com/powershell/scripting/powershell-support-lifecycle).
+PowerShell follows the [Modern Lifecycle Policy](https://learn.microsoft.com/powershell/scripting/install/PowerShell-Support-Lifecycle).

--- a/products/surface.md
+++ b/products/surface.md
@@ -3,7 +3,7 @@ permalink: /surface
 iconSlug: windows
 title: Microsoft Surface
 category: device
-releasePolicyLink: https://docs.microsoft.com/surface/surface-driver-firmware-lifecycle-support
+releasePolicyLink: https://learn.microsoft.com/surface/surface-driver-firmware-lifecycle-support
 activeSupportColumn: false
 latestColumn: true
 eolColumn: End of Servicing Date
@@ -121,6 +121,6 @@ releases:
 
 > Microsoft Surface is a series of touchscreen-based personal computers and interactive whiteboards designed and developed by Microsoft, running the Microsoft Windows operating system.
 
-Microsoft defines a supported Surface Device as one receiving driver and firmware updates, along with a supported Windows OS version. Surface devices will receive driver and firmware updates for Windows versions released in the prior 30 months. 
+Microsoft defines a supported Surface Device as one receiving driver and firmware updates, along with a supported Windows OS version. Surface devices will receive driver and firmware updates for Windows versions released in the prior 30 months.
 
-Microsoft publishes the [minimum supported Windows version](https://support.microsoft.com/en-gb/surface/surface-supported-operating-systems-9559cc3c-7a38-31b6-d9fb-571435e84cd1). Once the device support period is concluded, devices will continue to receive Windows OS feature and security updates.
+Microsoft publishes the [minimum supported Windows version](https://support.microsoft.com/surface/surface-supported-operating-systems-9559cc3c-7a38-31b6-d9fb-571435e84cd1). Once the device support period is concluded, devices will continue to receive Windows OS feature and security updates.

--- a/products/visualstudio.md
+++ b/products/visualstudio.md
@@ -5,7 +5,7 @@ sortReleasesBy: "releaseDate"
 releaseLabel: '__RELEASE_CYCLE__ __CODENAME__'
 iconSlug: visualstudio
 permalink: /visualstudio
-releasePolicyLink: https://docs.microsoft.com/visualstudio/productinfo/vs-servicing
+releasePolicyLink: https://learn.microsoft.com/visualstudio/productinfo/vs-servicing
 activeSupportColumn: false
 releaseColumn: false
 releaseDateColumn: false
@@ -113,7 +113,7 @@ releases:
 
 ---
 
-> [Visual Studio](https://visualstudio.microsoft.com/) is a full-featured IDE to code, debug, test, and deploy to any platform  
+> [Visual Studio](https://visualstudio.microsoft.com/) is a full-featured IDE to code, debug, test, and deploy to any platform
 
 The Long-Term Servicing Channel (LTSC) enables teams to remain supported on a minor version for up to 18 months after release. The LTSC are separate release Channels based on the even-numbered minor version updates. An LTSC release receives security and bug fixes but not additional new features.
 

--- a/products/windows.md
+++ b/products/windows.md
@@ -1,7 +1,7 @@
 ---
 title: Windows
 permalink: /windows
-releasePolicyLink: https://docs.microsoft.com/lifecycle/products/?terms=Windows
+releasePolicyLink: https://learn.microsoft.com/lifecycle/products/?terms=Windows
 category: os
 activeSupportColumn: true
 releaseColumn: false
@@ -184,12 +184,12 @@ releases:
 | (W)  | Home, Pro, Pro Education and Pro for Workstations editions |
 | LTS  | Long-Term Servicing Channel                                |
 
-[Windows 11 release information](https://docs.microsoft.com/windows/release-health/windows11-release-information)  
-[Windows 10 release information](https://docs.microsoft.com/windows/release-health/release-information)  
+[Windows 11 release information](https://learn.microsoft.com/windows/release-health/windows11-release-information)
+[Windows 10 release information](https://learn.microsoft.com/windows/release-health/release-information)
 [Windows 8.1 update information](https://support.microsoft.com/topic/windows-8-1-and-windows-server-2012-r2-update-history-47d81dd2-6804-b6ae-4112-20089467c7a6)
 [Windows 7 update information](https://support.microsoft.com/topic/windows-7-sp1-and-windows-server-2008-r2-sp1-update-history-720c2590-fd58-26ba-16cc-6d8f3b547599)
-[Windows Lifecycle FAQ](https://docs.microsoft.com/lifecycle/faq/windows)
+[Windows Lifecycle FAQ](https://learn.microsoft.com/lifecycle/faq/windows)
 
 Beginning with Windows 10, version 21H2, feature updates for Windows 10 release are released annually, in the second half of the calendar year.
 
-Prior releases (to Windows 10) are governed by the [Fixed Lifecycle Policy](https://docs.microsoft.com/lifecycle/policies/fixed). This policy comprises two phases: mainstream support and extended support.
+Prior releases (to Windows 10) are governed by the [Fixed Lifecycle Policy](https://learn.microsoft.com/lifecycle/policies/fixed). This policy comprises two phases: mainstream support and extended support.

--- a/products/windowsEmbedded.md
+++ b/products/windowsEmbedded.md
@@ -2,7 +2,7 @@
 title: Windows Embedded
 permalink: /windowsembedded
 iconSlug: windows
-releasePolicyLink: https://docs.microsoft.com/lifecycle/products/?terms=Windows%20Embedded
+releasePolicyLink: https://learn.microsoft.com/lifecycle/products/?terms=Windows%20Embedded
 category: os
 activeSupportColumn: true
 releaseColumn: false
@@ -37,5 +37,3 @@ releases:
     releaseDate: 2011-02-28
 
 ---
-
-

--- a/products/windowsServer.md
+++ b/products/windowsServer.md
@@ -2,7 +2,7 @@
 title: Windows Server
 permalink: /windowsserver
 iconSlug: windows
-releasePolicyLink: https://docs.microsoft.com/lifecycle/products/?terms=Windows%20Server
+releasePolicyLink: https://learn.microsoft.com/lifecycle/products/?terms=Windows%20Server
 category: os
 activeSupportColumn: true
 versionCommand: winver
@@ -99,5 +99,3 @@ releases:
     releaseDate: 2000-02-17
 
 ---
-
-

--- a/recommendations.md
+++ b/recommendations.md
@@ -235,5 +235,5 @@ nice to have. If you do provide such an image, here's some recommendations:
 
 Feedback on this document is welcome [on GitHub](https://github.com/endoflife-date/endoflife.date/discussions).
 
-[aks]: https://docs.microsoft.com/azure/aks/supported-kubernetes-versions?tabs=azure-cli#aks-kubernetes-release-calendar
+[aks]: https://learn.microsoft.com/azure/aks/supported-kubernetes-versions?tabs=azure-cli#aks-kubernetes-release-calendar
 [eks]: https://docs.aws.amazon.com/eks/latest/userguide/kubernetes-versions.html#kubernetes-release-calendar


### PR DESCRIPTION
1.
Microsoft documentation has moved from `docs.microsoft` to `learn.microsoft`.

https://thurrott.com/microsoft/273279

`docs.microsoft` currently redirects seamlessly to `learn.microsoft` and will likely do so for some time to come.

However it is probably still a good idea to change all `docs.microsoft` links to their `learn.microsoft` counterparts.

2.
There seem to be some Microsoft links by British and American contributors with localisation left in the URL.

Most Microsoft links will automatically detect and choose locales if this is left out of the URL. Leaving it in the URL means it will always go to that locale.

This is not a big deal for anglophones, since the differences between variations of English are minor, but it can be a big deal for non-English or English as a foreign language speakers. They might like to read documentation in their native language.

3.
The `node_modules` directory is not in `.gitignore`. This can be annoying when choosing which file to commit, since said modules crowd the list of changed files.