### PR TITLE
[MariaDB] Fix changelogTemplate

### DIFF
--- a/products/mariadb.md
+++ b/products/mariadb.md
@@ -3,7 +3,7 @@ title: MariaDB
 permalink: /mariadb
 category: db
 releasePolicyLink: https://mariadb.org/about/#maintenance-policy
-changelogTemplate: https://mariadb.com/kb/en/mariadb-{{"__LATEST__" | replace:'.',''}}-changelog/
+changelogTemplate: https://mariadb.com/kb/en/mariadb-{{"__LATEST__" | replace:'.','-'}}-changelog/
 activeSupportColumn: false
 releaseDateColumn: true
 purls:


### PR DESCRIPTION
The URL scheme from `https://mariadb.com/kb/en/mariadb-xyz-changelog/` to `https://mariadb.com/kb/en/mariadb-x-y-z-changelog/`.