### PR TITLE
[sort] Sort products manually and remove sortReleasesBy

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,16 +51,9 @@ layout: post
 # server-app are applications usually installed on the server-side
 category: os
 
-# What should be used to sort releases. Set to one of:
-# releaseCycle/eol/support/releaseDate/cycleShortHand/latest/latestShortHand
-# which must be present in all of the releases underneath
-sortReleasesBy: "releaseCycle"
-
 # Template to be used to generate a link for the release
 # __RELEASE_CYCLE__ will be replaced by the value of releaseCycle
-# __CYCLE_SHORT_HAND__ will be replaced by the optional changelogTemplate
 # __LATEST__ will be replaced by the value of latest
-# __LATEST_SHORT_HAND__ will be replaced by the optional latestShortHand
 # __CODENAME__ will be replaced by the optional codename
 
 # You can even use Liquid Templating inside the template, such as:
@@ -140,6 +133,7 @@ releases:
     releaseLabel: "Timeturner Firebolt (1.2)"
     # End of Security Support for the product. Alternatively, set to true|false if EOL is not pre-decided
     # In case there is extended/commercial support available, pick the date that would apply to the majority of users.
+    # Use valid dates, and do not add quotes around dates.
     eol: 2019-01-01
     # End of Active Support for the product. This is where bugfixes usually stop coming in. (remove if activeSupportColumn=false)
     # Alternatively, set to true|false if it is not pre-decided
@@ -160,12 +154,6 @@ releases:
     lts: true
     # Can be true/false. Only use if discontinuedColumn is set to true
     discontinued: true
-    # Optional, can be used to sort releases, and as part of the changelogTemplate (__LATEST_SHORT_HAND__).
-    latestShortHand: "10203"
-    # Optional, can be used to sort releases, and as part of the changelogTemplate (__CYCLE_SHORT_HAND__).
-    # Useful for sorting because 1.2 comes after 1.10 in normal sorting, so using cycleShortHand values of 102, 110
-    # makes sorting much easier
-    cycleShortHand: "102"
     # A link to the changelog for this specific release. Use this if the link is not
     # predictable and you can't use changelogTemplate.
     # Do not use a localized URL (such as one containing en-us) if possible

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -14,7 +14,7 @@ GEM
       eventmachine (>= 0.12.9)
       http_parser.rb (~> 0)
     eventmachine (1.2.7)
-    faraday (2.5.2)
+    faraday (2.6.0)
       faraday-net_http (>= 2.0, < 3.1)
       ruby2_keywords (>= 0.0.4)
     faraday-net_http (3.0.0)

--- a/HACKING.md
+++ b/HACKING.md
@@ -112,3 +112,7 @@ There are no javascript trackers or analytics on the website. Netlify Analytics 
 ## Automation
 
 The endoflife.date project runs a bit of automation on top of GitHub Actions to automate mundane tasks. This is primarily updating the latest version of each product, wherever possible. This is documented in the [wiki](https://github.com/endoflife-date/endoflife.date/wiki/Automation).
+
+## Bulk Updates
+
+To faciliate bulk updates to the products, a script `_auto/bulk-update.py` is available. You only need to write in the `update` function to make changes to all files together.

--- a/_auto/bulk-update.py
+++ b/_auto/bulk-update.py
@@ -1,0 +1,58 @@
+import sys
+import frontmatter
+import json
+import re
+import datetime
+from glob import glob
+from pathlib import Path
+from distutils.version import StrictVersion
+from ruamel.yaml import YAML
+from io import StringIO
+from os.path import exists
+
+DEFAULT_POST_TEMPLATE = """\
+---
+{metadata}
+---
+
+{content}
+"""
+
+def yaml_to_str(obj):
+  yaml = YAML()
+  yaml.indent(sequence=4)
+  string_stream = StringIO()
+  yaml.dump(obj, string_stream)
+  output_str = string_stream.getvalue()
+  string_stream.close()
+  return output_str
+
+"""
+Takes a product dict
+and return the updated version
+"""
+def update(obj):
+  return obj
+
+def update_product(name):
+  fn = 'products/%s.md' % name
+  print(name)
+  with open(fn, 'r+') as f:
+    yaml = YAML()
+    yaml.preserve_quotes = True
+    data = next(yaml.load_all(f))
+    f.seek(0)
+    _, content = frontmatter.parse(f.read())
+
+    data = update(data)
+    final_contents = DEFAULT_POST_TEMPLATE.format(
+      metadata=yaml_to_str(data),
+      content=content)
+
+    f.seek(0)
+    f.truncate()
+    f.write(final_contents)
+
+if __name__ == '__main__':
+  for x in glob('products/*.md'):
+    update_product(Path(x).stem)

--- a/_auto/validate.py
+++ b/_auto/validate.py
@@ -21,10 +21,7 @@ def validate_product(name):
     yaml.preserve_quotes = True
     data = next(yaml.load_all(f))
     for r in data['releases']:
-      if 'cycleShortHand' in r:
-        if not isinstance(r['cycleShortHand'], str):
-          print("%s cycleShortHand=%s is not a string" % (name, r['cycleShortHand']))
-          fail = True
+      pass
 
     f.seek(0)
     _, content = frontmatter.parse(f.read())

--- a/_layouts/product.html
+++ b/_layouts/product.html
@@ -27,8 +27,8 @@ layout: default
       {% if page.releaseColumn != false %}<th>Latest</th>{% endif %}
     </tr>
   </thead>
-{% assign sorted_releases = page.releases | sort: page.sortReleasesBy | reverse  %}
-{% for r in sorted_releases %}
+
+{% for r in page.releases %}
 {% assign support =r.support | date: '%s' | plus:0 %}
 {% assign securityFixes = r.eol | date: '%s' | plus:0 %}
 
@@ -56,13 +56,25 @@ or +1 (EoL is in the future)
 {% assign LTSLabel = page.LTSLabel | default: '<abbr title="Long Term Support">LTS</abbr>' %}
 
 {% if r.releaseLabel %}{% assign t=r.releaseLabel%}{%else%}{%assign t=page.releaseLabel | default: '__RELEASE_CYCLE__' %}{%endif%}
-{% capture releaseCycleText %}{{t | replace: '__RELEASE_CYCLE__',r.releaseCycle  | replace: '__LATEST__',latestVersionNumber | replace: '__LATEST_SHORT_HAND__',r.latestShortHand | replace: '__CYCLE_SHORT_HAND__',r.cycleShortHand | replace: '__CODENAME__',r.codename | liquify }}{% include ltslabel.html lts=r.lts label=LTSLabel %}{% endcapture %}
+{% capture releaseCycleText %}{{
+  t |
+  replace: '__RELEASE_CYCLE__',r.releaseCycle  |
+  replace: '__LATEST__',latestVersionNumber |
+  replace: '__CODENAME__',r.codename |
+  liquify
+}}{% include ltslabel.html lts=r.lts label=LTSLabel %}{% endcapture %}
 
 {% capture releaseLink %}
 {% if r.link and diff > 0 %}
 {{r.link}}
 {% elsif page.changelogTemplate and diff > 0 %}
-{{page.changelogTemplate | replace: '__RELEASE_CYCLE__',r.releaseCycle  | replace: '__LATEST__',latestVersionNumber | replace: '__LATEST_SHORT_HAND__',r.latestShortHand | replace: '__CYCLE_SHORT_HAND__',r.cycleShortHand | replace: '__CODENAME__',r.codename | replace: '__LATEST_RELEASE_DATE__', r.latestReleaseDate}}
+{{
+  page.changelogTemplate |
+  replace: '__RELEASE_CYCLE__',r.releaseCycle |
+  replace: '__LATEST__',latestVersionNumber |
+  replace: '__CODENAME__',r.codename |
+  replace: '__LATEST_RELEASE_DATE__', r.latestReleaseDate
+}}
 {% endif %}
 {% endcapture %}
 {% assign releaseLink = releaseLink | liquify | strip %}

--- a/_plugins/create-json-files.rb
+++ b/_plugins/create-json-files.rb
@@ -10,6 +10,7 @@
 require 'fileutils'
 require 'json'
 require 'yaml'
+import 'date'
 
 API_DIR = 'api'.freeze
 
@@ -17,7 +18,7 @@ class Product
   attr_reader :hash
 
   def initialize(markdown_file)
-    @hash = YAML.load_file(markdown_file)
+    @hash = YAML.load_file(markdown_file, permitted_classes: [Date])
   end
 
   def permalink

--- a/_plugins/create-json-files.rb
+++ b/_plugins/create-json-files.rb
@@ -10,15 +10,23 @@
 require 'fileutils'
 require 'json'
 require 'yaml'
-import 'date'
+require 'date'
 
 API_DIR = 'api'.freeze
+
+def load_yaml(file)
+  if YAML.respond_to?(:unsafe_load)
+    YAML.unsafe_load_file(file)
+  else
+    YAML.load_file(self[:encoded_value])
+  end
+end
 
 class Product
   attr_reader :hash
 
   def initialize(markdown_file)
-    @hash = YAML.load_file(markdown_file, permitted_classes: [Date])
+    @hash = load_yaml(markdown_file)
   end
 
   def permalink

--- a/_plugins/validate-releases.rb
+++ b/_plugins/validate-releases.rb
@@ -1,6 +1,7 @@
 require 'fileutils'
 require 'json'
 require 'yaml'
+require 'date'
 
 # These are fields we expect to be strings, but YAML
 # picks up version numbers (like 3.10) as numbers and would
@@ -11,7 +12,7 @@ STRING_KEYS = ['latest', 'releaseCycle']
 def process_files
   success = true
   Dir['products/*.md'].each do |markdown_file|
-    hash = YAML.load_file(markdown_file)
+    hash = YAML.load_file(markdown_file, permitted_classes: [Date])
     hash['releases'].each do |r|
       STRING_KEYS.each do |k|
         if r.key? k

--- a/_plugins/validate-releases.rb
+++ b/_plugins/validate-releases.rb
@@ -9,10 +9,18 @@ require 'date'
 # read as strings instead.
 STRING_KEYS = ['latest', 'releaseCycle']
 
+def load_yaml(file)
+  if YAML.respond_to?(:unsafe_load)
+    YAML.unsafe_load_file(file)
+  else
+    YAML.load_file(self[:encoded_value])
+  end
+end
+
 def process_files
   success = true
   Dir['products/*.md'].each do |markdown_file|
-    hash = YAML.load_file(markdown_file, permitted_classes: [Date])
+    hash = @hash = load_yaml(markdown_file)
     hash['releases'].each do |r|
       STRING_KEYS.each do |k|
         if r.key? k

--- a/assets/openapi.yml
+++ b/assets/openapi.yml
@@ -32,7 +32,6 @@ paths:
                 /api/ubuntu.json:
                   value:
                     - cycle: '21.04'
-                      cycleShortHand: HirsuteHippo
                       lts: false
                       releaseDate: '2021-04-22'
                       support: '2022-01-01'
@@ -40,7 +39,6 @@ paths:
                       latest: '21.04'
                       link: 'https://wiki.ubuntu.com/HirsuteHippo/ReleaseNotes/'
                     - cycle: '20.10'
-                      cycleShortHand: GroovyGorilla
                       lts: false
                       releaseDate: '2020-10-22'
                       support: '2021-07-07'
@@ -88,7 +86,6 @@ paths:
                     link: 'https://www.python.org/downloads/release/python-395/'
                 /api/ubuntu/21.04.json:
                   value:
-                    cycleShortHand: HirsuteHippo
                     lts: false
                     releaseDate: '2021-04-22'
                     support: '2022-01-01'
@@ -231,7 +228,6 @@ components:
             link: 'https://github.com/python/cpython/blob/2.7/Misc/NEWS.d/2.7.18rc1.rst'
         ubuntu:
           - cycle: '21.04'
-            cycleShortHand: HirsuteHippo
             lts: false
             releaseDate: '2021-04-22'
             support: '2022-01-01'
@@ -239,7 +235,6 @@ components:
             latest: '21.04'
             link: 'https://wiki.ubuntu.com/HirsuteHippo/ReleaseNotes/'
           - cycle: '20.10'
-            cycleShortHand: GroovyGorilla
             lts: false
             releaseDate: '2020-10-22'
             support: '2021-07-07'
@@ -247,7 +242,6 @@ components:
             latest: '20.10'
             link: 'https://wiki.ubuntu.com/GroovyGorilla/ReleaseNotes/'
           - cycle: '20.04'
-            cycleShortHand: FocalFossa
             lts: true
             releaseDate: '2020-04-23'
             support: '2022-10-01'
@@ -259,21 +253,18 @@ components:
             eol: '2020-07-06'
             latest: '19.10'
           - cycle: '18.04'
-            cycleShortHand: BionicBeaver
             lts: true
             releaseDate: '2018-04-26'
             support: '2020-09-30'
             eol: '2023-04-02'
             latest: 18.04.5
           - cycle: '16.04'
-            cycleShortHand: XenialXerus
             lts: true
             releaseDate: '2016-04-21'
             support: '2018-10-01'
             eol: '2021-04-02'
             latest: 16.04.7
           - cycle: '14.04'
-            cycleShortHand: TrustyTahr
             lts: true
             releaseDate: '2014-04-17'
             support: '2016-09-30'
@@ -323,9 +314,6 @@ components:
           minLength: 10
           maxLength: 10
           description: Wheter this release cycle has active support
-        cycleShortHand:
-          type: string
-          description: Optional shorthand name for this release cycle
         discontinued:
           type:
             - string

--- a/products/almalinux.md
+++ b/products/almalinux.md
@@ -6,7 +6,6 @@ versionCommand: lsb_release --release
 releasePolicyLink: https://blog.cloudlinux.com/announcing-open-sourced-community-driven-rhel-fork-by-cloudlinux
 activeSupportColumn: true
 releaseDateColumn: true
-sortReleasesBy: releaseDate
 iconSlug: NA
 changelogTemplate: https://wiki.almalinux.org/release-notes/__LATEST__.html
 purls:

--- a/products/alpinelinux.md
+++ b/products/alpinelinux.md
@@ -15,7 +15,6 @@ purls:
 auto:
   # upstream does not support filtering https://git.alpinelinux.org/aports
 -   git: https://github.com/alpinelinux/aports.git
-sortReleasesBy: 'releaseDate'
 releases:
 -   releaseCycle: "3.16"
     eol: 2024-05-23

--- a/products/amazon-linux.md
+++ b/products/amazon-linux.md
@@ -8,7 +8,6 @@ activeSupportColumn: false
 versionCommand: cat /etc/system-release
 eolColumn: Support
 releaseDateColumn: true
-sortReleasesBy: releaseDate
 purls:
 -   purl: pkg:os/amazonlinux
 auto:
@@ -19,17 +18,18 @@ auto:
 changelogTemplate: |
   https://docs.aws.amazon.com/AL2/latest/relnotes/relnotes-{{"__LATEST__"|slice:4,8 }}.html
 releases:
--   releaseCycle: '1'
-    releaseLabel: 'Amazon Linux AMI'
-    eol: 2020-12-31
-    latest: "2018.03"
-    releaseDate: "2010-09-14"
 -   releaseCycle: '2'
     releaseLabel: 'Amazon Linux 2'
     eol: 2024-06-30
     latest: "2.0.20220912.1"
     latestReleaseDate: 2022-09-22
     releaseDate: 2018-06-26
+-   releaseCycle: '1'
+    releaseLabel: 'Amazon Linux AMI'
+    eol: 2020-12-31
+    latest: "2018.03"
+    releaseDate: 2010-09-14
+
 
 ---
 

--- a/products/android.md
+++ b/products/android.md
@@ -10,7 +10,6 @@ activeSupportColumn: false
 releaseColumn: false
 releaseDateColumn: true
 eolColumn: Security Support
-sortReleasesBy: releaseDate
 releaseLabel: "Android __RELEASE_CYCLE__ '__CODENAME__'"
 releases:
 -   releaseCycle: "13"
@@ -18,7 +17,6 @@ releases:
     releaseLabel: Android 13 'Tiramisu'
     eol: false
     releaseDate: 2022-08-15
-
 -   releaseCycle: "12.1"
     codename: Snow Cone v2
     releaseLabel: Android 12.1 'Snow Cone v2' (aka 12L)

--- a/products/angular.md
+++ b/products/angular.md
@@ -5,7 +5,6 @@ versionCommand: ng version
 releasePolicyLink: https://angular.io/guide/releases
 activeSupportColumn: true
 releaseDateColumn: true
-sortReleasesBy: releaseDate
 changelogTemplate: https://github.com/angular/angular/releases/tag/__LATEST__
 purls:
 -   purl: pkg:npm/@angular/core

--- a/products/ansible.md
+++ b/products/ansible.md
@@ -5,7 +5,6 @@ versionCommand: ansible --version
 releasePolicyLink: https://docs.ansible.com/ansible/devel/reference_appendices/release_and_maintenance.html
 changelogTemplate: https://github.com/ansible-community/ansible-build-data/blob/main/__RELEASE_CYCLE__/CHANGELOG-v__RELEASE_CYCLE__.rst
 releaseDateColumn: true
-sortReleasesBy: "releaseCycle"
 activeSupportColumn: false
 eolColumn: Supported
 iconSlug: ansible

--- a/products/apache-airflow.md
+++ b/products/apache-airflow.md
@@ -12,7 +12,6 @@ activeSupportColumn: false
 versionCommand: airflow version
 releaseColumn: true
 releaseDateColumn: true
-sortReleasesBy: releaseDate
 purls:
 -   purl: pkg:pypi/apache-airflow
 -   repology: apache-airflow

--- a/products/apache-http-server.md
+++ b/products/apache-http-server.md
@@ -10,7 +10,6 @@ activeSupportColumn: false
 versionCommand: httpd -v
 releaseColumn: true
 releaseDateColumn: true
-sortReleasesBy: "releaseCycle"
 purls:
 -   repology: apache
 releases:

--- a/products/api-platform.md
+++ b/products/api-platform.md
@@ -8,24 +8,16 @@ versionCommand: composer show api-platform/core | grep versions
 changelogTemplate: |
   https://github.com/api-platform/core/releases/tag/v__LATEST__
 releaseDateColumn: true
-sortReleasesBy: 'releaseCycle'
 category: framework
 auto:
 -   git: https://github.com/api-platform/core.git
 releases:
-#  - releaseCycle: "3.1"
-#    releaseDate: 202X-XX-XX
-#    latestReleaseDate: 202X-XX-XX
-#    eol: false
-#    latest: "3.1.0"
-
 -   releaseCycle: "3.0"
     support: true
     eol: false
     latest: "3.0.1"
     latestReleaseDate: 2022-09-29
     releaseDate: 2022-09-15
-
 -   releaseCycle: "2.7"
     support: true
     eol: false

--- a/products/azure-devops.md
+++ b/products/azure-devops.md
@@ -9,7 +9,6 @@ category: server-app
 releasePolicyLink: https://learn.microsoft.com/lifecycle/products/?terms=Azure%20DevOps
 activeSupportColumn: true
 releaseDateColumn: true
-sortReleasesBy: releaseDate
 releases:
 -   releaseCycle: "2020"
     support: 2025-10-14

--- a/products/blender.md
+++ b/products/blender.md
@@ -11,7 +11,6 @@ auto:
 -   git: https://github.com/blender/blender.git
 changelogTemplate: https://www.blender.org/download/releases/{{"__RELEASE_CYCLE__"
   | replace:'.','-'}}/
-sortReleasesBy: releaseDate
 eolColumn: Critical bug fixes
 activeSupportColumn: true
 releases:

--- a/products/bootstrap.md
+++ b/products/bootstrap.md
@@ -2,7 +2,6 @@
 title: Bootstrap
 permalink: /bootstrap
 category: framework
-sortReleasesBy: "releaseCycle"
 activeSupportColumn: true
 changelogTemplate: https://github.com/twbs/bootstrap/releases/tag/v__LATEST__
 auto:

--- a/products/centos.md
+++ b/products/centos.md
@@ -6,32 +6,15 @@ versionCommand: lsb_release --release
 releasePolicyLink: https://wiki.centos.org/About/Product
 activeSupportColumn: true
 releaseDateColumn: true
-sortReleasesBy: releaseDate
 releaseLabel: "CentOS Stream __RELEASE_CYCLE__"
 purls:
 -   purl: pkg:os/centos
 releases:
--   releaseCycle: "6"
-    releaseLabel: "CentOS 6"
-    support: 2017-05-10
-    eol: 2020-11-30
-    latest: "6.10"
-    link: https://wiki.centos.org/Manuals/ReleaseNotes/CentOS6.10
-    releaseDate: 2011-07-10
--   releaseCycle: "7"
-    releaseLabel: "CentOS Linux 7"
-    support: 2020-08-06
-    eol: 2024-06-30
-    latest: "7 (2009)"
-    link: https://wiki.centos.org/Manuals/ReleaseNotes/CentOS7.2009
-    releaseDate: 2014-07-07
--   releaseCycle: "8"
-    releaseLabel: "CentOS Linux 8"
-    support: 2021-12-31
-    eol: 2021-12-31
-    latest: "8 (2111)"
-    link: https://wiki.centos.org/Manuals/ReleaseNotes/CentOS8.2111
-    releaseDate: 2019-09-24
+-   releaseCycle: "9"
+    support: 2027-05-31
+    eol: 2027-05-31
+    latest: "9"
+    releaseDate: 2021-09-15
 -   releaseCycle: "stream-8"
     support: 2024-05-31
     eol: 2024-05-31
@@ -39,12 +22,27 @@ releases:
     latest: "8"
     link: https://wiki.centos.org/Manuals/ReleaseNotes/CentOSStream
     releaseDate: 2019-09-24
--   releaseCycle: "9"
-    support: 2027-05-31
-    eol: 2027-05-31
-    latest: "9"
-
-    releaseDate: 2021-09-15
+-   releaseCycle: "8"
+    releaseLabel: "CentOS Linux 8"
+    support: 2021-12-31
+    eol: 2021-12-31
+    latest: "8 (2111)"
+    link: https://wiki.centos.org/Manuals/ReleaseNotes/CentOS8.2111
+    releaseDate: 2019-09-24
+-   releaseCycle: "7"
+    releaseLabel: "CentOS Linux 7"
+    support: 2020-08-06
+    eol: 2024-06-30
+    latest: "7 (2009)"
+    link: https://wiki.centos.org/Manuals/ReleaseNotes/CentOS7.2009
+    releaseDate: 2014-07-07
+-   releaseCycle: "6"
+    releaseLabel: "CentOS 6"
+    support: 2017-05-10
+    eol: 2020-11-30
+    latest: "6.10"
+    link: https://wiki.centos.org/Manuals/ReleaseNotes/CentOS6.10
+    releaseDate: 2011-07-10
 
 ---
 

--- a/products/cfengine.md
+++ b/products/cfengine.md
@@ -3,7 +3,6 @@ title: CFEngine
 versionCommand: cf-agent --version
 changelogTemplate: https://github.com/cfengine/core/blob/__RELEASE_CYCLE__.x/ChangeLog
 releaseDateColumn: true
-sortReleasesBy: "releaseCycle"
 activeSupportColumn: true
 eolColumn: Supported
 iconSlug: NA

--- a/products/citrix-apps-desktops.md
+++ b/products/citrix-apps-desktops.md
@@ -12,7 +12,6 @@ releasePolicyLink: https://www.citrix.com/support/product-lifecycle/product-matr
 activeSupportColumn: true
 releaseColumn: false
 releaseDateColumn: true
-sortReleasesBy: releaseDate
 LTSLabel: "<abbr title='Long Term Service Release'>LTSR</abbr>"
 releases:
 -   releaseCycle: "2209 (CR)"

--- a/products/coldfusion.md
+++ b/products/coldfusion.md
@@ -8,7 +8,6 @@ activeSupportColumn: false
 releaseColumn: false
 releaseDateColumn: true
 eolColumn: Core Support
-sortReleasesBy: "releaseCycle"
 versionCommand: writeoutput(server.coldfusion.productversion);
 releaseLabel: "ColdFusion __RELEASE_CYCLE__"
 releases:

--- a/products/composer.md
+++ b/products/composer.md
@@ -1,7 +1,6 @@
 ---
 title: Composer
 category: app
-sortReleasesBy: "releaseCycle"
 changelogTemplate: "https://getcomposer.org/changelog/__LATEST__"
 auto:
 -   git: https://github.com/composer/composer.git

--- a/products/consul.md
+++ b/products/consul.md
@@ -4,7 +4,6 @@ permalink: /consul
 category: server-app
 iconSlug: consul
 releasePolicyLink: https://support.hashicorp.com/hc/articles/360021185113
-sortReleasesBy: releaseDate
 changelogTemplate: https://github.com/hashicorp/consul/blob/v__LATEST__/CHANGELOG.md
 auto:
 -   git: https://github.com/hashicorp/consul.git

--- a/products/couchbase-server.md
+++ b/products/couchbase-server.md
@@ -6,7 +6,6 @@ alternate_urls:
 category: db
 iconSlug: couchbase
 releasePolicyLink: https://www.couchbase.com/support-policy/enterprise-software
-sortReleasesBy: "releaseCycle"
 changelogTemplate: https://docs.couchbase.com/server/__RELEASE_CYCLE__/release-notes/relnotes.html
 auto:
 -   dockerhub: library/couchbase

--- a/products/debian.md
+++ b/products/debian.md
@@ -7,7 +7,6 @@ releasePolicyLink: https://wiki.debian.org/DebianReleases
 activeSupportColumn: false
 releaseColumn: true
 releaseDateColumn: true
-sortReleasesBy: releaseDate
 releaseLabel: "__RELEASE_CYCLE__ (__CODENAME__)"
 purls:
 -   purl: pkg:os/debian

--- a/products/django.md
+++ b/products/django.md
@@ -8,7 +8,6 @@ changelogTemplate: https://docs.djangoproject.com/en/__RELEASE_CYCLE__/releases/
 activeSupportColumn: true
 versionCommand: python -c "import django; print(django.get_version())"
 releaseDateColumn: false
-sortReleasesBy: 'releaseCycle'
 auto:
 -   git: https://github.com/django/django.git
 purls:
@@ -22,7 +21,6 @@ releases:
     latest: "4.1.2"
     latestReleaseDate: 2022-10-04
     releaseDate: 2022-08-03
-
 -   releaseCycle: "4.0"
     support: 2022-08-01
     eol: 2023-04-01

--- a/products/docker-engine.md
+++ b/products/docker-engine.md
@@ -2,7 +2,6 @@
 title: Docker Engine
 category: app
 permalink: /docker-engine
-sortReleasesBy: "releaseCycle"
 releasePolicyLink: https://docs.docker.com/engine/release-notes/
 changelogTemplate: |
   https://docs.docker.com/engine/release-notes/#{{"__LATEST__" | replace:'.',''}}

--- a/products/dotnet.md
+++ b/products/dotnet.md
@@ -10,7 +10,6 @@ versionCommand: dotnet --version
 releasePolicyLink: https://dotnet.microsoft.com/platform/support/policy/dotnet-core
 changelogTemplate: https://github.com/dotnet/core/blob/main/release-notes/{{"__LATEST__"|split:'.'|slice:0,2|join:'.'}}/__LATEST__/__LATEST__.md
 releaseDateColumn: true
-sortReleasesBy: releaseDate
 eolColumn: Support Status
 auto:
 -   git: https://github.com/dotnet/core.git

