### PR TITLE
Adds new Quarkus and Linux releases

### DIFF
--- a/products/linuxkernel.md
+++ b/products/linuxkernel.md
@@ -18,6 +18,12 @@ auto:
     regex: ^v(?<major>0|[1-9]\d*)\.(?<minor>0|[1-9]\d*)(\.(?<patch>0|[1-9]\d*))?$
 
 releases:
+-   releaseCycle: "6.1"
+    eol: false
+    latest: "6.1"
+    latestReleaseDate: 2022-12-11
+    releaseDate: 2022-12-11
+
 -   releaseCycle: "6.0"
     eol: false
     latest: "6.0.13"

--- a/products/pan-cortex-xdr.md
+++ b/products/pan-cortex-xdr.md
@@ -1,15 +1,25 @@
 ---
 title: Palo Alto Networks Cortex XDR agent
 category: app
-permalink: /cortexxdr
+permalink: /cortex-xdr
 releasePolicyLink: https://www.paloaltonetworks.com/services/support/end-of-life-announcements/end-of-life-summary
 changelogTemplate: https://docs.paloaltonetworks.com/cortex/cortex-xdr/{{"__RELEASE_CYCLE__" | remove:'-' | replace:'.','-'}}/cortex-xdr-agent-release-notes/cortex-xdr-agent-release-information
 iconSlug: NA
 activeSupportColumn: false
 releaseColumn: false
 releaseDateColumn: true
-eolColumn: End-of-life Date
+eolColumn: Support Status
+alternate_urls:
+-   /pan-xdr
+-   /cortexxdr
+-   /xdr
+-   /pan-cortex-xdr
 releases:
+-   releaseCycle: "7.9"
+    eol: 2023-09-11
+    releaseDate: 2022-12-04
+    latestReleaseDate: 2022-12-04
+    latest: '7.9'
 -   releaseCycle: "7.8"
     eol: 2023-04-24
     releaseDate: 2022-07-24

--- a/products/quarkus.md
+++ b/products/quarkus.md
@@ -11,9 +11,16 @@ auto:
 # See https://rubular.com/r/NyoXd9iCLFcl25 for reference
     regex: '^v?(?<major>[1-9]\d*)\.(?<minor>0|[1-9]\d*)\.(?<patch>0|[1-9]\d*)(\.Final)?$'
 releases:
--   releaseCycle: "2.14"
+-   releaseCycle: "2.15"
     eol: false
     support: true
+    latest: "2.14.3"
+    latestReleaseDate: 2022-12-14
+    releaseDate: 2022-12-14
+
+-   releaseCycle: "2.14"
+    eol: 2022-12-14
+    support: 2022-12-14
     latest: "2.14.3"
     latestReleaseDate: 2022-12-06
     releaseDate: 2022-11-02
@@ -130,10 +137,10 @@ releases:
     latestReleaseDate: 2019-11-04
     releaseDate: 2018-12-12
 
-activeSupportColumn: true
-releaseColumn: true
 releaseDateColumn: true
-eolColumn: Security Support
+activeSupportColumn: false
+eolColumn: Support
+releaseColumn: true
 iconSlug: quarkus
 
 ---


### PR DESCRIPTION
Had to run this manually, since Dependabot won't run today because  #2050 already updated the dependency.

Logs for missing releases:

```
[WARN] gke:1.25.3-gke.800 (2022-12-14) not included
[WARN] gke:1.25.4-gke.2100 (2022-12-14) not included
[WARN] linuxkernel:6.1 (2022-12-11) not included
[WARN] quarkus:2.15.0 (2022-12-07) not included
```

The GKE ones are expected (1.25 is only present in the Rapid release). Updated the remaining two