### PR TITLE
[New Product] Mageia

### DIFF
--- a/products/mageia.md
+++ b/products/mageia.md
@@ -1,0 +1,39 @@
+---
+title: mageia
+category: os
+permalink: /mageia
+releasePolicyLink: https://www.mageia.org/en/support/
+releaseDateColumn: true
+eolColumn: End of Life
+versionCommand: cat /usr/lib/os-release
+changelogTemplate: https://wiki.mageia.org/en/Mageia___RELEASE_CYCLE___Release_Notes
+releaseLabel: "mageia __RELEASE_CYCLE__"
+
+releases:
+-   releaseCycle: "8"
+    releaseDate: 2021-02-26
+-   releaseCycle: "7"
+    eol: 2021-06-30
+    releaseDate: 2019-07-01
+-   releaseCycle: "6"
+    eol: 2019-09-30
+    releaseDate: 2017-07-16
+-   releaseCycle: "5"
+    eol: 2017-12-31
+    releaseDate: 2015-06-19
+-   releaseCycle: "4"
+    eol: 2015-09-19
+    releaseDate: 2014-02-01
+-   releaseCycle: "3"
+    eol: 2014-11-26
+    releaseDate: 2013-05-19
+-   releaseCycle: "2"
+    eol: 2013-11-22
+    releaseDate: 2012-05-22
+-   releaseCycle: "1"
+    eol: 2012-12-01
+    releaseDate: 2011-06-01
+
+---
+
+> [mageia](https://www.mageia.org/en/) is a GNU/Linux-based, Free Software operating system. It is a community project, supported by a nonprofit organisation of elected contributors.

--- a/products/mageia.md
+++ b/products/mageia.md
@@ -1,12 +1,12 @@
 ---
-title: mageia
+title: Mageia
 category: os
 iconSlug: NA
 permalink: /mageia
 releasePolicyLink: https://www.mageia.org/support/
 releaseDateColumn: true
 releaseColumn: false
-eolColumn: End of Life
+eolColumn: Supported
 versionCommand: cat /usr/lib/os-release
 changelogTemplate: https://wiki.mageia.org/en/Mageia___RELEASE_CYCLE___Release_Notes
 releaseLabel: "mageia __RELEASE_CYCLE__"

--- a/products/mageia.md
+++ b/products/mageia.md
@@ -1,9 +1,11 @@
 ---
 title: mageia
 category: os
+iconSlug: NA
 permalink: /mageia
-releasePolicyLink: https://www.mageia.org/en/support/
+releasePolicyLink: https://www.mageia.org/support/
 releaseDateColumn: true
+releaseColumn: false
 eolColumn: End of Life
 versionCommand: cat /usr/lib/os-release
 changelogTemplate: https://wiki.mageia.org/en/Mageia___RELEASE_CYCLE___Release_Notes
@@ -36,4 +38,6 @@ releases:
 
 ---
 
-> [mageia](https://www.mageia.org/en/) is a GNU/Linux-based, Free Software operating system. It is a community project, supported by a nonprofit organisation of elected contributors.
+> [Mageia](https://www.mageia.org/) is a GNU/Linux-based, Free Software operating system. It is a community project, supported by a nonprofit organisation of elected contributors.
+
+Mageia releases are supported at least for 18 months. Or a minimum of 3 months after the next release, whichever is longer.


### PR DESCRIPTION
EOL data from https://www.mageia.org/en/support/

mageia 8 is not EoLed yet because mageia 9 is not available. mageia 8 EoL will be mageia 9 release + 3 months

Publish dates:

* https://blog.mageia.org/en/2021/02/26/made-it-to-a-byte-announcing-the-release-of-mageia-8/
* https://blog.mageia.org/en/2019/07/01/magical-lucky-release-number-7-has-arrived/
* https://blog.mageia.org/en/2017/07/16/announcing-mageia-6/
* https://blog.mageia.org/en/2015/06/19/solid-and-strong-and-humming-along-heres-mageia-5/
* https://blog.mageia.org/en/2014/02/01/new-year-new-resolutions-and-a-new-mageia-heres-mageia-4/
* https://blog.mageia.org/en/2013/05/19/all-grown-up-and-ready-to-go-dancing-mageia-3s-out/
* https://blog.mageia.org/en/2012/05/22/mageia-2/
* https://blog.mageia.org/en/2011/06/01/mageia-1/