### PR TITLE
VMWare: Switch EOL and Active Support

### DIFF
--- a/products/vmware-esxi.md
+++ b/products/vmware-esxi.md
@@ -7,9 +7,8 @@ alternate_urls:
 -   /esx
 -   /vmwareesxi
 -   /vmesxi
-
-releasePolicyLink: https://www.vmware.com/support/policies/lifecycle.html
-activeSupportColumn: true
+activeSupportColumn: Technical Guidance
+releasePolicyLink: https://lifecycle.vmware.com
 releaseDateColumn: true
 eolColumn: Service Status
 discontinuedColumn: false
@@ -18,36 +17,36 @@ sortReleasesBy: "releaseCycle"
 
 releases:
 -   releaseCycle: "7.0"
-    eol: 2027-04-02
-    support: 2025-04-02
-    latest: "7.0 Update 3f"
-    link: "https://docs.vmware.com/en/VMware-vSphere/7.0/rn/vsphere-esxi-70u3f-release-notes.html"
+    support: 2027-04-02
+    eol: 2025-04-02
+    latest: "7.0 Update 3g"
+    link: "https://docs.vmware.com/en/VMware-vSphere/7.0/rn/vsphere-esxi-70u3g-release-notes.html"
     releaseDate: 2020-04-02
     latestReleaseDate: 2022-07-12
 -   releaseCycle: "6.7"
-    eol: 2023-11-15
-    support: 2022-10-15
+    support: 2023-11-15
+    eol: 2022-10-15
     latest: "6.7 PR ESXi670-202207001"
     link: "https://docs.vmware.com/en/VMware-vSphere/6.7/rn/esxi670-202207001.html"
     releaseDate: 2018-04-17
     latestReleaseDate: 2022-07-12
 -   releaseCycle: "6.5"
-    eol: 2023-11-15
-    support: 2022-10-15
+    support: 2023-11-15
+    eol: 2022-10-15
     latest: "6.5 PR ESXi650-202207001"
     link: "https://docs.vmware.com/en/VMware-vSphere/6.5/rn/esxi650-202207001.html"
     releaseDate: 2016-11-15
     latestReleaseDate: 2022-07-12
 -   releaseCycle: "6.0"
-    eol: 2022-03-12
-    support: 2020-03-12
+    support: 2022-03-12
+    eol: 2020-03-12
     latest: "6.0 PR ESXi600-202002001"
     link: "https://docs.vmware.com/en/VMware-vSphere/6.0/rn/esxi600-202002001.html"
     releaseDate: 2015-03-12
     latestReleaseDate: 2020-02-20
 -   releaseCycle: "5.5"
-    eol: 2020-09-19
-    support: 2018-09-19
+    support: 2020-09-19
+    eol: 2018-09-19
     latest: "5.5 Update 3b"
     link: "https://docs.vmware.com/en/VMware-vSphere/5.5/rn/vsphere-esxi-55u3b-release-notes.html"
     releaseDate: 2013-09-19
@@ -59,4 +58,8 @@ releases:
 
 VMware typically support ESXi for a duration of 7 years with 5 years of general support and an additional 2 years of technical guidance during which ESXi will no longer receieve bug fixes and security updates. Additional information on lifecycle phases can be found at <https://www.vmware.com/support/policies/enterprise-infrastructure.html>.
 
-For further details on product lifecycle visit <https://lifecycle.vmware.com>.
+## [Product Lifecycle](https://www.vmware.com/support/policies/lifecycle.html)
+
+**General Support**: The last date on which you can request support; the end of regular VMware maintenance updates and upgrades, _bug and security fixes,_ and technical assistance as per the Support and Subscription Terms and Conditions.
+
+**Technical Guidance**: The last date on which you can access support and workarounds for low-severity issues on supported configurations only. During the Technical Guidance phase, VMware does not offer new hardware support, server/client/guest OS updates, new security patches or bug fixes unless otherwise noted.

--- a/products/vmware-horizon.md
+++ b/products/vmware-horizon.md
@@ -7,7 +7,7 @@ alternate_urls:
 iconSlug: vmware
 category: app
 releasePolicyLink: https://lifecycle.vmware.com/
-activeSupportColumn: true
+activeSupportColumn: Technical Guidance
 releaseColumn: false
 releaseDateColumn: true
 sortReleasesBy: releaseDate
@@ -17,58 +17,65 @@ releases:
 -   releaseCycle: "8"
     codename: "2206"
     releaseDate: 2022-07-19
-    support: 2025-07-19
-    eol: 2026-07-19
+    eol: 2025-07-19
+    support: 2026-07-19
 -   releaseCycle: "8"
     codename: "2203"
     releaseDate: 2022-04-05
