### PR TITLE
[mssqlserver] Add 2022

### DIFF
--- a/products/mssqlserver.md
+++ b/products/mssqlserver.md
@@ -9,7 +9,7 @@ versionCommand: select @@version
 releaseDateColumn: true
 releases:
 -   releaseCycle: "2022"
-    releaseLabel: "2022 RTM"
+    releaseLabel: "2022"
     support: 2028-01-11
     eol: 2033-01-11
     latest: "16.0.1000.6"

--- a/products/mssqlserver.md
+++ b/products/mssqlserver.md
@@ -8,6 +8,12 @@ activeSupportColumn: true
 versionCommand: select @@version
 releaseDateColumn: true
 releases:
+-   releaseCycle: "2022"
+    releaseLabel: "2022 RTM"
+    support: 2028-01-11
+    eol: 2033-01-11
+    latest: "16.0.1000.6"
+    releaseDate: 2022-11-16
 -   releaseCycle: "2019"
     releaseLabel: "2019 CU18"
     support: 2025-01-07


### PR DESCRIPTION
Release blog: https://cloudblogs.microsoft.com/sqlserver/2022/11/16/sql-server-2022-is-now-generally-available/
Buildnumber: https://learn.microsoft.com/en-us/sql/sql-server/sql-server-2022-release-notes?view=sql-server-ver16#build-number
Dates from https://learn.microsoft.com/lifecycle/products/sql-server-2022