### PR TITLE
Remove unnecessary layout property on filebeat.md, cos.md and ansible-core.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,7 +38,6 @@ To add a new page to the website, [create a new markdown file with YAML frontmat
 ```yaml
 ---
 title: Timeturner
-layout: post
 # Possible values are os,db,app,lang,framework,device,service,server-app
 # If you add a new value, please mention it on the PR Description. Some rough guidelines:
 # os is operating systems (and similar projects)

--- a/products/ansible-core.md
+++ b/products/ansible-core.md
@@ -1,6 +1,5 @@
 ---
 permalink: /ansible-core
-layout: product
 title: Ansible-core
 versionCommand: ansible --version
 releasePolicyLink: https://docs.ansible.com/ansible-core/devel/reference_appendices/release_and_maintenance.html

--- a/products/cos.md
+++ b/products/cos.md
@@ -1,6 +1,5 @@
 ---
 title: Google Container-Optimized OS (COS)
-layout: product
 category: os
 changelogTemplate: "https://cloud.google.com/container-optimized-os/docs/release-notes/m__RELEASE_CYCLE__#__LATEST__"
 iconSlug: googlecloud

--- a/products/filebeat.md
+++ b/products/filebeat.md
@@ -1,5 +1,4 @@
 ---
-layout: product
 title: Filebeat
 category: server-app
 versionCommand: filebeat version


### PR DESCRIPTION
`layout: product` is already the default layout for pages in the products directory, there is no need to make it explicit.

The contribution guide was also fixed: `layout: post` was incorrectly set in the example of the _Adding a new product_ section.