### PR TITLE
[kotlin] Mark older versions as EOL

### DIFF
--- a/products/kotlin.md
+++ b/products/kotlin.md
@@ -6,7 +6,7 @@ permalink: /kotlin
 alternate_urls:
 -   /kotlinlang
 versionCommand: kotlinc-native -version
-releasePolicyLink: https://kotlinlang.org/docs/releases.html
+releasePolicyLink: https://kotlinlang.org/docs/security.html
 changelogTemplate: "https://github.com/JetBrains/kotlin/releases/tag/v__LATEST__"
 purls:
 -   repology: kotlin
@@ -21,33 +21,28 @@ releaseColumn: true
 
 releases:
 -   releaseCycle: "1.7"
-    eol: false #not sure about eol dates of kotlin if you find any information about this please change this part
-    support: false
+    eol: false
     latest: "1.7.22"
     link: https://kotlinlang.org/docs/whatsnew1720.html
     latestReleaseDate: 2022-11-25
     releaseDate: 2022-06-07
 -   releaseCycle: "1.6"
-    eol: false #not sure about eol dates of kotlin if you find any information about this please change this part
-    support: false
+    eol: 2022-06-07
     latest: "1.6.21"
     latestReleaseDate: 2022-04-18
     releaseDate: 2021-11-11
 -   releaseCycle: "1.5"
-    eol: false #not sure about eol dates of kotlin if you find any information about this please change this part
-    support: false
+    eol:2021-11-26
     latest: "1.5.32"
     latestReleaseDate: 2021-11-26
     releaseDate: 2021-04-26
 -   releaseCycle: "1.4"
-    eol: false #not sure about eol dates of kotlin if you find any information about this please change this part
-    support: false
+    eol: 2021-11-26
     latest: "1.4.32"
     latestReleaseDate: 2021-03-25
     releaseDate: 2020-08-13
 -   releaseCycle: "1.3"
-    eol: false #not sure about eol dates of kotlin if you find any information about this please change this part
-    support: false
+    eol: 2020-04-14
     latest: "1.3.72"
     latestReleaseDate: 2020-04-14
     releaseDate: 2018-10-25
@@ -58,4 +53,5 @@ releases:
 > Kotlin is designed to interoperate fully with Java, and the JVM version of Kotlin's standard library depends on the Java Class Library,
 > but type inference allows its syntax to be more concise. Kotlin mainly targets the JVM, but also compiles to JavaScript
 > (e.g., for frontend web applications using React) or native code (via LLVM); e.g., for native iOS apps sharing business logic with Android apps.
-> Language development costs are borne by JetBrains, while the Kotlin Foundation protects the Kotlin trademark.
+  
+Only the latest version sees active development and gets security fixes.

--- a/products/kotlin.md
+++ b/products/kotlin.md
@@ -32,7 +32,7 @@ releases:
     latestReleaseDate: 2022-04-18
     releaseDate: 2021-11-11
 -   releaseCycle: "1.5"
-    eol:2021-11-26
+    eol: 2021-11-26
     latest: "1.5.32"
     latestReleaseDate: 2021-11-26
     releaseDate: 2021-04-26

--- a/products/kotlin.md
+++ b/products/kotlin.md
@@ -54,7 +54,7 @@ releases:
 > but type inference allows its syntax to be more concise. Kotlin mainly targets the JVM, but also compiles to JavaScript
 > (e.g., for frontend web applications using React) or native code (via LLVM); e.g., for native iOS apps sharing business logic with Android apps.
   
-Only the latest version sees active development and gets security fixes.
+Kotlin support policy [is not clearly defined](https://discuss.kotlinlang.org/t/kotlin-support-roadmap/11454). But usually only the latest version sees active development and [gets bug and security fixes](https://kotlinlang.org/docs/kotlin-evolution.html#dealing-with-compiler-bugs).
 
 ## [API Compatibility](https://kotlinlang.org/docs/whatsnew16.html#supporting-previous-api-versions-for-a-longer-period)
 

--- a/products/kotlin.md
+++ b/products/kotlin.md
@@ -55,3 +55,7 @@ releases:
 > (e.g., for frontend web applications using React) or native code (via LLVM); e.g., for native iOS apps sharing business logic with Android apps.
   
 Only the latest version sees active development and gets security fixes.
+
+## [API Compatibility](https://kotlinlang.org/docs/whatsnew16.html#supporting-previous-api-versions-for-a-longer-period)
+
+Development is supported for three previous API versions, along with the current stable one.


### PR DESCRIPTION
Based on the guidance published here: https://kotlinlang.org/docs/security.html

>Always use the latest Kotlin release. 

Assuming this means the latest release cycle + patch release.

Updated EOL dates accordingly based, on some guesses. Picked the later of the last release date of the older cycle and the release date of the new cycle.