--- a/products/dotnetfx.md
+++ b/products/dotnetfx.md
@@ -10,7 +10,6 @@ versionCommand: reg query "HKLM\SOFTWARE\Microsoft\Net Framework Setup\NDP" /s
 releasePolicyLink: https://dotnet.microsoft.com/download/dotnet-framework
 releaseColumn: false
 releaseDateColumn: true
-sortReleasesBy: "releaseCycle"
 eolColumn: Support Status
 releases:
 -   releaseCycle: "4.8.1"

--- a/products/drupal.md
+++ b/products/drupal.md
@@ -18,7 +18,6 @@ purls:
 -   purl: pkg:docker/library/drupal
 -   purl: pkg:docker/bitnami/drupal-nginx
 -   purl: pkg:github/drupal/core
-sortReleasesBy: 'releaseCycle'
 releases:
 -   releaseCycle: "9.4"
     support: 2022-12-14

--- a/products/drush.md
+++ b/products/drush.md
@@ -15,7 +15,6 @@ purls:
 -   purl: pkg:composer/drush/drush
 -   repology: drush
 -   purl: pkg:github/drush-ops/drush
-sortReleasesBy: 'releaseCycle'
 iconSlug: drupal
 releases:
 -   releaseCycle: "11"

--- a/products/eks.md
+++ b/products/eks.md
@@ -1,7 +1,6 @@
 ---
 title: Amazon EKS
 category: service
-sortReleasesBy: "releaseCycle"
 changelogTemplate: https://github.com/aws/eks-distro/releases/tag/v{{"__LATEST__"
   | replace:".","-"}}
 # Source: https://github.com/awsdocs/amazon-eks-user-guide/commits/master/doc_source/platform-versions.md as source

--- a/products/elasticsearch.md
+++ b/products/elasticsearch.md
@@ -7,11 +7,9 @@ releasePolicyLink: https://www.elastic.co/support/eol
 changelogTemplate: >
   https://www.elastic.co/guide/en/elasticsearch/reference/{{"__LATEST__"|split:"."|pop|join:'.'}}/release-notes-__LATEST__.html
 versionCommand: $ES_HOME/bin/elasticsearch -v
-sortReleasesBy: releaseDate
 auto:
 -   git: https://github.com/elastic/elasticsearch.git
 releases:
-# The EOL will update on minor 8.x releases
 -   releaseCycle: "8"
     eol: 2023-10-26
     latest: "8.4.3"

--- a/products/electron.md
+++ b/products/electron.md
@@ -12,9 +12,6 @@ versionCommand: npm show electron version
 auto:
 -   git: https://github.com/electron/electron.git
 releaseDateColumn: true
-sortReleasesBy: releaseCycle
-# The approximate EoL going forward will be 8 months for every release
-# but this varies a lot currently due to the cadence change.
 releases:
 -   releaseCycle: "20"
     eol: false

--- a/products/elixir.md
+++ b/products/elixir.md
@@ -7,7 +7,6 @@ releasePolicyLink: https://hexdocs.pm/elixir/compatibility-and-deprecations.html
 changelogTemplate: https://github.com/elixir-lang/elixir/blob/v__RELEASE_CYCLE__/CHANGELOG.md
 activeSupportColumn: true
 releaseDateColumn: true
-sortReleasesBy: releaseDate
 auto:
 -   git: https://github.com/elixir-lang/elixir.git
 releases:

--- a/products/emberjs.md
+++ b/products/emberjs.md
@@ -5,7 +5,6 @@ iconSlug: emberdotjs
 alternate_urls:
 -   /ember
 category: framework
-sortReleasesBy: 'releaseCycle'
 releasePolicyLink: https://emberjs.com/releases
 changelogTemplate: https://github.com/emberjs/ember.js/releases/tag/v__LATEST__
 activeSupportColumn: true

--- a/products/eurolinux.md
+++ b/products/eurolinux.md
@@ -6,7 +6,6 @@ versionCommand: lsb_release --release
 releasePolicyLink: https://euro-linux.com/eurolinux/technical-specifications/
 activeSupportColumn: true
 releaseDateColumn: true
-sortReleasesBy: releaseDate
 iconSlug: NA
 changelogTemplate: https://euro-linux.com/eurolinux/technical-specifications/
 auto:

--- a/products/fedora.md
+++ b/products/fedora.md
@@ -5,7 +5,6 @@ releasePolicyLink: https://fedoraproject.org/wiki/End_of_life
 activeSupportColumn: false
 releaseDateColumn: true
 versionCommand: cat /etc/fedora-release
-sortReleasesBy: 'releaseCycle'
 changelogTemplate: https://fedoraproject.org/wiki/Releases/__RELEASE_CYCLE__/ChangeSet?rd=Releases/__RELEASE_CYCLE__
 auto:
 -   dockerhub: library/fedora

--- a/products/ffmpeg.md
+++ b/products/ffmpeg.md
@@ -9,7 +9,6 @@ versionCommand: ffmpeg -version
 activeSupportColumn: false
 releaseDateColumn: true
 eolColumn: Supported
-sortReleasesBy: releaseDate
 auto:
   # upstream https://git.ffmpeg.org/ffmpeg.git doesn't support filtering
 -   git: https://github.com/FFmpeg/FFmpeg.git
@@ -23,7 +22,6 @@ releases:
     lts: true
     latestReleaseDate: 2022-09-25
     releaseDate: 2022-07-22
-
 -   releaseCycle: "5.0"
     codename: Lorentz
     eol: false

--- a/products/filemaker.md
+++ b/products/filemaker.md
@@ -7,7 +7,6 @@ iconSlug: "NA"
 activeSupportColumn: false
 releaseColumn: false
 eolColumn: Support Status
-sortReleasesBy: releaseDate
 releaseLabel: 'FileMaker Platform __RELEASE_CYCLE__'
 releases:
 -   releaseCycle: "19"

--- a/products/firefox.md
+++ b/products/firefox.md
@@ -9,16 +9,13 @@ iconSlug: firefox
 LTSLabel: "<abbr title='Extended Support Release'>ESR</abbr>"
 changelogTemplate: |
   https://www.mozilla.org/firefox/__LATEST__/releasenotes/
-sortReleasesBy: releaseDate
 releases:
-
 -   releaseCycle: "105"
     eol: false
     latest: "105.0.1"
     latestReleaseDate: 2022-09-23
     lts: false
     releaseDate: 2022-09-20
-
 -   releaseCycle: "102"
     eol: false
     latest: "102.2.0"

--- a/products/fortios.md
+++ b/products/fortios.md
@@ -1,7 +1,6 @@
 ---
 title: FortiOS
 category: os
-sortReleasesBy: "releaseCycle"
 alternate_urls:
 -   /fortinet
 iconSlug: fortinet

--- a/products/freebsd.md
+++ b/products/freebsd.md
@@ -6,214 +6,130 @@ releasePolicyLink: https://www.freebsd.org/security/#sup
 activeSupportColumn: false
 releaseDateColumn: false
 releaseColumn: false
-sortReleasesBy: cycleShortHand
 versionCommand: freebsd-version
 releases:
--   releaseCycle: "stable/13"
-    cycleShortHand: "13"
-    eol: 2026-01-31
-
 -   releaseCycle: "releng/13.1"
-    cycleShortHand: "13.1"
     eol: false
     # 13.2-RELEASE + 3 months
     link: https://www.freebsd.org/releases/13.1R/announce/
-
     releaseDate: 2022-05-16
 -   releaseCycle: "releng/13.0"
-    cycleShortHand: "13.0"
     eol: 2022-08-16
     releaseDate: 2021-04-13
--   releaseCycle: "stable/12"
-    cycleShortHand: "12"
-    eol: 2024-06-30
-
+-   releaseCycle: "stable/13"
+    eol: 2026-01-31
 -   releaseCycle: "releng/12.3"
-    cycleShortHand: "12.3"
     eol: false
     # EOL will be 12.4-RELEASE + 3 months
-
     releaseDate: 2021-12-07
 -   releaseCycle: "releng/12.2"
-    cycleShortHand: "12.2"
     eol: 2022-03-31
-
     releaseDate: 2020-10-27
 -   releaseCycle: "releng/12.1"
-    cycleShortHand: "12.1"
     eol: 2021-01-31
-
     releaseDate: 2019-11-04
--   releaseCycle: "stable/11"
-    cycleShortHand: "11.0"
-    eol: 2021-09-30
-
+-   releaseCycle: "stable/12"
+    eol: 2024-06-30
 -   releaseCycle: "releng/11.4"
-    cycleShortHand: "11.4"
     eol: 2021-09-30
-
     releaseDate: 2020-06-16
+-   releaseCycle: "stable/11"
+    eol: 2021-09-30
 -   releaseCycle: "releng/10.4"
-    cycleShortHand: "10.4"
     eol: 2018-10-31
-
     releaseDate: 2017-10-03
 -   releaseCycle: "releng/10.3"
-    cycleShortHand: "10.3"
     eol: 2018-04-30
-
     releaseDate: 2016-04-04
 -   releaseCycle: "releng/10.2"
-    cycleShortHand: "10.2"
     eol: 2016-12-31
-
     releaseDate: 2015-08-13
 -   releaseCycle: "releng/10.1"
-    cycleShortHand: "10.1"
     eol: 2016-12-31
-
     releaseDate: 2014-11-14
 -   releaseCycle: "releng/10.0"
-    cycleShortHand: "10.0"
     eol: 2015-02-28
-
     releaseDate: 2014-01-20
 -   releaseCycle: "releng/9.3"
-    cycleShortHand: "9.3"
     eol: 2016-12-31
-
     releaseDate: 2014-07-16
 -   releaseCycle: "releng/9.2"
-    cycleShortHand: "9.2"
     eol: 2014-12-31
-
     releaseDate: 2013-09-30
 -   releaseCycle: "releng/9.1"
-    cycleShortHand: "9.1"
     eol: 2014-12-31
-
     releaseDate: 2012-12-30
 -   releaseCycle: "releng/9.0"
-    cycleShortHand: "9.0"
     eol: 2013-03-31
-
     releaseDate: 2012-01-10
 -   releaseCycle: "stable/9"
-    cycleShortHand: "9"
     eol: 2016-12-31
-
 -   releaseCycle: "releng/8.4"
-    cycleShortHand: "8.4"
     eol: 2015-08-01
-
     releaseDate: 2013-06-09
 -   releaseCycle: "releng/8.3"
-    cycleShortHand: "8.3"
     eol: 2014-04-30
-
     releaseDate: 2012-04-18
 -   releaseCycle: "releng/8.2"
-    cycleShortHand: "8.2"
     eol: 2012-07-31
-
     releaseDate: 2011-02-24
 -   releaseCycle: "releng/8.1"
-    cycleShortHand: "8.1"
     eol: 2012-07-31
-
     releaseDate: 2010-07-23
 -   releaseCycle: "releng/8.0"
-    cycleShortHand: "8.0"
     eol: 2010-11-30
-
     releaseDate: 2009-11-25
 -   releaseCycle: "stable/8"
-    cycleShortHand: "8"
     eol: 2015-08-01
-
 -   releaseCycle: "releng/7.4"
-    cycleShortHand: "7.4"
     eol: 2013-02-28
-
     releaseDate: 2011-02-24
 -   releaseCycle: "releng/7.3"
-    cycleShortHand: "7.3"
     eol: 2012-03-31
-
     releaseDate: 2010-03-23
 -   releaseCycle: "releng/7.2"
-    cycleShortHand: "7.2"
     eol: 2010-06-30
-
     releaseDate: 2009-03-04
 -   releaseCycle: "releng/7.1"
-    cycleShortHand: "7.1"
     eol: 2011-02-28
-
     releaseDate: 2009-01-04
 -   releaseCycle: "releng/7.0"
-    cycleShortHand: "7.0"
     eol: 2009-04-30
-
     releaseDate: 2008-02-27
 -   releaseCycle: "stable/7"
-    cycleShortHand: "7"
     eol: 2013-02-28
-
 -   releaseCycle: "releng/6.4"
-    cycleShortHand: "6.4"
     eol: 2010-11-30
-
     releaseDate: 2008-11-28
 -   releaseCycle: "releng/6.3"
-    cycleShortHand: "6.3"
     eol: 2010-01-31
-
     releaseDate: 2008-01-18
 -   releaseCycle: "releng/6.2"
-    cycleShortHand: "6.2"
     eol: 2008-05-31
-
     releaseDate: 2007-01-15
 -   releaseCycle: "releng/6.1"
-    cycleShortHand: "6.1"
     eol: 2008-05-31
-
     releaseDate: 2006-05-09
 -   releaseCycle: "releng/6.0"
-    cycleShortHand: "6.0"
     eol: 2007-01-31
-
     releaseDate: 2005-11-04
 -   releaseCycle: "stable/6"
-    cycleShortHand: "6"
     eol: 2010-11-30
-
 -   releaseCycle: "releng/5.5"
-    cycleShortHand: "5.5"
     eol: 2008-05-31
-
     releaseDate: 2006-05-25
 -   releaseCycle: "releng/5.4"
-    cycleShortHand: "5.4"
     eol: 2006-10-31
-
     releaseDate: 2005-05-09
 -   releaseCycle: "releng/5.3"
-    cycleShortHand: "5.3"
     eol: 2006-10-31
-
     releaseDate: 2004-11-06
 -   releaseCycle: "stable/5"
-    cycleShortHand: "5"
     eol: 2008-05-31
-
 -   releaseCycle: "releng/4.11"
     eol: 2007-01-31
-
     releaseDate: 2005-01-25
 -   releaseCycle: "stable/4"
-    cycleShortHand: "4"
     eol: 2007-01-31
 
 ---

--- a/products/gitlab.md
+++ b/products/gitlab.md
@@ -6,7 +6,6 @@ versionCommand: gitlab-rake gitlab:env:info
 releasePolicyLink: https://docs.gitlab.com/ce/policy/maintenance.html
 changelogTemplate: https://gitlab.com/gitlab-org/gitlab/-/releases/v__RELEASE_CYCLE__.0-ee
 releaseDateColumn: true
-sortReleasesBy: releaseDate
 activeSupportColumn: true
 eolColumn: Maintenance Support
 iconSlug: gitlab

--- a/products/gke.md
+++ b/products/gke.md
@@ -1,7 +1,6 @@
 ---
 title: Google Kubernetes Engine
 category: service
-sortReleasesBy: "releaseCycle"
 changelogTemplate: https://cloud.google.com/kubernetes-engine/docs/release-notes-nochannel
 # EoL is support + 3 months, but only for static releases
 # 1. Get the current version in a release channel from https://cloud.google.com/kubernetes-engine/docs/release-notes
@@ -9,25 +8,27 @@ changelogTemplate: https://cloud.google.com/kubernetes-engine/docs/release-notes
 # 3. support = Date from (2) + 12 months
 # 4. eol = Date from (2) + 14 months
 # We don't write down the "release" date since EoL is counted against Regular release channel, and release dates of a minor release are harder to track (and not helpful) for other release channels. Hence, releaseDateColumn is set to false.
+
+# The latest data is coming from the _data/gke.{json|yml} file
+# The file is generated at build-time
+# See #314 for an explanation
+
 releases:
-  # The latest data is coming from the _data/gke.{json|yml} file
-  # The file is generated at build-time
-  # See #314 for an explanation
--   releaseCycle: "Rapid"
-    eol: false
-    support: true
-    latest: '{{ site.data.gke.channels.RAPID" }}'
-    link: https://cloud.google.com/kubernetes-engine/docs/release-notes-rapid
--   releaseCycle: "Regular"
-    eol: false
-    support: true
-    latest: '{{ site.data.gke.channels.REGULAR" }}'
-    link: https://cloud.google.com/kubernetes-engine/docs/release-notes-regular
 -   releaseCycle: "Stable"
     eol: false
     support: true
     latest: '{{ site.data.gke.channels.STABLE" }}'
     link: https://cloud.google.com/kubernetes-engine/docs/release-notes-stable
+-   releaseCycle: "Regular"
+    eol: false
+    support: true
+    latest: '{{ site.data.gke.channels.REGULAR" }}'
+    link: https://cloud.google.com/kubernetes-engine/docs/release-notes-regular
+-   releaseCycle: "Rapid"
+    eol: false
+    support: true
+    latest: '{{ site.data.gke.channels.RAPID" }}'
+    link: https://cloud.google.com/kubernetes-engine/docs/release-notes-rapid
 -   releaseCycle: "1.22"
     eol: 2023-04-01
     support: 2023-02-01

--- a/products/go.md
+++ b/products/go.md
@@ -9,7 +9,6 @@ changelogTemplate: https://go.dev/doc/devel/release#go__RELEASE_CYCLE__.minor
 eolColumn: Supported
 versionCommand: go version
 releaseDateColumn: true
-sortReleasesBy: 'releaseDate'
 auto:
 -   git: https://github.com/golang/go.git
     regex: ^go(?<major>[1-9]\d*)\.(?<minor>0|[1-9]\d*)\.?(?<patch>0|[1-9]\d*)?$

--- a/products/godot.md
+++ b/products/godot.md
@@ -11,7 +11,6 @@ changelogTemplate: |
 eolColumn: Critical, Security and Platform support
 activeSupportColumn: true
 releaseDateColumn: true
-sortReleasesBy: "releaseCycle"
 auto:
 -   git: https://github.com/godotengine/godot.git
     regex: ^(?<version>\d+(\.\d+){1,3})-stable$

--- a/products/haproxy.md
+++ b/products/haproxy.md
@@ -13,7 +13,6 @@ releaseDateColumn: true
 # Script: https://github.com/endoflife-date/release-data/blob/main/src/haproxy.py
 auto:
 -   custom: true
-sortReleasesBy: 'releaseDate'
 releases:
 -   releaseCycle: "2.6"
     lts: true

--- a/products/hashicorp-vault.md
+++ b/products/hashicorp-vault.md
@@ -6,7 +6,6 @@ alternate_urls:
 category: server-app
 iconSlug: vault
 releasePolicyLink: https://support.hashicorp.com/hc/articles/360021185113
-sortReleasesBy: releaseDate
 changelogTemplate: https://github.com/hashicorp/vault/blob/v__LATEST__/CHANGELOG.md
 auto:
 -   git: https://github.com/hashicorp/vault.git

--- a/products/hbase.md
+++ b/products/hbase.md
@@ -11,19 +11,12 @@ activeSupportColumn: false
 eolColumn: Service Status
 releaseDateColumn: true
 releaseColumn: true
-sortReleasesBy: 'releaseCycle'
 iconSlug: NA
 auto:
 -   git: https://github.com/apache/hbase.git
     regex: '^rel\/(?<major>\d+)\.(?<minor>\d+)\.(?<patch>\d+)(\.(?<tiny>\d+))?$'
     template: "{{major}}.{{minor}}.{{patch}}{%if tiny%}.{{tiny}}{%endif%}"
 releases:
-# Uncomment when the first v3 stable release is out
-#-   releaseCycle: "3.0"
-#    eol: false
-#    releaseDate: 2021-07-20
-#    latest: "3.0.0-alpha-3"
-#    latestReleaseDate: 2022-06-27
 -   releaseCycle: "2.4"
     eol: false
     releaseDate: 2020-12-15

--- a/products/intelprocessors.md
+++ b/products/intelprocessors.md
@@ -10,40 +10,80 @@ eolColumn: Active Support
 latestColumn: false
 releaseColumn: false
 releaseDateColumn: true
-sortReleasesBy: 'releaseDate'
 releases:
--   releaseCycle: "Ivy Bridge"
-    discontinued: 2015-06-05
-    eol: 2019-12-31
-    releaseDate: 2012-04-29
+-   releaseCycle: "Alder Lake"
+    discontinued: false
+    eol: false
+    releaseDate: 2021-11-04
+-   releaseCycle: "Rocket Lake"
+    discontinued: false
+    eol: false
+    releaseDate: 2021-03-30
 
--   releaseCycle: ivy_bridge_xeon
-    releaseLabel: Ivy Bridge (Xeon E5v2/E7v2)
-    discontinued: 2015-06-05
-    eol: 2020-06-30
-    releaseDate: 2012-04-29
+-   releaseCycle: "Jasper Lake"
+    discontinued: false
+    eol: false
+    releaseDate: 2021-01-11
 
--   releaseCycle: haswell
-    releaseLabel: "Haswell"
+-   releaseCycle: "Elkhart Lake"
+    discontinued: false
+    eol: false
+    releaseDate: 2020-09-23
+
+-   releaseCycle: "Tiger Lake"
+    discontinued: false
+    eol: false
+    releaseDate: 2020-09-02
+
+-   releaseCycle: "Lakefield"
     discontinued: true
-    eol: 2021-06-30
-    releaseDate: 2013-06-04
+    eol: false
+    releaseDate: 2020-06-19
 
--   releaseCycle: haswell_xeon
-    releaseLabel: Haswell (Xeon E5v3/E7v3)
+-   releaseCycle: "Ice Lake"
+    discontinued: false
+    eol: false
+    releaseDate: 2019-09-01
+
+-   releaseCycle: "Comet Lake"
+    discontinued: false
+    eol: false
+    releaseDate: 2019-08-21
+
+-   releaseCycle: "Cannon Lake"
+    discontinued: 2020-02-28
+    eol: 2021-09-30
+    releaseDate: 2018-05-01
+
+-   releaseCycle: "Gemini Lake"
     discontinued: true
-    eol: 2021-12-31
-    releaseDate: 2013-06-04
+    eol: false
+    releaseDate: 2017-12-11
 
--   releaseCycle: "Crystal Well"
+-   releaseCycle: "Coffee Lake"
+    discontinued: 2021-12-24
+    eol: false
+    releaseDate: 2017-10-05
+
+-   releaseCycle: "Apollo Lake"
+    discontinued: false # TODO: This is likely incorrect, but I am assuming it is under production due to this CPU being launched semi recently and having its status say not discontinued: https://ark.intel.com/content/www/us/en/ark/products/195253/intel-pentium-processor-n4200e-2m-cache-up-to-2-50-ghz.html
+    eol: 2023-06-30
+    releaseDate: 2016-08-30
+
+-   releaseCycle: "Kaby Lake"
+    discontinued: 2020-10-09
+    eol: false
+    releaseDate: 2015-08-30
+
+-   releaseCycle: "Skylake"
+    discontinued: 2019-03-04
+    eol: 2022-09-30
+    releaseDate: 2015-08-05
+
+-   releaseCycle: "Braswell"
     discontinued: true
-    eol: 2021-06-30
-    releaseDate: 2013-06-02
-
--   releaseCycle: "Devil's Canyon"
-    discontinued: 2017-07-14
-    eol: 2021-06-30
-    releaseDate: 2014-06-02
+    eol: 2022-06-30
+    releaseDate: 2015-03-01
 
 -   releaseCycle: "broadwell"
     releaseLabel: Broadwell
@@ -62,105 +102,63 @@ releases:
     eol: 2022-12-31
     releaseDate: 2014-10-27
 
--   releaseCycle: "Skylake"
-    discontinued: 2019-03-04
-    eol: 2022-09-30
-    releaseDate: 2015-08-05
-
--   releaseCycle: "Apollo Lake"
-    discontinued: false # TODO: This is likely incorrect, but I am assuming it is under production due to this CPU being launched semi recently and having its status say not discontinued: https://ark.intel.com/content/www/us/en/ark/products/195253/intel-pentium-processor-n4200e-2m-cache-up-to-2-50-ghz.html
-    eol: 2023-06-30
-    releaseDate: 2016-08-30
+-   releaseCycle: "Devil's Canyon"
+    discontinued: 2017-07-14
+    eol: 2021-06-30
+    releaseDate: 2014-06-02
 
 -   releaseCycle: "Bay Trail"
     discontinued: true
     eol: 2021-06-30
     releaseDate: 2013-09-11
 
--   releaseCycle: "Braswell"
-    discontinued: true
-    eol: 2022-06-30
-    releaseDate: 2015-03-01
-
--   releaseCycle: "Cherry Trail"
-    discontinued: true
-    eol: 2022-06-30
-    releaseDate: 2013-03-02
-
--   releaseCycle: "Cannon Lake"
-    discontinued: 2020-02-28
-    eol: 2021-09-30
-    releaseDate: 2018-05-01
-
 -   releaseCycle: "Avoton"
     discontinued: true
     eol: 2021-06-30
     releaseDate: 2013-07-01 # Not accurate, date of start of quarter 3 of 2013
+
+-   releaseCycle: haswell
+    releaseLabel: "Haswell"
+    discontinued: true
+    eol: 2021-06-30
+    releaseDate: 2013-06-04
+
+-   releaseCycle: haswell_xeon
+    releaseLabel: Haswell (Xeon E5v3/E7v3)
+    discontinued: true
+    eol: 2021-12-31
+    releaseDate: 2013-06-04
+
+-   releaseCycle: "Crystal Well"
+    discontinued: true
+    eol: 2021-06-30
+    releaseDate: 2013-06-02
 
 -   releaseCycle: "Briarwood"
     discontinued: true
     eol: 2021-06-30
     releaseDate: 2013-04-01 # Not accurate, date of start of quarter 3 of 2013
 
+-   releaseCycle: "Cherry Trail"
+    discontinued: true
+    eol: 2022-06-30
+    releaseDate: 2013-03-02
+
 -   releaseCycle: "Centerton"
     discontinued: true
     eol: 2021-06-30
     releaseDate: 2012-12-11
 
--   releaseCycle: "Kaby Lake"
-    discontinued: 2020-10-09
-    eol: false
-    releaseDate: 2015-08-30
+-   releaseCycle: "Ivy Bridge"
+    discontinued: 2015-06-05
+    eol: 2019-12-31
+    releaseDate: 2012-04-29
 
--   releaseCycle: "Gemini Lake"
-    discontinued: true
-    eol: false
-    releaseDate: 2017-12-11
-
--   releaseCycle: "Coffee Lake"
-    discontinued: 2021-12-24
-    eol: false
-    releaseDate: 2017-10-05
-
--   releaseCycle: "Comet Lake"
-    discontinued: false
-    eol: false
-    releaseDate: 2019-08-21
-
--   releaseCycle: "Ice Lake"
-    discontinued: false
-    eol: false
-    releaseDate: 2019-09-01
-
--   releaseCycle: "Elkhart Lake"
-    discontinued: false
-    eol: false
-    releaseDate: 2020-09-23
-
--   releaseCycle: "Lakefield"
-    discontinued: true
-    eol: false
-    releaseDate: 2020-06-19
-
--   releaseCycle: "Tiger Lake"
-    discontinued: false
-    eol: false
-    releaseDate: 2020-09-02
-
--   releaseCycle: "Jasper Lake"
-    discontinued: false
-    eol: false
-    releaseDate: 2021-01-11
-
--   releaseCycle: "Rocket Lake"
-    discontinued: false
-    eol: false
-    releaseDate: 2021-03-30
-
--   releaseCycle: "Alder Lake"
-    discontinued: false
-    eol: false
-    releaseDate: 2021-11-04
+-   releaseCycle: ivy_bridge_xeon
+    releaseLabel: Ivy Bridge (Xeon E5v2/E7v2)
+    discontinued: 2015-06-05
+    eol: 2020-06-30
+    releaseDate: 2012-04-29
 
 ---
 

--- a/products/internetexplorer.md
+++ b/products/internetexplorer.md
@@ -7,35 +7,30 @@ releaseColumn: false
 iconSlug: internetexplorer
 activeSupportColumn: false
 eolColumn: Security and technical support
