### PR TITLE
[spring-boot] :rocket:  Spring Boot 3.0 Goes GA :clap: 

### DIFF
--- a/products/spring-boot.md
+++ b/products/spring-boot.md
@@ -12,8 +12,8 @@ auto:
     regex: '^v?(?<major>[1-9]\d*)\.(?<minor>0|[1-9]\d*)\.(?<patch>0|[1-9]\d*)(\.RELEASE)?$'
 releases:
 -   releaseCycle: "3.0"
-    eol: 2023-11-18
-    support: 2025-02-18
+    eol: 2023-11-24
+    support: 2025-02-24
     latest: "3.0.0"
     latestReleaseDate: 2022-11-24
     releaseDate: 2022-11-24

--- a/products/spring-boot.md
+++ b/products/spring-boot.md
@@ -11,6 +11,12 @@ auto:
 # See https://rubular.com/r/stJ20etRIblK0J for reference
     regex: '^v?(?<major>[1-9]\d*)\.(?<minor>0|[1-9]\d*)\.(?<patch>0|[1-9]\d*)(\.RELEASE)?$'
 releases:
+-   releaseCycle: "3.0"
+    eol: 2023-11-18
+    support: 2025-02-18
+    latest: "3.0.0"
+    latestReleaseDate: 2022-11-24
+    releaseDate: 2022-11-24
 -   releaseCycle: "2.7"
     eol: 2023-11-18
     support: 2025-02-18


### PR DESCRIPTION
# :grey_question: Context

On behalf of the team, it is my very great pleasure to announce that Spring Boot 3.0 is now generally available and 3.0.0 
can be found in Maven Central. https://spring.io/blog/2022/11/24/spring-boot-3-0-goes-ga

![image](https://user-images.githubusercontent.com/5235127/203854873-e4d19e41-9999-4565-9919-5ecd64e325de.png)

# :information_source: Official EOL elements

cf https://spring.io/projects/spring-boot#support

![image](https://user-images.githubusercontent.com/5235127/203856811-a6a6d3d0-207f-4369-b953-d3443b83ee0a.png)


# :bookmark: Ressources

- :bird: [Official Tweet](https://twitter.com/ankinson/status/1595849181800931328)
- :scroll: [ReleaseNote](https://spring.io/blog/2022/11/24/spring-boot-3-0-goes-ga)