### PR TITLE
[FreeBSD] date, expand the command, simplify blurb

### DIFF
--- a/products/freebsd.md
+++ b/products/freebsd.md
@@ -154,10 +154,10 @@ releases:
 
 ---
 
-> [FreeBSD](https://www.freebsd.org/) is an operating system used to power modern servers, desktops, and embedded platforms.
+> [FreeBSD](https://www.freebsd.org/) is an operating system for servers, desktops, and embedded platforms.
 
-Each major version’s stable branch (named `stable/x`) is explicitly supported for 5 years, while each individual point
-release (named `releng/x.y`) is only supported for three months after the next point release.
+Each major version’s stable branch (named `stable/x`) is supported for five years. 
 
-The _Security Support_ column indicates the earliest date on which support for that branch or release will end. Please
-note that these dates may be pushed back if circumstances warrant it.
+Each individual point release (branch named `releng/x.y`) is supported for three months after the next point release from the same branch.
+
+The _Security Support_ column indicates the earliest date on which support for that branch or release will end. 

--- a/products/freebsd.md
+++ b/products/freebsd.md
@@ -7,7 +7,8 @@ changelogTemplate: https://www.freebsd.org/releases/{{"__RELEASE_CYCLE__" | spli
 activeSupportColumn: false
 releaseDateColumn: false
 releaseColumn: false
-versionCommand: freebsd-version
+versionCommand: freebsd-version -kru
+
 releases:
 -   releaseCycle: "releng/13.1"
     eol: false
@@ -153,14 +154,10 @@ releases:
 
 ---
 
-> [FreeBSD](https://www.freebsd.org) is an operating system used to power modern servers, desktops, and embedded platforms.
+> [FreeBSD](https://www.freebsd.org/) is an operating system used to power modern servers, desktops, and embedded platforms.
 
-Each release is supported by the Security Officer for a limited time only. Under the current support model, each major version's stable branch is explicitly supported for 5 years, while each individual point release is only supported for three months after the next point release.
+Each major version’s stable branch (named `stable/x`) is explicitly supported for 5 years, while each individual point
+release (named `releng/x.y`) is only supported for three months after the next point release.
 
-The Expected EoL (end-of-life) column indicates the earliest date on which support for that branch or release will end. Please note that these dates may be pushed back if circumstances warrant it.
-
-The FreeBSD Security Officer provides security advisories for `-STABLE` Branches and the Security Branches. Advisories are not issued for the `-CURRENT` Branch, which is primarily oriented towards FreeBSD developers.
-
-The -STABLE branch tags have names like `stable/10`. The corresponding builds have names like `FreeBSD 10.1-STABLE`.
-
-Each FreeBSD Release has an associated Security Branch. The Security Branch tags have names like `releng/10.1`. The corresponding builds have names like `FreeBSD 10.1-RELEASE-p4`.
+The _Security Support_ column indicates the earliest date on which support for that branch or release will end. Please
+note that these dates may be pushed back if circumstances warrant it.


### PR DESCRIPTION
releng/13.0 died on 31st (not 16th) August 2022.

<https://www.freebsd.org/security/unsupported/>

The blurb is simplified, to include only what's immediately relevant to the (supported version) rows in the table that precedes the blurb. Readers can follow the additional links, to learn more, if required.

freebsd-version alone (run without options) does not tell whether the running kernel is patched, following installation of a patch. So: 

freebsd-version -kru

– and refer to the manual page.