### PR TITLE
Google Pixel: Show both security and OS Update end dates

### DIFF
--- a/products/pixel.md
+++ b/products/pixel.md
@@ -6,9 +6,9 @@ category: device
 versionCommand: "Settings -> About Phone -> Regulatory labels"
 releasePolicyLink: https://support.google.com/nexus/answer/4457705
 discontinuedColumn: true
-activeSupportColumn: false
+activeSupportColumn: true
 latestColumn: true
-eolColumn: Software Update (Guaranteed)
+eolColumn: End of guaranteed security updates
 releaseColumn: false
 releaseDateColumn: true
 releases:

--- a/products/pixel.md
+++ b/products/pixel.md
@@ -62,7 +62,7 @@ releases:
     eol: 2022-10-23
     support: 2022-10-23
     releaseDate: 2019-10-24
--   releaseCycle: "Pixel 3A / XL"
+-   releaseCycle: "Pixel 3a / XL"
     discontinued: 2020-07-01
     eol: 2022-05-06
     support: 2022-05-06

--- a/products/pixel.md
+++ b/products/pixel.md
@@ -14,74 +14,74 @@ releaseDateColumn: true
 releases:
 -   releaseCycle: "Pixel 7 Pro"
     discontinued: false
-    eol: 2027-10-13
-    support: 2027-10-13
+    eol: 2027-10-12
+    support: 2025-10-12
     releaseDate: 2022-10-13
 -   releaseCycle: "Pixel 7"
     discontinued: false
-    eol: 2027-10-13
-    support: 2027-10-13
+    eol: 2027-10-12
+    support: 2025-10-12
     releaseDate: 2022-10-13
 -   releaseCycle: "Pixel 6a"
     discontinued: false
-    eol: 2027-07-31
-    support: 2027-07-31
+    eol: 2027-07-27
+    support: 2025-07-27
     releaseDate: 2022-07-28
 -   releaseCycle: "Pixel 6 Pro"
     discontinued: false
-    eol: 2026-10-31
-    support: 2026-10-31
+    eol: 2026-10-27
+    support: 2024-10-27
     releaseDate: 2021-10-28
 -   releaseCycle: "Pixel 6"
     discontinued: false
-    eol: 2026-10-31
-    support: 2026-10-31
+    eol: 2026-10-27
+    support: 2024-10-27
     releaseDate: 2021-10-28
--   releaseCycle: "Pixel 5A"
+-   releaseCycle: "Pixel 5a"
     discontinued: false
-    eol: 2024-08-31
-    support: 2015-11-19
+    eol: 2024-08-25
+    support: 2024-08-25
     releaseDate: 2021-08-26
 -   releaseCycle: "Pixel 5"
     discontinued: 2021-08-20
-    eol: 2023-10-31
-    support: 2015-11-19
-    releaseDate: 2020-09-30
--   releaseCycle: "Pixel 4A 5G"
+    eol: 2023-10-14
+    support: 2023-10-14
+    releaseDate: 2020-10-15
+-   releaseCycle: "Pixel 4a (5G)"
     discontinued: 2021-08-20
-    eol: 2023-11-30
-    support: 2015-11-19
-    releaseDate: 2020-09-30
--   releaseCycle: "Pixel 4A"
+    eol: 2023-11-04
+    support: 2023-11-04
+    releaseDate: 2020-11-05
+-   releaseCycle: "Pixel 4a"
     discontinued: 2022-01-31
-    eol: 2023-08-31
-    support: 2015-11-19
-    releaseDate: 2020-08-03
+    eol: 2023-08-19
+    support: 2023-08-19
+    releaseDate: 2020-08-20
 -   releaseCycle: "Pixel 4 / XL"
     discontinued: 2020-08-06
-    eol: 2022-10-31
-    support: 2015-11-19
-    releaseDate: 2019-10-15
+    eol: 2022-10-23
+    support: 2022-10-23
+    releaseDate: 2019-10-24
 -   releaseCycle: "Pixel 3A / XL"
     discontinued: 2020-07-01
-    eol: 2022-05-31
-    support: 2015-11-19
+    eol: 2022-05-06
+    support: 2022-05-06
     releaseDate: 2019-05-07
 -   releaseCycle: "Pixel 3 / XL"
     discontinued: 2020-03-31
