### PR TITLE
[auto] Automation Upgrades

### DIFF
--- a/_auto/latest.py
+++ b/_auto/latest.py
@@ -127,6 +127,8 @@ def update_product(name):
                     didn't catch-up in time.
                     """
                     def new_version_is_higher(new_version):
+                        if 'latest' not in release:
+                            return True
                         old_version = release['latest']
                         old_date = release.get('latestReleaseDate', None)
                         # Do our best attempt at comparing the version numbers

--- a/_auto/latest.py
+++ b/_auto/latest.py
@@ -5,7 +5,6 @@ import re
 import datetime
 from glob import glob
 from pathlib import Path
-from distutils.version import StrictVersion
 from ruamel.yaml import YAML
 from ruamel.yaml.resolver import Resolver
 from deepdiff import DeepDiff
@@ -27,16 +26,6 @@ DEFAULT_POST_TEMPLATE = """\
 {content}
 """
 
-# https://stackoverflow.com/a/63092850/368328
-def sort_versions(data):
-    def key(n):
-        a = re.split(r"(\d+)", n)
-        a[1::2] = map(int, a[1::2])
-        return a
-
-    return sorted(data, key=lambda n: key(n))
-
-
 # https://stackoverflow.com/a/71329221/368328
 # Force encoding version numbers as strings
 Resolver.add_implicit_resolver(
@@ -56,7 +45,18 @@ This is important to avoid edge cases like a 4.10.x release being marked under t
 
 def releases_matches(r, prefix):
     return r.startswith(prefix) and (
-        r == prefix or r.startswith(prefix + ".") or r.startswith(prefix + "-")
+        # It exactly matches the release cycle
+        r == prefix or
+        # It matches the prefix with an extra alphabet as a character
+        # this is notably used in openssl
+        # prefix = 1.1.0, r = 1.1.0r
+        ((len(r) - len(prefix) == 1) and ord(r[len(prefix):]) in range(ord('a'),ord('z'))) or
+        # It matches the release cycle as a patch release
+        # prefix = 1.1, r = 1.1.2
+        r.startswith(prefix + ".") or
+        # It matches the release cycle as a version suffix
+        # prefix = 1.2, r = 1.2-final
+        r.startswith(prefix + "-")
     )
 
 
@@ -98,8 +98,11 @@ def update_product(name):
                 # Entire releases data as a dict
                 R1 = json.loads(releases_file.read())
                 # Just the list of versions
-                R2 = sort_versions(R1.keys())
-                R3 = set(R2)
+                # Sort the versions by the date of release
+                R2 = sorted(R1.keys(), key=lambda n: R1[n])
+                # Set of versions, we remove all matched
+                # versions from this to get to "unmatched" versions
+                version_set = set(R2)
 
             updated = False
 
@@ -110,12 +113,13 @@ def update_product(name):
                 first_version = find_first(R2, prefix)
                 latest_version = find_last(R2, prefix)
 
-                R3 = R3 - find_all(R3, prefix)
+                version_set = version_set - find_all(version_set, prefix)
 
                 if first_version:
                     release["releaseDate"] = datetime.date.fromisoformat(
                         R1[first_version]
                     )
+
                     release["latestReleaseDate"] = datetime.date.fromisoformat(
                         R1[latest_version]
                     )
@@ -136,8 +140,9 @@ def update_product(name):
                 f.truncate()
                 f.write(final_contents)
 
-            if len(R3) != 0:
-                for x in R3:
+            # Print all unmatched versions released in the last 30 days
+            if len(version_set) != 0:
+                for x in version_set:
                     date = datetime.date.fromisoformat(R1[x])
                     days_since_release = (datetime.date.today() - date).days
                     if days_since_release < 30:

--- a/_auto/latest.py
+++ b/_auto/latest.py
@@ -130,8 +130,10 @@ def update_product(name):
                         old_version = release['latest']
                         old_date = release.get('latestReleaseDate', None)
                         # We compare the dates if we have one
+                        # Since multiple releases can show up on the same date, we want a better
+                        # guarantee, and err on the side of using the next check instead.
                         if old_date:
-                            return old_date <= datetime.date.fromisoformat(R1[new_version])
+                            return old_date < datetime.date.fromisoformat(R1[new_version])
                         # Otherwise, we do our best attempt at comparing the version numbers
                         try:
                             return Version(new_version) >= Version(old_version)

--- a/_auto/latest.py
+++ b/_auto/latest.py
@@ -129,17 +129,14 @@ def update_product(name):
                     def new_version_is_higher(new_version):
                         old_version = release['latest']
                         old_date = release.get('latestReleaseDate', None)
-                        # We compare the dates if we have one
-                        # Since multiple releases can show up on the same date, we want a better
-                        # guarantee, and err on the side of using the next check instead.
-                        if old_date:
-                            return old_date < datetime.date.fromisoformat(R1[new_version])
-                        # Otherwise, we do our best attempt at comparing the version numbers
+                        # Do our best attempt at comparing the version numbers
                         try:
                             return Version(new_version) >= Version(old_version)
                         except:
-                            # Since the list is already sorted, we assume we've gotten a okay
-                            # chance at this point that the new version is higher
+                            # We compare the dates if we have one
+                            # Note that multiple releases can show up on the same date
+                            if old_date:
+                                return old_date < datetime.date.fromisoformat(R1[new_version])
                             return True
 
                     # Never downgrade a custom pinned version

--- a/products/dotnet.md
+++ b/products/dotnet.md
@@ -62,18 +62,6 @@ releases:
     latest: "2.0.9"
     releaseDate: 2017-08-14
     latestReleaseDate: 2018-07-10
--   releaseCycle: "1.1"
-    releaseLabel: "Core __RELEASE_CYCLE__"
-    eol: 2019-06-27
-    latest: "1.1.13"
-    releaseDate: 2016-11-16
-    latestReleaseDate: 2019-05-15
--   releaseCycle: "1.0"
-    releaseLabel: "Core __RELEASE_CYCLE__"
-    eol: 2019-06-27
-    latest: "1.0.16"
-    releaseDate: 2022-04-27
-    latestReleaseDate: 2019-05-15
 
 ---
 

--- a/products/hashicorp-vault.md
+++ b/products/hashicorp-vault.md
@@ -14,6 +14,11 @@ releaseDateColumn: true
 versionCommand: vault --version
 
 releases:
+-   releaseCycle: "1.12"
+    eol: false
+    latest: "1.12.0"
+    latestReleaseDate: 2022-10-10
+    releaseDate: 2022-10-10
 -   releaseCycle: "1.11"
     eol: false
     latest: "1.11.4"
@@ -25,7 +30,7 @@ releases:
     latestReleaseDate: 2022-09-22
     releaseDate: 2022-03-21
 -   releaseCycle: "1.9"
-    eol: false
+    eol: 2022-10-10
     latest: "1.9.10"
     latestReleaseDate: 2022-09-15
     releaseDate: 2021-11-16

--- a/products/openssl.md
+++ b/products/openssl.md
@@ -22,21 +22,21 @@ releases:
     latestReleaseDate: 2022-10-11
 -   releaseCycle: "1.1.1"
     eol: 2023-09-11
-    latest: "1.1.1"
+    latest: "1.1.1r"
     lts: true
     releaseDate: 2018-09-11
-    latestReleaseDate: 2018-09-11
+    latestReleaseDate: 2022-10-11
 -   releaseCycle: "1.1.0"
     eol: 2019-09-11
-    latest: "1.1.0"
+    latest: "1.1.0l"
     releaseDate: 2016-08-25
-    latestReleaseDate: 2016-08-25
+    latestReleaseDate: 2019-09-10
 -   releaseCycle: "1.0.2"
     eol: 2019-12-31
-    latest: "1.0.2"
+    latest: "1.0.2u"
     lts: true
     releaseDate: 2015-01-22
-    latestReleaseDate: 2015-01-22
+    latestReleaseDate: 2019-12-20
 
 ---
 

--- a/products/slackware.md
+++ b/products/slackware.md
@@ -36,7 +36,7 @@ releases:
     releaseDate: 2013-11-04
 -   releaseCycle: "14.0"
     eol: false
-    releaseDate: 20l2-09-26
+    releaseDate: 2012-09-26
 -   releaseCycle: "13.37"
     eol: 2018-07-05
     releaseDate: 2011-04-25

--- a/products/slackware.md
+++ b/products/slackware.md
@@ -5,7 +5,6 @@ alternate_urls:
 -   /slackware-linux
 title: Slackware Linux
 category: os
-releasePolicyLink: http://www.slackware.com/changelog/
 iconSlug: slackware
 changelogTemplate: http://www.slackware.com/announce/__RELEASE_CYCLE__.php
 activeSupportColumn: false

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ python-frontmatter==1.0.0
 PyYAML==6.0
 ruamel.yaml==0.17.21
 ruamel.yaml.clib==0.2.6
+packaging==21.3


### PR DESCRIPTION
- Fix openssl version sorting. See [current version](https://endoflife.date/openssl), which doesn't know about `1.1.1s`.
- Refuse to downgrade `latest` version information. This will avoid issues like the kernel version getting downgraded [here](https://github.com/endoflife-date/endoflife.date/pull/1730/files#diff-d9ebc72a3680725a31df54e46ad2e773ef16a13ad7ccea766c95b1951c96e846) because our automation hadn't caught up with the manual changes made in #1729. Similar issues will show up after merging #1750, since Distrowatch doesn't have the newer versions. We had similar issues with Debian, where we turned off automation instead.
- Added a new release cycle for Vault
- Fixed duplicate key (changelogTemplate) for slackware
- Removed 2 release cycles for dotnet, since the upstream data for those was incorrect (the `1.1.1` release was tagged in 2022 so it takes precedence over actual latest release `1.1.13`. It doesn't have much impact since the release cycle is EOL already.