### PR TITLE
[Looker] Fix URLs

### DIFF
--- a/products/looker.md
+++ b/products/looker.md
@@ -3,15 +3,15 @@ title: Looker
 permalink: /looker
 category: server-app
 iconSlug: looker
-releasePolicyLink: https://docs.looker.com/relnotes/release-overview
+releasePolicyLink: https://cloud.google.com/looker/docs/release-overview
 changelogTemplate: |
-  https://docs.looker.com/relnotes/v{{"__RELEASE_CYCLE__" | split:'.' | first}}-changelog#{{"__RELEASE_CYCLE__"}}
+  https://cloud.google.com/looker/docs/looker-{{"__RELEASE_CYCLE__" | split:'.' | first}}-changelog#{{"__RELEASE_CYCLE__" | replace:'.',''}}
 LTSLabel: "<abbr title='Extended Support Release'>ESR</abbr>"
 eolColumn: Support Status
 activeSupportColumn: false
 releaseDateColumn: true
 releaseColumn: false
-releaseImage: https://docs.looker.com/assets/images/2022-std-supp-releases.png
+releaseImage: https://cloud.google.com/static/looker/docs/images/2022-std-supp-releases.png
 releases:
 -   releaseCycle: "22.8"
     releaseDate: 2022-05-06
@@ -92,7 +92,7 @@ When a new release is ready for installation, any Looker user listed as a Techni
 
 ESR releases are quarterly instead of monthly, and get 3 months of support. Issues deemed S1 and S2 will be patched back to the currently supported ESR releases. Participants in the ESR program are required to pair production instances with staging instances. A ESR release is kept in "ESR-staging" for a month, where it is considered "pre-stable".
 