-sortReleasesBy: releaseDate
 releases:
-
--   releaseCycle: "7"
-    eol: 2023-10-10
-    releaseDate: 2006-10-18
-
--   releaseCycle: "8"
-    eol: 2016-01-12
-    releaseDate: 2009-06-17
-
-
--   releaseCycle: "9"
-    eol: 2016-01-12
-    releaseDate: 2011-03-15
-
--   releaseCycle: "10"
-    eol: 2020-01-31
-    releaseDate: 2012-10-30
-
 -   releaseCycle: "11" # This applies to 99% of users
     eol: 2022-06-14
     releaseDate: 2013-11-13
-
 
 -   releaseCycle: "11-ltsb"
     releaseLabel: "11 LTSB/LTSC/Server/Embedded"
     eol: 2031-10-14
     releaseDate: 2013-11-13
+-   releaseCycle: "10"
+    eol: 2020-01-31
+    releaseDate: 2012-10-30
+
+-   releaseCycle: "9"
+    eol: 2016-01-12
+    releaseDate: 2011-03-15
+
+-   releaseCycle: "8"
+    eol: 2016-01-12
+    releaseDate: 2009-06-17
+
+-   releaseCycle: "7"
+    eol: 2023-10-10
+    releaseDate: 2006-10-18
 
 ---
 

--- a/products/iphone.md
+++ b/products/iphone.md
@@ -11,76 +11,19 @@ activeSupportColumn: false
 eolColumn: Supported
 releaseColumn: false
 releaseDateColumn: true
-sortReleasesBy: releaseDate
 releases:
--   releaseCycle: "iPhone 5C"
-    discontinued: 2015-09-09
-    eol: 2017-09-19
-    releaseDate: 2013-09-20
--   releaseCycle: "iPhone 5S"
-    discontinued: 2016-03-21
-    eol: 2022-08-31
-    releaseDate: 2013-09-20
--   releaseCycle: "iPhone 6 / 6 Plus"
-    discontinued: 2016-09-07
-    eol: 2022-08-31
-    releaseDate: 2014-09-25
--   releaseCycle: "iPhone 6S / 6S Plus"
-    discontinued: 2018-09-12
-    eol: 2022-09-12
-    releaseDate: 2015-09-25
--   releaseCycle: "iPhone SE (1st generation)"
-    discontinued: 2018-09-12
-    eol: 2022-09-12
-    releaseDate: 2016-03-31
--   releaseCycle: "iPhone 7 / 7 Plus"
-    discontinued: 2019-09-10
-    eol: 2022-09-12
-    releaseDate: 2016-09-16
--   releaseCycle: "iPhone 8 / 8 Plus"
-    discontinued: 2020-04-15
-    eol: false
-    releaseDate: 2017-09-22
--   releaseCycle: "iPhone X"
-    discontinued: 2018-09-12
-    eol: false
-    releaseDate: 2017-09-12
--   releaseCycle: "iPhone XS / XS Max"
-    discontinued: 2019-09-10
-    eol: false
-    releaseDate: 2018-09-21
--   releaseCycle: "iPhone XR"
-    discontinued: 2021-09-07
-    eol: false
-    releaseDate: 2018-10-26
--   releaseCycle: "iPhone 11"
-    discontinued: 2022-09-07
-    eol: false
-    releaseDate: 2019-09-20
--   releaseCycle: "iPhone 11 Pro / 11 Pro Max"
-    discontinued: 2020-10-13
-    eol: false
-    releaseDate: 2019-09-20
--   releaseCycle: "iPhone SE (2nd generation)"
-    discontinued: 2022-03-08
-    eol: false
-    releaseDate: 2020-04-24
--   releaseCycle: "iPhone 12"
+-   releaseCycle: "iPhone 14 Plus"
     discontinued: false
     eol: false
-    releaseDate: 2020-10-23
--   releaseCycle: "iPhone 12 Mini"
-    discontinued: 2022-09-07
+    releaseDate: 2022-10-07
+-   releaseCycle: "iPhone 14 / 14 Pro / 14 Pro Max"
+    discontinued: false
     eol: false
-    releaseDate: 2020-11-13
--   releaseCycle: "iPhone 12 Pro"
-    discontinued: 2021-09-14
+    releaseDate: 2022-09-16
+-   releaseCycle: "iPhone SE (3rd generation)"
+    discontinued: false
     eol: false
-    releaseDate: 2020-10-23
--   releaseCycle: "iPhone 12 Pro Max"
-    discontinued: 2021-09-14
-    eol: false
-    releaseDate: 2020-11-13
+    releaseDate: 2022-03-18
 -   releaseCycle: "iPhone 13 / 13 Mini"
     discontinued: false
     eol: false
@@ -89,18 +32,74 @@ releases:
     discontinued: 2022-09-07
     eol: false
     releaseDate: 2021-09-24
--   releaseCycle: "iPhone SE (3rd generation)"
+-   releaseCycle: "iPhone 12 Mini"
+    discontinued: 2022-09-07
+    eol: false
+    releaseDate: 2020-11-13
+-   releaseCycle: "iPhone 12 Pro Max"
+    discontinued: 2021-09-14
+    eol: false
+    releaseDate: 2020-11-13
+-   releaseCycle: "iPhone 12"
     discontinued: false
     eol: false
-    releaseDate: 2022-03-18
--   releaseCycle: "iPhone 14 / 14 Pro / 14 Pro Max"
-    discontinued: false
+    releaseDate: 2020-10-23
+-   releaseCycle: "iPhone 12 Pro"
+    discontinued: 2021-09-14
     eol: false
-    releaseDate: 2022-09-16
--   releaseCycle: "iPhone 14 Plus"
-    discontinued: false
+    releaseDate: 2020-10-23
+-   releaseCycle: "iPhone SE (2nd generation)"
+    discontinued: 2022-03-08
     eol: false
-    releaseDate: 2022-10-07
+    releaseDate: 2020-04-24
+-   releaseCycle: "iPhone 11"
+    discontinued: 2022-09-07
+    eol: false
+    releaseDate: 2019-09-20
+-   releaseCycle: "iPhone 11 Pro / 11 Pro Max"
+    discontinued: 2020-10-13
+    eol: false
+    releaseDate: 2019-09-20
+-   releaseCycle: "iPhone XR"
+    discontinued: 2021-09-07
+    eol: false
+    releaseDate: 2018-10-26
+-   releaseCycle: "iPhone XS / XS Max"
+    discontinued: 2019-09-10
+    eol: false
+    releaseDate: 2018-09-21
+-   releaseCycle: "iPhone 8 / 8 Plus"
+    discontinued: 2020-04-15
+    eol: false
+    releaseDate: 2017-09-22
+-   releaseCycle: "iPhone X"
+    discontinued: 2018-09-12
+    eol: false
+    releaseDate: 2017-09-12
+-   releaseCycle: "iPhone 7 / 7 Plus"
+    discontinued: 2019-09-10
+    eol: 2022-09-12
+    releaseDate: 2016-09-16
+-   releaseCycle: "iPhone SE (1st generation)"
+    discontinued: 2018-09-12
+    eol: 2022-09-12
+    releaseDate: 2016-03-31
+-   releaseCycle: "iPhone 6S / 6S Plus"
+    discontinued: 2018-09-12
+    eol: 2022-09-12
+    releaseDate: 2015-09-25
+-   releaseCycle: "iPhone 6 / 6 Plus"
+    discontinued: 2016-09-07
+    eol: 2022-08-31
+    releaseDate: 2014-09-25
+-   releaseCycle: "iPhone 5C"
+    discontinued: 2015-09-09
+    eol: 2017-09-19
+    releaseDate: 2013-09-20
+-   releaseCycle: "iPhone 5S"
+    discontinued: 2016-03-21
+    eol: 2022-08-31
+    releaseDate: 2013-09-20
 
 ---
 

--- a/products/java.md
+++ b/products/java.md
@@ -10,7 +10,6 @@ versionCommand: java -version
 activeSupportColumn: true
 releasePolicyLink: https://www.oracle.com/technetwork/java/java-se-support-roadmap.html
 releaseDateColumn: true
-sortReleasesBy: 'releaseCycle'
 releases:
 -   releaseCycle: "19"
     support: 2023-03-01

--- a/products/jquery.md
+++ b/products/jquery.md
@@ -1,7 +1,6 @@
 ---
 title: jQuery
 category: framework
-sortReleasesBy: "releaseCycle"
 auto:
 -   git: https://github.com/jquery/jquery.git
 releases:

--- a/products/kdeplasma.md
+++ b/products/kdeplasma.md
@@ -7,7 +7,6 @@ releasePolicyLink: https://community.kde.org/Schedules/Plasma_5
 activeSupportColumn: true
 releaseDateColumn: true
 versionCommand: plasmashell -v
-sortReleasesBy: 'releaseCycle'
 changelogTemplate: https://kde.org/announcements/plasma/5/__LATEST__/
 category: os
 iconSlug: kde
@@ -20,7 +19,6 @@ releases:
     lts: false
     releaseDate: 2022-06-14
     latestReleaseDate: 2022-06-28
-
 -   releaseCycle: "5.24"
     latest: "5.24.5"
     support: 2022-06-14

--- a/products/kindle.md
+++ b/products/kindle.md
@@ -2,7 +2,6 @@
 title: Amazon Kindle
 iconSlug: amazon
 category: device
-sortReleasesBy: releaseDate
 releases:
 -   releaseCycle: "Kindle Paperwhite 5 (11th Generation)"
     eol: false
@@ -39,16 +38,16 @@ releases:
     latest: "5.14.3.0.1"
     link: https://www.amazon.com/Oasis8Notes
     releaseDate: 2016-04-27
--   releaseCycle: "Kindle Voyage (7th Generation)"
-    eol: 2021-04-01
-    latest: "5.13.6"
-    link: https://www.amazon.com/Voyage7Notes
-    releaseDate: 2014-11-04
 -   releaseCycle: "Kindle Paperwhite 3 (7th Generation)"
     eol: false
     latest: "5.14.3.0.1"
     link: https://www.amazon.com/Paperwhite7Notes
     releaseDate: 2015-06-30
+-   releaseCycle: "Kindle Voyage (7th Generation)"
+    eol: 2021-04-01
+    latest: "5.13.6"
+    link: https://www.amazon.com/Voyage7Notes
+    releaseDate: 2014-11-04
 -   releaseCycle: "Kindle 7 (7th Generation)"
     eol: 2019-10-01
     latest: "5.12.2.2"

--- a/products/kotlin.md
+++ b/products/kotlin.md
@@ -7,7 +7,6 @@ alternate_urls:
 -   /kotlinlang
 versionCommand: kotlinc-native -version
 releasePolicyLink: https://kotlinlang.org/docs/releases.html
-sortReleasesBy: "releaseDate"
 changelogTemplate: "https://github.com/JetBrains/kotlin/releases/tag/v__LATEST__"
 auto:
 -   git: https://github.com/JetBrains/kotlin.git

--- a/products/kubernetes.md
+++ b/products/kubernetes.md
@@ -7,7 +7,6 @@ releasePolicyLink: https://kubernetes.io/releases/patch-releases/
 releaseImage: https://upload.wikimedia.org/wikipedia/en/timeline/5s3rt0dg6aaqymdat8d2kt61fc3mt29.png
 changelogTemplate: https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-__RELEASE_CYCLE__.md
 releaseDateColumn: true
-sortReleasesBy: releaseDate
 activeSupportColumn: true
 eolColumn: Maintenance Support
 auto:

--- a/products/laravel.md
+++ b/products/laravel.md
@@ -7,7 +7,6 @@ changelogTemplate: https://laravel.com/docs/__RELEASE_CYCLE__.x/releases
 activeSupportColumn: true
 versionCommand: composer show laravel/framework|grep versions
 releaseDateColumn: true
-sortReleasesBy: 'releaseCycle'
 auto:
 -   git: https://github.com/laravel/framework.git
 purls:

--- a/products/libreoffice.md
+++ b/products/libreoffice.md
@@ -6,7 +6,6 @@ releasePolicyLink: https://wiki.documentfoundation.org/ReleasePlan
 activeSupportColumn: false
 releaseDateColumn: true
 eolColumn: Support Status
-sortReleasesBy: 'releaseCycle'
 category: app
 releases:
 -   releaseCycle: "7.4"

--- a/products/lineageos.md
+++ b/products/lineageos.md
@@ -1,7 +1,6 @@
 ---
 title: LineageOS
 category: os
-sortReleasesBy: "releaseCycle"
 releases:
 -   releaseCycle: "19"
     eol: false

--- a/products/linuxkernel.md
+++ b/products/linuxkernel.md
@@ -10,7 +10,6 @@ changelogTemplate: |
 activeSupportColumn: false
 releaseDateColumn: true
 releaseColumn: true
-sortReleasesBy: 'releaseDate'
 versionCommand: uname -r
 auto:
 # Note that we're tracking the linux kernel stable tree, not torvalds' tree
@@ -24,7 +23,6 @@ releases:
     latest: "6.0"
     latestReleaseDate: 2022-10-02
     releaseDate: 2022-10-02
-
 -   releaseCycle: "5.19"
     eol: false
     latest: "5.19.12"

--- a/products/linuxmint.md
+++ b/products/linuxmint.md
@@ -7,10 +7,24 @@ releasePolicyLink: https://linuxmint.com/download_all.php
 activeSupportColumn: true
 releaseDateColumn: true
 iconSlug: linuxmint
-sortReleasesBy: "releaseCycle"
 releaseLabel: "__RELEASE_CYCLE__ '__CODENAME__'"
 releases:
+-   releaseCycle: "lmde5"
+    releaseLabel: "LMDE 5"
+    codename: Elsie
+    support: true
+    eol: false
+    latest: "5"
+    link: https://blog.linuxmint.com/?p=4287
+    releaseDate: 2022-03-20
+-   releaseCycle: "lmde4"
+    releaseLabel: "LMDE 4"
+    support: 2022-08-01
+    eol: 2022-08-01
+    latest: "4"
+    link: https://linuxmint.com/rel_debbie.php
 
+    releaseDate: 2020-03-20
 -   releaseCycle: "21"
     codename: Vanessa
     lts: true
@@ -20,24 +34,6 @@ releases:
     link: https://linuxmint.com/rel_vanessa_cinnamon.php
     releaseDate: 2022-07-31
 
--   releaseCycle: "lmde5"
-    releaseLabel: "LMDE 5"
-    codename: Elsie
-    support: true
-    eol: false
-    latest: "5"
-    link: https://blog.linuxmint.com/?p=4287
-    releaseDate: 2022-03-20
-
-
--   releaseCycle: "lmde4"
-    releaseLabel: "LMDE 4"
-    support: 2022-08-01
-    eol: 2022-08-01
-    latest: "4"
-    link: https://linuxmint.com/rel_debbie.php
-
-    releaseDate: 2020-03-20
 -   releaseCycle: "20.3"
     codename: Una
     lts: true

--- a/products/log4j.md
+++ b/products/log4j.md
@@ -11,30 +11,25 @@ activeSupportColumn: false
 releaseDateColumn: true
 iconSlug: apache
 eolColumn: Supported
-sortReleasesBy: cycleShortHand
 auto:
 -   maven: org.apache.logging.log4j/log4j-core
 releases:
 -   releaseCycle: "2"
-    cycleShortHand: '299'
     eol: false
     latest: "2.19.0"
     latestReleaseDate: 2022-09-13
     releaseDate: 2014-07-12
 -   releaseCycle: "2.12"
-    cycleShortHand: '212'
     eol: 2021-12-14
     latest: "2.12.4"
     latestReleaseDate: 2021-12-28
     releaseDate: 2019-06-26
 -   releaseCycle: "2.3"
-    cycleShortHand: '203'
     eol: 2015-09-20
     latest: "2.3.2"
     latestReleaseDate: 2021-12-29
     releaseDate: 2015-05-10
 -   releaseCycle: "1"
-    cycleShortHand: '100'
     eol: 2015-10-15
     latest: "1.2.17"
     releaseDate: 2001-01-08

--- a/products/looker.md
+++ b/products/looker.md
@@ -11,7 +11,6 @@ eolColumn: Support Status
 activeSupportColumn: false
 releaseDateColumn: true
 releaseColumn: false
-sortReleasesBy: "releaseDate"
 releaseImage: https://docs.looker.com/assets/images/2022-std-supp-releases.png
 releases:
 -   releaseCycle: "22.8"

--- a/products/macos.md
+++ b/products/macos.md
@@ -3,7 +3,6 @@ title: macOS
 alternate_urls:
 -   /mac
 category: os
-sortReleasesBy: releaseDate
 releaseLabel: "macOS __RELEASE_CYCLE__ (__CODENAME__)"
 # Data: https://github.com/endoflife-date/release-data/blob/main/releases/macos.json
 # Source: https://support.apple.com/en-us/HT201222 (and older versions linked at bottom)

--- a/products/magento.md
+++ b/products/magento.md
@@ -10,7 +10,6 @@ versionCommand: php bin/magento --version
 auto:
 -   git: https://github.com/magento/magento2.git
 releaseDateColumn: true
-sortReleasesBy: 'releaseCycle'
 releases:
 -   releaseCycle: "2.4.5"
     eol: 2024-11-25

--- a/products/mariadb.md
+++ b/products/mariadb.md
@@ -23,8 +23,13 @@ auto:
     regex: ^mariadb-((?<major>5)\.(?<minor>5)\.(?<patch>(29|[3-9]\d))|(?<major>10)\.(?<minor>0)\.(?<patch>(1[2-9]|[2-9]\d))|(?<major>10)\.(?<minor>1)\.(?<patch>(1[8-9]|[2-9]\d))|(?<major>10)\.(?<minor>2)\.(?<patch>([6-9]|\d{2}))|(?<major>10)\.(?<minor>3)\.(?<patch>([7-9]|\d{2}))|(?<major>10)\.(?<minor>4)\.(?<patch>([6-9]|\d{2}))|(?<major>10)\.(?<minor>5)\.(?<patch>([4-9]|\d{2}))|(?<major>10)\.(?<minor>6)\.(?<patch>([3-9]|\d{2}))|(?<major>10)\.(?<minor>7)\.(?<patch>([2-9]|\d{2}))|(?<major>10)\.(?<minor>8)\.(?<patch>([3-9]|\d{2}))|(?<major>10)\.(?<minor>9)\.(?<patch>([2-9]|\d{2})))$
 versionCommand: mysqld --version
 eolColumn: Support Status
-sortReleasesBy: 'releaseCycle'
 releases:
+-   releaseCycle: "5.5"
+    eol: 2020-04-11
+    latest: "5.5.68"
+    lts: true
+    latestReleaseDate: 2020-05-06
+    releaseDate: 2013-01-29
 -   releaseCycle: "10.9"
     eol: 2023-08-22
     latest: "10.9.3"
@@ -76,12 +81,6 @@ releases:
     latest: "10.0.38"
     latestReleaseDate: 2019-01-29
     releaseDate: 2014-06-12
--   releaseCycle: "5.5"
-    eol: 2020-04-11
-    latest: "5.5.68"
-    lts: true
-    latestReleaseDate: 2020-05-06
-    releaseDate: 2013-01-29
 
 ---
 

--- a/products/mediawiki.md
+++ b/products/mediawiki.md
@@ -1,7 +1,6 @@
 ---
 title: MediaWiki
 category: server-app
-sortReleasesBy: "releaseCycle"
 changelogTemplate: "https://www.mediawiki.org/wiki/Release_notes/__RELEASE_CYCLE__"
 releaseImage: https://upload.wikimedia.org/wikipedia/mediawiki/timeline/bxn2hc9b02nf015vxy4zlq7sdr9cs6u.png
 iconSlug: NA

--- a/products/mongodb.md
+++ b/products/mongodb.md
@@ -3,7 +3,6 @@ title: MongoDB Server
 permalink: /mongodb
 category: db
 releasePolicyLink: https://www.mongodb.com/support-policy
-sortReleasesBy: "releaseCycle"
 changelogTemplate: https://www.mongodb.com/docs/v__RELEASE_CYCLE__/release-notes/__RELEASE_CYCLE__/
 activeSupportColumn: false
 releaseDateColumn: true

--- a/products/moodle.md
+++ b/products/moodle.md
@@ -2,7 +2,6 @@
 title: Moodle
 category: server-app
 
-sortReleasesBy: "support"
 changelogTemplate: "https://docs.moodle.org/dev/Moodle___LATEST___release_notes"
 
 releases:

--- a/products/msexchange.md
+++ b/products/msexchange.md
@@ -7,7 +7,6 @@ releasePolicyLink: https://learn.microsoft.com/lifecycle/products/?terms=Exchang
 activeSupportColumn: true
 versionCommand: Get-ExchangeServer | Format-List Name,Edition,AdminDisplayVersion
 releaseDateColumn: true
-sortReleasesBy: releaseDate
 releases:
 -   releaseCycle: "2019"
     releaseLabel: "2019 CU12 Aug22SU"

--- a/products/mssharepoint.md
+++ b/products/mssharepoint.md
@@ -8,7 +8,6 @@ category: server-app
 releasePolicyLink: https://learn.microsoft.com/lifecycle/products/?terms=SharePoint%20Server
 activeSupportColumn: true
 releaseDateColumn: true
-sortReleasesBy: releaseDate
 releases:
 -   releaseCycle: "2019"
     support: 2024-01-09

--- a/products/mssqlserver.md
+++ b/products/mssqlserver.md
@@ -7,7 +7,6 @@ releasePolicyLink: https://learn.microsoft.com/lifecycle/products/?terms=SQL%20S
 activeSupportColumn: true
 versionCommand: select @@version
 releaseDateColumn: true
-sortReleasesBy: 'latest'
 releases:
 -   releaseCycle: "2019"
     releaseLabel: "2019 CU18"

--- a/products/mysql.md
+++ b/products/mysql.md
@@ -1,7 +1,6 @@
 ---
 title: MySQL
 category: db
-sortReleasesBy: "releaseCycle"
 changelogTemplate: https://dev.mysql.com/doc/relnotes/mysql/__RELEASE_CYCLE__/en/news-{{"__LATEST__"
   | replace:'.','-'}}.html
 # dates below are for:

--- a/products/nextcloud.md
+++ b/products/nextcloud.md
@@ -1,7 +1,6 @@
 ---
 title: Nextcloud
 category: server-app
-sortReleasesBy: "releaseCycle"
 releasePolicyLink: https://github.com/nextcloud/server/wiki/Maintenance-and-Release-Schedule
 changelogTemplate: "https://nextcloud.com/changelog/#latest__RELEASE_CYCLE__"
 permalink: /nextcloud

--- a/products/nginx.md
+++ b/products/nginx.md
@@ -8,7 +8,6 @@ activeSupportColumn: false
 versionCommand: nginx -v
 releaseColumn: true
 releaseDateColumn: true
-sortReleasesBy: releaseDate
 changelogTemplate: https://nginx.org/en/CHANGES-__RELEASE_CYCLE__
 # https://rubular.com/r/bVKLuLKLLrHCTI
 auto:

--- a/products/nix.md
+++ b/products/nix.md
@@ -6,7 +6,6 @@ permalink: /nix
 alternate_urls:
 -   /nixlang
 releasePolicyLink: https://nixos.org/blog/announcements.html
-sortReleasesBy: "releaseCycle"
 changelogTemplate: https://nixos.org/manual/nix/stable/release-notes/rl-__RELEASE_CYCLE__.html
 versionCommand: nix --version
 auto:

--- a/products/nixos.md
+++ b/products/nixos.md
@@ -6,7 +6,6 @@ permalink: /nixos
 alternate_urls:
 -   /nixoslinux
 releasePolicyLink: https://nixos.org/blog/announcements.html
-sortReleasesBy: "releaseCycle"
 changelogTemplate: https://nixos.org/manual/nixos/stable/release-notes.html#sec-release-__LATEST__
 versionCommand: cat /etc/os-release
 activeSupportColumn: false

--- a/products/nodejs.md
+++ b/products/nodejs.md
@@ -14,7 +14,6 @@ auto:
 -   git: https://github.com/nodejs/node.git
 versionCommand: node --version
 releaseDateColumn: true
-sortReleasesBy: 'releaseCycle'
 releases:
 -   releaseCycle: "18"
     lts: 2022-10-25

--- a/products/nokia.md
+++ b/products/nokia.md
@@ -10,172 +10,7 @@ releasePolicyLink: https://www.nokia.com/phones/en_int/security-updates
 activeSupportColumn: false
 releaseDateColumn: true
 releaseColumn: false
-sortReleasesBy: releaseDate
 releases:
