### PR TITLE
Make sure `lts` field always has a value in API

### DIFF
--- a/_plugins/create-json-files.rb
+++ b/_plugins/create-json-files.rb
@@ -36,6 +36,7 @@ class Product
   def release_cycles
     hash.fetch('releases').map do |release|
       name = release.delete('releaseCycle')
+      release['lts'] = release['lts'] || false
       { 'name' => name, 'data' => release }
     end
   end


### PR DESCRIPTION
Set `lts` field of release cycles to `false` if the `lts` field does not exist in the YAML frontmatter. Always having a `lts` field in the API makes it more consistent.