### PR TITLE
Fix latest .NET 3.1 version

### DIFF
--- a/products/dotnet.md
+++ b/products/dotnet.md
@@ -11,8 +11,12 @@ releasePolicyLink: https://dotnet.microsoft.com/platform/support/policy/dotnet-c
 changelogTemplate: https://github.com/dotnet/core/blob/main/release-notes/{{"__LATEST__"|split:'.'|slice:0,2|join:'.'}}/__LATEST__/__LATEST__.md
 releaseDateColumn: true
 eolColumn: Support Status
+# The regex ignores 3 digit patch versions, which are incorrect tags upstream
+# such as https://github.com/dotnet/core/releases/tag/v3.1.201
+# https://rubular.com/r/CSjmTuMTbmRBQZ
 auto:
 -   git: https://github.com/dotnet/core.git
+    regex: '^v(?<major>\d+)\.(?<minor>\d+)\.?(?<patch>\d{0,2})?$'
 releases:
 -   releaseCycle: "6.0"
     lts: true

--- a/products/dotnet.md
+++ b/products/dotnet.md
@@ -29,7 +29,7 @@ releases:
 -   releaseCycle: "3.1"
     releaseLabel: "Core __RELEASE_CYCLE__"
     lts: true
-    latest: "3.1.201"
+    latest: "3.1.30"
     latestReleaseDate: 2020-03-24
     eol: 2022-12-13
     releaseDate: 2019-12-03


### PR DESCRIPTION
See
![image](https://user-images.githubusercontent.com/5808377/195865943-ae33d399-db75-4070-a870-7c21cebf58e3.png)

(https://devblogs.microsoft.com/dotnet/october-2022-updates/) and https://github.com/dotnet/core/blob/main/release-notes/3.1/3.1.30/3.1.30.md

and https://dotnet.microsoft.com/en-us/download/dotnet

3.1.201 is a version of something else