--   releaseCycle: "Nokia 1"
-    releaseDate: 2018-04-01
-    eol: 2021-04-01
-    link: https://www.nokia.com/phones/en_int/nokia-1-0
--   releaseCycle: "Nokia 1 Plus"
-    releaseDate: 2019-02-24
-    eol: 2022-02-01
-    link: https://www.nokia.com/phones/en_int/nokia-1-plus
--   releaseCycle: "Nokia 1.3"
-    releaseDate: 2020-04-02
-    eol: 2023-06-01
-    link: https://www.nokia.com/phones/en_int/nokia-1-3
--   releaseCycle: "Nokia 1.4"
-    releaseDate: 2021-02-03
-    eol: 2024-04-01
-    link: https://www.nokia.com/phones/en_int/nokia-1-4
--   releaseCycle: "Nokia 2"
-    releaseDate: 2017-11-01
-    eol: 2019-11-01
-    link: https://www.nokia.com/phones/en_int/nokia-2-0
--   releaseCycle: "Nokia 2.1"
-    releaseDate: 2018-08-01
-    eol: 2021-08-01
-    link: https://www.nokia.com/phones/en_int/nokia-2-1
--   releaseCycle: "Nokia 2.2"
-    releaseDate: 2019-06-11
-    eol: 2022-05-01
-    link: https://www.nokia.com/phones/en_int/nokia-2-2
--   releaseCycle: "Nokia 2.3"
-    releaseDate: 2019-12-19
-    eol: 2022-12-01
-    link: https://www.nokia.com/phones/en_int/nokia-2-3
--   releaseCycle: "Nokia 2.4"
-    releaseDate: 2020-09-30
-    eol: 2023-10-01
-    link: https://www.nokia.com/phones/en_int/nokia-2-4
--   releaseCycle: "Nokia 3"
-    releaseDate: 2017-06-17
-    eol: 2020-09-01
-    link: https://www.nokia.com/phones/en_int/nokia-3-0
--   releaseCycle: "Nokia 3.1"
-    releaseDate: 2018-05-01
-    eol: 2021-07-01
-    link: https://www.nokia.com/phones/en_int/nokia-3-1
--   releaseCycle: "Nokia 3.1 Plus"
-    releaseDate: 2018-04-01
-    eol: 2021-10-01
-    link: https://www.nokia.com/phones/en_int/nokia-3-plus
--   releaseCycle: "Nokia 3.2"
-    releaseDate: 2019-05-22
-    eol: 2022-04-01
-    link: https://www.nokia.com/phones/en_int/nokia-3-2
--   releaseCycle: "Nokia 3.4"
-    releaseDate: 2020-10-26
-    eol: 2023-11-01
-    link: https://www.nokia.com/phones/en_int/nokia-3-4
--   releaseCycle: "Nokia 4.2"
-    releaseDate: 2019-05-07
-    eol: 2022-04-01
-    link: https://www.nokia.com/phones/en_int/nokia-4-2
--   releaseCycle: "Nokia 5"
-    releaseDate: 2017-07-17
-    eol: 2020-10-01
-    link: https://www.nokia.com/phones/en_int/nokia-5-0
--   releaseCycle: "Nokia 5.1"
-    releaseDate: 2018-08-01
-    eol: 2021-08-01
-    link: https://www.nokia.com/phones/en_int/nokia-5-1
--   releaseCycle: "Nokia 5.1 Plus"
-    releaseDate: 2018-12-05
-    eol: 2021-10-01
-    link: https://www.nokia.com/phones/en_int/nokia-5-plus
--   releaseCycle: "Nokia 5.3"
-    releaseDate: 2020-04-02
-    eol: 2023-06-01
-    link: https://www.nokia.com/phones/en_int/nokia-5-3
--   releaseCycle: "Nokia 5.4"
-    releaseDate: 2020-12-25
-    eol: 2024-01-01
-    link: https://www.nokia.com/phones/en_int/nokia-5-4
--   releaseCycle: "Nokia 6"
-    releaseDate: 2017-01-19
-    eol: 2020-10-01
-    link: https://www.nokia.com/phones/en_int/nokia-6-0
--   releaseCycle: "Nokia 6.1"
-    releaseDate: 2018-05-06
-    eol: 2021-04-01
-    link: https://www.nokia.com/phones/en_int/nokia-6-1
--   releaseCycle: "Nokia 6.1 Plus"
-    releaseDate: 2018-08-21
-    eol: 2021-08-01
-    link: https://www.nokia.com/phones/en_int/nokia-6-plus
--   releaseCycle: "Nokia 6.2"
-    releaseDate: 2019-10-17
-    eol: 2022-10-01
-    link: https://www.nokia.com/phones/en_int/nokia-6-2
--   releaseCycle: "Nokia 7 Plus"
-    releaseDate: 2018-04-30
-    eol: 2021-04-01
-    link: https://www.nokia.com/phones/en_int/nokia-7-plus
--   releaseCycle: "Nokia 7.1"
-    releaseDate: 2018-10-28
-    eol: 2021-11-01
-    link: https://www.nokia.com/phones/en_int/nokia-7-1
--   releaseCycle: "Nokia 7.2"
-    releaseDate: 2019-09-23
-    eol: 2022-09-01
-    link: https://www.nokia.com/phones/en_int/nokia-7-2
--   releaseCycle: "Nokia 8"
-    releaseDate: 2017-09-07
-    eol: 2020-10-01
-    link: https://www.nokia.com/phones/en_int/nokia-8-0
--   releaseCycle: "Nokia 8 Sirocco"
-    releaseDate: 2018-04-23
-    eol: 2021-05-01
-    link: https://www.nokia.com/phones/en_int/nokia-8-sirocco
--   releaseCycle: "Nokia 8.1"
-    releaseDate: 2018-12-05
-    eol: 2021-12-01
-    link: https://www.nokia.com/phones/en_int/nokia-8-1
--   releaseCycle: "Nokia 8.3 5G"
-    releaseDate: 2020-09-15
-    eol: 2023-11-01
-    link: https://www.nokia.com/phones/en_int/nokia-8-3-5g
--   releaseCycle: "Nokia 9 Pureview"
-    releaseDate: 2019-03-13
-    eol: 2022-03-01
-    link: https://www.nokia.com/phones/en_int/nokia-9-pureview
--   releaseCycle: "Nokia C01 Plus"
-    releaseDate: 2021-06-28
-    eol: 2023-08-01
-    link: https://www.nokia.com/phones/en_int/nokia-c-01-plus
--   releaseCycle: "Nokia C1"
-    releaseDate: 2019-12-11
-    eol: 2021-12-01
-    link: https://www.nokia.com/phones/en_int/nokia-c-1
--   releaseCycle: "Nokia C1 2nd Edition"
-    releaseDate: 2021-08-27
-    eol: 2023-09-01
-    link: https://www.nokia.com/phones/en_int/nokia-c-1-2nd-edition
--   releaseCycle: "Nokia C1 Plus"
-    releaseDate: 2021-01-29
-    eol: 2023-01-01
-    link: https://www.nokia.com/phones/en_int/nokia-c-1-plus
--   releaseCycle: "Nokia C10"
-    releaseDate: 2021-06-29
-    eol: 2023-08-01
-    link: https://www.nokia.com/phones/en_int/nokia-c-10
--   releaseCycle: "Nokia C2"
-    releaseDate: 2020-03-22
-    eol: 2022-02-01
-    link: https://www.nokia.com/phones/en_int/nokia-c-2
--   releaseCycle: "Nokia C2 2nd Edition"
-    releaseDate: 2022-04-19
-    eol: 2024-05-01
-    link: https://www.nokia.com/phones/en_int/nokia-c-2-2nd-edition
--   releaseCycle: "Nokia C20"
-    releaseDate: 2021-06-06
-    eol: 2023-06-01
-    link: https://www.nokia.com/phones/en_int/nokia-c-20
--   releaseCycle: "Nokia C20 Plus"
-    releaseDate: 2021-06-16
-    eol: 2023-09-01
-    link: https://www.nokia.com/phones/en_in/nokia-c-20-plus
 -   releaseCycle: "Nokia C21"
     releaseDate: 2022-05-03
     eol: false
@@ -184,54 +19,218 @@ releases:
     releaseDate: 2022-04-29
     eol: false
     link: https://www.nokia.com/phones/en_int/nokia-c-21-plus
--   releaseCycle: "Nokia C3"
-    releaseDate: 2020-08-13
-    eol: 2022-11-01
-    link: https://www.nokia.com/phones/en_int/nokia-c-3
--   releaseCycle: "Nokia C30"
-    releaseDate: 2021-10-12
-    eol: 2023-10-01
-    link: https://www.nokia.com/phones/en_int/nokia-c-30
--   releaseCycle: "Nokia G10"
-    releaseDate: 2021-04-26
-    eol: 2024-07-01
-    link: https://www.nokia.com/phones/en_int/nokia-g-10
+-   releaseCycle: "Nokia C2 2nd Edition"
+    releaseDate: 2022-04-19
+    eol: 2024-05-01
+    link: https://www.nokia.com/phones/en_int/nokia-c-2-2nd-edition
 -   releaseCycle: "Nokia G11"
     releaseDate: 2022-03-24
     eol: 2025-05-01
     link: https://www.nokia.com/phones/en_int/nokia-g-11
--   releaseCycle: "Nokia G20"
-    releaseDate: 2021-05-17
-    eol: 2024-07-01
-    link: https://www.nokia.com/phones/en_int/nokia-g-20
 -   releaseCycle: "Nokia G21"
     releaseDate: 2022-02-15
     eol: 2025-03-01
     link: https://www.nokia.com/phones/en_int/nokia-g-21
--   releaseCycle: "Nokia G50"
-    releaseDate: 2021-10-13
-    eol: 2024-12-01
-    link: https://www.nokia.com/phones/en_int/nokia-g-50
 -   releaseCycle: "Nokia T20"
     releaseDate: 2021-11-02
     eol: 2024-11-01
     link: https://www.nokia.com/phones/en_int/nokia-t-20
--   releaseCycle: "Nokia X10"
-    releaseDate: 2021-06-07
-    eol: 2024-09-01
-    link: https://www.nokia.com/phones/en_int/nokia-x-10
--   releaseCycle: "Nokia X20"
-    releaseDate: 2021-05-12
-    eol: 2024-07-01
-    link: https://www.nokia.com/phones/en_int/nokia-x-20
--   releaseCycle: "Nokia X71"
-    releaseDate: 2019-04-17
-    eol: 2019-05-01
-    link: https://www.nokia.com/phones/zh_tw/nokia-x71
+-   releaseCycle: "Nokia G50"
+    releaseDate: 2021-10-13
+    eol: 2024-12-01
+    link: https://www.nokia.com/phones/en_int/nokia-g-50
+-   releaseCycle: "Nokia C30"
+    releaseDate: 2021-10-12
+    eol: 2023-10-01
+    link: https://www.nokia.com/phones/en_int/nokia-c-30
+-   releaseCycle: "Nokia C1 2nd Edition"
+    releaseDate: 2021-08-27
+    eol: 2023-09-01
+    link: https://www.nokia.com/phones/en_int/nokia-c-1-2nd-edition
 -   releaseCycle: "Nokia XR20"
     releaseDate: 2021-08-04
     eol: 2025-11-01
     link: https://www.nokia.com/phones/en_int/nokia-xr-20
+-   releaseCycle: "Nokia C10"
+    releaseDate: 2021-06-29
+    eol: 2023-08-01
+    link: https://www.nokia.com/phones/en_int/nokia-c-10
+-   releaseCycle: "Nokia C01 Plus"
+    releaseDate: 2021-06-28
+    eol: 2023-08-01
+    link: https://www.nokia.com/phones/en_int/nokia-c-01-plus
+-   releaseCycle: "Nokia C20 Plus"
+    releaseDate: 2021-06-16
+    eol: 2023-09-01
+    link: https://www.nokia.com/phones/en_in/nokia-c-20-plus
+-   releaseCycle: "Nokia X10"
+    releaseDate: 2021-06-07
+    eol: 2024-09-01
+    link: https://www.nokia.com/phones/en_int/nokia-x-10
+-   releaseCycle: "Nokia C20"
+    releaseDate: 2021-06-06
+    eol: 2023-06-01
+    link: https://www.nokia.com/phones/en_int/nokia-c-20
+-   releaseCycle: "Nokia G20"
+    releaseDate: 2021-05-17
+    eol: 2024-07-01
+    link: https://www.nokia.com/phones/en_int/nokia-g-20
+-   releaseCycle: "Nokia X20"
+    releaseDate: 2021-05-12
+    eol: 2024-07-01
+    link: https://www.nokia.com/phones/en_int/nokia-x-20
+-   releaseCycle: "Nokia G10"
+    releaseDate: 2021-04-26
+    eol: 2024-07-01
+    link: https://www.nokia.com/phones/en_int/nokia-g-10
+-   releaseCycle: "Nokia 1.4"
+    releaseDate: 2021-02-03
+    eol: 2024-04-01
+    link: https://www.nokia.com/phones/en_int/nokia-1-4
+-   releaseCycle: "Nokia C1 Plus"
+    releaseDate: 2021-01-29
+    eol: 2023-01-01
+    link: https://www.nokia.com/phones/en_int/nokia-c-1-plus
+-   releaseCycle: "Nokia 5.4"
+    releaseDate: 2020-12-25
+    eol: 2024-01-01
+    link: https://www.nokia.com/phones/en_int/nokia-5-4
+-   releaseCycle: "Nokia 3.4"
+    releaseDate: 2020-10-26
+    eol: 2023-11-01
+    link: https://www.nokia.com/phones/en_int/nokia-3-4
+-   releaseCycle: "Nokia 2.4"
+    releaseDate: 2020-09-30
+    eol: 2023-10-01
+    link: https://www.nokia.com/phones/en_int/nokia-2-4
+-   releaseCycle: "Nokia 8.3 5G"
+    releaseDate: 2020-09-15
+    eol: 2023-11-01
+    link: https://www.nokia.com/phones/en_int/nokia-8-3-5g
+-   releaseCycle: "Nokia C3"
+    releaseDate: 2020-08-13
+    eol: 2022-11-01
+    link: https://www.nokia.com/phones/en_int/nokia-c-3
+-   releaseCycle: "Nokia 1.3"
+    releaseDate: 2020-04-02
+    eol: 2023-06-01
+    link: https://www.nokia.com/phones/en_int/nokia-1-3
+-   releaseCycle: "Nokia 5.3"
+    releaseDate: 2020-04-02
+    eol: 2023-06-01
+    link: https://www.nokia.com/phones/en_int/nokia-5-3
+-   releaseCycle: "Nokia C2"
+    releaseDate: 2020-03-22
+    eol: 2022-02-01
+    link: https://www.nokia.com/phones/en_int/nokia-c-2
+-   releaseCycle: "Nokia 2.3"
+    releaseDate: 2019-12-19
+    eol: 2022-12-01
+    link: https://www.nokia.com/phones/en_int/nokia-2-3
+-   releaseCycle: "Nokia C1"
+    releaseDate: 2019-12-11
+    eol: 2021-12-01
+    link: https://www.nokia.com/phones/en_int/nokia-c-1
+-   releaseCycle: "Nokia 6.2"
+    releaseDate: 2019-10-17
+    eol: 2022-10-01
+    link: https://www.nokia.com/phones/en_int/nokia-6-2
+-   releaseCycle: "Nokia 7.2"
+    releaseDate: 2019-09-23
+    eol: 2022-09-01
+    link: https://www.nokia.com/phones/en_int/nokia-7-2
+-   releaseCycle: "Nokia 2.2"
+    releaseDate: 2019-06-11
+    eol: 2022-05-01
+    link: https://www.nokia.com/phones/en_int/nokia-2-2
+-   releaseCycle: "Nokia 3.2"
+    releaseDate: 2019-05-22
+    eol: 2022-04-01
+    link: https://www.nokia.com/phones/en_int/nokia-3-2
+-   releaseCycle: "Nokia 4.2"
+    releaseDate: 2019-05-07
+    eol: 2022-04-01
+    link: https://www.nokia.com/phones/en_int/nokia-4-2
+-   releaseCycle: "Nokia X71"
+    releaseDate: 2019-04-17
+    eol: 2019-05-01
+    link: https://www.nokia.com/phones/zh_tw/nokia-x71
+-   releaseCycle: "Nokia 9 Pureview"
+    releaseDate: 2019-03-13
+    eol: 2022-03-01
+    link: https://www.nokia.com/phones/en_int/nokia-9-pureview
+-   releaseCycle: "Nokia 1 Plus"
+    releaseDate: 2019-02-24
+    eol: 2022-02-01
+    link: https://www.nokia.com/phones/en_int/nokia-1-plus
+-   releaseCycle: "Nokia 5.1 Plus"
+    releaseDate: 2018-12-05
+    eol: 2021-10-01
+    link: https://www.nokia.com/phones/en_int/nokia-5-plus
+-   releaseCycle: "Nokia 8.1"
+    releaseDate: 2018-12-05
+    eol: 2021-12-01
+    link: https://www.nokia.com/phones/en_int/nokia-8-1
+-   releaseCycle: "Nokia 7.1"
+    releaseDate: 2018-10-28
+    eol: 2021-11-01
+    link: https://www.nokia.com/phones/en_int/nokia-7-1
+-   releaseCycle: "Nokia 6.1 Plus"
+    releaseDate: 2018-08-21
+    eol: 2021-08-01
+    link: https://www.nokia.com/phones/en_int/nokia-6-plus
+-   releaseCycle: "Nokia 2.1"
+    releaseDate: 2018-08-01
+    eol: 2021-08-01
+    link: https://www.nokia.com/phones/en_int/nokia-2-1
+-   releaseCycle: "Nokia 5.1"
+    releaseDate: 2018-08-01
+    eol: 2021-08-01
+    link: https://www.nokia.com/phones/en_int/nokia-5-1
+-   releaseCycle: "Nokia 6.1"
+    releaseDate: 2018-05-06
+    eol: 2021-04-01
+    link: https://www.nokia.com/phones/en_int/nokia-6-1
+-   releaseCycle: "Nokia 3.1"
+    releaseDate: 2018-05-01
+    eol: 2021-07-01
+    link: https://www.nokia.com/phones/en_int/nokia-3-1
+-   releaseCycle: "Nokia 7 Plus"
+    releaseDate: 2018-04-30
+    eol: 2021-04-01
+    link: https://www.nokia.com/phones/en_int/nokia-7-plus
+-   releaseCycle: "Nokia 8 Sirocco"
+    releaseDate: 2018-04-23
+    eol: 2021-05-01
+    link: https://www.nokia.com/phones/en_int/nokia-8-sirocco
+-   releaseCycle: "Nokia 1"
+    releaseDate: 2018-04-01
+    eol: 2021-04-01
+    link: https://www.nokia.com/phones/en_int/nokia-1-0
+-   releaseCycle: "Nokia 3.1 Plus"
+    releaseDate: 2018-04-01
+    eol: 2021-10-01
+    link: https://www.nokia.com/phones/en_int/nokia-3-plus
+-   releaseCycle: "Nokia 2"
+    releaseDate: 2017-11-01
+    eol: 2019-11-01
+    link: https://www.nokia.com/phones/en_int/nokia-2-0
+-   releaseCycle: "Nokia 8"
+    releaseDate: 2017-09-07
+    eol: 2020-10-01
+    link: https://www.nokia.com/phones/en_int/nokia-8-0
+-   releaseCycle: "Nokia 5"
+    releaseDate: 2017-07-17
+    eol: 2020-10-01
+    link: https://www.nokia.com/phones/en_int/nokia-5-0
+-   releaseCycle: "Nokia 3"
+    releaseDate: 2017-06-17
+    eol: 2020-09-01
+    link: https://www.nokia.com/phones/en_int/nokia-3-0
+-   releaseCycle: "Nokia 6"
+    releaseDate: 2017-01-19
+    eol: 2020-10-01
+    link: https://www.nokia.com/phones/en_int/nokia-6-0
 
 ---
 

--- a/products/nomad.md
+++ b/products/nomad.md
@@ -4,7 +4,6 @@ permalink: /nomad
 iconSlug: "NA"
 category: server-app
 releasePolicyLink: https://support.hashicorp.com/hc/articles/360021185113
-sortReleasesBy: "releaseCycle"
 changelogTemplate: https://github.com/hashicorp/nomad/blob/v__LATEST__/CHANGELOG.md
 activeSupportColumn: false
 releaseDateColumn: true
@@ -17,7 +16,6 @@ releases:
     latest: "1.4.1"
     latestReleaseDate: 2022-10-06
     releaseDate: 2022-10-04
-
 -   releaseCycle: "1.3"
     eol: false
     latest: "1.3.6"

--- a/products/nvidiadriver.md
+++ b/products/nvidiadriver.md
@@ -8,129 +8,101 @@ releasePolicyLink: https://www.nvidia.com/Download/index.aspx
 activeSupportColumn: true
 releaseDateColumn: true
 releaseColumn: true
-sortReleasesBy: 'cycleShortHand'
 versionCommand: nvidia-smi
 LTSLabel: "<abbr title='Long Term Support Branch'>LTSB</abbr>"
 releases:
--   releaseCycle: "R390-Linux"
-    lts: true
-    support: 2018-03-10
-    eol: 2022-12-31
-    latest: "390.147"
-    link: https://www.nvidia.com/Download/driverResults.aspx/184603
-    cycleShortHand: '1'
-
-    releaseDate: 2018-01-04
--   releaseCycle: "R390-Windows"
-    lts: true
-    support: 2018-07-31
-    eol: 2022-12-31
-    latest: "392.68"
-    link: https://www.nvidia.com/download/driverResults.aspx/181267
-    cycleShortHand: '2'
-
-    releaseDate: 2018-01-08
--   releaseCycle: "R418-Linux"
-    lts: true
-    support: 2019-03-20
-    eol: 2022-03-01
-    latest: "418.197.02"
-    link: https://docs.nvidia.com/datacenter/tesla/tesla-release-notes-418-19702/
-    cycleShortHand: '3'
-
-    releaseDate: 2019-01-30
--   releaseCycle: "R418-Windows"
-    lts: true
-    support: 2019-04-23
-    eol: 2022-03-01
-    latest: "427.45"
-    link: https://docs.nvidia.com/datacenter/tesla/tesla-release-notes-418-19702/
-    cycleShortHand: '4'
-
-    releaseDate: 2019-02-04
--   releaseCycle: "R450-Linux"
-    lts: true
-    support: 2020-10-7
-    eol: 2023-07-01
-    latest: "450.142.00"
-    link: https://docs.nvidia.com/datacenter/tesla/tesla-release-notes-450-142-00/
-    cycleShortHand: '5'
-
-    releaseDate: 2020-06-24
--   releaseCycle: "R450-Windows"
-    lts: true
-    support: 2020-12-15
-    eol: 2023-07-01
-    latest: "453.10"
-    link: https://docs.nvidia.com/datacenter/tesla/tesla-release-notes-450-142-00/
-    cycleShortHand: '6'
-
-    releaseDate: 2020-06-24
--   releaseCycle: "R460-Linux (PB)"
-    support: 2021-7-19
-    eol: 2022-01-01
-    latest: "460.91.03"
-    link: https://docs.nvidia.com/datacenter/tesla/tesla-release-notes-460-91-03/
-    cycleShortHand: '7'
-
-    releaseDate: 2021-1-7
--   releaseCycle: "R460-Windows (PB)"
-    support: 2021-06-23
-    eol: 2022-01-01
-    latest: "462.96"
-    link: https://docs.nvidia.com/datacenter/tesla/tesla-release-notes-460-91-03/
-    cycleShortHand: '8'
-
-    releaseDate: 2020-12-15
--   releaseCycle: "R470-Linux"
-    lts: true
-    support: 2021-10-26
-    eol: 2024-09-01
-    latest: "470.94"
-    link: https://www.nvidia.com/Download/driverResults.aspx/184163
-    cycleShortHand: '9'
-
-    releaseDate: 2021-7-19
--   releaseCycle: "R470-Windows"
-    lts: true
-    support: 2021-09-20
-    eol: 2024-09-01
-    latest: "472.39"
-    link: https://nvidia.custhelp.com/app/answers/detail/a_id/5251
-    cycleShortHand: '10'
-
-    releaseDate: 2021-06-22
+-   releaseCycle: "R510-Linux (PB)"
+    support: true
+    eol: 2023-01-01
+    latest: "510.60.02"
+    link: https://www.nvidia.com/download/driverResults.aspx/187162/en-us
+    releaseDate: 2022-01-11
+-   releaseCycle: "R510-Windows (PB)"
+    support: true
+    eol: 2023-01-01
+    latest: "512.15"
+    link: https://www.nvidia.com/download/driverResults.aspx/187304/en-us
+    releaseDate: 2022-01-14
 -   releaseCycle: "R495-Windows (NFB)"
     support: false
     eol: 2022-01-14
     latest: "497.29"
     link: https://www.nvidia.com/Download/driverResults.aspx/184717
-    cycleShortHand: '11'
-
     releaseDate: 2021-10-12
 -   releaseCycle: "R495-Linux (NFB)"
     support: false
     eol: 2022-01-11
     latest: "495.46"
     link: https://www.nvidia.com/Download/driverResults.aspx/184248
-    cycleShortHand: '11'
-
     releaseDate: 2021-10-26
--   releaseCycle: "R510-Windows (PB)"
-    support: true
-    eol: 2023-01-01
-    latest: "512.15"
-    link: https://www.nvidia.com/download/driverResults.aspx/187304/en-us
-    cycleShortHand: '12'
-
-    releaseDate: 2022-01-14
--   releaseCycle: "R510-Linux (PB)"
-    support: true
-    eol: 2023-01-01
-    latest: "510.60.02"
-    link: https://www.nvidia.com/download/driverResults.aspx/187162/en-us
-    cycleShortHand: '13'
-    releaseDate: 2022-01-11
+-   releaseCycle: "R470-Windows"
+    lts: true
+    support: 2021-09-20
+    eol: 2024-09-01
+    latest: "472.39"
+    link: https://nvidia.custhelp.com/app/answers/detail/a_id/5251
+    releaseDate: 2021-06-22
+-   releaseCycle: "R470-Linux"
+    lts: true
+    support: 2021-10-26
+    eol: 2024-09-01
+    latest: "470.94"
+    link: https://www.nvidia.com/Download/driverResults.aspx/184163
+    releaseDate: 2021-7-19
+-   releaseCycle: "R460-Windows (PB)"
+    support: 2021-06-23
+    eol: 2022-01-01
+    latest: "462.96"
+    link: https://docs.nvidia.com/datacenter/tesla/tesla-release-notes-460-91-03/
+    releaseDate: 2020-12-15
+-   releaseCycle: "R460-Linux (PB)"
+    support: 2021-7-19
+    eol: 2022-01-01
+    latest: "460.91.03"
+    link: https://docs.nvidia.com/datacenter/tesla/tesla-release-notes-460-91-03/
+    releaseDate: 2021-1-7
+-   releaseCycle: "R450-Windows"
+    lts: true
+    support: 2020-12-15
+    eol: 2023-07-01
+    latest: "453.10"
+    link: https://docs.nvidia.com/datacenter/tesla/tesla-release-notes-450-142-00/
+    releaseDate: 2020-06-24
+-   releaseCycle: "R450-Linux"
+    lts: true
+    support: 2020-10-7
+    eol: 2023-07-01
+    latest: "450.142.00"
+    link: https://docs.nvidia.com/datacenter/tesla/tesla-release-notes-450-142-00/
+    releaseDate: 2020-06-24
+-   releaseCycle: "R418-Windows"
+    lts: true
+    support: 2019-04-23
+    eol: 2022-03-01
+    latest: "427.45"
+    link: https://docs.nvidia.com/datacenter/tesla/tesla-release-notes-418-19702/
+    releaseDate: 2019-02-04
+-   releaseCycle: "R418-Linux"
+    lts: true
+    support: 2019-03-20
+    eol: 2022-03-01
+    latest: "418.197.02"
+    link: https://docs.nvidia.com/datacenter/tesla/tesla-release-notes-418-19702/
+    releaseDate: 2019-01-30
+-   releaseCycle: "R390-Windows"
+    lts: true
+    support: 2018-07-31
+    eol: 2022-12-31
+    latest: "392.68"
+    link: https://www.nvidia.com/download/driverResults.aspx/181267
+    releaseDate: 2018-01-08
+-   releaseCycle: "R390-Linux"
+    lts: true
+    support: 2018-03-10
+    eol: 2022-12-31
+    latest: "390.147"
+    link: https://www.nvidia.com/Download/driverResults.aspx/184603
+    releaseDate: 2018-01-04
 
 ---
 

--- a/products/nvidiaproducts.md
+++ b/products/nvidiaproducts.md
@@ -10,147 +10,31 @@ releasePolicyLink: https://www.nvidia.com/en-us/geforce/graphics-cards/
 activeSupportColumn: true
 releaseDateColumn: true
 discontinuedColumn: true
-sortReleasesBy: releaseDate
 releaseColumn: false
 releases:
