### PR TITLE
[FreeBSD] Replace links with a changelogTemplate

### DIFF
--- a/products/freebsd.md
+++ b/products/freebsd.md
@@ -14,7 +14,7 @@ releases:
     # 13.2-RELEASE + 3 months
     releaseDate: 2022-05-16
 -   releaseCycle: "releng/13.0"
-    eol: 2022-08-16
+    eol: 2022-08-31
     releaseDate: 2021-04-13
 -   releaseCycle: "stable/13"
     eol: 2026-01-31

--- a/products/freebsd.md
+++ b/products/freebsd.md
@@ -3,6 +3,7 @@ permalink: /freebsd
 title: FreeBSD
 category: os
 releasePolicyLink: https://www.freebsd.org/security/#sup
+changelogTemplate: https://www.freebsd.org/releases/{{"__RELEASE_CYCLE__" | split:'/' | last}}R/
 activeSupportColumn: false
 releaseDateColumn: false
 releaseColumn: false
@@ -11,166 +12,153 @@ releases:
 -   releaseCycle: "releng/13.1"
     eol: false
     # 13.2-RELEASE + 3 months
-    link: https://www.freebsd.org/releases/13.1R/announce/
     releaseDate: 2022-05-16
 -   releaseCycle: "releng/13.0"
     eol: 2022-08-16
     releaseDate: 2021-04-13
-    link: https://www.freebsd.org/releases/13.0R/announce/
 -   releaseCycle: "stable/13"
     eol: 2026-01-31
+    # prevent the link to be generated using the changelogTemplate
+    link: ""
+
 -   releaseCycle: "releng/12.4"
     releaseDate: 2022-12-05
     eol: 2023-12-31
-    link: https://www.freebsd.org/releases/12.4R/announce/
 -   releaseCycle: "releng/12.3"
     eol: 2023-03-05
     releaseDate: 2021-12-07
-    link: https://www.freebsd.org/releases/12.3R/announce/
 -   releaseCycle: "releng/12.2"
     eol: 2022-03-31
     releaseDate: 2020-10-27
-    link: https://www.freebsd.org/releases/12.2R/announce/
 -   releaseCycle: "releng/12.1"
     eol: 2021-01-31
     releaseDate: 2019-11-04
-    link: https://www.freebsd.org/releases/12.1R/announce/
 -   releaseCycle: "releng/12.0"
     eol: 2020-02-04
     releaseDate: 2018-12-11
-    link: https://www.freebsd.org/releases/12.0R/announce/
 -   releaseCycle: "stable/12"
     eol: 2023-12-31
+    # prevent the link to be generated using the changelogTemplate
+    link: ""
+
 -   releaseCycle: "releng/11.4"
     eol: 2021-09-30
     releaseDate: 2020-06-16
-    link: https://www.freebsd.org/releases/11.4R/announce/
 -   releaseCycle: "stable/11"
     eol: 2021-09-30
+    link: ""
+
 -   releaseCycle: "releng/10.4"
     eol: 2018-10-31
     releaseDate: 2017-10-03
-    link: https://www.freebsd.org/releases/10.4R/announce/
 -   releaseCycle: "releng/10.3"
     eol: 2018-04-30
     releaseDate: 2016-04-04
-    link: https://www.freebsd.org/releases/10.3R/announce/
 -   releaseCycle: "releng/10.2"
     eol: 2016-12-31
     releaseDate: 2015-08-13
-    link: https://www.freebsd.org/releases/10.2R/announce/
 -   releaseCycle: "releng/10.1"
     eol: 2016-12-31
     releaseDate: 2014-11-14
-    link: https://www.freebsd.org/releases/10.1R/announce/
 -   releaseCycle: "releng/10.0"
     eol: 2015-02-28
     releaseDate: 2014-01-20
-    link: https://www.freebsd.org/releases/10.0R/announce/
+-   releaseCycle: "stable/10"
+    eol: 2018-10-31
+    link: ""
+
 -   releaseCycle: "releng/9.3"
     eol: 2016-12-31
     releaseDate: 2014-07-16
-    link: https://www.freebsd.org/releases/9.3R/announce/
 -   releaseCycle: "releng/9.2"
     eol: 2014-12-31
     releaseDate: 2013-09-30
-    link: https://www.freebsd.org/releases/9.2R/announce/
 -   releaseCycle: "releng/9.1"
     eol: 2014-12-31
     releaseDate: 2012-12-30
-    link: https://www.freebsd.org/releases/9.1R/announce/
 -   releaseCycle: "releng/9.0"
     eol: 2013-03-31
     releaseDate: 2012-01-10
-    link: https://www.freebsd.org/releases/9.0R/announce/
 -   releaseCycle: "stable/9"
     eol: 2016-12-31
+    link: ""
+
 -   releaseCycle: "releng/8.4"
     eol: 2015-08-01
     releaseDate: 2013-06-09
-    link: https://www.freebsd.org/releases/8.4R/announce/
 -   releaseCycle: "releng/8.3"
     eol: 2014-04-30
     releaseDate: 2012-04-18
-    link: https://www.freebsd.org/releases/8.3R/announce/
 -   releaseCycle: "releng/8.2"
     eol: 2012-07-31
     releaseDate: 2011-02-24
-    link: https://www.freebsd.org/releases/8.2R/announce/
 -   releaseCycle: "releng/8.1"
     eol: 2012-07-31
     releaseDate: 2010-07-23
-    link: https://www.freebsd.org/releases/8.1R/announce/
 -   releaseCycle: "releng/8.0"
     eol: 2010-11-30
     releaseDate: 2009-11-25