-    eol: 2021-10-31
-    support: 2015-11-19
+    eol: 2021-10-08
+    support: 2021-10-08
     releaseDate: 2018-10-09
 -   releaseCycle: "Pixel 2 / XL"
     discontinued: 2019-04-01
-    eol: 2020-10-31
-    support: 2015-11-19
-    releaseDate: 2017-10-04
+    eol: 2020-10-18
+    support: 2020-10-18
+    releaseDate: 2017-10-19
 -   releaseCycle: "Pixel / Pixel XL"
     discontinued: 2018-04-11
-    eol: 2018-10-31
-    support: 2015-11-19
-    releaseDate: 2016-10-04
+    eol: 2019-10-19
+    support: 2019-10-19
+    releaseDate: 2016-10-20
 
 ---
 

--- a/products/pixel.md
+++ b/products/pixel.md
@@ -85,8 +85,23 @@ releases:
 
 ---
 
-> Google Pixel is Google's current line of Android Phones and other consumer electronics.
+> Pixel is Google's current line of Android phones and other consumer electronics.
 
-The Pixel phones come out around the first or second week of October every year (the A series being unpredictable). Pixels support their devices for about three years with guaranteed software/security updates. That is only the guaranteed date, however Google may provide additional year(s) of updates, but is not bound to.
+In recent years, flagship Pixel phones have been released in October each year, followed by an additional mid-range variant known as the 'A-series' several months later. Pixel phones are supported with guaranteed software updates for three years.
 
-For more info on each model, visit: [Pixel 7](https://en.wikipedia.org/wiki/Pixel_7), [Pixel 6a](https://en.wikipedia.org/wiki/Pixel_6a), [Pixel 6 Pro](https://en.wikipedia.org/wiki/Pixel_6), [Pixel 6](https://en.wikipedia.org/wiki/Pixel_6), [Pixel 5a](https://en.wikipedia.org/wiki/Pixel_5a), [Pixel 5](https://en.wikipedia.org/wiki/Pixel_5), [Pixel 4a](https://en.wikipedia.org/wiki/Pixel_4a), [Pixel 4](https://en.wikipedia.org/wiki/Pixel_4), [Pixel 3a](https://en.wikipedia.org/wiki/Pixel_3a), [Pixel 3](https://en.wikipedia.org/wiki/Pixel_3), [Pixel 2](https://en.wikipedia.org/wiki/Pixel_2), [Pixel (1st generation)](https://en.wikipedia.org/wiki/Pixel_(1st_generation))
+Starting with the Pixel 6, Google has committed to at least five years of security updates, extending an additional two years beyond the 3-year Android version update commitment. The end date for guaranteed Android version updates is indicated in the 'Active Support' column.
+
+More information on each model can be found on Wikipedia:
+
+- [Pixel 7](https://en.wikipedia.org/wiki/Pixel_7)
+- [Pixel 6a](https://en.wikipedia.org/wiki/Pixel_6a)
+- [Pixel 6 Pro](https://en.wikipedia.org/wiki/Pixel_6)
+- [Pixel 6](https://en.wikipedia.org/wiki/Pixel_6)
+- [Pixel 5a](https://en.wikipedia.org/wiki/Pixel_5a)
+- [Pixel 5](https://en.wikipedia.org/wiki/Pixel_5)
+- [Pixel 4a](https://en.wikipedia.org/wiki/Pixel_4a)
+- [Pixel 4](https://en.wikipedia.org/wiki/Pixel_4)
+- [Pixel 3a](https://en.wikipedia.org/wiki/Pixel_3a)
+- [Pixel 3](https://en.wikipedia.org/wiki/Pixel_3)
+- [Pixel 2](https://en.wikipedia.org/wiki/Pixel_2)
+- [Pixel (1st generation)](https://en.wikipedia.org/wiki/Pixel_(1st_generation))

--- a/products/pixel.md
+++ b/products/pixel.md
@@ -8,7 +8,7 @@ releasePolicyLink: https://support.google.com/nexus/answer/4457705
 discontinuedColumn: true
 activeSupportColumn: true
 latestColumn: true
-eolColumn: End of guaranteed security updates
+eolColumn: Guaranteed Security Updates
 releaseColumn: false
 releaseDateColumn: true
 releases:


### PR DESCRIPTION
Summary of changes:

- Add 'Active Support' column
- Add missing end-of-support dates
- Adjust end-of-support dates to be exactly 3 or 5 years after release dates
- Fix formatting of product names
- Update description

Fixes #1648 