--   releaseCycle: "Consumer Fahrenheit (NVx)"
-    support: 2005-03-11 # Verify support date.
-    eol: 2005-03-11
-    discontinued: true
-
-    releaseDate: 1998-06-15
--   releaseCycle: "Consumer Celsius (NV1x)"
-    support: 2005-04-14 # Verify support date.
-    eol: 2005-04-14
-    discontinued: true
-
-    releaseDate: 1999-10-11
--   releaseCycle: "Consumer Kelvin (NV1x, NV2x)"
-    support: 2006-11-02 # Verify support date.
-    eol: 2006-11-02
-    discontinued: true
-
-    releaseDate: 2001-02-27
--   releaseCycle: "Consumer Rankine (NV3x)"
-    support: 2008-06-23 # Verify support date.
-    eol: 2008-06-23
-    discontinued: true
-
-    releaseDate: 2003-01-27
--   releaseCycle: "Consumer Curie (NV4x, G7x)"
-    support: 2013-02-25
-    eol: 2015-02-24
-    discontinued: true
-
-    releaseDate: 2004-04-14
--   releaseCycle: "Consumer Tesla (Cxx, G8x, G9x, GT2xx, ION)"
-    support: 2016-04-01
-    eol: 2016-12-14
-    discontinued: true
-
-    releaseDate: 2006-11-08
--   releaseCycle: "Consumer Fermi (GF1xx)*"
-    support: 2018-03-10
-    eol: 2018-03-10
-    discontinued: true
-
-    releaseDate: 2010-03-26
--   releaseCycle: "Professional Fermi (GF1xx)**"
-    support: 2018-07-31
-    eol: 2022-12-31
-    discontinued: true
-
-    releaseDate: 2010-07-23
--   releaseCycle: "Consumer Kepler (GKxxx)"
-    support: 2021-09-20
-    eol: 2024-09-01
-    discontinued: true
-
-    releaseDate: 2012-03-22
--   releaseCycle: "Professional Kepler (GKxxx)"
-    support: 2021-09-20
-    eol: 2024-09-01
-    discontinued: true
-
-    releaseDate: 2013-03-01
--   releaseCycle: "Mobile Professional Kepler (GKxxx)"
-    support: 2019-04-23
-    eol: 2022-03-01
-    discontinued: true
-
-    releaseDate: 2012-03-22
--   releaseCycle: "Mobile Consumer Kepler (GKxxx)"
-    support: 2019-03-11
-    eol: 2019-04-11
-    discontinued: true
-
-    releaseDate: 2012-03-22
--   releaseCycle: "Consumer Maxwell (GMxxx)"
-    support: true
-    eol: false
-    discontinued: true
-
-    releaseDate: 2014-09-19
--   releaseCycle: "Professional Maxwell (GMxxx)"
-    support: true
-    eol: false
-    discontinued: true
-
-    releaseDate: 2015-06-29
--   releaseCycle: "Mobile Professional Maxwell (GMxxx)"
-    support: true
-    eol: false
-    discontinued: true
-
-    releaseDate: 2015-08-18
--   releaseCycle: "Mobile Consumer Maxwell (GMxxx)"
-    support: true
-    eol: false
-    discontinued: true
-
-    releaseDate: 2014-10-07
--   releaseCycle: "Consumer Pascal (GP10x)"
-    support: true
-    eol: false
-    discontinued: true
-
-    releaseDate: 2016-05-27
--   releaseCycle: "Professional Pascal (GP10x)"
-    support: true
-    eol: false
-    discontinued: true
-
-    releaseDate: 2016-04-05
--   releaseCycle: "Mobile Professional Pascal (GP10x)"
-    support: true
-    eol: false
-    discontinued: true
-
-    releaseDate: 2017-02-06
--   releaseCycle: "Mobile Consumer Pascal (GP10x)"
-    support: true
-    eol: false
-    discontinued: true
-
-    releaseDate: 2016-08-15
--   releaseCycle: "Professional Volta (GV100)"
-    support: true
-    eol: false
-    discontinued: true
-
-    releaseDate: 2017-12-07
--   releaseCycle: "Consumer Turing (TU1xX)"
+-   releaseCycle: "Mobile Professional Ampere (GA10x)"
     support: true
     eol: false
     discontinued: false
 
-    releaseDate: 2018-09-20
--   releaseCycle: "Professional Turing (TU1xX)"
+    releaseDate: 2021-04-12
+-   releaseCycle: "Mobile Consumer Ampere (GA10x)"
+    support: true
+    eol: false
+    discontinued: false
+    releaseDate: 2021-01-12
+-   releaseCycle: "Professional Ampere (GA10x)"
     support: true
     eol: false
     discontinued: false
 
-    releaseDate: 2018-08-13
+    releaseDate: 2020-10-05
+-   releaseCycle: "Consumer Ampere (GA10x)"
+    support: true
+    eol: false
+    discontinued: false
+
+    releaseDate: 2020-09-01
 -   releaseCycle: "Mobile Professional Turing (TU1xX)"
     support: true
     eol: false
@@ -163,29 +47,144 @@ releases:
     discontinued: false
 
     releaseDate: 2019-01-29
--   releaseCycle: "Consumer Ampere (GA10x)"
+-   releaseCycle: "Consumer Turing (TU1xX)"
     support: true
     eol: false
     discontinued: false
 
-    releaseDate: 2020-09-01
--   releaseCycle: "Professional Ampere (GA10x)"
+    releaseDate: 2018-09-20
+-   releaseCycle: "Professional Turing (TU1xX)"
     support: true
     eol: false
     discontinued: false
 
-    releaseDate: 2020-10-05
--   releaseCycle: "Mobile Professional Ampere (GA10x)"
+    releaseDate: 2018-08-13
+-   releaseCycle: "Professional Volta (GV100)"
     support: true
     eol: false
-    discontinued: false
+    discontinued: true
 
-    releaseDate: 2021-04-12
--   releaseCycle: "Mobile Consumer Ampere (GA10x)"
+    releaseDate: 2017-12-07
+-   releaseCycle: "Mobile Professional Pascal (GP10x)"
     support: true
     eol: false
-    discontinued: false
-    releaseDate: 2021-01-12
+    discontinued: true
+
+    releaseDate: 2017-02-06
+-   releaseCycle: "Mobile Consumer Pascal (GP10x)"
+    support: true
+    eol: false
+    discontinued: true
+
+    releaseDate: 2016-08-15
+-   releaseCycle: "Consumer Pascal (GP10x)"
+    support: true
+    eol: false
+    discontinued: true
+
+    releaseDate: 2016-05-27
+-   releaseCycle: "Professional Pascal (GP10x)"
+    support: true
+    eol: false
+    discontinued: true
+
+    releaseDate: 2016-04-05
+-   releaseCycle: "Mobile Professional Maxwell (GMxxx)"
+    support: true
+    eol: false
+    discontinued: true
+
+    releaseDate: 2015-08-18
+-   releaseCycle: "Professional Maxwell (GMxxx)"
+    support: true
+    eol: false
+    discontinued: true
+
+    releaseDate: 2015-06-29
+-   releaseCycle: "Mobile Consumer Maxwell (GMxxx)"
+    support: true
+    eol: false
+    discontinued: true
+
+    releaseDate: 2014-10-07
+-   releaseCycle: "Consumer Maxwell (GMxxx)"
+    support: true
+    eol: false
+    discontinued: true
+
+    releaseDate: 2014-09-19
+-   releaseCycle: "Professional Kepler (GKxxx)"
+    support: 2021-09-20
+    eol: 2024-09-01
+    discontinued: true
+
+    releaseDate: 2013-03-01
+-   releaseCycle: "Consumer Kepler (GKxxx)"
+    support: 2021-09-20
+    eol: 2024-09-01
+    discontinued: true
+
+    releaseDate: 2012-03-22
+-   releaseCycle: "Mobile Professional Kepler (GKxxx)"
+    support: 2019-04-23
+    eol: 2022-03-01
+    discontinued: true
+
+    releaseDate: 2012-03-22
+-   releaseCycle: "Mobile Consumer Kepler (GKxxx)"
+    support: 2019-03-11
+    eol: 2019-04-11
+    discontinued: true
+
+    releaseDate: 2012-03-22
+-   releaseCycle: "Professional Fermi (GF1xx)**"
+    support: 2018-07-31
+    eol: 2022-12-31
+    discontinued: true
+
+    releaseDate: 2010-07-23
+-   releaseCycle: "Consumer Fermi (GF1xx)*"
+    support: 2018-03-10
+    eol: 2018-03-10
+    discontinued: true
+
+    releaseDate: 2010-03-26
+-   releaseCycle: "Consumer Tesla (Cxx, G8x, G9x, GT2xx, ION)"
+    support: 2016-04-01
+    eol: 2016-12-14
+    discontinued: true
+
+    releaseDate: 2006-11-08
+-   releaseCycle: "Consumer Curie (NV4x, G7x)"
+    support: 2013-02-25
+    eol: 2015-02-24
+    discontinued: true
+
+    releaseDate: 2004-04-14
+-   releaseCycle: "Consumer Rankine (NV3x)"
+    support: 2008-06-23 # Verify support date.
+    eol: 2008-06-23
+    discontinued: true
+
+    releaseDate: 2003-01-27
+-   releaseCycle: "Consumer Kelvin (NV1x, NV2x)"
+    support: 2006-11-02 # Verify support date.
+    eol: 2006-11-02
+    discontinued: true
+
+    releaseDate: 2001-02-27
+-   releaseCycle: "Consumer Celsius (NV1x)"
+    support: 2005-04-14 # Verify support date.
+    eol: 2005-04-14
+    discontinued: true
+
+    releaseDate: 1999-10-11
+-   releaseCycle: "Consumer Fahrenheit (NVx)"
+    support: 2005-03-11 # Verify support date.
+    eol: 2005-03-11
+    discontinued: true
+
+    releaseDate: 1998-06-15
 
 ---
 

--- a/products/office.md
+++ b/products/office.md
@@ -9,7 +9,6 @@ releasePolicyLink: https://learn.microsoft.com/lifecycle/products/?terms=Office
 activeSupportColumn: true
 releaseColumn: false
 releaseDateColumn: true
-sortReleasesBy: releaseDate
 releases:
 -   releaseCycle: "Office 2021"
     support: 2026-10-13
@@ -27,22 +26,22 @@ releases:
     support: 2018-04-10
     eol: 2023-04-11
     releaseDate: 2014-02-25
--   releaseCycle: "Office for Mac 2011 SP3"
-    support: 2017-10-10
-    eol: 2017-10-10
-    releaseDate: 2013-01-29
 -   releaseCycle: "Office 2010 SP2"
     support: 2015-10-13
     eol: 2020-10-13
     releaseDate: 2013-07-23
--   releaseCycle: "Office 2008 for Mac SP2"
-    support: 2013-04-09
-    eol: 2013-04-09
-    releaseDate: 2009-10-18
+-   releaseCycle: "Office for Mac 2011 SP3"
+    support: 2017-10-10
+    eol: 2017-10-10
+    releaseDate: 2013-01-29
 -   releaseCycle: "Office 2007 SP3"
     support: 2012-10-09
     eol: 2017-10-10
     releaseDate: 2011-10-25
+-   releaseCycle: "Office 2008 for Mac SP2"
+    support: 2013-04-09
+    eol: 2013-04-09
+    releaseDate: 2009-10-18
 
 ---
 

--- a/products/openbsd.md
+++ b/products/openbsd.md
@@ -6,7 +6,6 @@ versionCommand: uname -r
 activeSupportColumn: false
 releaseDateColumn: true
 releaseColumn: false
-sortReleasesBy: releaseDate
 releases:
 -   eol: 2023-05-01
     releaseCycle: "7.1"

--- a/products/opensearch.md
+++ b/products/opensearch.md
@@ -6,7 +6,6 @@ permalink: /opensearch
 releasePolicyLink: https://www.opensearch.org/releases.html
 releaseDateColumn: true
 eolColumn: Bug fix and security support
-sortReleasesBy: releaseCycle
 changelogTemplate: "https://github.com/opensearch-project/opensearch-build/blob/main/release-notes/opensearch-release-notes-__LATEST__.md"
 auto:
 -   git: https://github.com/opensearch-project/OpenSearch.git

--- a/products/openssl.md
+++ b/products/openssl.md
@@ -10,7 +10,6 @@ eolColumn: Supported
 activeSupportColumn: false
 versionCommand: openssl version
 releaseDateColumn: true
-sortReleasesBy: releaseCycle
 releases:
 -   releaseCycle: "3.0"
     eol: 2026-09-07

--- a/products/opensuse.md
+++ b/products/opensuse.md
@@ -11,7 +11,6 @@ releaseColumn: false
 releaseDateColumn: true
 eolColumn: End of Life
 versionCommand: cat /usr/lib/os-release
-sortReleasesBy: releaseDate
 releaseImage: https://upload.wikimedia.org/wikipedia/en/timeline/qaub9pjgtzf5zjbrlbjruujp47jv6r5.png
 changelogTemplate: https://doc.opensuse.org/release-notes/x86_64/openSUSE/Leap/__RELEASE_CYCLE__/
 releaseLabel: "openSUSE Leap __RELEASE_CYCLE__"

--- a/products/openzfs.md
+++ b/products/openzfs.md
@@ -13,12 +13,10 @@ auto:
 -   git: https://github.com/openzfs/zfs.git
     regex: ^zfs-(?<major>0|[1-9]\d*)\.(?<minor>0|[1-9]\d*)\.(?<patch>0|([1-9]|[1-8]\d|9[0-8]))$
 releaseDateColumn: true
-sortReleasesBy: 'releaseCycle'
 iconSlug: openzfs
 eolColumn: Critical bug fixes
 releaseLabel: "OpenZFS __RELEASE_CYCLE__"
 releases:
-
 -   releaseCycle: "2.1"
     eol: 2023-07-02
     lts: true

--- a/products/oraclelinux.md
+++ b/products/oraclelinux.md
@@ -7,7 +7,6 @@ releasePolicyLink: https://www.oracle.com/a/ocom/docs/elsp-lifetime-069338.pdf
 activeSupportColumn: true
 releaseDateColumn: true
 eolColumn: Extended Support
-sortReleasesBy: releaseDate
 iconSlug: oracle
 changelogTemplate: https://docs.oracle.com/en/operating-systems/oracle-linux/__RELEASE_CYCLE__/relnotes__LATEST__/
 # https://regex101.com/r/fRdw9L/1

--- a/products/pan-gp.md
+++ b/products/pan-gp.md
@@ -8,70 +8,9 @@ activeSupportColumn: true
 releaseColumn: false
 releaseDateColumn: true
 eolColumn: End-of-life Date
-sortReleasesBy: releaseDate
-# Data: https://github.com/endoflife-date/release-data/blob/main/releases/pangp.json
-# Source: https://www.paloaltonetworks.com/services/support/end-of-life-announcements/end-of-life-summary
-# Script: https://github.com/endoflife-date/release-data/blob/main/src/pan-gp.py
 auto:
 -   custom: true
 releases:
--   releaseCycle: "3.0"
-    eol: 2018-02-15
-    support: 2017-05-18
-    releaseDate: 2016-02-16
-    latestReleaseDate: 2016-02-16
-    latest: '3.0'
--   releaseCycle: "3.1"
-    eol: 2018-06-23
-    support: 2017-09-23
-    releaseDate: 2016-06-23
-    latestReleaseDate: 2016-06-23
-    latest: '3.1'
--   releaseCycle: "4.0"
-    eol: 2019-01-30
-    support: 2018-05-02
-    releaseDate: 2017-01-30
-    latestReleaseDate: 2017-01-30
-    latest: '4.0'
--   releaseCycle: "4.1"
-    eol: 2020-03-01
-    support: 2019-06-01
-    releaseDate: 2018-03-01
-    latestReleaseDate: 2018-03-01
-    latest: '4.1'
--   releaseCycle: "5.0"
-    eol: 2021-02-12
-    support: 2020-05-12
-    releaseDate: 2019-02-12
-    latestReleaseDate: 2019-02-12
-    latest: '5.0'
--   releaseCycle: "5.1"
-    eol: 2022-12-12
-    support: 2021-03-12
-    releaseDate: 2019-12-12
-    latestReleaseDate: 2019-12-12
-    latest: '5.1'
--   releaseCycle: "5.2"
-    eol: 2023-02-28
-    support: 2023-02-28
-    releaseDate: 2020-07-30
-    latestReleaseDate: 2020-07-30
-    latest: '5.2'
-    link: https://docs.paloaltonetworks.com/globalprotect/5-2/globalprotect-app-release-notes
--   releaseCycle: "5.3"
-    eol: 2023-06-01
-    support: 2022-12-01
-    releaseDate: 2021-06-01
-    latestReleaseDate: 2021-06-01
-    latest: '5.3'
-    link: https://docs.paloaltonetworks.com/globalprotect/5-3/globalprotect-app-release-notes/gp-app-release-information
--   releaseCycle: "6.0"
-    eol: 2024-02-22
-    support: 2024-02-22
-    releaseDate: 2022-02-22
-    latestReleaseDate: 2022-02-22
-    latest: '6.0'
-    link: https://docs.paloaltonetworks.com/globalprotect/6-0/globalprotect-app-release-notes
 -   releaseCycle: "6.1"
     eol: 2024-09-01
     support: 2024-09-01
@@ -79,6 +18,64 @@ releases:
     latestReleaseDate: 2022-09-01
     latest: '6.1.0'
     link: https://docs.paloaltonetworks.com/globalprotect/6-1/globalprotect-app-release-notes
+-   releaseCycle: "6.0"
+    eol: 2024-02-22
+    support: 2024-02-22
+    releaseDate: 2022-02-22
+    latestReleaseDate: 2022-02-22
+    latest: '6.0'
+    link: https://docs.paloaltonetworks.com/globalprotect/6-0/globalprotect-app-release-notes
+-   releaseCycle: "5.3"
+    eol: 2023-06-01
+    support: 2022-12-01
+    releaseDate: 2021-06-01
+    latestReleaseDate: 2021-06-01
+    latest: '5.3'
+    link: https://docs.paloaltonetworks.com/globalprotect/5-3/globalprotect-app-release-notes/gp-app-release-information
+-   releaseCycle: "5.2"
+    eol: 2023-02-28
+    support: 2023-02-28
+    releaseDate: 2020-07-30
+    latestReleaseDate: 2020-07-30
+    latest: '5.2'
+    link: https://docs.paloaltonetworks.com/globalprotect/5-2/globalprotect-app-release-notes
+-   releaseCycle: "5.1"
+    eol: 2022-12-12
+    support: 2021-03-12
+    releaseDate: 2019-12-12
+    latestReleaseDate: 2019-12-12
+    latest: '5.1'
+-   releaseCycle: "5.0"
+    eol: 2021-02-12
+    support: 2020-05-12
+    releaseDate: 2019-02-12
+    latestReleaseDate: 2019-02-12
+    latest: '5.0'
+-   releaseCycle: "4.1"
+    eol: 2020-03-01
+    support: 2019-06-01
+    releaseDate: 2018-03-01
+    latestReleaseDate: 2018-03-01
+    latest: '4.1'
+-   releaseCycle: "4.0"
+    eol: 2019-01-30
+    support: 2018-05-02
+    releaseDate: 2017-01-30
+    latestReleaseDate: 2017-01-30
+    latest: '4.0'
+-   releaseCycle: "3.1"
+    eol: 2018-06-23
+    support: 2017-09-23
+    releaseDate: 2016-06-23
+    latestReleaseDate: 2016-06-23
+    latest: '3.1'
+-   releaseCycle: "3.0"
+    eol: 2018-02-15
+    support: 2017-05-18
+    releaseDate: 2016-02-16
+    latestReleaseDate: 2016-02-16
+    latest: '3.0'
+
 
 ---
 

--- a/products/pan-os.md
+++ b/products/pan-os.md
@@ -8,7 +8,6 @@ activeSupportColumn: false
 releaseColumn: true
 releaseDateColumn: true
 eolColumn: End-of-life Date
-sortReleasesBy: releaseDate
 versionCommand: show system info | match sw-version
 releases:
 -   releaseCycle: "10.2"

--- a/products/pan-xdr.md
+++ b/products/pan-xdr.md
@@ -10,68 +10,67 @@ activeSupportColumn: false
 releaseColumn: false
 releaseDateColumn: true
 eolColumn: End-of-life Date
-sortReleasesBy: releaseDate
 releases:
--   releaseCycle: "3.1"
-    eol: 2015-09-03
-    releaseDate: 2014-09-03
--   releaseCycle: "3.2"
-    eol: 2016-03-31
-    releaseDate: 2015-03-31
--   releaseCycle: "3.3"
-    eol: 2017-02-28
-    releaseDate: 2015-11-10
--   releaseCycle: "3.4"
-    eol: 2019-08-21
-    releaseDate: 2016-08-21
--   releaseCycle: "4.0"
-    eol: 2018-04-05
-    releaseDate: 2017-04-05
--   releaseCycle: "4.1"
-    eol: 2019-09-15
-    releaseDate: 2017-09-15
--   releaseCycle: "4.2"
-    eol: 2022-03-01
-    releaseDate: 2018-06-25
--   releaseCycle: "5.0"
-    eol: 2024-06-01
-    releaseDate: 2018-03-19
--   releaseCycle: "6.0"
-    eol: 2020-02-26
-    releaseDate: 2019-02-26
--   releaseCycle: "6.1"
-    eol: 2022-07-01
-    releaseDate: 2019-07-02
--   releaseCycle: "7.0"
-    eol: 2021-06-04
-    releaseDate: 2019-12-04
--   releaseCycle: "7.1"
-    eol: 2021-06-04
-    releaseDate: 2020-04-22
--   releaseCycle: "7.2"
-    eol: 2022-03-07
-    releaseDate: 2020-09-07
--   releaseCycle: "7.3"
-    eol: 2022-02-01
-    releaseDate: 2021-02-01
--   releaseCycle: "7.4"
-    eol: 2022-05-24
-    releaseDate: 2021-05-24
--   releaseCycle: "7.5"
-    eol: 2022-08-22
-    releaseDate: 2021-08-22
+-   releaseCycle: "7.8"
+    eol: 2023-04-24
+    releaseDate: 2022-07-24
+-   releaseCycle: "7.7"
+    eol: 2022-12-27
+    releaseDate: 2022-03-27
 -   releaseCycle: "7.5 CE"
     eol: 2024-03-06
     releaseDate: 2022-03-06
 -   releaseCycle: "7.6"
     eol: 2022-09-05
     releaseDate: 2021-12-05
--   releaseCycle: "7.7"
-    eol: 2022-12-27
-    releaseDate: 2022-03-27
--   releaseCycle: "7.8"
-    eol: 2023-04-24
-    releaseDate: 2022-07-24
+-   releaseCycle: "7.5"
+    eol: 2022-08-22
+    releaseDate: 2021-08-22
+-   releaseCycle: "7.4"
+    eol: 2022-05-24
+    releaseDate: 2021-05-24
+-   releaseCycle: "7.3"
+    eol: 2022-02-01
+    releaseDate: 2021-02-01
+-   releaseCycle: "7.2"
+    eol: 2022-03-07
+    releaseDate: 2020-09-07
+-   releaseCycle: "7.1"
+    eol: 2021-06-04
+    releaseDate: 2020-04-22
+-   releaseCycle: "7.0"
+    eol: 2021-06-04
+    releaseDate: 2019-12-04
+-   releaseCycle: "6.1"
+    eol: 2022-07-01
+    releaseDate: 2019-07-02
+-   releaseCycle: "6.0"
+    eol: 2020-02-26
+    releaseDate: 2019-02-26
+-   releaseCycle: "4.2"
+    eol: 2022-03-01
+    releaseDate: 2018-06-25
+-   releaseCycle: "5.0"
+    eol: 2024-06-01
+    releaseDate: 2018-03-19
+-   releaseCycle: "4.1"
+    eol: 2019-09-15
+    releaseDate: 2017-09-15
+-   releaseCycle: "4.0"
+    eol: 2018-04-05
+    releaseDate: 2017-04-05
+-   releaseCycle: "3.4"
+    eol: 2019-08-21
+    releaseDate: 2016-08-21
+-   releaseCycle: "3.3"
+    eol: 2017-02-28
+    releaseDate: 2015-11-10
+-   releaseCycle: "3.2"
+    eol: 2016-03-31
+    releaseDate: 2015-03-31
+-   releaseCycle: "3.1"
+    eol: 2015-09-03
+    releaseDate: 2014-09-03
 
 ---
 

--- a/products/perl.md
+++ b/products/perl.md
@@ -1,7 +1,6 @@
 ---
 title: Perl
 category: lang
-sortReleasesBy: "releaseCycle"
 changelogTemplate: "https://perldoc.perl.org/__LATEST__/perldelta"
 auto:
   # Using the default regex loses all releases before 5.10

--- a/products/php.md
+++ b/products/php.md
@@ -11,7 +11,6 @@ auto:
     regex: ^php-(?<major>0|[1-9]\d*)\.(?<minor>0|[1-9]\d*)\.(?<patch>0|[1-9]\d*)$
 versionCommand: php --version
 releaseDateColumn: true
-sortReleasesBy: 'releaseDate'
 releases:
 -   releaseCycle: "8.1"
     support: 2023-11-25

--- a/products/pixel.md
+++ b/products/pixel.md
@@ -11,88 +11,73 @@ latestColumn: true
 eolColumn: Software Update (Guaranteed)
 releaseColumn: false
 releaseDateColumn: true
-sortReleasesBy: 'cycleShortHand'
 releases:
 -   releaseCycle: "Pixel 7 Pro"
-    cycleShortHand: '710'
     discontinued: false
     eol: 2027-10-13
     support: 2027-10-13
     releaseDate: 2022-10-13
 -   releaseCycle: "Pixel 7"
-    cycleShortHand: '700'
     discontinued: false
     eol: 2027-10-13
     support: 2027-10-13
     releaseDate: 2022-10-13
 -   releaseCycle: "Pixel 6a"
-    cycleShortHand: '620'
     discontinued: false
     eol: 2027-07-31
     support: 2027-07-31
     releaseDate: 2022-07-28
 -   releaseCycle: "Pixel 6 Pro"
-    cycleShortHand: '610'
     discontinued: false
     eol: 2026-10-31
     support: 2026-10-31
     releaseDate: 2021-10-28
 -   releaseCycle: "Pixel 6"
-    cycleShortHand: '600'
     discontinued: false
     eol: 2026-10-31
     support: 2026-10-31
     releaseDate: 2021-10-28
 -   releaseCycle: "Pixel 5A"
-    cycleShortHand: '510'
     discontinued: false
     eol: 2024-08-31
     support: 2015-11-19
     releaseDate: 2021-08-26
 -   releaseCycle: "Pixel 5"
-    cycleShortHand: '500'
     discontinued: 2021-08-20
     eol: 2023-10-31
     support: 2015-11-19
     releaseDate: 2020-09-30
 -   releaseCycle: "Pixel 4A 5G"
-    cycleShortHand: '420'
     discontinued: 2021-08-20
     eol: 2023-11-30
     support: 2015-11-19
     releaseDate: 2020-09-30
 -   releaseCycle: "Pixel 4A"
-    cycleShortHand: '410'
     discontinued: 2022-01-31
     eol: 2023-08-31
     support: 2015-11-19
     releaseDate: 2020-08-03
 -   releaseCycle: "Pixel 4 / XL"
-    cycleShortHand: '400'
     discontinued: 2020-08-06
     eol: 2022-10-31
     support: 2015-11-19
     releaseDate: 2019-10-15
 -   releaseCycle: "Pixel 3A / XL"
-    cycleShortHand: '310'
     discontinued: 2020-07-01
     eol: 2022-05-31
     support: 2015-11-19
     releaseDate: 2019-05-07
 -   releaseCycle: "Pixel 3 / XL"
-    cycleShortHand: '300'
     discontinued: 2020-03-31
     eol: 2021-10-31
     support: 2015-11-19
     releaseDate: 2018-10-09
 -   releaseCycle: "Pixel 2 / XL"
-    cycleShortHand: '200'
     discontinued: 2019-04-01
     eol: 2020-10-31
     support: 2015-11-19
     releaseDate: 2017-10-04
 -   releaseCycle: "Pixel / Pixel XL"
-    cycleShortHand: '100'
     discontinued: 2018-04-11
     eol: 2018-10-31
     support: 2015-11-19

--- a/products/postfix.md
+++ b/products/postfix.md
@@ -14,7 +14,6 @@ auto:
 -   git: https://github.com/vdukhovni/postfix.git
     regex: ^v(?<major>0|[1-9]\d*)\.(?<minor>0|[1-9]\d*)(\.(?<patch>0|[1-9]\d*))?$
 
