### PR TITLE
[Ubuntu] Rename Ubuntu Advantage to Ubuntu Pro

### DIFF
--- a/products/linuxmint.md
+++ b/products/linuxmint.md
@@ -119,7 +119,7 @@ releases:
 
 >[Linux Mint](https://linuxmint.com/) is a community-driven Linux distribution for desktop and laptop computers based on Debian and Ubuntu, bundled with a variety of free and open-source applications. It has an Ubuntu-based release simply named Linux Mint, and a Debian-based release called LMDE (Linux Mint Debian Edition).
 
-Linux Mint releases follows [the support cycle](https://linuxmint.com/download_all.php) of the Ubuntu release they are based on. This support does not extend to the duration of <abbr title="Extended Security Maintenance">ESM</abbr>. Linux Mint users can opt in to receive [Extended Security Maintenance](https://ubuntu.com/security/esm) via [Ubuntu Advantage](https://ubuntu.com/advantage) for some packages once the main support period ends. But Linux Mint considers that release End of Life once it enters that state, so Linux Mint packages will not be receiving any updates.
+Linux Mint releases follows [the support cycle](https://linuxmint.com/download_all.php) of the Ubuntu release they are based on. This support does not extend to the duration of <abbr title="Extended Security Maintenance">ESM</abbr>. Linux Mint users can opt in to receive [Extended Security Maintenance](https://ubuntu.com/security/esm) via [Ubuntu Pro](https://ubuntu.com/pro) for some packages once the main support period ends. But Linux Mint considers that release End of Life once it enters that state, so Linux Mint packages will not be receiving any updates.
 
 [Linux Mint Debian Edition][lmde] (LMDE) stops supporting a release shortly after a new LMDE release comes out. This however is still subject to change on a release by release basis.
 

--- a/products/ubuntu.md
+++ b/products/ubuntu.md
@@ -111,7 +111,7 @@ LTS releases are in "General Support" for 5 years and "Extended Security Mainten
 
 During the lifetime of an Ubuntu release, Canonical provides security maintenance. Basic Security Maintenance covers binary packages that reside in the `main` and `restricted` components of the Ubuntu archive, typically for a period of 5 years from LTS release.
 
-Extended Security Maintenance (ESM) provides security updates on Ubuntu LTS releases for additional 5 years. It is available with the Ubuntu Advantage subscription or a Free subscription. Please see the [Ubuntu Website]({{page.link}}) for details.
+Extended Security Maintenance (ESM) provides security updates on Ubuntu LTS releases for additional 5 years. It is available with the Ubuntu Pro subscription or a Free subscription. Please see the [Ubuntu Website]({{page.link}}) for details.
 
 The dates for active and security support are taken from [here](https://github.com/canonical-web-and-design/ubuntu.com/blob/master/static/js/src/chart-data.js) what is used for the graph rendering on the [Release Cycle Page](https://ubuntu.com/about/release-cycle).
 


### PR DESCRIPTION
The Ubuntu Advantage program has been rebranded to Ubuntu Pro, as seen on https://ubuntu.com/pro.