### PR TITLE
[linux] Add missing eol date for 5.18

### DIFF
--- a/products/linuxkernel.md
+++ b/products/linuxkernel.md
@@ -23,6 +23,7 @@ releases:
     latest: "6.0.5"
     latestReleaseDate: 2022-10-26
     releaseDate: 2022-10-02
+
 -   releaseCycle: "5.19"
     eol: 2022-10-24
     latest: "5.19.17"
@@ -30,7 +31,7 @@ releases:
     releaseDate: 2022-07-31
 
 -   releaseCycle: "5.18"
-    eol: true
+    eol: 2022-08-21
     latest: "5.18.19"
     latestReleaseDate: 2022-08-21
     releaseDate: 2022-05-22


### PR DESCRIPTION
Add missing eol date for 5.18

```
From: Greg Kroah-Hartman <gregkh@linuxfoundation.org>
To: linux-kernel@vger.kernel.org, akpm@linux-foundation.org,
	torvalds@linux-foundation.org, stable@vger.kernel.org
Cc: lwn@lwn.net, jslaby@suse.cz,
	Greg Kroah-Hartman <gregkh@linuxfoundation.org>
Subject: [Linux 5.18.19](https://lore.kernel.org/lkml/166108895535224@kroah.com/#r)
Date: Sun, 21 Aug 2022 15:36:36 +0200	[[thread overview]](https://lore.kernel.org/lkml/166108895535224@kroah.com/#r)
Message-ID: <166108895535224@kroah.com> ([raw](https://lore.kernel.org/lkml/166108895535224@kroah.com/raw))

Note, this is the LAST 5.18.y kernel to be released.  This branch is now
end-of-life.  Please move to 5.19.y at this point in time
```
source : https://lore.kernel.org/lkml/166108895535224@kroah.com/