### PR TITLE
Add end of life date for .NET Framework 4.6.2

### DIFF
--- a/products/dotnetfx.md
+++ b/products/dotnetfx.md
@@ -29,7 +29,7 @@ releases:
     eol: false
     releaseDate: 2017-04-05
 -   releaseCycle: "4.6.2"
-    eol: false
+    eol: 2027-01-12
     releaseDate: 2016-08-02
 -   releaseCycle: "4.6.1"
     eol: 2022-04-26


### PR DESCRIPTION
Microsoft currently lists an End Date for .NET 4.6.2 of Jan 12, 2027 at https://learn.microsoft.com/en-us/lifecycle/products/microsoft-net-framework