-sortReleasesBy: "releaseCycle"
 releases:
 -   releaseCycle: "3.7"
     eol: false

--- a/products/postgresql.md
+++ b/products/postgresql.md
@@ -11,7 +11,6 @@ activeSupportColumn: false
 eolColumn: Support Status
 versionCommand: psql -c "SELECT version();"
 releaseDateColumn: true
-sortReleasesBy: 'releaseCycle'
 auto:
 -   git: https://github.com/postgres/postgres.git
   # https://rubular.com/r/KlemgnguNe0e5X

--- a/products/powershell.md
+++ b/products/powershell.md
@@ -6,7 +6,6 @@ versionCommand: pwsh -v
 releasePolicyLink: https://learn.microsoft.com/lifecycle/products/powershell
 changelogTemplate: https://github.com/PowerShell/PowerShell/blob/master/CHANGELOG/__RELEASE_CYCLE__.md
 releaseDateColumn: true
-sortReleasesBy: releaseDate
 eolColumn: Support Status
 auto:
 -   git: https://github.com/PowerShell/PowerShell.git

--- a/products/python.md
+++ b/products/python.md
@@ -7,7 +7,6 @@ releasePolicyLink: https://devguide.python.org/versions.html
 changelogTemplate: |
   https://python.org/downloads/release/python-{{"__LATEST__" | replace:'.',''}}/
 releaseDateColumn: true
-sortReleasesBy: releaseDate
 auto:
 -   git: https://github.com/python/cpython.git
   # The v is mandatory here because each branch EOL is tagged:

--- a/products/qt.md
+++ b/products/qt.md
@@ -7,7 +7,6 @@ versionCommand: qmake --version
 changelogTemplate: https://www.qt.io/blog/qt-{{"__LATEST__"}}-released
 releasePolicyLink: https://cdn2.hubspot.net/hubfs/149513/_Website_Blog/Qt%20offering%20change%20FAQ-2020-01-27.pdf
 releaseDateColumn: true
-sortReleasesBy: 'releaseDate'
 auto:
   # Upstream does not support filtering https://code.qt.io/qt/qt5.git
 -   git: https://github.com/qt/qt5.git

--- a/products/rabbitmq.md
+++ b/products/rabbitmq.md
@@ -3,7 +3,6 @@ title: RabbitMQ
 permalink: /rabbitmq
 category: server-app
 releasePolicyLink: https://www.rabbitmq.com/versions.html
-sortReleasesBy: releaseDate
 changelogTemplate: https://github.com/rabbitmq/rabbitmq-server/releases/tag/v__LATEST__
 activeSupportColumn: false
 releaseDateColumn: true

--- a/products/react.md
+++ b/products/react.md
@@ -3,7 +3,6 @@ title: React
 permalink: /react
 iconSlug: react
 category: framework
-sortReleasesBy: 'releaseCycle'
 releasePolicyLink: https://reactjs.org/docs/release-channels.html
 changelogTemplate: https://github.com/facebook/react/releases/tag/v__LATEST__
 activeSupportColumn: true

--- a/products/readynas.md
+++ b/products/readynas.md
@@ -1,65 +1,64 @@
 ---
 title: Netgear ReadyNAS
 category: device
-sortReleasesBy: "releaseCycle"
 changelogTemplate: "https://www.netgear.com/support/product/__RELEASE_CYCLE__.aspx"
 releases:
--   releaseCycle: "RN102"
-    eol: true
--   releaseCycle: "RN104"
-    eol: true
--   releaseCycle: "RN202"
-    eol: true
--   releaseCycle: "RN204"
-    eol: true
--   releaseCycle: "RN212"
-    eol: false
--   releaseCycle: "RN214"
-    eol: false
--   releaseCycle: "RN2120"
-    eol: true
--   releaseCycle: "RN312"
-    eol: true
--   releaseCycle: "RN314"
-    eol: true
--   releaseCycle: "RN316"
-    eol: true
--   releaseCycle: "RN422"
-    eol: false
--   releaseCycle: "RN424"
-    eol: false
--   releaseCycle: "RN426"
-    eol: false
--   releaseCycle: "RN516"
-    eol: true
--   releaseCycle: "RN524X"
-    eol: false
--   releaseCycle: "RN526X"
-    eol: false
--   releaseCycle: "RN528X"
-    eol: false
--   releaseCycle: "RN626X"
-    eol: false
--   releaseCycle: "RN628X"
-    eol: false
--   releaseCycle: "RN716X"
-    eol: true
--   releaseCycle: "RR2304"
-    eol: false
--   releaseCycle: "RN3130"
-    eol: false
--   releaseCycle: "RN3138"
-    eol: false
--   releaseCycle: "RN3220"
-    eol: true
--   releaseCycle: "RR3312"
-    eol: false
--   releaseCycle: "RR4312X"
-    eol: false
 -   releaseCycle: "RR4360X"
     eol: false
 -   releaseCycle: "RR4360S"
     eol: false
+-   releaseCycle: "RR4312X"
+    eol: false
+-   releaseCycle: "RR3312"
+    eol: false
+-   releaseCycle: "RR2304"
+    eol: false
+-   releaseCycle: "RN716X"
+    eol: true
+-   releaseCycle: "RN628X"
+    eol: false
+-   releaseCycle: "RN626X"
+    eol: false
+-   releaseCycle: "RN528X"
+    eol: false
+-   releaseCycle: "RN526X"
+    eol: false
+-   releaseCycle: "RN524X"
+    eol: false
+-   releaseCycle: "RN516"
+    eol: true
+-   releaseCycle: "RN426"
+    eol: false
+-   releaseCycle: "RN424"
+    eol: false
+-   releaseCycle: "RN422"
+    eol: false
+-   releaseCycle: "RN3220"
+    eol: true
+-   releaseCycle: "RN316"
+    eol: true
+-   releaseCycle: "RN314"
+    eol: true
+-   releaseCycle: "RN3138"
+    eol: false
+-   releaseCycle: "RN3130"
+    eol: false
+-   releaseCycle: "RN312"
+    eol: true
+-   releaseCycle: "RN214"
+    eol: false
+-   releaseCycle: "RN2120"
+    eol: true
+-   releaseCycle: "RN212"
+    eol: false
+-   releaseCycle: "RN204"
+    eol: true
+-   releaseCycle: "RN202"
+    eol: true
+-   releaseCycle: "RN104"
+    eol: true
+-   releaseCycle: "RN102"
+    eol: true
 iconSlug: NA
 permalink: /readynas
 activeSupportColumn: false

--- a/products/redhat.md
+++ b/products/redhat.md
@@ -11,7 +11,6 @@ LTSLabel: "<abbr title='Extended Life Cycle Support'>ELS</abbr>"
 activeSupportColumn: true
 releaseDateColumn: true
 releaseColumn: false
-sortReleasesBy: releaseDate
 releaseLabel: "RHEL __RELEASE_CYCLE__"
 releases:
 -   releaseCycle: "9"

--- a/products/redis.md
+++ b/products/redis.md
@@ -7,7 +7,6 @@ changelogTemplate: https://raw.githubusercontent.com/antirez/redis/__RELEASE_CYC
 activeSupportColumn: false
 versionCommand: $ redis-server --version
 releaseDateColumn: false
-sortReleasesBy: 'releaseCycle'
 auto:
 -   git: https://github.com/redis/redis.git
 releases:

--- a/products/redmine.md
+++ b/products/redmine.md
@@ -6,7 +6,6 @@ category: server-app
 activeSupportColumn: false
 releaseDateColumn: true
 releaseColumn: true
-sortReleasesBy: releaseCycle
 iconSlug: redmine
 auto:
 -   git: https://github.com/redmine/redmine.git

--- a/products/rockylinux.md
+++ b/products/rockylinux.md
@@ -11,7 +11,6 @@ alternate_urls:
 releasePolicyLink: https://forums.rockylinux.org/t/what-is-eol-of-rl8/3316/2
 activeSupportColumn: true
 releaseDateColumn: true
-sortReleasesBy: releaseDate
 releaseLabel: "Rocky Linux __RELEASE_CYCLE__"
 auto:
 -   distrowatch: rocky

--- a/products/ros.md
+++ b/products/ros.md
@@ -8,7 +8,6 @@ releaseColumn: true
 eolColumn: End Of Life
 versionCommand: rosversion -d
 releaseDateColumn: true
-sortReleasesBy: 'releaseCycle'
 releaseLabel: '__CODENAME__'
 changelogTemplate: 'https://wiki.ros.org/__RELEASE_CYCLE__'
 releases:

--- a/products/roundcube.md
+++ b/products/roundcube.md
@@ -2,7 +2,6 @@
 title: Roundcube Webmail
 permalink: /roundcube
 category: tool
-sortReleasesBy: "releaseCycle"
 activeSupportColumn: true
 changelogTemplate: https://github.com/roundcube/roundcubemail/releases/tag/__LATEST__
 auto:

--- a/products/ruby-on-rails.md
+++ b/products/ruby-on-rails.md
@@ -10,7 +10,6 @@ releasePolicyLink: https://guides.rubyonrails.org/maintenance_policy.html
 changelogTemplate: https://github.com/rails/rails/releases/tag/v__LATEST__
 releaseDateColumn: true
 category: framework
-sortReleasesBy: release
 auto:
 -   git: https://github.com/rails/rails.git
     regex: v(?<major>[1-9]\d*)\.(?<minor>0|[1-9]\d*)\.(?<patch>0|[1-9]\d*)(\.(?<tiny>0|[1-9]\d*))?$

--- a/products/ruby.md
+++ b/products/ruby.md
@@ -15,7 +15,6 @@ auto:
 category: lang
 releaseDateColumn: true
 eolColumn: Support Status
-sortReleasesBy: releaseDate
 releases:
 -   releaseCycle: "3.1"
     eol: 2025-12-25

--- a/products/samsungmobile.md
+++ b/products/samsungmobile.md
@@ -9,8 +9,12 @@ activeSupportColumn: true
 eolColumn: Security Updates
 releaseColumn: false
 releaseDateColumn: true
-sortReleasesBy: releaseDate
 releases:
+
+-   releaseCycle: "Galaxy A13 LTE"
+    support: true
+    eol: false
+    releaseDate: 2022-04-22
 
 -   releaseCycle: "Galaxy A53 5G"
     support: true
@@ -22,909 +26,705 @@ releases:
     eol: false
     releaseDate: 2022-04-01
 
--   releaseCycle: "Galaxy A13 LTE"
-    support: true
-    eol: false
-    releaseDate: 2022-04-22
-
 -   releaseCycle: "Galaxy A13 5G"
     support: true
     eol: false
-
     releaseDate: 2021-12-03
+
 -   releaseCycle: "Galaxy F42 5G"
     support: true
     eol: false
-
     releaseDate: 2021-10-03
+
 -   releaseCycle: "Galaxy M52 5G"
     support: true
     eol: false
-
     releaseDate: 2021-10-03
--   releaseCycle: "Galaxy M32"
-    support: true
-    eol: false
 
+-   releaseCycle: "Galaxy M22" # Unclear date, defaulting to announcement date
+    support: true
+    eol: false
+    releaseDate: 2021-09-14
 
-    releaseDate: 2021-06-28
--   releaseCycle: "Galaxy S21 Ultra"
-    support: true
-    eol: false
-    releaseDate: 2021-01-14
--   releaseCycle: "Galaxy S21+"
-    support: true
-    eol: false
-    releaseDate: 2021-01-14
--   releaseCycle: "Galaxy S21"
-    support: true
-    eol: false
-    releaseDate: 2021-01-14
--   releaseCycle: "Galaxy S20 Ultra"
-    support: true
-    eol: false
-    releaseDate: 2020-02-21
--   releaseCycle: "Galaxy S20+"
-    support: true
-    eol: false
-    releaseDate: 2020-02-21
--   releaseCycle: "Galaxy S20"
-    support: true
-    eol: false
-
-    releaseDate: 2020-02-21
--   releaseCycle: "Galaxy S10 5G" #This loses active support with Android 12.
-    support: true
-    eol: false
-    releaseDate: 2019-02-20
--   releaseCycle: "Galaxy S10" #This loses active support with Android 12.
-    support: true
-    eol: false
-    releaseDate: 2019-02-20
--   releaseCycle: "Galaxy S10+" #This loses active support with Android 12.
-    support: true
-    eol: false
-    releaseDate: 2019-02-20
--   releaseCycle: "Galaxy S10e" #This loses active support with Android 12.
-    support: true
-    eol: false
-    releaseDate: 2019-02-20
--   releaseCycle: "Galaxy S10 Lite"
-    support: true
-    eol: false
-
-    releaseDate: 2020-01-03
--   releaseCycle: "Galaxy Note 20 Ultra"
-    support: true
-    eol: false
-    releaseDate: 2020-08-21
--   releaseCycle: "Galaxy Note 20"
-    support: true
-    eol: false
-    releaseDate: 2020-08-21
--   releaseCycle: "Galaxy Note 10+" #This loses active support with Android 12.
-    support: true
-    eol: false
-    releaseDate: 2019-08-23
--   releaseCycle: "Galaxy Note 10" #This loses active support with Android 12.
-    support: true
-    eol: false
-    releaseDate: 2019-08-23
--   releaseCycle: "Galaxy Note 10 Lite"
-    support: true
-    eol: false
-
-    releaseDate: 2020-01-03
--   releaseCycle: "Galaxy Fold" #This loses active support with Android 12.
-    support: true
-    eol: false
-
-    releaseDate: 2019-09-06
--   releaseCycle: "Galaxy Z Fold 2"
-    support: true
-    eol: false
-    releaseDate: 2020-09-18
--   releaseCycle: "Galaxy Z Flip"
-    support: true
-    eol: false
-
-    releaseDate: 2020-02-14
--   releaseCycle: "Galaxy Z Flip 5G"
-    support: true
-    eol: false
-    releaseDate: 2020-08-07
--   releaseCycle: "Galaxy Z Fold 3"
-    support: true
-    eol: false
-
-    releaseDate: 2021-08-27
--   releaseCycle: "Galaxy Z Flip 3"
-    support: true
-    eol: false
-
-    releaseDate: 2021-08-11
--   releaseCycle: "Galaxy A71 5G"
-    support: true
-    eol: false
-    releaseDate: 2020-06-15
--   releaseCycle: "Galaxy A71"
-    support: true
-    eol: false
-
-    releaseDate: 2020-01-17
--   releaseCycle: "Galaxy A51 5G"
-    support: true
-    eol: false
-    releaseDate: 2020-08-07
--   releaseCycle: "Galaxy A51"
-    support: true
-    eol: false
-
-    releaseDate: 2019-12-27
--   releaseCycle: "Galaxy A52"
-    support: true
-    eol: false
-
-    releaseDate: 2021-03-26
--   releaseCycle: "Galaxy A52 5G"
-    support: true
-    eol: false
-    releaseDate: 2021-03-17
 -   releaseCycle: "Galaxy A52s"
     support: true
     eol: false
-
-
     releaseDate: 2021-09-01
--   releaseCycle: "Galaxy A72"
+
+-   releaseCycle: "Galaxy Z Fold 3"
     support: true
     eol: false
+    releaseDate: 2021-08-27
 
-    releaseDate: 2021-03-26
--   releaseCycle: "Galaxy A90 5G" #This loses active support with Android 12.
-    support: true
-    eol: false # Quarterly Security Updates. This is a weird one. Getting 12 but not under the monthly security support branch.
-    releaseDate: 2019-09-03
--   releaseCycle: "Galaxy A01" #This loses active support with Android 12.
-    support: true
-    eol: false # Quarterly
-    releaseDate: 2019-12-18
--   releaseCycle: "Galaxy A11" #This loses active support with Android 12.
-    support: true
-    eol: false # Quarterly 
-
-    releaseDate: 2020-05-15
--   releaseCycle: "Galaxy A31" #This loses active support with Android 12.
-    support: true
-    eol: false # Quarterly
-
-    releaseDate: 2020-04-27
--   releaseCycle: "Galaxy A41" #This loses active support with Android 12.
-    support: true
-    eol: false # Quarterly
-
-    releaseDate: 2020-03-18
--   releaseCycle: "Galaxy A21" #This loses active support with Android 12.
-    support: true
-    eol: false # Quarterly
-
-    releaseDate: 2020-06-26
--   releaseCycle: "Galaxy A21s" #This loses active support with Android 12.
-    support: true
-    eol: false # Quarterly
-
-    releaseDate: 2020-06-02
--   releaseCycle: "Galaxy A Quantum"
-    support: true
-    eol: false
-    releaseDate: 2020-05-22
--   releaseCycle: "Galaxy A Quantum 2"
-    support: true
-    eol: false
-
-    releaseDate: 2021-04-23
--   releaseCycle: "Galaxy A42 5G"
-    support: true
-    eol: false
-
-    releaseDate: 2020-11-11
--   releaseCycle: "Galaxy A02" #This loses active support with Android 12.
-    support: true
-    eol: false
-
-    releaseDate: 2021-01-27
--   releaseCycle: "Galaxy A02s" #This loses active support with Android 12.
-    support: true
-    eol: false
-
-    releaseDate: 2021-01-04
 -   releaseCycle: "Galaxy A03s"
     support: true
     eol: false
-
     releaseDate: 2021-08-18
--   releaseCycle: "Galaxy A12" #This loses active support with Android 12.
-    support: true
-    eol: false
 
-    releaseDate: 2020-11-24
--   releaseCycle: "Galaxy A32"
+-   releaseCycle: "Galaxy Z Flip 3"
     support: true
     eol: false
+    releaseDate: 2021-08-11
 
-    releaseDate: 2021-02-25
--   releaseCycle: "Galaxy A32 5G"
-    support: true
+-   releaseCycle: "Galaxy M21 2021"
+    support: false
     eol: false
+    releaseDate: 2021-07-26
 
-    releaseDate: 2021-01-13
--   releaseCycle: "Galaxy A22"
+-   releaseCycle: "Galaxy F22"
     support: true
     eol: false
-    releaseDate: 2021-06-03
+    releaseDate: 2021-07-13
+
+-   releaseCycle: "Galaxy M32"
+    support: true
+    eol: false
+    releaseDate: 2021-06-28
+
+-   releaseCycle: "Galaxy M32"
+    support: true
+    eol: false
+    releaseDate: 2021-06-28
+
 -   releaseCycle: "Galaxy A22 5G"
     support: true
     eol: false
     releaseDate: 2021-06-24
+
+-   releaseCycle: "Galaxy A22"
+    support: true
+    eol: false
+    releaseDate: 2021-06-03
+
+-   releaseCycle: "Galaxy Tab A7 Lite"
+    support: true
+    eol: false
+    releaseDate: 2021-05-27
+
+-   releaseCycle: "Galaxy Tab S7 FE"
+    support: true
+    eol: false
+    releaseDate: 2021-05-25
+
+-   releaseCycle: "Galaxy A82 5G"
+    support: false
+    eol: false
+    releaseDate: 2021-05-05
+
 -   releaseCycle: "Galaxy M42 5G"
     support: true
     eol: false
-
     releaseDate: 2021-04-30
--   releaseCycle: "Galaxy M12"
+
+-   releaseCycle: "Galaxy A Quantum 2"
     support: true
     eol: false
-    releaseDate: 2020-11-24
--   releaseCycle: "Galaxy M62"
-    support: true
-    eol: false
+    releaseDate: 2021-04-23
 
-    releaseDate: 2021-03-03
--   releaseCycle: "Galaxy M01"
-    support: true
-    eol: false
-
-    releaseDate: 2020-06-02
--   releaseCycle: "Galaxy M02s" #This loses active support with Android 12.
-    support: true
-    eol: false
-
-    releaseDate: 2021-01-07
--   releaseCycle: "Galaxy M02" #This loses active support with Android 12.
-    support: true
-    eol: false
-
-    releaseDate: 2021-02-09
--   releaseCycle: "Galaxy M21" #This loses active support with Android 12.
-    support: true
-    eol: false
-
-    releaseDate: 2020-03-23
--   releaseCycle: "Galaxy M21s"
-    support: true
-    eol: false
-
-    releaseDate: 2020-11-06
--   releaseCycle: "Galaxy M22" # Unclear date, defaulting to announcement date
-    support: true
-    eol: false
-
-    releaseDate: 2021-09-14
--   releaseCycle: "Galaxy M31"
-    support: true
-    eol: false
-    releaseDate: 2020-03-05
--   releaseCycle: "Galaxy M31 Prime" #This loses active support with Android 12.
-    support: true
-    eol: false
-    releaseDate: 2020-10-17
--   releaseCycle: "Galaxy M32"
-    support: true
-    eol: false
-    releaseDate: 2021-06-28
--   releaseCycle: "Galaxy M51" #This loses active support with Android 12.
-    support: true
-    eol: false
-    releaseDate: 2020-08-06
--   releaseCycle: "Galaxy M31s" #This loses active support with Android 12.
-    support: true
-    eol: false
-    releaseDate: 2021-02-09
--   releaseCycle: "Galaxy F41" #This loses active support with Android 12.
-    support: true
-    eol: false
-
-
-    releaseDate: 2020-10-16
--   releaseCycle: "Galaxy F62"
-    support: true
-    eol: false
-
-    releaseDate: 2021-02-22
--   releaseCycle: "Galaxy F02s" #This loses active support with Android 12.
-    support: true
-    eol: false
-
-
-
-
-
-
-    releaseDate: 2021-04-09
 -   releaseCycle: "Galaxy F12"
     support: true
     eol: false
-
-
-
-
-
     releaseDate: 2021-04-12
--   releaseCycle: "Galaxy F22"
+
+-   releaseCycle: "Galaxy F02s" #This loses active support with Android 12.
     support: true
     eol: false
+    releaseDate: 2021-04-09
 
-    releaseDate: 2021-07-13
--   releaseCycle: "Galaxy XCover Pro" # Unclear release date.
-    support: true #This loses active support with Android 12.
+-   releaseCycle: "Galaxy A52"
+    support: true
     eol: false
+    releaseDate: 2021-03-26
 
-    releaseDate: 2020-01-01
+-   releaseCycle: "Galaxy A72"
+    support: true
+    eol: false
+    releaseDate: 2021-03-26
+
+-   releaseCycle: "Galaxy A52 5G"
+    support: true
+    eol: false
+    releaseDate: 2021-03-17
+
 -   releaseCycle: "Galaxy Xcover 5"
     support: true
     eol: false
     releaseDate: 2021-03-12
+
+-   releaseCycle: "Galaxy M62"
+    support: true
+    eol: false
+    releaseDate: 2021-03-03
+
+-   releaseCycle: "Galaxy A32"
+    support: true
+    eol: false
+    releaseDate: 2021-02-25
+
+-   releaseCycle: "Galaxy F62"
+    support: true
+    eol: false
+    releaseDate: 2021-02-22
+
+-   releaseCycle: "Galaxy M02" #This loses active support with Android 12.
+    support: true
+    eol: false
+    releaseDate: 2021-02-09
+
+-   releaseCycle: "Galaxy M31s" #This loses active support with Android 12.
+    support: true
+    eol: false
+    releaseDate: 2021-02-09
+
+-   releaseCycle: "Galaxy A02" #This loses active support with Android 12.
+    support: true
+    eol: false
+    releaseDate: 2021-01-27
+
+-   releaseCycle: "Galaxy S21 Ultra"
+    support: true
+    eol: false
+    releaseDate: 2021-01-14
+
+-   releaseCycle: "Galaxy S21+"
+    support: true
+    eol: false
+    releaseDate: 2021-01-14
+
+-   releaseCycle: "Galaxy S21"
+    support: true
+    eol: false
+    releaseDate: 2021-01-14
+
+-   releaseCycle: "Galaxy A32 5G"
+    support: true
+    eol: false
+    releaseDate: 2021-01-13
+
+-   releaseCycle: "Galaxy M02s" #This loses active support with Android 12.
+    support: true
+    eol: false
+    releaseDate: 2021-01-07
+
+-   releaseCycle: "Galaxy A02s" #This loses active support with Android 12.
+    support: true
+    eol: false
+    releaseDate: 2021-01-04
+
+-   releaseCycle: "Galaxy A12" #This loses active support with Android 12.
+    support: true
+    eol: false
+    releaseDate: 2020-11-24
+
+-   releaseCycle: "Galaxy M12"
+    support: true
+    eol: false
+    releaseDate: 2020-11-24
+
+-   releaseCycle: "Galaxy A42 5G"
+    support: true
+    eol: false
+    releaseDate: 2020-11-11
+
+-   releaseCycle: "Galaxy M21s"
+    support: true
+    eol: false
+    releaseDate: 2020-11-06
+
+-   releaseCycle: "Samsung W21 5G"
+    support: false
+    eol: false
+    releaseDate: 2020-11-04
+
+-   releaseCycle: "Galaxy M31 Prime" #This loses active support with Android 12.
+    support: true
+    eol: false
+    releaseDate: 2020-10-17
+
+-   releaseCycle: "Galaxy F41" #This loses active support with Android 12.
+    support: true
+    eol: false
+    releaseDate: 2020-10-16
+
+-   releaseCycle: "Galaxy Tab Active 3" # Confirm this.
+    support: true #This loses active support with Android 12.
+    eol: false
+    releaseDate: 2020-09-28
+
+-   releaseCycle: "Galaxy Z Fold 2"
+    support: true
+    eol: false
+    releaseDate: 2020-09-18
+
+-   releaseCycle: "Galaxy Tab A7" #This loses active support with Android 12.
+    support: true
+    eol: false
+    releaseDate: 2020-09-11
+
+-   releaseCycle: "Galaxy Note 20 Ultra"
+    support: true
+    eol: false
+    releaseDate: 2020-08-21
+
+-   releaseCycle: "Galaxy Note 20"
+    support: true
+    eol: false
+    releaseDate: 2020-08-21
+
+-   releaseCycle: "Galaxy Z Flip 5G"
+    support: true
+    eol: false
+    releaseDate: 2020-08-07
+
+-   releaseCycle: "Galaxy A51 5G"
+    support: true
+    eol: false
+    releaseDate: 2020-08-07
+
+-   releaseCycle: "Galaxy M51" #This loses active support with Android 12.
+    support: true
+    eol: false
+    releaseDate: 2020-08-06
+
+-   releaseCycle: "Galaxy A01 Core"
+    support: false
+    eol: false
+    releaseDate: 2020-08-06
+
 -   releaseCycle: "Galaxy Tab S7+"
     support: true
     eol: false
-
-
-
-
     releaseDate: 2020-08-05
+
 -   releaseCycle: "Galaxy Tab S7 "
     support: true
     eol: false
-
-
-
     releaseDate: 2020-08-05
--   releaseCycle: "Galaxy Tab S7 FE"
+
+-   releaseCycle: "Galaxy A21" #This loses active support with Android 12.
+    support: true
+    eol: false # Quarterly
+    releaseDate: 2020-06-26
+
+-   releaseCycle: "Galaxy A71 5G"
     support: true
     eol: false
+    releaseDate: 2020-06-15
 
+-   releaseCycle: "Galaxy A21s" #This loses active support with Android 12.
+    support: true
+    eol: false # Quarterly
+    releaseDate: 2020-06-02
 
-
-
-    releaseDate: 2021-05-25
--   releaseCycle: "Galaxy Tab S6 5G"
+-   releaseCycle: "Galaxy M01"
     support: true
     eol: false
