### PR TITLE
[Spring Framework] 6.0.0 released and update product description

### DIFF
--- a/products/spring-boot.md
+++ b/products/spring-boot.md
@@ -73,9 +73,14 @@ iconSlug: springboot
 
 ---
 
-> [Spring Boot](https://github.com/spring-projects/spring-boot) helps you to create Spring-powered, production-grade applications and services with absolute minimum fuss. It takes an opinionated view of the Spring platform so that new and existing users can quickly get to the bits they need.
+> [Spring Boot](https://github.com/spring-projects/spring-boot) helps you to create Spring-powered, production-grade
+> applications and services with absolute minimum fuss. It takes an opinionated view of the Spring platform so that new
+> and existing users can quickly get to the bits they need.
 
-See [here](https://spring.io/projects/spring-boot#support) for more details about support roadmap.
+See [Spring Boot Milestones page](https://github.com/spring-projects/spring-boot/milestones) for upcoming releases.
+See [Spring Boot Support page](https://spring.io/projects/spring-boot#support) for more details about support roadmap.
 
-- Spring Boot 3.x requires **at least a Java 17 runtime**
+- Spring Boot 3.x requires **at least a Java 17 runtime**,
 - Spring Boot 2.7.5 (and therefore the latest Spring Framework 5.3.23) supports Java 19 while also remaining compatible with Java 11 and 8.
+
+A commercial offer for extended support after OSS End-Of-Life is available.

--- a/products/spring-framework.md
+++ b/products/spring-framework.md
@@ -9,39 +9,46 @@ auto:
   # See https://rubular.com/r/XQUdQN2MHdmmCD for reference
     regex: '^v?(?<major>[1-9]\d*)\.(?<minor>0|[1-9]\d*)\.(?<patch>0|[1-9]\d*)(\.RELEASE)?$'
 releases:
+-   releaseCycle: "6.0"
+    eol: 2024-08-31
+    support: 2024-08-31
+    latest: "6.0.0"
+    latestReleaseDate: 2022-11-16
+    releaseDate: 2022-11-16
 -   releaseCycle: "5.3"
-    eol: false
-    support: true
+    lts: true
+    eol: 2024-12-31
+    support: 2024-12-31
     latest: "5.3.24"
     latestReleaseDate: 2022-11-16
     releaseDate: 2020-10-27
 -   releaseCycle: "5.2"
     eol: 2021-12-31
-    support: true
+    support: 2021-12-31
     latest: "5.2.22"
     latestReleaseDate: 2022-05-11
     releaseDate: 2019-09-30
 -   releaseCycle: "5.1"
-    eol: 2020-12-09
-    support: false
+    eol: 2020-12-31
+    support: 2020-12-31
     latest: "5.1.20"
     latestReleaseDate: 2020-12-09
     releaseDate: 2018-09-21
 -   releaseCycle: "5.0"
-    eol: 2020-12-09
-    support: false
+    eol: 2020-12-31
+    support: 2020-12-31
     latest: "5.0.20"
     latestReleaseDate: 2020-12-09
     releaseDate: 2017-09-28
 -   releaseCycle: "4.3"
     eol: 2020-12-31
-    support: false
+    support: 2020-12-31
     latest: "4.3.30"
     latestReleaseDate: 2020-12-09
     releaseDate: 2016-06-10
 -   releaseCycle: "3.2"
     eol: 2016-12-31
-    support: false
+    support: 2016-12-31
     latest: "3.2.18"
     latestReleaseDate: 2016-12-21
     releaseDate: 2012-12-13
@@ -55,6 +62,14 @@ iconSlug: spring
 
 ---
 
-> The [Spring Framework](https://spring.io/projects/spring-framework) provides a comprehensive programming and configuration model for modern Java-based enterprise applications - on any kind of deployment platform.
+> The [Spring Framework](https://spring.io/projects/spring-framework) provides a comprehensive programming and
+> configuration model for modern Java-based enterprise applications - on any kind of deployment platform.
 
-See [Spring Framework Milestones](https://github.com/spring-projects/spring-framework/milestones) for upcoming releases. EoL policy described in [here](https://github.com/spring-projects/spring-framework/wiki/Spring-Framework-Versions)
+See [Spring Boot Milestones page](https://github.com/spring-projects/spring-framework/milestones) for upcoming releases.
+See [Spring Boot Support page](https://spring.io/projects/spring-framework#support) for more details about support
+roadmap.
+
+- Spring Framework 6.x requires **at least a Java 17 runtime**,
+- Spring Framework 5.3.x supports Java 19 while also remaining compatible with Java 11 and 8.
+
+A commercial offer for extended support after OSS End-Of-Life is available.


### PR DESCRIPTION
The support policy is best described on https://spring.io/projects/spring-framework#support, so the link https://github.com/spring-projects/spring-framework/wiki/Spring-Framework-Versions was replaced by this one.
    
Also :
 5.3.x eol / support date has been updated according to information found on that page.
 The Spring Boot and Spring Framework product descriptions were made similar.
- A paragraph was also added to indicate a commercial support exists for both products.
