### PR TITLE
[Fedora] Update delayed F35 EOL date

### DIFF
--- a/products/fedora.md
+++ b/products/fedora.md
@@ -19,7 +19,7 @@ releases:
     releaseDate: 2022-05-10
 -   releaseCycle: "35"
     latest: "35"
-    eol: 2022-11-15
+    eol: 2022-12-13
     latestReleaseDate: 2021-11-02
     releaseDate: 2021-11-02
 -   releaseCycle: "34"


### PR DESCRIPTION
> Fedora Linux 35 EOL auto closure: Tue 2022-12-13

* https://fedorapeople.org/groups/schedule/f-37/f-37-key-tasks.html

This is because the F37 release has been delayed until 2022-11-15, so it can include the OpenSSL critical security fix scheduled for release on 2022-11-01:

* https://news.itsfoss.com/fedora-37-release-delay/

And the F35 EOL depends on the F37 release and is about a month after.