### PR TITLE
[Intel] Add Alder Lake Release

### DIFF
--- a/products/intelprocessors.md
+++ b/products/intelprocessors.md
@@ -11,10 +11,16 @@ latestColumn: false
 releaseColumn: false
 releaseDateColumn: true
 releases:
+-   releaseCycle: "Raptor Lake"
+    discontinued: false
+    eol: false
+    releaseDate: 2022-10-20
+    
 -   releaseCycle: "Alder Lake"
     discontinued: false
     eol: false
     releaseDate: 2021-11-04
+
 -   releaseCycle: "Rocket Lake"
     discontinued: false
     eol: false


### PR DESCRIPTION
Adds release for 13th Gen Intel Core processors (code name Raptor Lake).
[Press release with launch date](https://www.intel.com/content/www/us/en/newsroom/news/13th-gen-core-launch.html#gs.fo6nhi)
[Mention of code name](https://www.intel.com/content/www/us/en/newsroom/resources/13th-gen-core.html?wapkw=raptor%20lake)