### PR TITLE
fix: Consul 1.10 is EOLd

### DIFF
--- a/products/consul.md
+++ b/products/consul.md
@@ -33,7 +33,7 @@ releases:
     latestReleaseDate: 2022-10-19
     releaseDate: 2021-12-14
 -   releaseCycle: "1.10"
-    eol: true
+    eol: 2022-08-09
     latest: "1.10.12"
     latestReleaseDate: 2022-07-13
     releaseDate: 2021-06-22

--- a/products/consul.md
+++ b/products/consul.md
@@ -33,7 +33,7 @@ releases:
     latestReleaseDate: 2022-10-19
     releaseDate: 2021-12-14
 -   releaseCycle: "1.10"
-    eol: false
+    eol: true
     latest: "1.10.12"
     latestReleaseDate: 2022-07-13
     releaseDate: 2021-06-22


### PR DESCRIPTION
Since Consul 1.13 was released, they stopped publishing any Consul 1.10.x.

https://github.com/hashicorp/consul/tags?after=v1.13.1