### PR TITLE
[ansible-core] 2.14

### DIFF
--- a/products/ansible-core.md
+++ b/products/ansible-core.md
@@ -14,21 +14,27 @@ category: framework
 auto:
 -   git: https://github.com/ansible/ansible.git
 releases:
+-   releaseCycle: "2.14"
+    releaseDate: 2022-11-07
+    eol: 2024-05-31
+    latest: "2.14.0"
+    latestReleaseDate: 2022-11-07
+
 -   releaseCycle: "2.13"
     releaseDate: 2022-05-16
-    eol: false
+    eol: 2023-11-30
     latest: "2.13.6"
     latestReleaseDate: 2022-11-07
 
 -   releaseCycle: "2.12"
     releaseDate: 2021-11-08
-    eol: false
+    eol: 2023-05-31
     latest: "2.12.10"
     latestReleaseDate: 2022-10-11
 
 -   releaseCycle: "2.11"
     releaseDate: 2021-04-26
-    eol: false
+    eol: 2022-11-07
     latest: "2.11.12"
     latestReleaseDate: 2022-05-23
 


### PR DESCRIPTION
Ansible 2.14.0 has been released on 2022-11-07 (https://github.com/ansible/ansible/blob/stable-2.14/changelogs/CHANGELOG-v2.14.rst).

Following the 2.14 release the 2.11 is now eoled, as stated in https://docs.ansible.com/ansible/devel/reference_appendices/release_and_maintenance.html#ansible-core-release-cycle (quote: ansible-core has a graduated maintenance structure that extends to three major releases). The eol date is the 2.14.0 release date.

2.13 and 2.12 dates has been changed to their expected eol date, as seen on https://docs.ansible.com/ansible/devel/reference_appendices/release_and_maintenance.html#ansible-core-changelogs.