### PR TITLE
Rename liquify.rb and jekyll-element-filters.rb modules

### DIFF
--- a/_plugins/jekyll-element-filters.rb
+++ b/_plugins/jekyll-element-filters.rb
@@ -1,6 +1,6 @@
 require 'nokogiri'
 
-module LiquidFilter
+module ElementFilter
   def extract_element(html, element)
     entries = []
     @doc = Nokogiri::HTML::DocumentFragment.parse(html)
@@ -21,7 +21,7 @@ module LiquidFilter
   end
 end
 
-Liquid::Template.register_filter(LiquidFilter)
+Liquid::Template.register_filter(ElementFilter)
 
 
 

--- a/_plugins/liquify.rb
+++ b/_plugins/liquify.rb
@@ -1,6 +1,6 @@
 # https://fettblog.eu/snippets/jekyll/liquid-in-frontmatter/
 # This lets use use Liquid templating in front matter
-module LiquidFilter
+module LiquifyFilter
   def liquify(input)
     Liquid::Template.parse(input).render(@context)
   end
@@ -20,4 +20,4 @@ module LiquidFilter
     URI::parse(uri_str).send(part.to_s)
   end
 end
-Liquid::Template.register_filter(LiquidFilter)
+Liquid::Template.register_filter(LiquifyFilter)


### PR DESCRIPTION
If two module with the same name are declared they conflict (without warning during site build). Renaming modules fixes the issue.