### PR TITLE
[ci] Faster Iterations for our Automation

### DIFF
--- a/_auto/deploy.sh
+++ b/_auto/deploy.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+### Update latest information
+# See https://github.com/endoflife-date/endoflife.date/pull/2081
+git submodule update --remote
+pip install -r requirements.txt
+# If the latest.py script fails,
+# We don't want to raise any errors
+# just undo the changes, and carry on
+if ! python _auto/latest.py ; then
+  git checkout -- products/
+fi
+
+# Finally, do a build
+bundle exec jekyll build

--- a/_auto/deploy.sh
+++ b/_auto/deploy.sh
@@ -7,7 +7,7 @@ pip install -r requirements.txt
 # If the latest.py script fails,
 # We don't want to raise any errors
 # just undo the changes, and carry on
-if ! python _auto/latest.py ; then
+if ! python3 _auto/latest.py ; then
   git checkout -- products/
 fi
 

--- a/_config.yml
+++ b/_config.yml
@@ -1,5 +1,4 @@
 title: endoflife.date
-baseurl: /
 url: https://endoflife.date
 markdown: kramdown
 plugins:

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,19 +1,14 @@
 [build]
   command = """
-  git submodule update --remote
-  pip install -r requirements.txt
-  python _auto/latest.py
-  bundle exec jekyll build
+  ./_auto/deploy.sh
   """
   publish = "_site/"
 
 [context.deploy-preview]
   command = """
-  printf "url: %s" "$DEPLOY_PRIME_URL" > _config_netlify.yml
-  git submodule update --remote
-  pip install -r requirements.txt
-  python _auto/latest.py
-  bundle exec jekyll build --config _config.yml,_config_netlify.yml
+  # Replace the Deploy URL with the Preview URL
+  sed -i "/url\:/curl\: $DEPLOY_PRIME_URL" _config.yml
+  ./_auto/deploy.sh
   """
 
 [[plugins]]

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,5 +1,8 @@
 [build]
   command = """
+  git submodule update --remote
+  pip install -r requirements.txt
+  python _auto/latest.py
   bundle exec jekyll build
   """
   publish = "_site/"
@@ -7,6 +10,9 @@
 [context.deploy-preview]
   command = """
   printf "url: %s" "$DEPLOY_PRIME_URL" > _config_netlify.yml
+  git submodule update --remote
+  pip install -r requirements.txt
+  python _auto/latest.py
   bundle exec jekyll build --config _config.yml,_config_netlify.yml
   """
 


### PR DESCRIPTION
I like our current split-repo automation setup. Specifically:

1. I like that updated data is commited back to the product files
2. We have a PR created and merged automatically, so changes are easily reviewed.
3. The automation runs once every 4 hours, but we only get a single PR a day - easier to track changes. Having upto 6 PRs per day might get too much, so this feels like a nice cadence.
4. We rely on GitHub Dependabot, which means less code at our end to update dependencies.

The downsides however:

1. Dependabot only runs once a weekday (so no PRs on Saturday/Sunday)

As a result, we'll often get scenarios where the latest versions are updated in the release-data repository, but it might take 2-3 days for it to reflect on the website. This isn't ideal, and often contributors will submit a patch to fix, because the automation hasn't caught up.

A quick fix would have been to switch away from Dependabot, and do the following on every automation run:

1. Run latest.py
2. Commit back the updated data to the website
3. Which triggers a new deploy.

I don't like this approach, since this clutters our main repo with needless commits, and skips the review process entirely.

## Proposal

1. Always run the `latest.py` script against the latest version of `release-data` **on every deploy**. (This PR). All deploys (previews or main) will always use the latest release-data. In case some products are patched, the last updated date will also get updated alongside on the website.
5. Trigger a website deploy on every commit to `main` on the release-data repository (https://github.com/endoflife-date/release-data/pull/45). Any new versions that are caught by our automation (once every 4 hours) will get released immediately on the main website.

All together:

1. The website will be updated at a quicker pace (once every 4 hours, but depends on when new versions are released)
2. In case there are any corrections needed, the data on the website will be inaccurate till it is caught on the next Dependabot PR (Could be 1-2 days).
3. We're trading-off on correctness and reviews, to get faster iterations.

As a side-effect, it gets easier to test new automation changes:

1. Make the changes in the `release-data` repo, get them merged.
2. The website automatically gets update with the new data
3. If any changes are needed in the YAML, file a PR here, and it will automatically pick up the new release-data commit, no need to update the submodule.