### PR TITLE
[auto] Downgrade back to Python 3.10

### DIFF
--- a/.github/workflows/auto-merge-release-updates.yml
+++ b/.github/workflows/auto-merge-release-updates.yml
@@ -23,7 +23,7 @@ jobs:
           submodules: true
       - uses: actions/setup-python@v4
         with:
-          python-version: '3.11'
+          python-version: '3.10'
       - name: Install Python Dependencies
         run: pip install -r requirements.txt
       - name: Update latest releases


### PR DESCRIPTION
Didn't test ruamel on py311, and it broke as a native extension. Reverting for now to get #1375 merged and automation working.