### PR TITLE
[WordPress] Add older Versions

### DIFF
--- a/products/wordpress.md
+++ b/products/wordpress.md
@@ -183,7 +183,7 @@ Only the latest major release is supported. Security patches are backported when
 
 ## PHP Support
 
-Version | PHP
+WordPress Version | Supported PHP Versions
 --------|-----------
 3.7     | 5.2 - 5.5 
 3.8     | 5.2 - 5.5 

--- a/products/wordpress.md
+++ b/products/wordpress.md
@@ -66,4 +66,4 @@ versionCommand: wp core version
 
 > [WordPress](https://wordpress.org/) is a free and open-source content management system written in PHP.
 
-Only the latest major release is supported. Security patches are backported when possible, but this is not guaranteed. As of September 2022, Version 3.7 to 4.0 won't get security updates after Dec 1, 2022
+Only the latest major release is supported. Security patches are backported when possible, but this is not guaranteed. As of September 2022, Version 3.7 to 4.0 won't get security updates after Dec 1, 2022.

--- a/products/wordpress.md
+++ b/products/wordpress.md
@@ -4,17 +4,47 @@ category: server-app
 releasePolicyLink: https://codex.wordpress.org/Supported_Versions
 changelogTemplate:  https://wordpress.org/support/wordpress-version/version-{{"__LATEST__" | replace:'.','-'}}/
 sortReleasesBy: "releaseCycle"
+activeSupportColumn: true
 releases:
 -   releaseCycle: "6.0"
     eol: false
+    support: true
     releaseDate: 2022-05-24
     latest: "6.0.2"
     latestReleaseDate: 2022-08-30
 -   releaseCycle: "5.9"
-    eol: 2022-05-24
+    eol: false
+    support: 2022-05-24
     releaseDate: 2022-01-25
     latestReleaseDate: 2022-08-30
     latest: "5.9.4"
+-   releaseCycle: "5.8"
+    eol: false
+    support: 2022-01-25
+    releaseDate: 2021-07-20
+    latestReleaseDate: 2022-08-30
+    latest: "5.8.5"
+-   releaseCycle: "5.7"
+    eol: false
+    support: 2021-07-20
+    releaseDate: 2021-03-09
+    latestReleaseDate: 2022-08-30
+    latest: "5.7.7"
+-   releaseCycle: "5.6"
+    eol: false
+    support: 2021-03-09
+    releaseDate: 2020-12-08
+    latestReleaseDate: 2022-08-30
+    latest: "5.6.9"
+-   releaseCycle: "5.5"
+    eol: false
+    support: 2020-12-08
+    releaseDate: 2020-08-11
+    latestReleaseDate: 2022-08-30
+    latest: "5.5.10"
+
+
+
 auto:
 -   git: https://github.com/WordPress/wordpress-develop.git
 purls:
@@ -36,4 +66,4 @@ versionCommand: wp core version
 
 > [WordPress](https://wordpress.org/) is a free and open-source content management system written in PHP.
 
-Only the latest major release is supported. Security patches are backported when possible, but this is not guaranteed.
+Only the latest major release is supported. Security patches are backported when possible, but this is not guaranteed. As of September 2022, Version 3.7-

--- a/products/wordpress.md
+++ b/products/wordpress.md
@@ -42,6 +42,54 @@ releases:
     releaseDate: 2020-08-11
     latestReleaseDate: 2022-08-30
     latest: "5.5.10"
+-   releaseCycle: "5.4"
+    eol: false
+    support: 2020-08-11
+    releaseDate: 2020-03-31
+    latestReleaseDate: 2022-08-30
+    latest: "5.4.11"
+-   releaseCycle: "5.3"
+    eol: false
+    support: 2020-03-31
+    releaseDate: 2019-11-12
+    latestReleaseDate: 2022-08-30
+    latest: "5.3.13"
+-   releaseCycle: "5.2"
+    eol: false
+    support: 2019-11-12
+    releaseDate: 2019-05-07
+    latestReleaseDate: 2022-08-30
+    latest: "5.2.16"
+-   releaseCycle: "5.1"
+    eol: false
+    support: 2019-05-07
+    releaseDate: 2019-02-21
+    latestReleaseDate: 2022-08-30
+    latest: "5.1.14"
+-   releaseCycle: "5.0"
+    eol: false
+    support: 2019-02-21
+    releaseDate: 2018-12-06
+    latestReleaseDate: 2022-08-30
+    latest: "5.0.17"
+-   releaseCycle: "4.9"
+    eol: false
+    support: 2018-12-06
+    releaseDate: 2017-11-16
+    latestReleaseDate: 2022-08-30
+    latest: "4.9.21"
+-   releaseCycle: "4.8"
+    eol: false
+    support: 2017-11-16
+    releaseDate: 2017-06-08
+    latestReleaseDate: 2022-08-30
+    latest: "4.8.20"
+-   releaseCycle: "4.7"
+    eol: false
+    support: 2017-06-08
+    releaseDate: 2016-12-06
+    latestReleaseDate: 2022-08-30
+    latest: "4.7.24"
 
 
 

--- a/products/wordpress.md
+++ b/products/wordpress.md
@@ -90,6 +90,72 @@ releases:
     releaseDate: 2016-12-06
     latestReleaseDate: 2022-08-30
     latest: "4.7.24"
+-   releaseCycle: "4.6"
+    eol: false
+    support: 2016-12-06
+    releaseDate: 2016-08-16
+    latestReleaseDate: 2022-08-30
+    latest: "4.6.24"
+-   releaseCycle: "4.5"
+    eol: false
+    support: 2016-08-16
+    releaseDate: 2016-04-12
+    latestReleaseDate: 2022-08-30
+    latest: "4.5.27"
+-   releaseCycle: "4.4"
+    eol: false
+    support: 2016-04-12
+    releaseDate: 2015-12-08
+    latestReleaseDate: 2022-08-30
+    latest: "4.4.28"
+-   releaseCycle: "4.3"
+    eol: false
+    support: 2015-12-08
+    releaseDate: 2015-08-18
+    latestReleaseDate: 2022-08-30
+    latest: "4.3.29"
+-   releaseCycle: "4.2"
+    eol: false
+    support: 2015-08-18
+    releaseDate: 2015-04-23
+    latestReleaseDate: 2022-08-30
+    latest: "4.2.33"
+-   releaseCycle: "4.1"
+    eol: false
+    support: 2015-04-23
+    releaseDate: 2014-12-18
+    latestReleaseDate: 2022-08-30
+    latest: "4.1.36"
+-   releaseCycle: "4.0"
+    eol: 2022-12-01
+    support: 2014-12-18
+    releaseDate: 2014-09-04
+    latestReleaseDate: 2022-08-30
+    latest: "4.0.36"
+-   releaseCycle: "3.9"
+    eol: 2022-12-01
+    support: 2014-09-04
+    releaseDate: 2014-04-16
+    latestReleaseDate: 2022-08-30
+    latest: "3.9.37"
+-   releaseCycle: "3.8"
+    eol: 2022-12-01
+    support: 2014-04-16
+    releaseDate: 2013-12-12
+    latestReleaseDate: 2022-08-30
+    latest: "3.8.39"
+-   releaseCycle: "3.7"
+    eol: 2022-12-01
+    support: 2013-12-12
+    releaseDate: 2013-10-24
+    latestReleaseDate: 2022-08-30
+    latest: "3.7.39"
+-   releaseCycle: "3.6"
+    eol: 2013-10-24
+    support: 2013-10-24
+    releaseDate: 2013-08-01
+    latestReleaseDate: 2013-09-11
+    latest: "3.6.1"
 
 
 

--- a/products/wordpress.md
+++ b/products/wordpress.md
@@ -56,7 +56,6 @@ purls:
   - purl: pkg:docker/rapidfort/wordpress
 iconSlug: wordpress
 permalink: /wordpress
-activeSupportColumn: false
 releaseColumn: true
 releaseDateColumn: true
 discontinuedColumn: false

--- a/products/wordpress.md
+++ b/products/wordpress.md
@@ -180,3 +180,33 @@ versionCommand: wp core version
 > [WordPress](https://wordpress.org/) is a free and open-source content management system written in PHP.
 
 Only the latest major release is supported. Security patches are backported when possible, but this is not guaranteed. [Version 3.7 to 4.0 won't get security updates after Dec 1, 2022](https://wordpress.org/news/2022/09/dropping-security-updates-for-wordpress-versions-3-7-through-4-0/).
+
+## PHP Support
+
+Version | PHP
+--------|-----------
+3.7     | 5.2 - 5.5 
+3.8     | 5.2 - 5.5 
+3.9     | 5.2 - 5.5 
+4.0     | 5.2 - 5.5 
+4.1     | 5.2 - 5.6 
+4.2     | 5.2 - 5.6 
+4.3     | 5.2 - 5.6 
+4.4     | 5.2 - 7.0 
+4.5     | 5.2 - 7.0 
+4.6     | 5.2 - 7.0 
+4.7     | 5.2 - 7.1
+4.8     | 5.2 - 7.1
+4.9     | 5.2 - 7.2
+5.0     | 5.2 - 7.3
+5.1     | 5.2 - 7.3
+5.2     | 5.6 - 7.3
+5.3     | 5.6 - 7.4
+5.4     | 5.6 - 7.4
+5.5     | 5.6 - 7.4
+5.6     | 5.6 - 8.0
+5.7     | 5.6 - 8.0
+5.8     | 5.6 - 8.0
+5.9     | 5.6 - 8.1
+6.0     | 5.6 - 8.1
+

--- a/products/wordpress.md
+++ b/products/wordpress.md
@@ -179,4 +179,4 @@ versionCommand: wp core version
 
 > [WordPress](https://wordpress.org/) is a free and open-source content management system written in PHP.
 
-Only the latest major release is supported. Security patches are backported when possible, but this is not guaranteed. As of September 2022, Version 3.7 to 4.0 won't get security updates after Dec 1, 2022.
+Only the latest major release is supported. Security patches are backported when possible, but this is not guaranteed. [Version 3.7 to 4.0 won't get security updates after Dec 1, 2022](https://wordpress.org/news/2022/09/dropping-security-updates-for-wordpress-versions-3-7-through-4-0/).

--- a/products/wordpress.md
+++ b/products/wordpress.md
@@ -66,4 +66,4 @@ versionCommand: wp core version
 
 > [WordPress](https://wordpress.org/) is a free and open-source content management system written in PHP.
 
-Only the latest major release is supported. Security patches are backported when possible, but this is not guaranteed. As of September 2022, Version 3.7-
+Only the latest major release is supported. Security patches are backported when possible, but this is not guaranteed. As of September 2022, Version 3.7 to 4.0 won't get security updates after Dec 1, 2022

--- a/products/wordpress.md
+++ b/products/wordpress.md
@@ -181,7 +181,7 @@ versionCommand: wp core version
 
 Only the latest major release is supported. Security patches are backported when possible, but this is not guaranteed. [Version 3.7 to 4.0 won't get security updates after Dec 1, 2022](https://wordpress.org/news/2022/09/dropping-security-updates-for-wordpress-versions-3-7-through-4-0/).
 
-## PHP Support
+## [PHP Support](https://make.wordpress.org/core/handbook/references/php-compatibility-and-wordpress-versions/)
 
 WordPress Version | Supported PHP Versions
 --------|-----------


### PR DESCRIPTION
In September 2022 WordPress posted an article that they will drop security updates for 3.7-4.0

https://wordpress.org/news/2022/09/dropping-security-updates-for-wordpress-versions-3-7-through-4-0/

this suggests that with a new release the old version won't get bug fixes, but security updates until they announce something different. this PR adds WordPress 3.6 to 5.8.

dates from https://wordpress.org/download/releases/

PHP Support from https://make.wordpress.org/core/handbook/references/php-compatibility-and-wordpress-versions/