-    link: https://www.freebsd.org/releases/8.0R/announce/
 -   releaseCycle: "stable/8"
     eol: 2015-08-01
+    link: ""
+
 -   releaseCycle: "releng/7.4"
     eol: 2013-02-28
     releaseDate: 2011-02-24
-    link: https://www.freebsd.org/releases/7.4R/announce/
 -   releaseCycle: "releng/7.3"
     eol: 2012-03-31
     releaseDate: 2010-03-23
-    link: https://www.freebsd.org/releases/7.3R/announce/
 -   releaseCycle: "releng/7.2"
     eol: 2010-06-30
     releaseDate: 2009-03-04
-    link: https://www.freebsd.org/releases/7.2R/announce/
 -   releaseCycle: "releng/7.1"
     eol: 2011-02-28
     releaseDate: 2009-01-04
-    link: https://www.freebsd.org/releases/7.1R/announce/
 -   releaseCycle: "releng/7.0"
     eol: 2009-04-30
     releaseDate: 2008-02-27
-    link: https://www.freebsd.org/releases/7.0R/announce/
 -   releaseCycle: "stable/7"
     eol: 2013-02-28
+    link: ""
+
 -   releaseCycle: "releng/6.4"
     eol: 2010-11-30
     releaseDate: 2008-11-28
-    link: https://www.freebsd.org/releases/6.4R/announce/
 -   releaseCycle: "releng/6.3"
     eol: 2010-01-31
     releaseDate: 2008-01-18
-    link: https://www.freebsd.org/releases/6.3R/announce/
 -   releaseCycle: "releng/6.2"
     eol: 2008-05-31
     releaseDate: 2007-01-15
-    link: https://www.freebsd.org/releases/6.2R/announce/
 -   releaseCycle: "releng/6.1"
     eol: 2008-05-31
     releaseDate: 2006-05-09
-    link: https://www.freebsd.org/releases/6.1R/announce/
 -   releaseCycle: "releng/6.0"
     eol: 2007-01-31
     releaseDate: 2005-11-04
-    link: https://www.freebsd.org/releases/6.0R/announce/
 -   releaseCycle: "stable/6"
     eol: 2010-11-30
+    link: ""
+
 -   releaseCycle: "releng/5.5"
     eol: 2008-05-31
     releaseDate: 2006-05-25
-    link: https://www.freebsd.org/releases/5.5R/announce/
 -   releaseCycle: "releng/5.4"
     eol: 2006-10-31
     releaseDate: 2005-05-09
-    link: https://www.freebsd.org/releases/5.4R/announce/
 -   releaseCycle: "releng/5.3"
     eol: 2006-10-31
     releaseDate: 2004-11-06
-    link: https://www.freebsd.org/releases/5.3R/announce/
 -   releaseCycle: "stable/5"
     eol: 2008-05-31
+    link: ""
+
 -   releaseCycle: "releng/4.11"
     eol: 2007-01-31
     releaseDate: 2005-01-25
-    link: https://www.freebsd.org/releases/4.11R/announce/
 -   releaseCycle: "stable/4"
     eol: 2007-01-31
+    link: ""
 
 ---
 

--- a/products/freebsd.md
+++ b/products/freebsd.md
@@ -20,7 +20,6 @@ releases:
     eol: 2026-01-31
     # prevent the link to be generated using the changelogTemplate
     link: ""
-
 -   releaseCycle: "releng/12.4"
     releaseDate: 2022-12-05
     eol: 2023-12-31
@@ -40,14 +39,12 @@ releases:
     eol: 2023-12-31
     # prevent the link to be generated using the changelogTemplate
     link: ""
-
 -   releaseCycle: "releng/11.4"
     eol: 2021-09-30
     releaseDate: 2020-06-16
 -   releaseCycle: "stable/11"
     eol: 2021-09-30
     link: ""
-
 -   releaseCycle: "releng/10.4"
     eol: 2018-10-31
     releaseDate: 2017-10-03
@@ -66,7 +63,6 @@ releases:
 -   releaseCycle: "stable/10"
     eol: 2018-10-31
     link: ""
-
 -   releaseCycle: "releng/9.3"
     eol: 2016-12-31
     releaseDate: 2014-07-16
@@ -82,7 +78,6 @@ releases:
 -   releaseCycle: "stable/9"
     eol: 2016-12-31
     link: ""
-
 -   releaseCycle: "releng/8.4"
     eol: 2015-08-01
     releaseDate: 2013-06-09
@@ -101,7 +96,6 @@ releases:
 -   releaseCycle: "stable/8"
     eol: 2015-08-01
     link: ""
-
 -   releaseCycle: "releng/7.4"
     eol: 2013-02-28
     releaseDate: 2011-02-24
@@ -120,7 +114,6 @@ releases:
 -   releaseCycle: "stable/7"
     eol: 2013-02-28
     link: ""
-
 -   releaseCycle: "releng/6.4"
     eol: 2010-11-30
     releaseDate: 2008-11-28
@@ -139,7 +132,6 @@ releases:
 -   releaseCycle: "stable/6"
     eol: 2010-11-30
     link: ""
-
 -   releaseCycle: "releng/5.5"
     eol: 2008-05-31
     releaseDate: 2006-05-25
@@ -152,7 +144,6 @@ releases:
 -   releaseCycle: "stable/5"
     eol: 2008-05-31
     link: ""
-
 -   releaseCycle: "releng/4.11"
     eol: 2007-01-31
     releaseDate: 2005-01-25


### PR DESCRIPTION
A `link: ""` must be defined on `stable/X` releases to prevent the `changelogTemplate` to be applied on those cycles. Those are not real release cycles so they do not have a changelog.

Also fixed releng/13.0 EOL date in a separate commit.