### PR TITLE
[Unity] Fix changelogTemplate

### DIFF
--- a/products/unity.md
+++ b/products/unity.md
@@ -8,8 +8,7 @@ releasePolicyLink: https://unity3d.com/unity/qa/lts-releases
 releaseDateColumn: true
 releaseColumn: true
 iconSlug: unity
-changelogTemplate: |
-  https://unity3d.com/unity/whats-new/__LATEST__
+changelogTemplate: https://unity3d.com/unity/whats-new/{{"__LATEST__" | split:'f' | first}}
 releaseImage: https://blog-api.unity.com/sites/default/files/2022-04/Unity-2021-LTS-Timeline.jpg
 releases:
 #  - releaseCycle: "2022.2"


### PR DESCRIPTION
Fix broken link to release notes for version 2022.1.20f1 (and future versions using similar number format)