+    releaseDate: 2020-06-02
 
-
-
-    releaseDate: 2020-01-30
--   releaseCycle: "Galaxy Tab S6" #This loses active support with Android 12.
+-   releaseCycle: "Galaxy A Quantum"
     support: true
     eol: false
+    releaseDate: 2020-05-22
 
-
-
-    releaseDate: 2019-08-01
 -   releaseCycle: "Galaxy Tab S6 Lite"
     support: true
     eol: false
     releaseDate: 2020-05-16
+
+-   releaseCycle: "Galaxy A11" #This loses active support with Android 12.
+    support: true
+    eol: false # Quarterly
+    releaseDate: 2020-05-15
+
+-   releaseCycle: "Galaxy A31" #This loses active support with Android 12.
+    support: true
+    eol: false # Quarterly
+    releaseDate: 2020-04-27
+
 -   releaseCycle: "Galaxy Tab A 8.4 (2020)" # Yeah we need to specify the year here, multiple models from different years with the same name.
     support: true #This loses active support with Android 12.
     eol: false
-
-
     releaseDate: 2020-03-25
--   releaseCycle: "Galaxy Tab A7" #This loses active support with Android 12.
+
+-   releaseCycle: "Galaxy M21" #This loses active support with Android 12.
     support: true
     eol: false
+    releaseDate: 2020-03-23
 
+-   releaseCycle: "Galaxy A41" #This loses active support with Android 12.
+    support: true
+    eol: false # Quarterly
+    releaseDate: 2020-03-18
 
-    releaseDate: 2020-09-11
--   releaseCycle: "Galaxy Tab A7 Lite"
+-   releaseCycle: "Galaxy M31"
     support: true
     eol: false
+    releaseDate: 2020-03-05
 
+-   releaseCycle: "Galaxy S20 Ultra"
+    support: true
+    eol: false
+    releaseDate: 2020-02-21
 
-    releaseDate: 2021-05-27
--   releaseCycle: "Galaxy Tab Active 3" # Confirm this.
+-   releaseCycle: "Galaxy S20+"
+    support: true
+    eol: false
+    releaseDate: 2020-02-21
+
+-   releaseCycle: "Galaxy S20"
+    support: true
+    eol: false
+    releaseDate: 2020-02-21
+
+-   releaseCycle: "Galaxy Z Flip"
+    support: true
+    eol: false
+    releaseDate: 2020-02-14
+
+-   releaseCycle: "Galaxy Tab S6 5G"
+    support: true
+    eol: false
+    releaseDate: 2020-01-30
+
+-   releaseCycle: "Galaxy A71"
+    support: true
+    eol: false
+    releaseDate: 2020-01-17
+
+-   releaseCycle: "Galaxy S10 Lite"
+    support: true
+    eol: false
+    releaseDate: 2020-01-03
+
+-   releaseCycle: "Galaxy Note 10 Lite"
+    support: true
+    eol: false
+    releaseDate: 2020-01-03
+
+-   releaseCycle: "Galaxy XCover Pro" # Unclear release date.
     support: true #This loses active support with Android 12.
     eol: false
+    releaseDate: 2020-01-01
 
-# Current Models for Quarterly Security Updates
-# Excluding: Galaxy A90 5G, Galaxy A01, Galaxy A11, Galaxy A21, Galaxy A21s, Galaxy A31, Galaxy A31, Galaxy A41, Galaxy A51, Galaxy A51 5G, Galaxy A71, Galaxy A71 5G ...
-# ... Galaxy A02, Galaxy A02s, Galaxy A03s, Galaxy A12, Galaxy A22, Galaxy A22 5G, Galaxy A32, Galaxy A32 5G, Galaxy A42 5G, Galaxy A72,Galaxy M01,Galaxy M11, Galaxy M21 ...
-# Galaxy M31, Galaxy M31, Galaxy M51, Galaxy M12, Galaxy M32, Galaxy M42 5G, Galaxy M62, Galaxy F12, Galaxy F22, Galaxy F62, Galaxy Tab A 8.4 (2020), Galaxy Tab A7 ...
-# Galaxy Tab A7 Lite,  Galaxy Tab Active 3, Galaxy Tab S6, Galaxy Tab S6 5G, Galaxy Tab S6 Lite, Galaxy Tab S7, Galaxy Tab S7+, Galaxy Tab S7 FE
-
-    releaseDate: 2020-09-28
--   releaseCycle: "Galaxy A70s"
-    support: false
+-   releaseCycle: "Galaxy A51"
+    support: true
     eol: false
+    releaseDate: 2019-12-27
 
+-   releaseCycle: "Galaxy A01" #This loses active support with Android 12.
+    support: true
+    eol: false # Quarterly
+    releaseDate: 2019-12-18
 
-
-
-
-    releaseDate: 2019-09-01
--   releaseCycle: "Galaxy A50s"
-    support: false
-    eol: false
-
-
-
-
-
-
-
-
-    releaseDate: 2019-09-01
--   releaseCycle: "Galaxy A40"
-    support: false
-    eol: false
-
-
-
-
-
-
-
-    releaseDate: 2019-04-01
--   releaseCycle: "Galaxy A20s"
-    support: false
-    eol: false
-
-
-
-
-
-
-
-
-    releaseDate: 2019-10-05
--   releaseCycle: "Galaxy Note 9"
-    support: false
-    eol: false
-
-
-
-
-
-
-
-
-
-
-    releaseDate: 2018-08-24
--   releaseCycle: "Galaxy Note 8"
-    support: false
-    eol: 2021-11-17
-
-
-
-
-
-
-
-    releaseDate: 2017-09-01
--   releaseCycle: "Galaxy S9+"
-    support: false
-    eol: false
-
-
-
-
-
-
-
-
-    releaseDate: 2018-03-09
--   releaseCycle: "Galaxy S9"
-    support: false
-    eol: false
-
-
-
-
-
-
-
-    releaseDate: 2018-03-09
--   releaseCycle: "Galaxy S8 Active"
-    support: false
-    eol: 2021-11-17
-
-
-
-
-
-
-
-
-    releaseDate: 2017-08-01
--   releaseCycle: "Galaxy A8 (2018) Enterprise"
-    support: false
-    eol: 2021-12-31
-
-
-
-
-
-
-
-
-
-
-    releaseDate: 2018-01-01
--   releaseCycle: "Samsung W21 5G"
-    support: false
-    eol: false
-
-
-
-
-
-
-
-
-    releaseDate: 2020-11-04
 -   releaseCycle: "Samsung W20 5G"
     support: false
     eol: false
-
-
-
-
-
-
-
-
     releaseDate: 2019-11-20
--   releaseCycle: "Galaxy Tab Active Pro"
-    support: false
-    eol: false
 
-
-
-
-
-
-
-
-    releaseDate: 2019-10-01
--   releaseCycle: "Galaxy Tab Active 2"
-    support: false
-    eol: 2021-11-17
-
-
-
-
-
-
-
-
-
-    releaseDate: 2017-10-20
--   releaseCycle: "Galaxy M21 2021"
-    support: false
-    eol: false
-
-
-
-
-
-
-
-
-
-    releaseDate: 2021-07-26
 -   releaseCycle: "Galaxy M30s"
     support: false
     eol: false
-
-
-
-
-
-
-
     releaseDate: 2019-10-30
+
+-   releaseCycle: "Galaxy A20s"
+    support: false
+    eol: false
+    releaseDate: 2019-10-05
+
+-   releaseCycle: "Galaxy Tab Active Pro"
+    support: false
+    eol: false
+    releaseDate: 2019-10-01
+
+-   releaseCycle: "Galaxy Fold" #This loses active support with Android 12.
+    support: true
+    eol: false
+    releaseDate: 2019-09-06
+
+-   releaseCycle: "Galaxy A90 5G" #This loses active support with Android 12.
+    support: true
+    eol: false # Quarterly Security Updates. This is a weird one. Getting 12 but not under the monthly security support branch.
+    releaseDate: 2019-09-03
+
+-   releaseCycle: "Galaxy A70s"
+    support: false
+    eol: false
+    releaseDate: 2019-09-01
+
+-   releaseCycle: "Galaxy A50s"
+    support: false
+    eol: false
+    releaseDate: 2019-09-01
+
 -   releaseCycle: "Galaxy M10s"
     support: false
     eol: false
-
-
-
-
-
-
-
     releaseDate: 2019-09-01
--   releaseCycle: "Galaxy A82 5G"
-    support: false
-    eol: false
 
-
-
-
-
-    releaseDate: 2021-05-05
--   releaseCycle: "Galaxy A01 Core"
-    support: false
-    eol: false
-
-
-# Current Models for Biannual Security Updates
-
-    releaseDate: 2020-08-06
--   releaseCycle: "Galaxy View2"
-    support: false
-    eol: 2021-12-31
-
-
-
-    releaseDate: 2019-04-01
--   releaseCycle: "Galaxy Tab S5e"
-    support: false
-    eol: false
-
-
-
-    releaseDate: 2019-04-01
--   releaseCycle: "Galaxy Tab S4 10.5"
-    support: false
-    eol: false
-
-
-
-    releaseDate: 2018-08-01
--   releaseCycle: "Galaxy Tab E 8.0"
-    support: false
-    eol: 2021-11-17
-
-
-
-    releaseDate: 2016-01-01
--   releaseCycle: "Galaxy Tab A 8.0 with S Pen (2019)"
-    support: false
-    eol: 2021-11-17
-
-
-
-    releaseDate: 2019-04-01
--   releaseCycle: "Galaxy Tab A 10.1 (2019)"
-    support: false
-    eol: false
-
-
-
-    releaseDate: 2019-04-01
--   releaseCycle: "Galaxy Tab A 8.0 (2019)"
-    support: false
-    eol: 2021-11-17
-
-
-
-    releaseDate: 2019-07-01
--   releaseCycle: "Galaxy Tab A 10.5 (2018)"
-    support: false
-    eol: false
-
-
-
-    releaseDate: 2018-08-01
--   releaseCycle: "Galaxy Tab A 8.0 (2017)"
-    support: false
-    eol: 2021-11-17
-
-
-
-    releaseDate: 2017-09-01
--   releaseCycle: "Galaxy J8"
-    support: false
-    eol: false
-
-
-
-    releaseDate: 2018-07-01
--   releaseCycle: "Galaxy J7+"
-    support: false
-    eol: 2021-11-17
-
-
-
-    releaseDate: 2017-09-01
--   releaseCycle: "Galaxy J7 Top"
-    support: false
-    eol: 2021-12-31
-
-
-
-    releaseDate: 2018-07-01
--   releaseCycle: "Galaxy J7 Prime 2"
-    support: false
-    eol: 2021-12-31
-
-
-
-    releaseDate: 2018-04-01
--   releaseCycle: "Galaxy J7 Duo"
-    support: false
-    eol: false
-
-
-    releaseDate: 2018-04-01
--   releaseCycle: "Galaxy J6+"
-    support: false
-    eol: false
-
-
-
-    releaseDate: 2018-10-01
--   releaseCycle: "Galaxy J6"
-    support: false
-    eol: false
-
-
-
-    releaseDate: 2018-05-01
--   releaseCycle: "Galaxy J4 Core"
-    support: false
-    eol: false
-
-
-
-    releaseDate: 2018-11-01
--   releaseCycle: "Galaxy J4+"
-    support: false
-    eol: false
-
-
-
-    releaseDate: 2018-10-01
--   releaseCycle: "Galaxy J4"
-    support: false
-    eol: false
-
-
-
-    releaseDate: 2018-05-01
--   releaseCycle: "Galaxy J3"
-    support: false
-    eol: 2021-12-31
-
-
-
-    releaseDate: 2018-06-01
--   releaseCycle: "Galaxy J2 Core"
-    support: false
-    eol: 2021-12-31
-
-
-
-    releaseDate: 2018-08-01
--   releaseCycle: "Galaxy A80"
-    support: false
-    eol: false
-
-
-
-    releaseDate: 2019-05-01
--   releaseCycle: "Galaxy A70"
-    support: false
-    eol: false
-
-
-
-    releaseDate: 2019-05-01
--   releaseCycle: "Galaxy A60"
-    support: false
-    eol: false
-
-
-
-    releaseDate: 2019-06-01
--   releaseCycle: "Galaxy A30"
-    support: false
-    eol: false
-
-
-
-    releaseDate: 2019-03-01
--   releaseCycle: "Galaxy A20"
-    support: false
-    eol: false
-
-
-
-    releaseDate: 2019-04-05
--   releaseCycle: "Galaxy A20e"
-    support: false
-    eol: false
-
-
-
-    releaseDate: 2019-05-01
 -   releaseCycle: "Galaxy A10s"
     support: false
     eol: false
-
-
-
     releaseDate: 2019-08-27
+
 -   releaseCycle: "Galaxy A10e"
     support: false
     eol: false
-
-
-
     releaseDate: 2019-08-27
--   releaseCycle: "Galaxy A10"
+
+-   releaseCycle: "Galaxy Note 10+" #This loses active support with Android 12.
+    support: true
+    eol: false
+    releaseDate: 2019-08-23
+
+-   releaseCycle: "Galaxy Note 10" #This loses active support with Android 12.
+    support: true
+    eol: false
+    releaseDate: 2019-08-23
+
+-   releaseCycle: "Galaxy Tab S6" #This loses active support with Android 12.
+    support: true
+    eol: false
+    releaseDate: 2019-08-01
+
+-   releaseCycle: "Galaxy Tab A 8.0 (2019)"
+    support: false
+    eol: 2021-11-17
+    releaseDate: 2019-07-01
+
+-   releaseCycle: "Galaxy A60"
     support: false
     eol: false
+    releaseDate: 2019-06-01
 
-
-
-    releaseDate: 2019-03-19
--   releaseCycle: "Galaxy A9 (2018)"
+-   releaseCycle: "Galaxy A80"
     support: false
     eol: false
+    releaseDate: 2019-05-01
 
-
-
-    releaseDate: 2018-11-01
--   releaseCycle: "Galaxy A8s"
+-   releaseCycle: "Galaxy A70"
     support: false
     eol: false
+    releaseDate: 2019-05-01
 
-
-
-    releaseDate: 2018-12-01
--   releaseCycle: "Galaxy A8 Star"
+-   releaseCycle: "Galaxy A20e"
     support: false
     eol: false
+    releaseDate: 2019-05-01
 
+-   releaseCycle: "Galaxy A20"
+    support: false
+    eol: false
+    releaseDate: 2019-04-05
 
+-   releaseCycle: "Galaxy A40"
+    support: false
+    eol: false
+    releaseDate: 2019-04-01
 
-    releaseDate: 2018-06-01
--   releaseCycle: "Galaxy A8+"
+-   releaseCycle: "Galaxy View2"
     support: false
     eol: 2021-12-31
+    releaseDate: 2019-04-01
 
-
-
-    releaseDate: 2018-01-01
--   releaseCycle: "Galaxy A7"
+-   releaseCycle: "Galaxy Tab S5e"
     support: false
     eol: false
+    releaseDate: 2019-04-01
 
+-   releaseCycle: "Galaxy Tab A 8.0 with S Pen (2019)"
+    support: false
+    eol: 2021-11-17
+    releaseDate: 2019-04-01
 
-
-    releaseDate: 2018-10-01
--   releaseCycle: "Galaxy A6+"
+-   releaseCycle: "Galaxy Tab A 10.1 (2019)"
     support: false
     eol: false
+    releaseDate: 2019-04-01
 
-
-
-    releaseDate: 2018-05-01
--   releaseCycle: "Galaxy A6"
-    support: false
-    eol: false
-
-
-
-    releaseDate: 2018-05-01
 -   releaseCycle: "Galaxy A2 Core"
     support: false
     eol: false
     releaseDate: 2019-04-01
+
+-   releaseCycle: "Galaxy A10"
+    support: false
+    eol: false
+    releaseDate: 2019-03-19
+
+-   releaseCycle: "Galaxy A30"
+    support: false
+    eol: false
+    releaseDate: 2019-03-01
+
+-   releaseCycle: "Galaxy S10 5G" #This loses active support with Android 12.
+    support: true
+    eol: false
+    releaseDate: 2019-02-20
+
+-   releaseCycle: "Galaxy S10" #This loses active support with Android 12.
+    support: true
+    eol: false
+    releaseDate: 2019-02-20
+
+-   releaseCycle: "Galaxy S10+" #This loses active support with Android 12.
+    support: true
+    eol: false
+    releaseDate: 2019-02-20
+
+-   releaseCycle: "Galaxy S10e" #This loses active support with Android 12.
+    support: true
+    eol: false
+    releaseDate: 2019-02-20
+
+-   releaseCycle: "Galaxy A8s"
+    support: false
+    eol: false
+    releaseDate: 2018-12-01
+
+-   releaseCycle: "Galaxy J4 Core"
+    support: false
+    eol: false
+    releaseDate: 2018-11-01
+
+-   releaseCycle: "Galaxy A9 (2018)"
+    support: false
+    eol: false
+    releaseDate: 2018-11-01
+
+-   releaseCycle: "Galaxy J6+"
+    support: false
+    eol: false
+    releaseDate: 2018-10-01
+
+-   releaseCycle: "Galaxy J4+"
+    support: false
+    eol: false
+    releaseDate: 2018-10-01
+
+-   releaseCycle: "Galaxy A7"
+    support: false
+    eol: false
+    releaseDate: 2018-10-01
+
+-   releaseCycle: "Galaxy Note 9"
+    support: false
+    eol: false
+    releaseDate: 2018-08-24
+
+-   releaseCycle: "Galaxy Tab S4 10.5"
+    support: false
+    eol: false
+    releaseDate: 2018-08-01
+
+-   releaseCycle: "Galaxy Tab A 10.5 (2018)"
+    support: false
+    eol: false
+    releaseDate: 2018-08-01
+
+-   releaseCycle: "Galaxy J2 Core"
+    support: false
+    eol: 2021-12-31
+    releaseDate: 2018-08-01
+
+-   releaseCycle: "Galaxy J8"
+    support: false
+    eol: false
+    releaseDate: 2018-07-01
+
+-   releaseCycle: "Galaxy J7 Top"
+    support: false
+    eol: 2021-12-31
+    releaseDate: 2018-07-01
+
+-   releaseCycle: "Galaxy J3"
+    support: false
+    eol: 2021-12-31
+    releaseDate: 2018-06-01
+
+-   releaseCycle: "Galaxy A8 Star"
+    support: false
+    eol: false
+    releaseDate: 2018-06-01
+
+-   releaseCycle: "Galaxy J6"
+    support: false
+    eol: false
+    releaseDate: 2018-05-01
+
+-   releaseCycle: "Galaxy J4"
+    support: false
+    eol: false
+    releaseDate: 2018-05-01
+
+-   releaseCycle: "Galaxy A6+"
+    support: false
+    eol: false
+    releaseDate: 2018-05-01
+
+-   releaseCycle: "Galaxy A6"
+    support: false
+    eol: false
+    releaseDate: 2018-05-01
+
+-   releaseCycle: "Galaxy J7 Prime 2"
+    support: false
+    eol: 2021-12-31
+    releaseDate: 2018-04-01
+
+-   releaseCycle: "Galaxy J7 Duo"
+    support: false
+    eol: false
+    releaseDate: 2018-04-01
+
+-   releaseCycle: "Galaxy S9+"
+    support: false
+    eol: false
+    releaseDate: 2018-03-09
+
+-   releaseCycle: "Galaxy S9"
+    support: false
+    eol: false
+    releaseDate: 2018-03-09
+
+-   releaseCycle: "Galaxy A8 (2018) Enterprise"
+    support: false
+    eol: 2021-12-31
+    releaseDate: 2018-01-01
+
+-   releaseCycle: "Galaxy A8+"
+    support: false
+    eol: 2021-12-31
+    releaseDate: 2018-01-01
+
+-   releaseCycle: "Galaxy Tab Active 2"
+    support: false
+    eol: 2021-11-17
+    releaseDate: 2017-10-20
+
+-   releaseCycle: "Galaxy Note 8"
+    support: false
+    eol: 2021-11-17
+    releaseDate: 2017-09-01
+
+-   releaseCycle: "Galaxy Tab A 8.0 (2017)"
+    support: false
+    eol: 2021-11-17
+    releaseDate: 2017-09-01
+
+-   releaseCycle: "Galaxy J7+"
+    support: false
+    eol: 2021-11-17
+    releaseDate: 2017-09-01
+
+-   releaseCycle: "Galaxy S8 Active"
+    support: false
+    eol: 2021-11-17
+    releaseDate: 2017-08-01
+
+-   releaseCycle: "Galaxy Tab E 8.0"
+    support: false
+    eol: 2021-11-17
+    releaseDate: 2016-01-01
 
 ---
 

--- a/products/sles.md
+++ b/products/sles.md
@@ -13,7 +13,6 @@ releaseColumn: true
 releaseDateColumn: true
 LTSLabel: "<abbr title='Long Term Service Pack Support'>LTSS</abbr>"
 versionCommand: cat /etc/os-release
-sortReleasesBy: releaseDate
 changelogTemplate: https://www.suse.com/releasenotes/x86_64/SUSE-SLES/{{"__LATEST__"|
   replace:'SLES ','' | replace:' ','-'}}/
 releaseLabel: "SUSE Linux Enterprise Server __RELEASE_CYCLE__"

--- a/products/solr.md
+++ b/products/solr.md
@@ -19,7 +19,6 @@ changelogTemplate: https://solr.apache.org/docs/{{"__LATEST__" | replace:'.','_'
 activeSupportColumn: false
 releaseDateColumn: false
 releaseColumn: true
-sortReleasesBy: 'releaseCycle'
 iconSlug: apachesolr
 releases:
 -   releaseCycle: "9"

--- a/products/splunk.md
+++ b/products/splunk.md
@@ -4,7 +4,6 @@ permalink: /splunk
 category: server-app
 iconSlug: splunk
 releasePolicyLink: https://www.splunk.com/en_us/legal/splunk-software-support-policy.html
-sortReleasesBy: "releaseCycle"
 changelogTemplate: https://docs.splunk.com/Documentation/Splunk/__LATEST__/ReleaseNotes/MeetSplunk
 activeSupportColumn: false
 releaseDateColumn: true

--- a/products/spring-framework.md
+++ b/products/spring-framework.md
@@ -3,7 +3,6 @@ title: Spring Framework
 alternate_urls:
 -   /spring
 category: framework
-sortReleasesBy: "releaseCycle"
 changelogTemplate: "https://github.com/spring-projects/spring-framework/releases/tag/v__LATEST__"
 auto:
 -   git: https://github.com/spring-projects/spring-framework.git

--- a/products/surface.md
+++ b/products/surface.md
@@ -9,20 +9,79 @@ latestColumn: true
 eolColumn: End of Servicing Date
 releaseColumn: false
 releaseDateColumn: true
-sortReleasesBy: eol
 releases:
--   releaseCycle: Surface RT
-    eol: 2017-04-11
-    releaseDate: 2012-10-26
--   releaseCycle: Surface Pro
-    eol: 2017-04-11
-    releaseDate: 2013-02-09
--   releaseCycle: Surface 2
-    eol: 2018-04-10
-    releaseDate: 2013-10-22
--   releaseCycle: Surface Pro 2
-    eol: 2018-04-10
-    releaseDate: 2013-10-22
+-   releaseCycle: Surface Laptop SE
+    eol: 2026-01-11
+    releaseDate: 2022-01-11
+-   releaseCycle: Surface Pro 8
+    eol: 2025-10-5
+    releaseDate: 2021-10-05
+-   releaseCycle: Surface Laptop Studio
+    eol: 2025-10-5
+    releaseDate: 2021-10-05
+-   releaseCycle: Surface Go 3
+    eol: 2025-10-5
+    releaseDate: 2021-10-05
+-   releaseCycle: Surface Laptop 4
+    eol: 2025-04-15
+    releaseDate: 2021-04-15
+-   releaseCycle: Surface Pro 7+
+    eol: 2025-01-15
+    releaseDate: 2021-01-15
+-   releaseCycle: Surface Hub 2S 85"
+    eol: 2025-01-11
+    releaseDate: 2021-01-11
+-   releaseCycle: Surface Studio 2
+    eol: 2024-10-2
+    releaseDate: 2018-10-02
+-   releaseCycle: Surface Pro X
+    eol: 2024-10-13
+    releaseDate: 2019-11-05
+-   releaseCycle: Surface Laptop Go
+    eol: 2024-10-13
+    releaseDate: 2020-10-13
+-   releaseCycle: Surface Go 2
+    eol: 2024-05-6
+    releaseDate: 2020-05-06
+-   releaseCycle: Surface Book 3
+    eol: 2024-05-26
+    releaseDate: 2020-05-26
+-   releaseCycle: Surface Pro (5th gen)
+    eol: 2024-01-15
+    releaseDate: 2017-06-15
+-   releaseCycle: Surface Pro LTE (Model 1807)
+    eol: 2024-01-15
+    releaseDate: 2017-12-01
+-   releaseCycle: Surface Laptop 3
+    eol: 2023-10-22
+    releaseDate: 2019-10-22
+-   releaseCycle: Surface Pro 7
+    eol: 2023-10-22
+    releaseDate: 2019-10-22
+-   releaseCycle: Surface Pro 6
+    eol: 2023-06-30
+    releaseDate: 2018-10-16
+-   releaseCycle: Surface Book 2
+    eol: 2023-05-30
+    releaseDate: 2017-11-17
+-   releaseCycle: Surface Hub 2S
+    eol: 2023-04-17
+    releaseDate: 2019-04-17
+-   releaseCycle: Surface Laptop 2
+    eol: 2022-12-27
+    releaseDate: 2018-10-16
+-   releaseCycle: Surface Hub 55
+    eol: 2022-11-30
+    releaseDate: 2015-06-01
+-   releaseCycle: Surface Hub 84
+    eol: 2022-11-30
+    releaseDate: 2015-06-01
+-   releaseCycle: Surface Go with LTE Advanced
+    eol: 2022-11-20
+    releaseDate: 2018-11-20
+-   releaseCycle: Surface Go
+    eol: 2022-08-02
+    releaseDate: 2018-08-02
 -   releaseCycle: Surface Pro 3
     eol: 2021-11-13
     releaseDate: 2014-06-20
@@ -44,78 +103,18 @@ releases:
 -   releaseCycle: Surface Laptop (1st gen)
     eol: 2021-11-13
     releaseDate: 2017-06-14
