### PR TITLE
[design] Move product description to the top

### DIFF
--- a/_layouts/product.html
+++ b/_layouts/product.html
@@ -2,6 +2,14 @@
 layout: default
 ---
 
+{% if page.iconSlug and page.iconSlug != "NA" %}
+<img alt="{{page.title}} Logo" class=productlogo width=50 height=50 src="https://simpleicons.org/icons/{{page.iconSlug}}.svg" >
+{% elsif page.iconSlug != "NA" %}
+<img alt="{{page.title}} Logo" class=productlogo width=50 height=50 src="https://simpleicons.org/icons{{page.permalink}}.svg" >
+{% endif %}
+
+<div class="description">{{content | extract_element:'blockquote' | first }}</div>
+
 {% if page.releaseImage %}
 <img alt="Release Schedule Image Gantt Chart for {{page.title}}" src="{{page.releaseImage}}" />
 {% endif %}
@@ -195,13 +203,9 @@ or +1 (EoL is in the future)
 {% endfor %}
 </table>
 
-{% if page.iconSlug and page.iconSlug != "NA" %}
-<img alt="{{page.title}} Logo" class=productlogo width=50 height=50 src="https://simpleicons.org/icons/{{page.iconSlug}}.svg" >
-{% elsif page.iconSlug != "NA" %}
-<img alt="{{page.title}} Logo" class=productlogo width=50 height=50 src="https://simpleicons.org/icons{{page.permalink}}.svg" >
-{% endif %}
-
-<div class="maincontent">{{content}}</div>
+<div class="policytext">
+  {{content | remove_first_element:'blockquote'}}
+</div>
 {% if page.releasePolicyLink and page.releasePolicyLink != "" %}
 <p>More information is available on the <a href="{{page.releasePolicyLink}}">{{page.title}} website</a>. </p>
 {% endif %}

--- a/_plugins/jekyll-element-filters.rb
+++ b/_plugins/jekyll-element-filters.rb
@@ -1,0 +1,28 @@
+require 'nokogiri'
+
+module LiquidFilter
+  def extract_element(html, element)
+    entries = []
+    @doc = Nokogiri::HTML::DocumentFragment.parse(html)
+
+    @doc.css(element).each do |node|
+      entries << node.to_html
+    end
+    entries
+  end
+
+  # Removes the first element of the
+  # kind from the HTML
+  def remove_first_element(html, element)
+    doc = Nokogiri::HTML::DocumentFragment.parse(html)
+    e = doc.css(element)
+    e.first.remove if e && e.first
+    doc.to_html
+  end
+end
+
+Liquid::Template.register_filter(LiquidFilter)
+
+
+
+

--- a/_sass/custom/custom.scss
+++ b/_sass/custom/custom.scss
@@ -11,7 +11,7 @@ a {
   color: #6c4dec;
 }
 
-.maincontent {
+.description {
   >blockquote {
     margin-left: 60px;
   }


### PR DESCRIPTION
So the layout becomes:

- Description
- Table
- Policy

Fixes #2065

I tested this with additional quotes in the policy section as well, and it worked fine. We'll face issues with products missing a description, but that shouldn't be happening.