### PR TITLE
Add macOS Ventura 13.0

### DIFF
--- a/products/macos.md
+++ b/products/macos.md
@@ -13,7 +13,7 @@ releases:
 -   releaseCycle: "13"
     codename: "Ventura"
     eol: false
-    link: 
+    link: https://support.apple.com/HT213268
     releaseDate: 2022-10-24
     latestReleaseDate: 2022-10-24
     latest: '13.0'

--- a/products/macos.md
+++ b/products/macos.md
@@ -10,20 +10,27 @@ releaseLabel: "macOS __RELEASE_CYCLE__ (__CODENAME__)"
 auto:
 -   custom: true
 releases:
+-   releaseCycle: "13"
+    codename: "Ventura"
+    eol: false
+    link: 
+    releaseDate: 2022-10-24
+    latestReleaseDate: 2022-10-24
+    latest: '13.0'
 -   releaseCycle: "12"
     codename: "Monterey"
     eol: false
     link: https://support.apple.com/HT212585
     releaseDate: 2021-10-25
     latestReleaseDate: 2022-09-12
-    latest: '12.6'
+    latest: '12.6.1'
 -   releaseCycle: "11"
     codename: "Big Sur"
     eol: false
     link: https://support.apple.com/HT211896
     releaseDate: 2020-11-12
     latestReleaseDate: 2022-09-12
-    latest: '11.7'
+    latest: '11.7.1'
 -   releaseCycle: "10.15"
     codename: "Catalina"
     eol: 2022-09-12


### PR DESCRIPTION
There doesn't seem to be a "What's new in the updates for macOS Ventura" support page yet.

The ones for Monterey and Big Sur also have not been updated with their `.1` releases.