### PR TITLE
Amazon products harmonization

### DIFF
--- a/products/eks.md
+++ b/products/eks.md
@@ -48,7 +48,6 @@ iconSlug: kubernetes
 permalink: /amazon-eks
 alternate_urls:
 -   /eks
--   /amazon-eks
 -   /amazon-elastic-kubernetes-service
 releasePolicyLink: https://docs.aws.amazon.com/eks/latest/userguide/kubernetes-versions.html
 activeSupportColumn: false

--- a/products/kindle.md
+++ b/products/kindle.md
@@ -62,6 +62,8 @@ releases:
     latest: "5.12.2.2"
     releaseDate: 2013-09-30
 permalink: /kindle
+alternate_urls:
+-   /amazon-kindle
 releasePolicyLink: https://www.amazon.com/gp/help/customer/display.html?nodeId=GKMQC26VQQMM8XSW
 activeSupportColumn: false
 releaseColumn: true


### PR DESCRIPTION
- [Amazon Kindle] Add `/amazon-kindle` alternate URL
- [Amazon EKS] Remove `/amazon-eks` from alternate URL (`/amazon-eks` is the main URL)