--   releaseCycle: Surface Pro (5th gen)
-    eol: 2024-01-15
-    releaseDate: 2017-06-15
--   releaseCycle: Surface Book 2
-    eol: 2023-05-30
-    releaseDate: 2017-11-17
--   releaseCycle: Surface Pro LTE (Model 1807)
-    eol: 2024-01-15
-    releaseDate: 2017-12-01
--   releaseCycle: Surface Go
-    eol: 2022-08-02
-    releaseDate: 2018-08-02
--   releaseCycle: Surface Studio 2
-    eol: 2024-10-2
-    releaseDate: 2018-10-02
--   releaseCycle: Surface Laptop 2
-    eol: 2022-12-27
-    releaseDate: 2018-10-16
--   releaseCycle: Surface Pro 6
-    eol: 2023-06-30
-    releaseDate: 2018-10-16
--   releaseCycle: Surface Go with LTE Advanced
-    eol: 2022-11-20
-    releaseDate: 2018-11-20
--   releaseCycle: Surface Laptop 3
-    eol: 2023-10-22
-    releaseDate: 2019-10-22
--   releaseCycle: Surface Pro 7
-    eol: 2023-10-22
-    releaseDate: 2019-10-22
--   releaseCycle: Surface Pro X
-    eol: 2024-10-13
-    releaseDate: 2019-11-05
--   releaseCycle: Surface Go 2
-    eol: 2024-05-6
-    releaseDate: 2020-05-06
--   releaseCycle: Surface Book 3
-    eol: 2024-05-26
-    releaseDate: 2020-05-26
--   releaseCycle: Surface Laptop Go
-    eol: 2024-10-13
-    releaseDate: 2020-10-13
--   releaseCycle: Surface Pro 7+
-    eol: 2025-01-15
-    releaseDate: 2021-01-15
--   releaseCycle: Surface Laptop 4
-    eol: 2025-04-15
-    releaseDate: 2021-04-15
--   releaseCycle: Surface Pro 8
-    eol: 2025-10-5
-    releaseDate: 2021-10-05
--   releaseCycle: Surface Laptop Studio
-    eol: 2025-10-5
-    releaseDate: 2021-10-05
--   releaseCycle: Surface Go 3
-    eol: 2025-10-5
-    releaseDate: 2021-10-05
--   releaseCycle: Surface Laptop SE
-    eol: 2026-01-11
-    releaseDate: 2022-01-11
--   releaseCycle: Surface Hub 55
-    eol: 2022-11-30
-    releaseDate: 2015-06-01
--   releaseCycle: Surface Hub 84
-    eol: 2022-11-30
-    releaseDate: 2015-06-01
--   releaseCycle: Surface Hub 2S
-    eol: 2023-04-17
-    releaseDate: 2019-04-17
--   releaseCycle: Surface Hub 2S 85"
-    eol: 2025-01-11
-    releaseDate: 2021-01-11
+-   releaseCycle: Surface 2
+    eol: 2018-04-10
+    releaseDate: 2013-10-22
+-   releaseCycle: Surface Pro 2
+    eol: 2018-04-10
+    releaseDate: 2013-10-22
+-   releaseCycle: Surface RT
+    eol: 2017-04-11
+    releaseDate: 2012-10-26
+-   releaseCycle: Surface Pro
+    eol: 2017-04-11
+    releaseDate: 2013-02-09
 
 ---
 

--- a/products/symfony.md
+++ b/products/symfony.md
@@ -7,7 +7,6 @@ versionCommand: composer show symfony/symfony | grep versions
 changelogTemplate: |
   https://symfony.com/blog/symfony-{{"__LATEST__" | replace:'.','-'}}-released
 releaseDateColumn: true
-sortReleasesBy: 'releaseCycle'
 auto:
 -   git: https://github.com/symfony/symfony.git
 category: framework

--- a/products/tarantool.md
+++ b/products/tarantool.md
@@ -11,7 +11,6 @@ category: db
 iconSlug: NA
 eolColumn: Support Status
 releaseDateColumn: false
-sortReleasesBy: releaseDate
 releases:
 -   releaseCycle: "2.10"
     eol: false

--- a/products/terraform.md
+++ b/products/terraform.md
@@ -4,7 +4,6 @@ permalink: /terraform
 category: app
 iconSlug: terraform
 releasePolicyLink: https://support.hashicorp.com/hc/articles/360021185113
-sortReleasesBy: releaseDate
 changelogTemplate: https://github.com/hashicorp/terraform/blob/v__LATEST__/CHANGELOG.md
 auto:
 -   git: https://github.com/hashicorp/terraform.git

--- a/products/tomcat.md
+++ b/products/tomcat.md
@@ -11,9 +11,7 @@ auto:
 versionCommand: ./bin/version.sh
 releaseColumn: true
 releaseDateColumn: true
-sortReleasesBy: "releaseCycle"
 releases:
-# 10.1 is still in Beta
 -   releaseCycle: "10.0"
     eol: false
     latest: "10.0.26"

--- a/products/typo3.md
+++ b/products/typo3.md
@@ -2,7 +2,6 @@
 title: TYPO3
 category: server-app
 releasePolicyLink: https://get.typo3.org/
-sortReleasesBy: "releaseCycle"
 releases:
 -   releaseCycle: "11"
     eol: 2024-10-31

--- a/products/ubuntu.md
+++ b/products/ubuntu.md
@@ -19,7 +19,6 @@ purls:
 activeSupportColumn: true
 releaseDateColumn: true
 releaseImage: https://user-images.githubusercontent.com/44484725/135176160-a1d5dd88-fc56-44ee-9ce8-98d52a41da2b.png
-sortReleasesBy: "releaseCycle"
 releaseLabel: "__RELEASE_CYCLE__ '__CODENAME__'"
 releases:
 -   releaseCycle: "22.04"

--- a/products/unity.md
+++ b/products/unity.md
@@ -10,18 +10,15 @@ iconSlug: unity
 changelogTemplate: |
   https://unity3d.com/unity/whats-new/__LATEST__
 releaseImage: https://blog-api.unity.com/sites/default/files/2022-04/Unity-2021-LTS-Timeline.jpg
-sortReleasesBy: releaseDate
 releases:
 #  - releaseCycle: "2022.2"
 #    release: 2022-XX-XX
 #    eol: false
 #    latest: "2022.2.0"
-
 -   releaseCycle: "2022.1"
     eol: false
     latest: "2022.1.14"
     releaseDate: 2022-05-09
-
 -   releaseCycle: "2021"
     eol: 2024-04-19
     lts: true

--- a/products/unrealircd.md
+++ b/products/unrealircd.md
@@ -1,7 +1,6 @@
 ---
 title: UnrealIRCd
 category: server-app
-sortReleasesBy: "releaseCycle"
 activeSupportColumn: true
 permalink: /unrealircd
 releasePolicyLink: https://www.unrealircd.org/docs/UnrealIRCd_releases

--- a/products/varnish.md
+++ b/products/varnish.md
@@ -2,7 +2,6 @@
 title: Varnish
 permalink: /varnish
 category: server-app
-sortReleasesBy: "releaseCycle"
 releasePolicyLink: https://varnish-cache.org/releases/
 changelogTemplate: https://varnish-cache.org/releases/rel__LATEST__.html
 iconSlug: NA

--- a/products/visualstudio.md
+++ b/products/visualstudio.md
@@ -1,7 +1,6 @@
 ---
 title: Visual Studio
 category: app
-sortReleasesBy: "releaseDate"
 releaseLabel: '__RELEASE_CYCLE__ __CODENAME__'
 iconSlug: visualstudio
 permalink: /visualstudio
@@ -18,7 +17,6 @@ releases:
     lts: true
     eol: 2024-01-09
     releaseDate: 2022-05-10
-
 -   releaseCycle: "2022"
     codename: "17.0"
     lts: true

--- a/products/vmware-esxi.md
+++ b/products/vmware-esxi.md
@@ -13,8 +13,6 @@ releaseDateColumn: true
 eolColumn: Service Status
 discontinuedColumn: false
 versionCommand: vmware -l
-sortReleasesBy: "releaseCycle"
-
 releases:
 -   releaseCycle: "7.0"
     support: 2027-04-02
@@ -51,7 +49,6 @@ releases:
     link: "https://docs.vmware.com/en/VMware-vSphere/5.5/rn/vsphere-esxi-55u3b-release-notes.html"
     releaseDate: 2013-09-19
     latestReleaseDate:
-
 
 ---
 

--- a/products/vmware-horizon.md
+++ b/products/vmware-horizon.md
@@ -10,7 +10,6 @@ releasePolicyLink: https://lifecycle.vmware.com
 activeSupportColumn: Technical Guidance
 releaseColumn: false
 releaseDateColumn: true
-sortReleasesBy: releaseDate
 releaseLabel: 'Horizon __RELEASE_CYCLE__ __CODENAME__'
 LTSLabel: "<abbr title='Extended Service Branch'>ESB</abbr>"
 releases:
@@ -44,24 +43,24 @@ releases:
     releaseDate: 2021-01-07
     eol: 2024-01-07
     support: 2025-01-07
+-   releaseCycle: "7.13"
+    releaseDate: 2020-10-15
+    eol: 2022-10-15
+    support: 2023-03-23
 -   releaseCycle: "8"
     codename: "2006"
     releaseDate: 2020-08-11
     eol: 2025-08-11
     support: 2027-08-11
--   releaseCycle: "7.5"
-    lts: true
-    releaseDate: 2018-05-29
-    eol: 2020-11-30
-    support: 2023-03-22
--   releaseCycle: "7.13"
-    releaseDate: 2020-10-15
-    eol: 2022-10-15
-    support: 2023-03-23
 -   releaseCycle: "7.10"
     lts: true
     releaseDate: 2019-09-17
     eol: 2022-03-17
+    support: 2023-03-22
+-   releaseCycle: "7.5"
+    lts: true
+    releaseDate: 2018-05-29
+    eol: 2020-11-30
     support: 2023-03-22
 -   releaseCycle: "7.12"
     releaseLabel: "7.0 – 7.9, 7.11, 7.12"

--- a/products/vue.md
+++ b/products/vue.md
@@ -8,7 +8,6 @@ releasePolicyLink: https://vuejs.org/about/releases.html
 activeSupportColumn: true
 versionCommand: npm list vue
 releaseDateColumn: true
-sortReleasesBy: 'releaseCycle'
 iconSlug: vuedotjs
 auto:
 -   git: https://github.com/vuejs/core.git

--- a/products/wagtail.md
+++ b/products/wagtail.md
@@ -12,7 +12,6 @@ auto:
 purls:
 -   repology: python:wagtail
 -   purl: pkg:pypi/wagtail
-sortReleasesBy: releaseDate
 releases:
 -   releaseCycle: "4.0"
     support: 2022-11-01

--- a/products/windows.md
+++ b/products/windows.md
@@ -7,179 +7,178 @@ activeSupportColumn: true
 releaseColumn: false
 releaseDateColumn: true
 versionCommand: winver
-sortReleasesBy: releaseDate
 releases:
 -   releaseCycle: "Windows 11, version 22H2 (E)"
-    cycleShortHand: 10.0.22621
+    buildID: 10.0.22621
     support: 2025-10-14
     eol: 2025-10-14
     releaseDate: 2022-09-20
 -   releaseCycle: "Windows 11, version 22H2 (W)"
-    cycleShortHand: 10.0.22621
+    buildID: 10.0.22621
     support: 2024-10-14
     eol: 2024-10-14
     releaseDate: 2022-09-20
 -   releaseCycle: "Windows 10, version 21H2"
     lts: true
-    cycleShortHand: 10.0.19044
+    buildID: 10.0.19044
     support: 2027-01-12
     eol: 2032-01-13
     releaseDate: 2021-11-16
 -   releaseCycle: "Windows 10, version 21H2 (E)"
-    cycleShortHand: 10.0.19044
+    buildID: 10.0.19044
     support: 2024-06-11
     eol: 2024-06-11
     releaseDate: 2021-11-16
 -   releaseCycle: "Windows 10, version 21H2 (W)"
-    cycleShortHand: 10.0.19044
+    buildID: 10.0.19044
     support: 2023-06-13
     eol: 2023-06-13
     releaseDate: 2021-11-16
 -   releaseCycle: "Windows 11, version 21H2 (E)"
-    cycleShortHand: 10.0.22000
+    buildID: 10.0.22000
     support: 2024-10-08
     eol: 2024-10-08
     releaseDate: 2021-10-04
 -   releaseCycle: "Windows 11, version 21H2 (W)"
-    cycleShortHand: 10.0.22000
+    buildID: 10.0.22000
     support: 2023-10-10
     eol: 2023-10-10
     releaseDate: 2021-10-04
 -   releaseCycle: "Windows 10, version 21H1 (E)(W)"
-    cycleShortHand: 10.0.19043
+    buildID: 10.0.19043
     support: 2022-12-13
     eol: 2022-12-13
     releaseDate: 2021-05-18
 -   releaseCycle: "Windows 10, version 20H2 (E)"
-    cycleShortHand: 10.0.19042
+    buildID: 10.0.19042
     support: 2023-05-09
     eol: 2023-05-09
     releaseDate: 2020-10-20
 -   releaseCycle: "Windows 10, version 20H2 (W)"
-    cycleShortHand: 10.0.19042
+    buildID: 10.0.19042
     support: 2022-05-10
     eol: 2022-05-10
     releaseDate: 2020-10-20
 -   releaseCycle: "Windows 10, version 2004 (E)(W)"
-    cycleShortHand: 10.0.19041
+    buildID: 10.0.19041
     support: 2021-12-14
     eol: 2021-12-14
     releaseDate: 2020-05-27
 -   releaseCycle: "Windows 10, version 1909 (E)"
-    cycleShortHand: 10.0.18363
+    buildID: 10.0.18363
     support: 2022-05-10
     eol: 2022-05-10
     releaseDate: 2019-11-12
 -   releaseCycle: "Windows 10, version 1909 (W)"
-    cycleShortHand: 10.0.18363
+    buildID: 10.0.18363
     support: 2021-05-11
     eol: 2021-05-11
     releaseDate: 2019-11-12
 -   releaseCycle: "Windows 10, version 1903 (E)(W)"
-    cycleShortHand: 10.0.18362
+    buildID: 10.0.18362
     support: 2020-12-08
     eol: 2020-12-08
     releaseDate: 2019-08-29
 -   releaseCycle: "Windows 10, version 1809"
     lts: true
-    cycleShortHand: 10.0.17763
+    buildID: 10.0.17763
     support: 2024-01-09
     eol: 2029-01-09
     releaseDate: 2018-11-13
 -   releaseCycle: "Windows 10, version 1809 (E)"
-    cycleShortHand: 10.0.17763
+    buildID: 10.0.17763
     support: 2021-05-11
     eol: 2021-05-11
     releaseDate: 2018-11-13
 -   releaseCycle: "Windows 10, version 1809 (W)"
-    cycleShortHand: 10.0.17763
+    buildID: 10.0.17763
     support: 2020-11-10
     eol: 2020-11-10
     releaseDate: 2018-11-13
 -   releaseCycle: "Windows 10, version 1803 (E)"
-    cycleShortHand: 10.0.17134
+    buildID: 10.0.17134
     support: 2020-05-11
     eol: 2021-05-11
     releaseDate: 2018-04-30
 -   releaseCycle: "Windows 10, version 1803 (W)"
-    cycleShortHand: 10.0.17134
+    buildID: 10.0.17134
     support: 2019-11-12
     eol: 2020-05-11
     releaseDate: 2018-04-30
 -   releaseCycle: "Windows 10, version 1709 (E)"
-    cycleShortHand: 10.0.16299
+    buildID: 10.0.16299
     support: 2020-10-13
     eol: 2020-09-13
     releaseDate: 2017-10-17
 -   releaseCycle: "Windows 10, version 1709 (W)"
-    cycleShortHand: 10.0.16299
+    buildID: 10.0.16299
     support: 2019-04-09
     eol: 2019-04-09
     releaseDate: 2017-10-17
 -   releaseCycle: "Windows 10, version 1703 (E)"
-    cycleShortHand: 10.0.15063
+    buildID: 10.0.15063
     support: 2019-10-08
     eol: 2019-10-08
     releaseDate: 2017-04-11
 -   releaseCycle: "Windows 10, version 1703 (W)"
-    cycleShortHand: 10.0.15063
+    buildID: 10.0.15063
     support: 2018-10-09
     eol: 2018-10-09
     releaseDate: 2017-04-11
 -   releaseCycle: "Windows 10, version 1607"
     lts: true
-    cycleShortHand: 10.0.14393
+    buildID: 10.0.14393
     support: 2021-10-12
     eol: 2026-10-13
     releaseDate: 2016-08-02
 -   releaseCycle: "Windows 10, version 1607 (E)"
-    cycleShortHand: 10.0.14393
+    buildID: 10.0.14393
     support: 2019-04-09
     eol: 2019-04-09
     releaseDate: 2016-08-02
 -   releaseCycle: "Windows 10, version 1607 (W)"
-    cycleShortHand: 10.0.14393
+    buildID: 10.0.14393
     support: 2018-04-10
     eol: 2018-04-10
     releaseDate: 2016-08-02
 -   releaseCycle: "Windows 10, version 1511 (E)(W)"
-    cycleShortHand: 10.0.10586
+    buildID: 10.0.10586
     support: 2017-10-10
     eol: 2017-10-10
     releaseDate: 2015-11-10
 -   releaseCycle: "Windows 10, version 1507"
     lts: true
-    cycleShortHand: 10.0.10240
+    buildID: 10.0.10240
     support: 2020-10-13
     eol: 2025-10-14
     releaseDate: 2015-07-29
 -   releaseCycle: "Windows 10, version 1507 (E)(W)"
-    cycleShortHand: 10.0.10240
+    buildID: 10.0.10240
     support: 2017-05-09
     eol: 2017-05-09
     releaseDate: 2015-07-29
 -   releaseCycle: "Windows 8.1"
-    cycleShortHand: 6.3.9600
+    buildID: 6.3.9600
     support: 2018-01-09
     eol: 2023-01-10
     releaseDate: 2013-11-13
 -   releaseCycle: "Windows 8"
-    cycleShortHand: 6.2.9200
+    buildID: 6.2.9200
     support: 2016-01-12
     eol: 2016-01-12
     releaseDate: 2012-10-30
 -   releaseCycle: "Windows 7 SP1"
-    cycleShortHand: 6.1.7601
+    buildID: 6.1.7601
     support: 2015-01-13
     eol: 2020-01-14
     releaseDate: 2011-02-22
 -   releaseCycle: "Windows Vista SP2"
-    cycleShortHand: 6.0.6200
+    buildID: 6.0.6200
     support: 2012-04-10
     eol: 2017-04-11
     releaseDate: 2009-04-29
 -   releaseCycle: "Windows XP SP3"
-    cycleShortHand: 5.1.2600
+    buildID: 5.1.2600
     support: 2009-04-14
     eol: 2014-04-08
     releaseDate: 2008-04-21

--- a/products/windowsEmbedded.md
+++ b/products/windowsEmbedded.md
@@ -8,13 +8,8 @@ activeSupportColumn: true
 releaseColumn: false
 releaseDateColumn: true
 versionCommand: winver
-sortReleasesBy: releaseDate
 releaseLabel: "Windows Embedded __RELEASE_CYCLE__"
 releases:
--   releaseCycle: "Compact 2013"
-    support: 2018-10-09
-    eol: 2023-10-10
-    releaseDate: 2013-08-11
 -   releaseCycle: "8.1 Industry"
     support: 2018-07-10
     eol: 2023-07-11
@@ -23,6 +18,10 @@ releases:
     support: 2018-01-01
     eol: 2023-01-01
     releaseDate: 2013-11-13
+-   releaseCycle: "Compact 2013"
+    support: 2018-10-09
+    eol: 2023-10-10
+    releaseDate: 2013-08-11
 -   releaseCycle: "POSReady 7"
     support: 2016-10-11
     eol: 2021-10-12

--- a/products/windowsServer.md
+++ b/products/windowsServer.md
@@ -8,96 +8,101 @@ activeSupportColumn: true
 versionCommand: winver
 releaseColumn: false
 releaseDateColumn: true
-sortReleasesBy: releaseDate
 releaseLabel: 'Windows Server __RELEASE_CYCLE__'
 releases:
 -   releaseCycle: "2022"
-    cycleShortHand: 10.0.20348
+    buildNumber: 10.0.20348
     support: 2026-10-13
     eol: 2031-10-14
     releaseDate: 2021-08-18
 -   releaseCycle: "20H2"
-    cycleShortHand: 10.0.19042
+    buildNumber: 10.0.19042
     support: 2022-05-10
     eol: 2022-05-10
     releaseDate: 2020-10-20
 -   releaseCycle: "2004"
-    cycleShortHand: 10.0.19041
+    buildNumber: 10.0.19041
     support: 2021-12-14
     eol: 2021-12-14
     releaseDate: 2020-05-27
 -   releaseCycle: "1909"
-    cycleShortHand: 10.0.18363
+    buildNumber: 10.0.18363
     support: 2021-05-11
     eol: 2021-05-11
     releaseDate: 2019-11-12
--   releaseCycle: "1903"
-    cycleShortHand: 10.0.18362
-    support: 2020-12-08
-    eol: 2020-12-08
-    releaseDate: 2018-05-21
 -   releaseCycle: "1809"
-    cycleShortHand: 10.0.17763
+    buildNumber: 10.0.17763
     support: 2020-11-10
     eol: 2020-11-10
     releaseDate: 2018-11-13
 -   releaseCycle: "2019"
-    cycleShortHand: 10.0.17763
+    buildNumber: 10.0.17763
     support: 2024-01-09
     eol: 2029-01-09
     releaseDate: 2018-11-13
+-   releaseCycle: "1903"
+    buildNumber: 10.0.18362
+    support: 2020-12-08
+    eol: 2020-12-08
+    releaseDate: 2018-05-21
 -   releaseCycle: "1803"
-    cycleShortHand: 10.0.17134
+    buildNumber: 10.0.17134
     support: 2019-11-12
     eol: 2019-11-12
     releaseDate: 2018-04-30
 -   releaseCycle: "1709"
-    cycleShortHand: 10.0.16299
+    buildNumber: 10.0.16299
     support: 2019-04-09
     eol: 2019-04-09
     releaseDate: 2017-10-17
 -   releaseCycle: "2016"
-    cycleShortHand: 10.0.14393
+    buildNumber: 10.0.14393
     support: 2022-01-11
     eol: 2027-01-12
     releaseDate: 2016-10-15
 -   releaseCycle: "2016"
     releaseLabel: "Windows Storage Server 2016"
-    cycleShortHand: 10.0.14393
+    buildNumber: 10.0.14393
     support: 2022-01-11
     eol: 2027-01-12
     releaseDate: 2016-10-15
 -   releaseCycle: "2012-R2"
-    cycleShortHand: 6.3.9600
+    buildNumber: 6.3.9600
     support: 2018-10-09
     eol: 2023-10-10
     releaseDate: 2013-11-25
 -   releaseCycle: "2012"
-    cycleShortHand: 6.2.9200
+    buildNumber: 6.2.9200
     support: 2018-10-09
     eol: 2023-10-10
     releaseDate: 2012-10-30
 -   releaseCycle: "2008-R2-SP1"
-    cycleShortHand: 6.1.7601
+    buildNumber: 6.1.7601
     support: 2015-01-13
     eol: 2020-01-14
     releaseDate: 2011-02-22
 -   releaseCycle: "2008-SP2"
-    cycleShortHand: 6.0.6003
+    buildNumber: 6.0.6003
     support: 2015-01-13
     eol: 2020-01-14
     releaseDate: 2009-04-29
 -   releaseCycle: "2003"
-    cycleShortHand: 5.2.3790
+    buildNumber: 5.2.3790
     support: 2010-07-13
     eol: 2015-07-14
     releaseDate: 2003-04-24
 -   releaseCycle: "2000"
-    cycleShortHand: 5.0.2195
+    buildNumber: 5.0.2195
     support: 2005-06-30
     eol: 2010-07-13
     releaseDate: 2000-02-17
 
 ---
 
+> Windows Server (formerly Windows NT Server) is a group of operating systems (OS) for servers by Microsoft. The brand name was changed to Windows Server in 2003.
 
+Traditionally, Microsoft supports Windows Server for 10 years, with five years of mainstream support and an additional five years of extended support. Between 2015 and 2021, Microsoft referred to these releases as "long-term support" releases to set them apart from semi-annual releases.
+
+For sixteen years, Microsoft released a major version of Windows Server every four years, with one minor version released two years after a major release. The minor versions had an "R2" suffix in their names. In October 2018, Microsoft broke this tradition with the release of Windows Server 2019, which should have been "Windows Server 2016 R2". Windows Server 2022 is also a minor upgrade over its predecessor.
+
+Following the release of Windows Server 2016, Microsoft attempted to mirror the lifecycle of Windows 10 in the Windows Server family, releasing new versions twice a year which were supported for 18 months. These semi-annual versions were only available as part of Microsoft subscription services, including Software Assurance, Azure Marketplace, and Microsoft Visual Studio subscriptions, until their discontinuation in July 2021. The semi-annual releases did not include any desktop environments. All Semi-Annual releases are now unsupported.

--- a/products/wordpress.md
+++ b/products/wordpress.md
@@ -4,7 +4,6 @@ category: server-app
 releasePolicyLink: https://codex.wordpress.org/Supported_Versions
 changelogTemplate: https://wordpress.org/support/wordpress-version/version-{{"__LATEST__"
   | replace:'.','-'}}/
-sortReleasesBy: "releaseCycle"
 activeSupportColumn: true
 releases:
 -   releaseCycle: "6.0"

--- a/products/yocto.md
+++ b/products/yocto.md
@@ -11,25 +11,17 @@ releaseDateColumn: true
 eolColumn: Support Status
 discontinuedColumn: false
 versionCommand: bitbake -e | grep '^DISTRO_VERSION\|DISTRO_CODENAME='
-sortReleasesBy: "releaseDate"
 changelogTemplate: |
   https://docs.yoctoproject.org/migration-guides/migration-{{"__RELEASE_CYCLE__"| split: " " | first}}.html
 iconSlug: NA
 releaseLabel: "__RELEASE_CYCLE__ '__CODENAME__'"
 releases:
-#  - releaseCycle: "4.1"
-#    codename: 'Langdale'
-#    latest: "4.1.0"
-#    release: 2022-10-01
-#    eol:     2023-05-01
-
 -   releaseCycle: "4.0"
     codename: 'Kirkstone'
     lts: true
     latest: "4.0"
     eol: 2024-04-27
     releaseDate: 2022-04-27
-
 -   releaseCycle: "3.4"
     codename: 'Honister'
     latest: "3.4.3"

--- a/products/zabbix.md
+++ b/products/zabbix.md
@@ -8,7 +8,6 @@ changelogTemplate: https://www.zabbix.com/rn/rn__LATEST__
 auto:
 -   git: https://github.com/zabbix/zabbix.git
 releaseDateColumn: true
-sortReleasesBy: "releaseCycle"
 activeSupportColumn: true
 eolColumn: Security Support
 iconSlug: NA

--- a/products/zookeeper.md
+++ b/products/zookeeper.md
@@ -10,7 +10,6 @@ changelogTemplate: https://zookeeper.apache.org/doc/r{{"__LATEST__"}}/releasenot
 activeSupportColumn: true
 releaseDateColumn: true
 releaseColumn: true
-sortReleasesBy: 'releaseCycle'
 purls:
 -   repology: zookeeper
 -   purl: pkg:maven/org.apache.zookeeper/zookeeper


### PR DESCRIPTION
Completely removes all mentions of sorting, as based on @generalmimon's suggestion [here](https://github.com/endoflife-date/endoflife.date/issues/199#issuecomment-1247942302)

Fixes #1643, by getting rid of all cycleShorthand mentions as well. 

The windows pages were using buildIDs for sorting via `cycleShortHand` - I've renamed it to `buildID` to preserve the information for now. We can decide how/if we want to use it later.

I've validated the sorting for all pages that seemed impacted, and corrected. There's some minor swaps where sorting was indeterminate (dates of two rows are matching) - I've ignored those, and let it be.

I lost some comments in the Samsung Page - wasn't sure where they needed to be added.

The sorting order is "as on the markdown file", so newer stuff should be added to the top of the file.