### PR TITLE
[Spring Boot] Use 'End of Support' date instead 'End Commercial Support' for support date (closes #1907)

### DIFF
--- a/products/spring-boot.md
+++ b/products/spring-boot.md
@@ -13,61 +13,61 @@ auto:
 releases:
 -   releaseCycle: "3.0"
     eol: 2023-11-24
-    support: 2025-02-24
+    support: 2023-11-24
     latest: "3.0.0"
     latestReleaseDate: 2022-11-24
     releaseDate: 2022-11-24
 -   releaseCycle: "2.7"
     eol: 2023-11-18
-    support: 2025-02-18
+    support: 2023-11-18
     latest: "2.7.5"
     latestReleaseDate: 2022-10-20
     releaseDate: 2022-05-19
 -   releaseCycle: "2.6"
     eol: 2022-11-24
-    support: 2024-02-24
+    support: 2022-11-24
     latest: "2.6.13"
     latestReleaseDate: 2022-10-20
     releaseDate: 2021-11-19
 -   releaseCycle: "2.5"
     eol: 2022-05-19
-    support: 2023-08-24
+    support: 2022-05-19
     latest: "2.5.14"
     latestReleaseDate: 2022-05-19
     releaseDate: 2021-05-20
 -   releaseCycle: "2.4"
     eol: 2021-11-18
-    support: 2023-02-23
+    support: 2021-11-18
     latest: "2.4.13"
     latestReleaseDate: 2021-11-18
     releaseDate: 2020-11-12
 -   releaseCycle: "2.3"
     eol: 2021-05-20
-    support: 2022-08-20
+    support: 2021-05-20
     latest: "2.3.12"
     latestReleaseDate: 2021-06-10
     releaseDate: 2020-05-15
 -   releaseCycle: "2.2"
     eol: 2020-10-16
-    support: 2022-01-16
+    support: 2020-10-16
     latest: "2.2.13"
     latestReleaseDate: 2021-01-14
     releaseDate: 2019-10-16
 -   releaseCycle: "2.1"
     eol: 2019-10-30
-    support: 2021-01-30
+    support: 2019-10-30
     latest: "2.1.18"
     latestReleaseDate: 2020-10-29
     releaseDate: 2018-10-30
 -   releaseCycle: "2.0"
     eol: 2019-03-01
-    support: 2020-06-01
+    support: 2019-03-01
     latest: "2.0.9"
     latestReleaseDate: 2019-04-03
     releaseDate: 2018-03-01
 -   releaseCycle: "1.5"
     eol: 2019-08-06
-    support: 2020-11-06
+    support: 2019-08-06
     latest: "1.5.22"
     latestReleaseDate: 2019-08-06
     releaseDate: 2017-01-30


### PR DESCRIPTION
See https://spring.io/projects/spring-boot#support.