### PR TITLE
[ansible] add  python requirement (modules)

### DIFF
--- a/products/ansible.md
+++ b/products/ansible.md
@@ -73,6 +73,6 @@ See the [Ansible Roadmap][roadmap] for upcoming release details.
 
 | ansible Version | Minimum Python Version (controller) | Minimum Python Version (modules) |
 |-----------------|-------------------------------------|----------------------------------|
-| 7               | 3.9                                 | N/A                              |
+| 7               | 3.9                                 | 2.7 or 3.5                       |
 | 6               | 3.8                                 | 2.7 or 3.5                       |
 | 2.9             | 2.7 or 3.5                          | 2.6 or 3.5                       |


### PR DESCRIPTION
- Added minimum python requirement (modules) for Ansible 7 release