### PR TITLE
Display the last modified date of products pages

### DIFF
--- a/_layouts/product.html
+++ b/_layouts/product.html
@@ -220,4 +220,7 @@ title="Click the Pencil, the link takes you directly to the correct page">on Git
 
 <p>A JSON version of this page is available at <a href="/api{{page.permalink}}.json">/api{{page.permalink}}.json</a>. See the <a href="/docs/api/">API Documentation</a> for more.</p>
 
-{%if page.auto %}Latest releases on this page are automatically updated{% endif %}
+<p>
+This page was last updated on {{ page.last_modified_at | date_to_long_string }}.
+{%if page.auto %}Latest releases are automatically updated.{% endif %}
+</p>


### PR DESCRIPTION
This information is very useful because it offers users a way to evaluate if information on a product page is up-to-date.

Unfortunately adding the same information in the API is not as easy:

- no product-level info is available from the API at the moment (=> requires a change in API responses),
- the latest commit date is not available immediatly in Jekyll plugins (=> requires integrating a library such as https://github.com/ruby-git/ruby-git).