### PR TITLE
Show `latestReleaseDate` if available

### DIFF
--- a/_layouts/product.html
+++ b/_layouts/product.html
@@ -186,6 +186,9 @@ or +1 (EoL is in the future)
     {% else %}
       {{latestVersionNumber}}
     {% endif %}
+    {% if diff > 0 and r.latestReleaseDate %}
+    <div>({{r.latestReleaseDate | date_to_string}})</div>
+    {% endif %}
   </td>
   {% endif %}
 </tr>


### PR DESCRIPTION
`latestReleaseDate` is displayed under the version and not in a `title` because it is an interesting information even for EOLed version, but those version does not have links.