### PR TITLE
[react] Add older cycles and add note

### DIFF
--- a/products/react.md
+++ b/products/react.md
@@ -10,19 +10,42 @@ releaseDateColumn: true
 auto:
 -   git: https://github.com/facebook/react.git
 releases:
--   releaseCycle: "18"
+-   releaseCycle: "18.2"
     support: true
     eol: false
     latest: "18.2.0"
     latestReleaseDate: 2022-06-14
+    releaseDate: 2022-06-14
+-   releaseCycle: "18.1"
+    support: false
+    eol: false
+    latest: "18.2.0"
+    latestReleaseDate: 2022-04-26
+    releaseDate: 2022-04-26
+-   releaseCycle: "18.0"
+    support: false
+    eol: false
+    latest: "18.0.0"
+    latestReleaseDate: 2022-03-29
     releaseDate: 2022-03-29
 -   releaseCycle: "17"
     eol: false
     support: 2022-03-29
     latest: "17.0.2"
-
     latestReleaseDate: 2021-03-22
     releaseDate: 2020-10-20
+-   releaseCycle: "16"
+    eol: false
+    support: 2020-10-20
+    latest: "16.14.0"
+    latestReleaseDate: 2020-10-14
+    releaseDate: 2017-09-26
+-   releaseCycle: "15"
+    eol: false
+    support: 2017-09-26
+    latest: "15.0.2"
+    latestReleaseDate: 2016-04-29
+    releaseDate: 2016-04-08
 
 ---
 
@@ -31,3 +54,7 @@ releases:
 ## Versioning
 
 React follows [Semantic Versioning](https://semver.org/) principles. The only officially supported release channel for user-facing applications is Latest. New features are released in minor versions. Patch releases are made only for the most critical bugs and security vulnerabilities. Major releases can also contain new features, and any release can include bug fixes.
+
+## Support
+
+Critical Security fixes will be backported to all minor releases of the current major, as well as to latest minor release of previous major releases.

--- a/products/react.md
+++ b/products/react.md
@@ -17,13 +17,13 @@ releases:
     latestReleaseDate: 2022-06-14
     releaseDate: 2022-06-14
 -   releaseCycle: "18.1"
-    support: false
+    support: 2022-06-14
     eol: false
-    latest: "18.2.0"
+    latest: "18.1.0"
     latestReleaseDate: 2022-04-26
     releaseDate: 2022-04-26
 -   releaseCycle: "18.0"
-    support: false
+    support: 2022-04-26
     eol: false
     latest: "18.0.0"
     latestReleaseDate: 2022-03-29
@@ -55,6 +55,9 @@ releases:
 
 React follows [Semantic Versioning](https://semver.org/) principles. The only officially supported release channel for user-facing applications is Latest. New features are released in minor versions. Patch releases are made only for the most critical bugs and security vulnerabilities. Major releases can also contain new features, and any release can include bug fixes.
 
-## Support
+## [Support](https://github.com/reactjs/reactjs.org/issues/1745)
 
-Critical Security fixes will be backported to all minor releases of the current major, as well as to latest minor release of previous major releases.
+**Active Support**: Only the latest release cycle gets non-critical bugfixes, and new features.
+
+**Security Support**: Critical Security fixes are backported to all minor releases of the current major, as well as to latest minor release of previous major releases.
+


### PR DESCRIPTION
Latest major -> v18, all minor releases get security support Previous majors, only the latest minor release gets security support

So, if a vulnerability shows up today, we should see the following releases:

18.2.1, 18.1.1, 18.0.1, 17.0.3, 16.14.1, 15.0.3

Unsure about 0.x releases, so not adding them

See https://github.com/reactjs/reactjs.org/issues/1745