-![ESR release schedule image](https://docs.looker.com/assets/images/2022-std-esr-supp-releases.png)
+![ESR release schedule image](https://cloud.google.com/static/looker/docs/images/2022-std-esr-supp-releases.png)
 
 ## [Notifications][emails]
 

--- a/products/looker.md
+++ b/products/looker.md
@@ -9,6 +9,7 @@ changelogTemplate: |
 LTSLabel: "<abbr title='Extended Support Release'>ESR</abbr>"
 eolColumn: Support Status
 activeSupportColumn: false
+releaseColumn: false
 releaseDateColumn: true
 releaseImage: https://cloud.google.com/static/looker/docs/images/2022-std-supp-releases.png
 releases:
@@ -16,79 +17,81 @@ releases:
     releaseDate: 2022-05-06
     # Update once 22.14 is released
     eol: 2022-08-15
-    latest: "22.8"
+
 -   releaseCycle: "22.6"
     releaseDate: 2022-04-18
     lts: 2022-06-01
     eol: 2022-08-31
-    latest: "22.8"
+
 -   releaseCycle: "22.4"
     releaseDate: 2022-03-14
     # Update once 22.10 is released
     eol: 2022-06-15
-    latest: "22.4"
+
 -   releaseCycle: "22.2"
     releaseDate: 2022-02-15
     eol: 2022-05-16
-    latest: "22.2"
+
 -   releaseCycle: "22.0"
     releaseDate: 2022-01-18
     eol: 2022-05-31
     lts: 2022-03-01
-    latest: "22.0"
+
 -   releaseCycle: "21.20"
     eol: 2022-03-15
     releaseDate: 2021-11-16
+
 -   releaseCycle: "21.18"
     eol: 2022-02-28
     lts: 2021-12-01
     releaseDate: 2021-10-19
-    latest: "21.18"
+
 -   releaseCycle: "21.16"
     eol: 2021-12-15
     releaseDate: 2021-09-14
-    latest: "21.16"
+
 -   releaseCycle: "21.14"
     eol: 2021-11-16
     releaseDate: 2021-08-16
+
 -   releaseCycle: "21.12"
     eol: 2021-11-30
     lts: 2021-09-01
     releaseDate: 2021-07-15
+
 -   releaseCycle: "21.10"
     eol: 2021-09-14
     releaseDate: 2021-06-10
-    latest: "21.10"
+
 -   releaseCycle: "21.8"
     eol: 2021-10-16
     releaseDate: 2021-05-13
-    latest: "21.8"
+
 -   releaseCycle: "21.6"
     eol: 2021-08-31
     lts: 2021-06-01
     releaseDate: 2021-04-15
-    latest: "21.6"
+
 -   releaseCycle: "21.4"
     eol: 2021-06-10
     releaseDate: 2021-03-11
-    latest: "21.4"
+
 -   releaseCycle: "21.0"
     eol: 2021-05-31
     lts: 2021-03-01
     releaseDate: 2021-01-20
-    latest: "21.0"
+
 -   releaseCycle: "7.20"
     eol: true
     releaseDate: 2020-11-15
-    latest: "7.20"
+
 -   releaseCycle: "7.18"
     eol: true
     releaseDate: 2020-10-15
-    latest: "7.18"
+
 -   releaseCycle: "7.16"
     eol: true
     releaseDate: 2020-09-17
-    latest: "7.16"
 
 ---
 

--- a/products/looker.md
+++ b/products/looker.md
@@ -10,7 +10,6 @@ LTSLabel: "<abbr title='Extended Support Release'>ESR</abbr>"
 eolColumn: Support Status
 activeSupportColumn: false
 releaseDateColumn: true
-releaseColumn: false
 releaseImage: https://cloud.google.com/static/looker/docs/images/2022-std-supp-releases.png
 releases:
 -   releaseCycle: "22.8"

--- a/products/looker.md
+++ b/products/looker.md
@@ -16,21 +16,26 @@ releases:
     releaseDate: 2022-05-06
     # Update once 22.14 is released
     eol: 2022-08-15
+    latest: "22.8"
 -   releaseCycle: "22.6"
     releaseDate: 2022-04-18
     lts: 2022-06-01
     eol: 2022-08-31
+    latest: "22.8"
 -   releaseCycle: "22.4"
     releaseDate: 2022-03-14
     # Update once 22.10 is released
     eol: 2022-06-15
+    latest: "22.4"
 -   releaseCycle: "22.2"
     releaseDate: 2022-02-15
     eol: 2022-05-16
+    latest: "22.2"
 -   releaseCycle: "22.0"
     releaseDate: 2022-01-18
     eol: 2022-05-31
     lts: 2022-03-01
+    latest: "22.0"
 -   releaseCycle: "21.20"
     eol: 2022-03-15
     releaseDate: 2021-11-16
@@ -38,9 +43,11 @@ releases:
     eol: 2022-02-28
     lts: 2021-12-01
     releaseDate: 2021-10-19
+    latest: "21.18"
 -   releaseCycle: "21.16"
     eol: 2021-12-15
     releaseDate: 2021-09-14
+    latest: "21.16"
 -   releaseCycle: "21.14"
     eol: 2021-11-16
     releaseDate: 2021-08-16
@@ -51,29 +58,37 @@ releases:
 -   releaseCycle: "21.10"
     eol: 2021-09-14
     releaseDate: 2021-06-10
+    latest: "21.10"
 -   releaseCycle: "21.8"
     eol: 2021-10-16
     releaseDate: 2021-05-13
+    latest: "21.8"
 -   releaseCycle: "21.6"
     eol: 2021-08-31
     lts: 2021-06-01
     releaseDate: 2021-04-15
+    latest: "21.6"
 -   releaseCycle: "21.4"
     eol: 2021-06-10
     releaseDate: 2021-03-11
+    latest: "21.4"
 -   releaseCycle: "21.0"
     eol: 2021-05-31
     lts: 2021-03-01
     releaseDate: 2021-01-20
+    latest: "21.0"
 -   releaseCycle: "7.20"
     eol: true
     releaseDate: 2020-11-15
+    latest: "7.20"
 -   releaseCycle: "7.18"
     eol: true
     releaseDate: 2020-10-15
+    latest: "7.18"
 -   releaseCycle: "7.16"
     eol: true
     releaseDate: 2020-09-17
+    latest: "7.16"
 
 ---
 


### PR DESCRIPTION
- replace changelogTemplate and releasePolicyLink to avoid unnecessary redirects,
- fix changelogTemplate and ESR release schedule image URLs.

The URL https://docs.looker.com/relnotes has been left as is because :

- I found no corresponding URL on https://cloud.google.com/looker/docs/,
- it is still redirected to the correct page.