### PR TITLE
[auto] Add warnings about new releases

### DIFF
--- a/_auto/latest.py
+++ b/_auto/latest.py
@@ -7,6 +7,7 @@ from glob import glob
 from pathlib import Path
 from distutils.version import StrictVersion
 from ruamel.yaml import YAML
+from ruamel.yaml.resolver import Resolver
 from deepdiff import DeepDiff
 from io import StringIO
 from os.path import exists
@@ -33,6 +34,18 @@ def sort_versions(data):
         a[1::2] = map(int, a[1::2])
         return a
     return sorted(data, key=lambda n: key(n))
+
+# https://stackoverflow.com/a/71329221/368328
+# Force encoding version numbers as strings
+Resolver.add_implicit_resolver(
+    'tag:yaml.org,2002:string',
+    re.compile(r'\d+\.\d+\.\d+', re.X),
+    list('.0123456789'))
+Resolver.add_implicit_resolver(
+    'tag:yaml.org,2002:string',
+    re.compile(r'\d+\.\d+', re.X),
+    list('.0123456789'))
+
 
 """
 matches releases that are exact (such as 4.1 being the first release for the 4.1 release cycle)

--- a/products/composer.md
+++ b/products/composer.md
@@ -29,7 +29,7 @@ releases:
     lts: true
     releaseDate: 2021-12-22
 
--   releaseCycle: "1.x"
+-   releaseCycle: "1"
     latest: "1.10.26"
     latestReleaseDate: 2022-04-13
     eol: 2020-10-24

--- a/products/consul.md
+++ b/products/consul.md
@@ -17,6 +17,11 @@ releaseDateColumn: true
 versionCommand: consul --version
 
 releases:
+-   releaseCycle: "1.13"
+    eol: false
+    releaseDate: 2022-08-09
+    latestReleaseDate: 2022-09-20
+    latest: 1.13.2
 -   releaseCycle: "1.12"
     eol: false
     latest: "1.12.5"

--- a/products/consul.md
+++ b/products/consul.md
@@ -21,7 +21,7 @@ releases:
     eol: false
     releaseDate: 2022-08-09
     latestReleaseDate: 2022-09-20
-    latest: 1.13.2
+    latest: '1.13.2'
 -   releaseCycle: "1.12"
     eol: false
     latest: "1.12.5"

--- a/products/dotnet.md
+++ b/products/dotnet.md
@@ -26,37 +26,50 @@ releases:
     latest: "5.0.17"
     latestReleaseDate: 2022-05-10
     releaseDate: 2020-11-10
--   releaseCycle: "Core 3.1"
+-   releaseCycle: "3.1"
+    releaseLabel: "Core __RELEASE_CYCLE__"
     lts: true
-    latest: "3.1.29"
-    latestReleaseDate: 2022-09-13
+    latest: "3.1.201"
+    latestReleaseDate: 2020-03-24
     eol: 2022-12-13
     releaseDate: 2019-12-03
--   releaseCycle: "Core 3.0"
+-   releaseCycle: "3.0"
+    releaseLabel: "Core __RELEASE_CYCLE__"
     latest: "3.0.3"
     eol: 2020-03-03
     releaseDate: 2019-09-23
--   releaseCycle: "Core 2.2"
+    latestReleaseDate: 2020-02-19
+-   releaseCycle: "2.2"
+    releaseLabel: "Core __RELEASE_CYCLE__"
     latest: "2.2.8"
     eol: 2019-12-23
     releaseDate: 2018-12-04
--   releaseCycle: "Core 2.1"
+    latestReleaseDate: 2019-11-19
+-   releaseCycle: "2.1"
+    releaseLabel: "Core __RELEASE_CYCLE__"
     lts: true
     latest: "2.1.30"
     eol: 2021-08-21
     releaseDate: 2018-05-30
--   releaseCycle: "Core 2.0"
+    latestReleaseDate: 2021-08-19
+-   releaseCycle: "2.0"
+    releaseLabel: "Core __RELEASE_CYCLE__"
     eol: 2018-10-01
     latest: "2.0.9"
     releaseDate: 2017-08-14
--   releaseCycle: "Core 1.1"
+    latestReleaseDate: 2018-07-10
+-   releaseCycle: "1.1"
+    releaseLabel: "Core __RELEASE_CYCLE__"
     eol: 2019-06-27
     latest: "1.1.13"
     releaseDate: 2016-11-16
--   releaseCycle: "Core 1.0"
+    latestReleaseDate: 2019-05-15
+-   releaseCycle: "1.0"
+    releaseLabel: "Core __RELEASE_CYCLE__"
     eol: 2019-06-27
     latest: "1.0.16"
-    releaseDate: 2016-06-27
+    releaseDate: 2022-04-27
+    latestReleaseDate: 2019-05-15
 
 ---
 

--- a/products/electron.md
+++ b/products/electron.md
@@ -13,6 +13,11 @@ auto:
 -   git: https://github.com/electron/electron.git
 releaseDateColumn: true
 releases:
+-   releaseCycle: "21"
+    eol: false
+    releaseDate: 2022-09-26
+    latestReleaseDate: 2022-10-05
+    latest: 21.1.0
 -   releaseCycle: "20"
     eol: false
     latest: "20.3.1"

--- a/products/electron.md
+++ b/products/electron.md
@@ -17,7 +17,7 @@ releases:
     eol: false
     releaseDate: 2022-09-26
     latestReleaseDate: 2022-10-05
-    latest: 21.1.0
+    latest: "21.1.0"
 -   releaseCycle: "20"
     eol: false
     latest: "20.3.1"

--- a/products/elixir.md
+++ b/products/elixir.md
@@ -10,9 +10,15 @@ releaseDateColumn: true
 auto:
 -   git: https://github.com/elixir-lang/elixir.git
 releases:
+-   releaseCycle: "1.14"
+    releaseDate: 2022-09-01
+    eol: false # release date of 1.19
+    support: true # release date of 1.15
+    latestReleaseDate: 2022-09-01
+    latest: "1.14.0"
 -   releaseCycle: "1.13"
     eol: 2024-06-01 # projected release date of 1.18.0
-    support: 2022-06-01 # projected release date of 1.14.0
+    support: 2022-09-01 # release date of 1.14.0
     latest: "1.13.4"
     latestReleaseDate: 2022-04-07
     releaseDate: 2021-12-03
@@ -35,7 +41,7 @@ releases:
     latestReleaseDate: 2020-07-04
     releaseDate: 2020-01-27
 -   releaseCycle: "1.9"
-    eol: 2022-06-01 # projected release date of 1.14.0
+    eol: 2022-09-01 # release date of 1.14.0
     support: 2020-01-27 # release date of 1.10.0
     latest: "1.9.4"
     latestReleaseDate: 2019-11-05

--- a/products/hbase.md
+++ b/products/hbase.md
@@ -17,6 +17,11 @@ auto:
     regex: '^rel\/(?<major>\d+)\.(?<minor>\d+)\.(?<patch>\d+)(\.(?<tiny>\d+))?$'
     template: "{{major}}.{{minor}}.{{patch}}{%if tiny%}.{{tiny}}{%endif%}"
 releases:
+-   releaseCycle: "2.5"
+    eol: false
+    releaseDate: 2022-08-31
+    latestReleaseDate: 2022-08-31
+    latest: '2.5.0'
 -   releaseCycle: "2.4"
     eol: false
     releaseDate: 2020-12-15

--- a/products/ipados.md
+++ b/products/ipados.md
@@ -20,12 +20,13 @@ releases:
     eol: 2021-10-01
     releaseDate: 2020-09-16
     latestReleaseDate: 2021-10-26
-    latest: 14.8.1
+    latest: '14.8.1'
 -   releaseCycle: "13"
     eol: 2020-09-16
     releaseDate: 2019-09-24
     latestReleaseDate: 2020-07-15
     latest: '13.6'
+
 
 ---
 

--- a/products/laravel.md
+++ b/products/laravel.md
@@ -18,41 +18,41 @@ releases:
 -   releaseCycle: "9"
     support: 2023-08-08
     eol: 2024-02-08
-    latest: 9.34.0
+    latest: '9.34.0'
     lts: false
     latestReleaseDate: 2022-10-04
     releaseDate: 2022-02-08
 -   releaseCycle: "8"
     support: 2022-07-26
     eol: 2023-01-24
-    latest: 8.83.25
+    latest: '8.83.25'
     lts: false
     latestReleaseDate: 2022-09-30
     releaseDate: 2020-09-08
 -   releaseCycle: "7"
     support: 2020-10-06
     eol: 2021-03-03
-    latest: 7.30.6
+    latest: '7.30.6'
     lts: false
     latestReleaseDate: 2021-12-07
     releaseDate: 2020-03-03
 -   releaseCycle: "6"
     support: 2022-01-25
     eol: 2022-09-06
-    latest: 6.20.44
+    latest: '6.20.44'
     lts: true
     latestReleaseDate: 2022-01-12
     releaseDate: 2019-09-03
 -   releaseCycle: "5.8"
     support: 2019-08-26
     eol: 2020-02-26
-    latest: 5.8.38
+    latest: '5.8.38'
     latestReleaseDate: 2020-04-14
     releaseDate: 2019-02-26
 -   releaseCycle: "5.5"
     support: 2019-08-30
     eol: 2020-08-30
-    latest: 5.5.50
+    latest: '5.5.50'
     lts: true
     latestReleaseDate: 2020-08-18
     releaseDate: 2017-08-30

--- a/products/macos.md
+++ b/products/macos.md
@@ -30,46 +30,46 @@ releases:
     link: https://support.apple.com/HT210642
     releaseDate: 2019-10-07
     latestReleaseDate: 2020-09-24
-    latest: 10.15.7
+    latest: '10.15.7'
 -   releaseCycle: "10.14"
     codename: "Mojave"
     eol: 2021-10-25
     releaseDate: 2018-09-24
     latestReleaseDate: 2019-07-22
-    latest: 10.14.6
+    latest: '10.14.6'
 -   releaseCycle: "10.13"
     codename: "High Sierra"
     eol: 2020-12-01
     releaseDate: 2017-09-25
     latestReleaseDate: 2018-07-09
-    latest: 10.13.6
+    latest: '10.13.6'
 -   releaseCycle: "10.12"
     codename: "Sierra"
     eol: 2019-10-01
     releaseDate: 2016-09-20
     latestReleaseDate: 2017-07-19
-    latest: 10.12.6
+    latest: '10.12.6'
 -   releaseCycle: "10.11"
     codename: "El Capitan"
     releaseLabel: "OS X __RELEASE_CYCLE__ (__CODENAME__)"
     eol: 2018-12-01
     releaseDate: 2015-09-30
     latestReleaseDate: 2016-07-18
-    latest: 10.11.6
+    latest: '10.11.6'
 -   releaseCycle: "10.10"
     releaseLabel: "OS X __RELEASE_CYCLE__ (__CODENAME__)"
     codename: "Yosemite"
     eol: 2017-08-01
     releaseDate: 2014-10-16
     latestReleaseDate: 2015-08-13
-    latest: 10.10.5
+    latest: '10.10.5'
 -   releaseCycle: "10.9"
     releaseLabel: "OS X __RELEASE_CYCLE__ (__CODENAME__)"
     codename: "Mavericks"
     eol: 2016-12-01
     releaseDate: 2013-10-22
     latestReleaseDate: 2014-09-17
-    latest: 10.9.5
+    latest: '10.9.5'
 permalink: /macos
 releasePolicyLink: https://developer.apple.com/documentation/macos-release-notes
 activeSupportColumn: false

--- a/products/mongodb.md
+++ b/products/mongodb.md
@@ -28,13 +28,13 @@ releases:
     eol: 2022-04-01
     releaseDate: 2022-01-13
     latestReleaseDate: 2022-02-17
-    latest: 5.2.1
+    latest: '5.2.1'
 -   releaseCycle: "5.1"
     codename: "rapid"
     eol: 2022-01-01
     releaseDate: 2021-11-04
     latestReleaseDate: 2021-12-01
-    latest: 5.1.1
+    latest: '5.1.1'
 -   releaseCycle: "5.0"
     eol: 2024-10-01
     latest: "5.0.13"
@@ -88,37 +88,37 @@ releases:
 -   releaseCycle: "2.2"
     eol: 2014-02-28
     latestReleaseDate: 2014-01-15
-    latest: 2.2.7
+    latest: '2.2.7'
     releaseDate: 2012-08-28
 -   releaseCycle: "2.0"
     eol: 2013-03-31
     latestReleaseDate: 2013-04-02
-    latest: 2.0.9
+    latest: '2.0.9'
     releaseDate: 2011-09-11
 -   releaseCycle: "1.8"
     eol: 2012-09-30
     latestReleaseDate: 2012-02-01
-    latest: 1.8.5
+    latest: '1.8.5'
     releaseDate: 2011-03-16
 -   releaseCycle: "1.6"
     eol: 2012-02-28
     latestReleaseDate: 2010-12-08
-    latest: 1.6.5
+    latest: '1.6.5'
     releaseDate: 2010-08-05
 -   releaseCycle: "1.4"
     eol: 2012-09-30
     latestReleaseDate: 2010-08-31
-    latest: 1.4.5
+    latest: '1.4.5'
     releaseDate: 2010-03-25
 -   releaseCycle: "1.2"
     eol: 2011-06-30
     latestReleaseDate: 2010-04-07
-    latest: 1.2.5
+    latest: '1.2.5'
     releaseDate: 2009-12-10
 -   releaseCycle: "1.0"
     eol: 2010-08-31
     latestReleaseDate: 2009-10-22
-    latest: 1.0.1
+    latest: '1.0.1'
     releaseDate: 2009-08-27
 
 ---

--- a/products/mongodb.md
+++ b/products/mongodb.md
@@ -19,22 +19,34 @@ releases:
     releaseDate: 2022-07-05
 -   releaseCycle: "5.3"
     codename: "rapid"
-    eol: false
+    eol: 2022-07-01
     latest: "5.3.2"
     latestReleaseDate: 2022-06-15
     releaseDate: 2022-03-22
+-   releaseCycle: "5.2"
+    codename: "rapid"
+    eol: 2022-04-01
+    releaseDate: 2022-01-13
+    latestReleaseDate: 2022-02-17
+    latest: 5.2.1
+-   releaseCycle: "5.1"
+    codename: "rapid"
+    eol: 2022-01-01
+    releaseDate: 2021-11-04
+    latestReleaseDate: 2021-12-01
+    latest: 5.1.1
 -   releaseCycle: "5.0"
-    eol: false
+    eol: 2024-10-01
     latest: "5.0.13"
     latestReleaseDate: 2022-09-29
     releaseDate: 2021-07-08
 -   releaseCycle: "4.4"
-    eol: false
+    eol: 2024-02-01
     latest: "4.4.17"
     latestReleaseDate: 2022-09-28
     releaseDate: 2020-07-25
 -   releaseCycle: "4.2"
-    eol: false
+    eol: 2023-04-01
     latest: "4.2.23"
     latestReleaseDate: 2022-09-29
     releaseDate: 2019-08-09
@@ -114,3 +126,7 @@ releases:
 > [MongoDB Server](https://www.mongodb.com/) is a general purpose, document-based, distributed database built for modern application developers and for the cloud era.
 
 Rapid Releases are made available approximately once each quarter that does not contain a Major Release and introduce new features and improvements. Rapid Releases are only supported within MongoDB Atlas and are not supported for on-premises deployments.
+
+GA Major releases of the MongoDB Server are supported for 30 months. Compatibility of the MongoDB Stable API with the MongoDB Server is supported. Each GA release of the Stable API is compatible with all GA Major Releases of the MongoDB Server that are released on or within five years of the Release Date of that version of the Stable API.
+
+Lifecycle Schedule is documented at <https://www.mongodb.com/support-policy/lifecycles>.

--- a/products/mysql.md
+++ b/products/mysql.md
@@ -19,25 +19,25 @@ auto:
     template: "{{c}}.{{v}}"
 releases:
 -   releaseCycle: "8.0"
-    latest: 8.0.30
+    latest: '8.0.30'
     support: 2023-04-30
     eol: 2026-04-30
     latestReleaseDate: 2022-07-06
     releaseDate: 2018-04-08
 -   releaseCycle: "5.7"
-    latest: 5.7.39
+    latest: '5.7.39'
     support: 2020-10-31
     eol: 2023-10-31
     latestReleaseDate: 2022-06-06
     releaseDate: 2015-10-09
 -   releaseCycle: "5.6"
-    latest: 5.6.51
+    latest: '5.6.51'
     support: 2018-02-28
     eol: 2021-02-28
     latestReleaseDate: 2021-01-05
     releaseDate: 2013-02-01
 -   releaseCycle: "5.5"
-    latest: 5.5.63
+    latest: '5.5.63'
     support: 2015-12-31
     eol: 2018-12-31
     latestReleaseDate: 2018-12-21

--- a/products/nix.md
+++ b/products/nix.md
@@ -20,12 +20,12 @@ releases:
     eol: false
     releaseDate: 2022-08-29
     latestReleaseDate: 2022-09-15
-    latest: 2.11.1
+    latest: "2.11.1"
 -   releaseCycle: "2.10"
     eol: true
     releaseDate: 2022-07-11
     latestReleaseDate: 2022-07-15
-    latest: 2.10.3
+    latest: '2.10.3'
 -   releaseCycle: "2.9"
     latest: "2.9.2"
     eol: true

--- a/products/nix.md
+++ b/products/nix.md
@@ -16,9 +16,19 @@ releaseDateColumn: true
 # when adding a new release mark the previous release EOL until a more detailed
 # policy is provided - https://github.com/NixOS/nix/issues/6063
 releases:
+-   releaseCycle: "2.11"
+    eol: false
+    releaseDate: 2022-08-29
+    latestReleaseDate: 2022-09-15
+    latest: 2.11.1
+-   releaseCycle: "2.10"
+    eol: true
+    releaseDate: 2022-07-11
+    latestReleaseDate: 2022-07-15
+    latest: 2.10.3
 -   releaseCycle: "2.9"
     latest: "2.9.2"
-    eol: false
+    eol: true
     latestReleaseDate: 2022-06-29
     releaseDate: 2022-05-30
 -   releaseCycle: "2.8"

--- a/products/pan-xdr.md
+++ b/products/pan-xdr.md
@@ -15,50 +15,41 @@ releases:
     eol: 2023-04-24
     releaseDate: 2022-07-24
     latestReleaseDate: 2022-07-24
-    latest: '7.8'
 -   releaseCycle: "7.7"
     eol: 2022-12-27
     releaseDate: 2022-03-27
     latestReleaseDate: 2022-03-27
-    latest: '7.7'
--   releaseCycle: "7.5 CE"
+-   releaseCycle: "7.5-ce"
     eol: 2024-03-06
     releaseDate: 2022-03-06
 -   releaseCycle: "7.6"
     eol: 2022-09-05
     releaseDate: 2021-12-05
     latestReleaseDate: 2021-12-05
-    latest: '7.6'
 -   releaseCycle: "7.5"
     eol: 2022-08-22
     releaseDate: 2021-08-22
     latestReleaseDate: 2022-03-06
-    latest: '7.5-ce'
 -   releaseCycle: "7.4"
     eol: 2022-05-24
     releaseDate: 2021-05-24
     latestReleaseDate: 2021-05-24
-    latest: '7.4'
 -   releaseCycle: "7.3"
     eol: 2022-02-01
     releaseDate: 2021-02-01
     latestReleaseDate: 2021-02-01
-    latest: '7.3'
 -   releaseCycle: "7.2"
     eol: 2022-03-07
     releaseDate: 2020-09-07
     latestReleaseDate: 2020-09-07
-    latest: '7.2'
 -   releaseCycle: "7.1"
     eol: 2021-06-04
     releaseDate: 2020-04-22
     latestReleaseDate: 2020-04-22
-    latest: '7.1'
 -   releaseCycle: "7.0"
     eol: 2021-06-04
     releaseDate: 2019-12-04
     latestReleaseDate: 2019-12-04
-    latest: '7.0'
 -   releaseCycle: "6.1"
     eol: 2022-07-01
     releaseDate: 2019-07-02

--- a/products/pan-xdr.md
+++ b/products/pan-xdr.md
@@ -33,7 +33,7 @@ releases:
     eol: 2022-08-22
     releaseDate: 2021-08-22
     latestReleaseDate: 2022-03-06
-    latest: 7.5-ce
+    latest: '7.5-ce'
 -   releaseCycle: "7.4"
     eol: 2022-05-24
     releaseDate: 2021-05-24

--- a/products/perl.md
+++ b/products/perl.md
@@ -7,6 +7,11 @@ auto:
   # Feel free to file a PR to fix this
 -   git: https://github.com/Perl/perl5.git
 releases:
+-   releaseCycle: "5.37"
+    eol: false
+    releaseDate: 2022-05-27
+    latestReleaseDate: 2022-09-20
+    latest: 5.37.4
 -   releaseCycle: "5.36"
     eol: 2025-05-27
     support: true

--- a/products/perl.md
+++ b/products/perl.md
@@ -2,25 +2,35 @@
 title: Perl
 category: lang
 changelogTemplate: "https://perldoc.perl.org/__LATEST__/perldelta"
+releaseImage: https://www.versio.io/img/product-release-version-end-of-life/Perl_Foundation-Perl.jpg
 auto:
   # Using the default regex loses all releases before 5.10
   # Feel free to file a PR to fix this
 -   git: https://github.com/Perl/perl5.git
 releases:
+# eol dates are always releaseDate + 3 YEARS
+# support: true for latest 2 releases
+# support: releaseDate(R+2) for R-th release
+# So the support(5.34) = releaseDate(5.36)
 -   releaseCycle: "5.37"
-    eol: false
+    eol: 2025-05-27
+    support: true
     releaseDate: 2022-05-27
     latestReleaseDate: 2022-09-20
-    latest: 5.37.4
+    latest: "5.37.4"
 -   releaseCycle: "5.36"
     eol: 2025-05-27
     support: true
     latest: "5.36.0"
     latestReleaseDate: 2022-05-27
     releaseDate: 2022-05-27
+-   releaseCycle: "5.35"
+    releaseDate: 2021-05-20
+    latestReleaseDate: 2022-04-20
+    latest: '5.35.11'
 -   releaseCycle: "5.34"
     eol: 2024-05-20
-    support: true
+    support: 2022-05-27
     latest: "5.34.1"
     latestReleaseDate: 2022-03-12
     releaseDate: 2021-05-20

--- a/products/rabbitmq.md
+++ b/products/rabbitmq.md
@@ -11,6 +11,11 @@ auto:
 -   git: https://github.com/rabbitmq/rabbitmq-server.git
     regex: ^(rabbitmq_v(?<major>[1-9]\d*)_(?<minor>0|[1-9]\d*)_(?<patch>0|[1-9]\d*)|v(?<major>[1-9]\d*)\.(?<minor>0|[1-9]\d*)\.(?<patch>0|[1-9]\d*))$
 releases:
+-   releaseCycle: "3.11"
+    eol: false
+    releaseDate: 2022-09-26
+    latestReleaseDate: 2022-09-26
+    latest: 3.11.0
 -   releaseCycle: "3.10"
     eol: false
     latest: "3.10.8"
@@ -22,7 +27,7 @@ releases:
     latestReleaseDate: 2022-09-22
     releaseDate: 2021-07-23
 -   releaseCycle: "3.8"
-    eol: 2022-01-31
+    eol: 2022-07-31
     latest: "3.8.35"
     latestReleaseDate: 2022-07-09
     releaseDate: 2019-10-01

--- a/products/rabbitmq.md
+++ b/products/rabbitmq.md
@@ -15,7 +15,7 @@ releases:
     eol: false
     releaseDate: 2022-09-26
     latestReleaseDate: 2022-09-26
-    latest: 3.11.0
+    latest: "3.11.0"
 -   releaseCycle: "3.10"
     eol: false
     latest: "3.10.8"

--- a/products/terraform.md
+++ b/products/terraform.md
@@ -15,7 +15,7 @@ releases:
     eol: false
     releaseDate: 2022-09-21
     latestReleaseDate: 2022-10-06
-    latest: 1.3.2
+    latest: "1.3.2"
 -   releaseCycle: "1.2"
     eol: false
     latest: "1.2.9"

--- a/products/terraform.md
+++ b/products/terraform.md
@@ -11,6 +11,11 @@ activeSupportColumn: false
 releaseDateColumn: true
 versionCommand: terraform --version
 releases:
+-   releaseCycle: "1.3"
+    eol: false
+    releaseDate: 2022-09-21
+    latestReleaseDate: 2022-10-06
+    latest: 1.3.2
 -   releaseCycle: "1.2"
     eol: false
     latest: "1.2.9"

--- a/products/terraform.md
+++ b/products/terraform.md
@@ -11,21 +11,27 @@ activeSupportColumn: false
 releaseDateColumn: true
 versionCommand: terraform --version
 releases:
+# EOL(R) = releaseDate(R+2)
 -   releaseCycle: "1.3"
-    eol: false
+    eol: false # releaseDate(1.5)
     releaseDate: 2022-09-21
     latestReleaseDate: 2022-10-06
     latest: "1.3.2"
 -   releaseCycle: "1.2"
-    eol: false
+    eol: false # releaseDate(1.4)
     latest: "1.2.9"
     latestReleaseDate: 2022-09-07
     releaseDate: 2022-05-18
 -   releaseCycle: "1.1"
-    eol: false
+    eol: 2022-09-21
     latest: "1.1.9"
     latestReleaseDate: 2022-04-20
     releaseDate: 2021-12-08
+-   releaseCycle: "1.0"
+    eol: 2022-05-18
+    releaseDate: 2021-06-08
+    latestReleaseDate: 2021-11-10
+    latest: '1.0.11'
 
 ---
 

--- a/products/tomcat.md
+++ b/products/tomcat.md
@@ -65,13 +65,15 @@ Initial releases of a new major version typically process from Alpha, through Be
 
 Prior major releases have been supported for approximately 10 years. When a release is sunset and moved to End-of-life status, a notice is provided roughly an year in advance.
 
+Generally 3 major versions of Tomcat are concurrently supported. When Tomcat 10.0 was released as stable Tomcat 7 became EOL. 8.5 is expected to become unsupported once Tomcat 11 becomes stable.
+
 ## Java Compatibility
 
 Different versions of Apache Tomcat are available for different versions of the specifications, and the Tomcat website has a [table](https://tomcat.apache.org/whichversion.html) documenting which version of the specification is implemented by a given release.
 
 | Tomcat Version | Minimum Java Version |
 |----------------|----------------------|
-| 10.1 (Beta)    | 11                   |
+| 10.1           | 11                   |
 | 10.0           | 8                    |
 | 9              | 8                    |
 | 8.5            | 7                    |

--- a/products/tomcat.md
+++ b/products/tomcat.md
@@ -12,6 +12,12 @@ versionCommand: ./bin/version.sh
 releaseColumn: true
 releaseDateColumn: true
 releases:
+-   releaseCycle: "10.1"
+    eol: false
+    link: https://tomcat.apache.org/tomcat-10.1-doc/
+    releaseDate: 2022-09-23
+    latestReleaseDate: 2022-09-23
+    latest: 10.1.0
 -   releaseCycle: "10.0"
     eol: false
     latest: "10.0.26"

--- a/products/tomcat.md
+++ b/products/tomcat.md
@@ -17,7 +17,7 @@ releases:
     link: https://tomcat.apache.org/tomcat-10.1-doc/
     releaseDate: 2022-09-23
     latestReleaseDate: 2022-09-23
-    latest: 10.1.0
+    latest: "10.1.0"
 -   releaseCycle: "10.0"
     eol: false
     latest: "10.0.26"

--- a/products/varnish.md
+++ b/products/varnish.md
@@ -17,22 +17,22 @@ releases:
 -   releaseCycle: "7.2"
     eol: 2023-09-15
     latestReleaseDate: 2022-09-15
-    latest: 7.2.0
+    latest: '7.2.0'
     releaseDate: 2022-09-15
 -   releaseCycle: "7.1"
     eol: 2023-03-15
     latestReleaseDate: 2022-08-05
-    latest: 7.1.1
+    latest: '7.1.1'
     releaseDate: 2022-03-15
 -   releaseCycle: "7.0"
     eol: 2022-09-15
     latestReleaseDate: 2022-08-05
-    latest: 7.0.3
+    latest: '7.0.3'
     releaseDate: 2021-09-15
 -   releaseCycle: "6.0"
     eol: false
     latestReleaseDate: 2022-01-12
-    latest: 6.0.10
+    latest: '6.0.10'
     lts: true
     releaseDate: 2018-03-15
 

--- a/products/watchos.md
+++ b/products/watchos.md
@@ -15,17 +15,17 @@ releases:
     eol: false
     releaseDate: 2022-09-22
     latestReleaseDate: 2022-09-22
-    latest: 9.0.1
+    latest: '9.0.1'
 -   releaseCycle: "8"
     eol: 2022-09-22
     releaseDate: 2021-10-11
     latestReleaseDate: 2022-08-17
-    latest: 8.7.1
+    latest: '8.7.1'
 -   releaseCycle: "7"
     eol: 2021-10-11
     releaseDate: 2020-09-16
     latestReleaseDate: 2021-09-13
-    latest: 7.6.2
+    latest: '7.6.2'
 -   releaseCycle: "6"
     eol: 2020-09-16
     releaseDate: 2019-09-30
@@ -35,17 +35,17 @@ releases:
     eol: 2019-09-30
     releaseDate: 2018-09-27
     latestReleaseDate: 2020-11-05
-    latest: 5.3.9
+    latest: '5.3.9'
 -   releaseCycle: "4"
     eol: 2018-09-27
     releaseDate: 2017-10-04
     latestReleaseDate: 2018-07-09
-    latest: 4.3.2
+    latest: '4.3.2'
 -   releaseCycle: "3"
     eol: 2017-10-04
     releaseDate: 2016-10-24
     latestReleaseDate: 2017-07-19
-    latest: 3.2.3
+    latest: '3.2.3'
 
 ---
 


### PR DESCRIPTION
On every latest update (dependabot PRs), this will provide info
in logs about new releases that aren't accounted for in existing
release cycles. Recent = new release in last 30 days.

Mostly, these are new release cycles that will needed to be added

Ocassionally, these will be "not-yet-stable" release cycles so we
might decide against including them (such as is the case for 2 current
warnings - Amazon Linux 2022, and perl 5.37)