### PR TITLE
[typo3] Add Automation

### DIFF
--- a/products/typo3.md
+++ b/products/typo3.md
@@ -5,7 +5,7 @@ releasePolicyLink: https://get.typo3.org/
 # https://rubular.com/r/3pouRtwM0s9Usv
 auto:
 -   git: https://github.com/TYPO3/typo3.git
-    regex: '^(v?(?<major>[1-9]\d*)\.(?<minor>0|[1-9]\d*)\.?(?<patch>0|[1-9]\d*)?)|(TYPO3_(?<major>\d)-(?<minor>\d)-(?<patch>\d+(FINAL)?))$'
+    regex: '^(v?(?<major>[1-9]\d*)\.(?<minor>0|[1-9]\d*)\.?(?<patch>0|[1-9]\d*)?)|(TYPO3_(?<major>\d)-(?<minor>\d)-((?<patch>\d+)(FINAL)?))$'
 releases:
 -   releaseCycle: "11"
     eol: 2024-10-31

--- a/products/typo3.md
+++ b/products/typo3.md
@@ -9,6 +9,7 @@ auto:
 releases:
 -   releaseCycle: "11"
     eol: 2024-10-31
+    lts: 2021-10-05
     support: 2023-03-31
     releaseDate: 2021-10-05
     latest: "11.5.16"
@@ -16,6 +17,7 @@ releases:
     latestReleaseDate: 2022-09-13
 -   releaseCycle: "10"
     eol: 2023-04-30
+    lts: 2020-04-07
     support: 2021-10-31
     releaseDate: 2020-04-21
     latest: "10.4.32"

--- a/products/typo3.md
+++ b/products/typo3.md
@@ -2,6 +2,10 @@
 title: TYPO3
 category: server-app
 releasePolicyLink: https://get.typo3.org/
+# https://rubular.com/r/3pouRtwM0s9Usv
+auto:
+-   git: https://github.com/TYPO3/typo3.git
+    regex: '^(v?(?<major>[1-9]\d*)\.(?<minor>0|[1-9]\d*)\.?(?<patch>0|[1-9]\d*)?)|(TYPO3_(?<major>\d)-(?<minor>\d)-(?<patch>\d+(FINAL)?))$'
 releases:
 -   releaseCycle: "11"
     eol: 2024-10-31


### PR DESCRIPTION
All releases are stable releases, and should be included in our automation.

@hebbet your note [here](https://github.com/endoflife-date/endoflife.date/pull/1501#issuecomment-1231581327) seems to apply only to LTS (v11 was a stable release from the moment v11 came out, from what I understand). It just wasn't an LTS till v11.5 - so we should use `lts: date` perhaps to account for that.