### PR TITLE
[Kindle] Add Kindle 11 and update to latest version infos

### DIFF
--- a/products/kindle.md
+++ b/products/kindle.md
@@ -7,45 +7,45 @@ releases:
     eol: false
     latest: "5.15.1"
     link: https://www.amazon.com/Kindle11Notes
-    releaseDate: 2021-10-27
+    releaseDate: 2022-09-13
 -   releaseCycle: "Kindle Paperwhite 5 (11th Generation)"
     eol: false
-    latest: "5.14.3.0.1"
+    latest: "5.15.1"
     link: https://www.amazon.com/Paperwhite11Notes
     releaseDate: 2021-10-27
 -   releaseCycle: "Kindle Oasis 3 (10th Generation)"
     eol: false
-    latest: "5.14.3.0.1"
+    latest: "5.15.1"
     link: https://www.amazon.com/Oasis10Notes
     releaseDate: 2019-07-24
 -   releaseCycle: "Kindle 10 (10th Generation)"
     eol: false
-    latest: "5.14.3.0.1"
+    latest: "5.15.1"
     link: https://www.amazon.com/Kindle10Notes
     releaseDate: 2019-04-10
 -   releaseCycle: "Kindle Paperwhite 4 (10th Generation)"
     eol: false
-    latest: "5.14.3.0.1"
+    latest: "5.15.1"
     link: https://www.amazon.com/Paperwhite10Notes
     releaseDate: 2018-11-07
 -   releaseCycle: "Kindle Oasis 2 (9th Generation)"
     eol: false
-    latest: "5.14.3.0.1"
+    latest: "5.15.1"
     link: https://www.amazon.com/Oasis9Notes
     releaseDate: 2017-10-31
 -   releaseCycle: "Kindle 8 (8th Generation)"
     eol: false
-    latest: "5.14.3.0.1"
+    latest: "5.15.1"
     link: https://www.amazon.com/Kindle8Notes
     releaseDate: 2016-06-22
 -   releaseCycle: "Kindle Oasis (8th Generation)"
     eol: false
-    latest: "5.14.3.0.1"
+    latest: "5.15.1"
     link: https://www.amazon.com/Oasis8Notes
     releaseDate: 2016-04-27
 -   releaseCycle: "Kindle Paperwhite 3 (7th Generation)"
     eol: false
-    latest: "5.14.3.0.1"
+    latest: "5.15.1"
     link: https://www.amazon.com/Paperwhite7Notes
     releaseDate: 2015-06-30
 -   releaseCycle: "Kindle Voyage (7th Generation)"

--- a/products/kindle.md
+++ b/products/kindle.md
@@ -3,6 +3,11 @@ title: Amazon Kindle
 iconSlug: amazon
 category: device
 releases:
+-   releaseCycle: "Kindle 11 (11th Generation)"
+    eol: false
+    latest: "5.15.1"
+    link: https://www.amazon.com/Kindle11Notes
+    releaseDate: 2021-10-27
 -   releaseCycle: "Kindle Paperwhite 5 (11th Generation)"
     eol: false
     latest: "5.14.3.0.1"


### PR DESCRIPTION
The Amazon Kindle page is out of date. This PR:
- adds the Kindle 11, which was released [September 13, 2022](https://www.techradar.com/news/new-amazon-kindle-2022-price-screen-features-and-whats-new)
- updates the currently supported products to the [latest versions](https://www.amazon.com/gp/help/customer/display.html?nodeId=GKMQC26VQQMM8XSW)

🙏 I would appreciate the `hacktoberfest-approved` label.