### PR TITLE
[Wagtail] Use wagtail.org instead of wagtail.io in URLs

### DIFF
--- a/products/wagtail.md
+++ b/products/wagtail.md
@@ -3,7 +3,7 @@ title: Wagtail
 permalink: /wagtail
 category: framework
 releasePolicyLink: https://github.com/wagtail/wagtail/wiki/Release-schedule
-changelogTemplate: https://docs.wagtail.io/en/stable/releases/__LATEST__.html
+changelogTemplate: https://docs.wagtail.org/en/stable/releases/__LATEST__.html
 activeSupportColumn: true
 releaseDateColumn: true
 versionCommand: python -c "import wagtail; print(wagtail.__version__)"
@@ -112,7 +112,7 @@ releases:
 
 Minor/Feature releases of Wagtail are released every three months. A feature release will usually stop receiving patch release updates when the next feature release comes out. LTS releases receive fixes for security and data-loss related issues. Typically, an LTS release will happen once every four feature releases and receive updates for five feature releases, giving a support period of fifteen months with a three-month overlap. LTS releases will ensure compatibility with at least one [Django LTS release][django-lts].
 
-The Wagtail team provides [official security support](https://docs.wagtail.io/en/stable/contributing/security.html#supported-versions) for:
+The Wagtail team provides [official security support](https://docs.wagtail.org/en/stable/contributing/security.html#supported-versions) for:
 
 * The two most recent Wagtail release series.
 * The latest LTS release.


### PR DESCRIPTION
The Wagtail project website migrated from wagtail.io to wagtail.org. Updating the URLs avoid unnecessary redirects.