### PR TITLE
iOS 16.1.2

### DIFF
--- a/products/ios.md
+++ b/products/ios.md
@@ -14,8 +14,8 @@ releases:
 -   releaseCycle: "16"
     releaseDate: 2022-09-12
     eol: false
-    latestReleaseDate: 2022-11-09
-    latest: "16.1.1"
+    latestReleaseDate: 2022-11-30
+    latest: "16.1.2"
 -   releaseCycle: "15"
     eol: false
     releaseDate: 2021-09-20


### PR DESCRIPTION
Apple has released iOS 16.1.2 yesterday. Source: https://developer.apple.com/news/releases/?id=11302022a