-    support: 2025-04-05
-    eol: 2026-04-05
+    eol: 2025-04-05
+    support: 2026-04-05
 -   releaseCycle: "8"
     codename: "2111"
     releaseDate: 2021-11-30
-    support: 2024-11-30
-    eol: 2025-11-30
+    eol: 2024-11-30
+    support: 2025-11-30
 -   releaseCycle: "8"
     codename: "2106"
     releaseDate: 2021-07-15
-    support: 2024-07-15
-    eol: 2025-07-15
+    eol: 2024-07-15
+    support: 2025-07-15
 -   releaseCycle: "8"
     codename: "2103"
     releaseDate: 2021-03-23
-    support: 2024-03-23
-    eol: 2025-03-23
+    eol: 2024-03-23
+    support: 2025-03-23
 -   releaseCycle: "8"
     codename: "2012"
     releaseDate: 2021-01-07
-    support: 2024-01-07
-    eol: 2025-01-07
+    eol: 2024-01-07
+    support: 2025-01-07
 -   releaseCycle: "8"
     codename: "2006"
     releaseDate: 2020-08-11
-    support: 2025-08-11
-    eol: 2027-08-11
+    eol: 2025-08-11
+    support: 2027-08-11
 -   releaseCycle: "7.5"
     lts: true
     releaseDate: 2018-05-29
-    support: 2020-11-30
-    eol: 2023-03-22
+    eol: 2020-11-30
+    support: 2023-03-22
 -   releaseCycle: "7.13"
     releaseDate: 2020-10-15
-    support: 2022-10-15
-    eol: 2023-03-23
+    eol: 2022-10-15
+    support: 2023-03-23
 -   releaseCycle: "7.10"
     lts: true
     releaseDate: 2019-09-17
-    support: 2022-03-17
-    eol: 2023-03-22
+    eol: 2022-03-17
+    support: 2023-03-22
 -   releaseCycle: "7.0 – 7.9, 7.11, 7.12"
     releaseDate: 2016-03-22
-    support: 2021-03-22
-    eol: 2023-03-22
+    eol: 2021-03-22
+    support: 2023-03-22
 ---
 
 > [VMware Horizon](https://www.vmware.com/products/horizon.html) enables a digital workspace with the efficient delivery of virtual desktops and applications that equips workers anywhere, anytime, and on any device.
 
 [Starting in Q2 2018,](https://kb.vmware.com/s/article/52845) Horizon introduced an option of Extended Service Branch (ESB) in addition to the Current Release (CR) branch.  ESBs receive three planned periodic maintenance updates – typically 6 months, 9 months and 15 months after the base version release.
+
+## Product Lifecycle
+
+
+**General Support**: The last date on which you can request support; the end of regular VMware maintenance updates and upgrades, _bug and security fixes,_ and technical assistance as per the Support and Subscription Terms and Conditions.
+
+**Technical Guidance**: The last date on which you can access support and workarounds for low-severity issues on supported configurations only. During the Technical Guidance phase, VMware does not offer new hardware support, server/client/guest OS updates, new security patches or bug fixes unless otherwise noted.

--- a/products/vmware-horizon.md
+++ b/products/vmware-horizon.md
@@ -6,7 +6,7 @@ alternate_urls:
 -   /vmware-horizon
 iconSlug: vmware
 category: app
-releasePolicyLink: https://lifecycle.vmware.com/
+releasePolicyLink: https://lifecycle.vmware.com
 activeSupportColumn: Technical Guidance
 releaseColumn: false
 releaseDateColumn: true
@@ -63,7 +63,8 @@ releases:
     releaseDate: 2019-09-17
     eol: 2022-03-17
     support: 2023-03-22
--   releaseCycle: "7.0 – 7.9, 7.11, 7.12"
+-   releaseCycle: "7.12"
+    releaseLabel: "7.0 – 7.9, 7.11, 7.12"
     releaseDate: 2016-03-22
     eol: 2021-03-22
     support: 2023-03-22
@@ -73,8 +74,7 @@ releases:
 
 [Starting in Q2 2018,](https://kb.vmware.com/s/article/52845) Horizon introduced an option of Extended Service Branch (ESB) in addition to the Current Release (CR) branch.  ESBs receive three planned periodic maintenance updates – typically 6 months, 9 months and 15 months after the base version release.
 
-## Product Lifecycle
-
+## [Product Lifecycle](https://lifecycle.vmware.com/)
 
 **General Support**: The last date on which you can request support; the end of regular VMware maintenance updates and upgrades, _bug and security fixes,_ and technical assistance as per the Support and Subscription Terms and Conditions.
 


### PR DESCRIPTION
Instead of using "Technical Guidance" as security support, use General support as `eol` (security fixes aren't offered beyond this date). Use the "Technical Guidance" as a support date.

cc @lryanuk