### PR TITLE
[style] Adds more margin for description

### DIFF
--- a/_sass/custom/custom.scss
+++ b/_sass/custom/custom.scss
@@ -20,6 +20,8 @@ a {
       clear: both;
     }
   }
+  // Icons are 50x50, so this adds another 10 pixels
+  min-height: 60px;
 }
 .productlogo {
   float: left;


### PR DESCRIPTION
Fixes issue with wordpress (and other pages) that didn't have enough content in the description.

See #2069 for screenshots.