### PR TITLE
Remove bogus latestReleastDate entry

### DIFF
--- a/products/go.md
+++ b/products/go.md
@@ -17,7 +17,6 @@ releases:
 -   releaseCycle: "1.19"
     eol: false
     latest: "1.19.1"
-    latestReleastDate: 2022-08-02
     releaseDate: 2022-08-02
     latestReleaseDate: 2022-09-06
 -   releaseCycle: "1.18"


### PR DESCRIPTION
Using [norwegianblue](https://github.com/hugovk/norwegianblue), I noticed that the data for go shows the column `latestReleastDate`.:

```console
$ eol go    
| cycle | releaseDate | latest  | latestReleaseDate |    eol     | latestReleastDate |
|:------|:-----------:|:--------|:-----------------:|:----------:|:-----------------:|
| 1.19  |  2022-08-02 | 1.19.1  |     2022-09-06    |   False    |     2022-08-02    |
| 1.18  |  2022-03-15 | 1.18.6  |     2022-09-06    |   False    |                   |
| 1.17  |  2021-08-16 | 1.17.13 |     2022-08-01    | 2022-08-02 |                   |
| 1.16  |  2021-02-16 | 1.16.15 |     2022-03-03    |    True    |                   |
| 1.15  |  2020-08-11 | 1.15.15 |     2021-08-04    |    True    |                   |
| 1.14  |  2020-02-25 | 1.14.15 |     2021-02-04    |    True    |                   |
| 1.13  |  2019-09-03 | 1.13.15 |     2020-08-06    |    True    |                   |
| 1.12  |  2019-02-25 | 1.12.17 |     2020-02-12    |    True    |                   |
| 1.11  |  2018-08-24 | 1.11.13 |     2019-08-13    |    True    |                   |
| 1.10  |  2018-02-16 | 1.10.8  |     2019-01-23    |    True    |                   |
```

I tracked the origin to this file.

This patch removes the bogus entry.