### PR TITLE
[haproxy] v2.7.0 released

### DIFF
--- a/products/haproxy.md
+++ b/products/haproxy.md
@@ -14,6 +14,12 @@ releaseDateColumn: true
 auto:
 -   custom: true
 releases:
+-   releaseCycle: "2.7"
+    lts: false
+    eol: 2024-01-01
+    latest: "2.7.0"
+    latestReleaseDate: 2022-12-01
+    releaseDate: 2022-12-01
 -   releaseCycle: "2.6"
     lts: true
     eol: 2027-04-01


### PR DESCRIPTION
Updated automation for 2.7 here: https://github.com/endoflife-date/release-data/commit/931ff740105b5ebeeb9a53c79cb67dfd1a31dec3
Date from here: https://www.haproxy.org/