### PR TITLE
Add mongodb-server purl

### DIFF
--- a/products/mongodb.md
+++ b/products/mongodb.md
@@ -14,6 +14,7 @@ purls:
 -   purl: pkg:rpm/amzn/mongodb-org-server
 -   purl: pkg:rpm/redhat/mongodb-org-server
 -   purl: pkg:rpm/centos/mongodb-org-server
+-   repology: mongodb
 auto:
 -   git: https://github.com/mongodb/mongo.git
     regex: ^r(?<major>0|[1-9]\d*)\.(?<minor>0|[1-9]\d*)\.(?<patch>0|[1-9]\d*)$

--- a/products/mongodb.md
+++ b/products/mongodb.md
@@ -7,7 +7,7 @@ changelogTemplate: https://www.mongodb.com/docs/v__RELEASE_CYCLE__/release-notes
 activeSupportColumn: false
 releaseDateColumn: true
 releaseLabel: "__RELEASE_CYCLE__{%if r.codename %} ({{r.codename}}){%endif%}"
-versionCommand: mongod --version\
+versionCommand: mongod --version
 purls:
 -   purl: pkg:deb/debian/mongodb-org-server
 -   purl: pkg:deb/ubuntu/mongodb-org-server

--- a/products/mongodb.md
+++ b/products/mongodb.md
@@ -7,7 +7,13 @@ changelogTemplate: https://www.mongodb.com/docs/v__RELEASE_CYCLE__/release-notes
 activeSupportColumn: false
 releaseDateColumn: true
 releaseLabel: "__RELEASE_CYCLE__{%if r.codename %} ({{r.codename}}){%endif%}"
-versionCommand: mongod --version
+versionCommand: mongod --version\
+purls:
+-   purl: pkg:deb/debian/mongodb-org-server
+-   purl: pkg:deb/ubuntu/mongodb-org-server
+-   purl: pkg:rpm/amzn/mongodb-org-server
+-   purl: pkg:rpm/redhat/mongodb-org-server
+-   purl: pkg:rpm/centos/mongodb-org-server
 auto:
 -   git: https://github.com/mongodb/mongo.git
     regex: ^r(?<major>0|[1-9]\d*)\.(?<minor>0|[1-9]\d*)\.(?<patch>0|[1-9]\d*)$


### PR DESCRIPTION
Related to https://github.com/endoflife-date/endoflife.date/issues/763

It seems quite tedious to add these all manually. Could we not generate a complete list of PURLs based on pkg manager / os / package name? 