### PR TITLE
[fedora] Use DistroWatch for release dates instead of Docker Hub

### DIFF
--- a/products/fedora.md
+++ b/products/fedora.md
@@ -8,7 +8,7 @@ versionCommand: cat /etc/fedora-release
 changelogTemplate: https://fedoraproject.org/wiki/Releases/__RELEASE_CYCLE__/ChangeSet?rd=Releases/__RELEASE_CYCLE__
 auto:
 -   distrowatch: fedora
-    regex: '^Distribution Release: Fedora (?P<major>\d{2})$'
+    regex: '^Distribution Release: Fedora (?P<version>\d{2})$'
     template: '{{version}}'
 category: os
 releases:

--- a/products/fedora.md
+++ b/products/fedora.md
@@ -7,8 +7,8 @@ releaseDateColumn: true
 versionCommand: cat /etc/fedora-release
 changelogTemplate: https://fedoraproject.org/wiki/Releases/__RELEASE_CYCLE__/ChangeSet?rd=Releases/__RELEASE_CYCLE__
 auto:
--   dockerhub: library/fedora
-    regex: ^(?<version>\d+)$
+-   distrowatch: fedora
+    regex: '^Distribution Release: Fedora (?P<major>\d{2})$'
     template: '{{version}}'
 category: os
 releases:


### PR DESCRIPTION
Fedora 34-36 have inaccurate release dates because endoflife.date is using the Docker Hub tag date, which changes every time the container image is updated. This pull request switches the data source to DistroWatch instead.