### PR TITLE
[wordpress] fix link for 3.9.39

### DIFF
--- a/products/wordpress.md
+++ b/products/wordpress.md
@@ -144,6 +144,8 @@ releases:
     releaseDate: 2014-04-16
     latestReleaseDate: 2022-10-17
     latest: "3.9.39"
+    # 3.9.39 was a mistakenly released and equals to 3.9.38 ( without a changelog )
+    link: https://wordpress.org/support/wordpress-version/version-3-9-38/
 -   releaseCycle: "3.8"
     eol: 2022-12-01
     support: 2014-04-16


### PR DESCRIPTION
This is a workaround until they release 3.9.40