### PR TITLE
[Windows] 21H2 LTSC doesn't have extended support but IoT 21H2 does

### DIFF
--- a/products/windows.md
+++ b/products/windows.md
@@ -28,11 +28,17 @@ releases:
     support: 2024-10-14
     eol: 2024-10-14
     releaseDate: 2022-09-20
--   releaseCycle: "Windows 10, version 21H2"
+-   releaseCycle: "Windows 10, version 21H2 IoT"
     lts: true
     buildID: 10.0.19044
     support: 2027-01-12
     eol: 2032-01-13
+    releaseDate: 2021-11-16
+-   releaseCycle: "Windows 10, version 21H2"
+    lts: true
+    buildID: 10.0.19044
+    support: 2027-01-12
+    eol: 2027-01-12
     releaseDate: 2021-11-16
 -   releaseCycle: "Windows 10, version 21H2 (E)"
     buildID: 10.0.19044

--- a/products/windows.md
+++ b/products/windows.md
@@ -123,6 +123,8 @@ releases:
 
 [Windows 11 release information](https://docs.microsoft.com/windows/release-health/windows11-release-information)  
 [Windows 10 release information](https://docs.microsoft.com/windows/release-health/release-information)  
+[Windows 8.1 update information](https://support.microsoft.com/topic/windows-8-1-and-windows-server-2012-r2-update-history-47d81dd2-6804-b6ae-4112-20089467c7a6)
+[Windows 7 update information](https://support.microsoft.com/topic/windows-7-sp1-and-windows-server-2008-r2-sp1-update-history-720c2590-fd58-26ba-16cc-6d8f3b547599)
 [Windows Lifecycle FAQ](https://docs.microsoft.com/lifecycle/faq/windows)
 
 Beginning with Windows 10, version 21H2, feature updates for Windows 10 release are released annually, in the second half of the calendar year.

--- a/products/windows.md
+++ b/products/windows.md
@@ -95,6 +95,19 @@ releases:
     release: 2011-02-22
     support: 2015-01-13
     eol: 2020-01-14
+  - releaseCycle: "Windows Vista SP2"
+    cycleShortHand: 6.0.6200
+    release: 2009-04-29
+    support: 2012-04-10
+    eol: 2017-04-11
+  - releaseCycle: "Windows XP SP3"
+    cycleShortHand: 5.1.2600
+    release: 2008-04-21
+    support: 2009-04-14
+    eol: 2014-04-08
+
+
+
 ---
 
 | Note | Comment                                                    |

--- a/products/windows.md
+++ b/products/windows.md
@@ -90,6 +90,11 @@ releases:
     release: 2013-11-13
     support: 2018-01-09
     eol: 2023-01-10
+  - releaseCycle: "Windows 8"
+    cycleShortHand: 6.2.9200 
+    release: 2012-10-30
+    support: 2016-01-12
+    eol: 2016-01-12
   - releaseCycle: "Windows 7 SP1"
     cycleShortHand: 6.1.7601
     release: 2011-02-22

--- a/products/windowsServer.md
+++ b/products/windowsServer.md
@@ -90,7 +90,7 @@ releases:
     eol: 2020-01-14
   - releaseCycle: "2003"
     cycleShortHand: 5.2.3790
-    release: 2003-05-28
+    release: 2003-04-24
     support: 2010-07-13
     eol: 2015-07-14
   - releaseCycle: "2000"

--- a/products/windowsServer.md
+++ b/products/windowsServer.md
@@ -84,7 +84,7 @@ releases:
     support: 2015-01-13
     eol: 2020-01-14
   - releaseCycle: "2008-SP2"
-    cycleShortHand: 6.0.6002
+    cycleShortHand: 6.0.6003
     release: 2009-04-29
     support: 2015-01-13
     eol: 2020-01-14


### PR DESCRIPTION
Win10 LTSC 21H2 doesn't have extended support and its EOL date is 2027-01-12 https://learn.microsoft.com/en-us/lifecycle/products/windows-10-enterprise-ltsc-2021

Stranger, Microsoft did give the IoT version of 21H2 LTSC extended support as seen below and it does follow the 10 year cycle.

https://learn.microsoft.com/en-us/lifecycle/products/windows-10-iot-enterprise-ltsc-2021

I've included both EOL dates in this edit but the IoT one might deserve it's own page/merge it into Windows Embedded
