### PR TITLE
[SpringFramework] Fix duplicated phrase in description

### DIFF
--- a/products/spring-framework.md
+++ b/products/spring-framework.md
@@ -55,6 +55,6 @@ iconSlug: spring
 
 ---
 
-> [Spring Framework](https://spring.io/projects/spring-framework) The Spring Framework provides a comprehensive programming and configuration model for modern Java-based enterprise applications - on any kind of deployment platform.
+> The [Spring Framework](https://spring.io/projects/spring-framework) provides a comprehensive programming and configuration model for modern Java-based enterprise applications - on any kind of deployment platform.
 
 See [Spring Framework Milestones](https://github.com/spring-projects/spring-framework/milestones) for upcoming releases. EoL policy described in [here](https://github.com/spring-projects/spring-framework/wiki/Spring-Framework-Versions)


### PR DESCRIPTION
`Spring Framework The Spring Framework provides a` -> `The Spring Framework provides a`