### PR TITLE
[wordpress] fix 6.1.0 's broken link

### DIFF
--- a/products/wordpress.md
+++ b/products/wordpress.md
@@ -12,6 +12,8 @@ releases:
     releaseDate: 2022-11-02
     latest: "6.1.0"
     latestReleaseDate: 2022-11-02
+    #temporary link until a point version released
+    link: https://wordpress.org/support/wordpress-version/version-6-1/
 -   releaseCycle: "6.0"
     eol: false
     support: 2022-11-01


### PR DESCRIPTION
a wordaround for 6.1
This is a simple example of bug/problem which i have mentioned over #1774 
[for refrance to #1206 ]