### PR TITLE
[Quarkus] 2.14.0.Final was released today

### DIFF
--- a/products/quarkus.md
+++ b/products/quarkus.md
@@ -17,6 +17,7 @@ releases:
     latest: "2.14.0"
     latestReleaseDate: 2022-11-09
     releaseDate: 2022-11-09
+
 -   releaseCycle: "2.13"
     eol: 2025-05-18
     support: 2025-11-18

--- a/products/quarkus.md
+++ b/products/quarkus.md
@@ -11,6 +11,12 @@ auto:
 # See https://rubular.com/r/NyoXd9iCLFcl25 for reference
     regex: '^v?(?<major>[1-9]\d*)\.(?<minor>0|[1-9]\d*)\.(?<patch>0|[1-9]\d*)(\.Final)?$'
 releases:
+-   releaseCycle: "2.14"
+    eol: 2025-05-18
+    support: 2025-11-18
+    latest: "2.14.0"
+    latestReleaseDate: 2022-11-09
+    releaseDate: 2022-11-09
 -   releaseCycle: "2.13"
     eol: 2025-05-18
     support: 2025-11-18


### PR DESCRIPTION
[Quarkus] 2.14.0.Final was released today cf https://quarkus.io/blog/quarkus-2-14-0-final-released/ cf  #1840

![image](https://user-images.githubusercontent.com/5235127/200996764-3060fb65-1c92-4008-9386-79985d263dcf.png)
