### PR TITLE
Drop redundant product names in release labels

### DIFF
--- a/products/android.md
+++ b/products/android.md
@@ -7,22 +7,22 @@ alternate_urls:
 -   /aosp
 -   /androidos
 releasePolicyLink: https://developer.android.com/about/versions
+changelogTemplate: https://developer.android.com/about/versions/__RELEASE_CYCLE__
 activeSupportColumn: false
 releaseColumn: false
 releaseDateColumn: true
 eolColumn: Security Support
-releaseLabel: "Android __RELEASE_CYCLE__ '__CODENAME__'"
-changelogTemplate: https://developer.android.com/about/versions/__RELEASE_CYCLE__
+releaseLabel: "__RELEASE_CYCLE__ '__CODENAME__'"
+
 releases:
 -   releaseCycle: "13"
     codename: Tiramisu
-    releaseLabel: Android 13 'Tiramisu'
     eol: false
     releaseDate: 2022-08-15
 
 -   releaseCycle: "12.1"
     codename: Snow Cone v2
-    releaseLabel: Android 12.1 'Snow Cone v2' (aka 12L)
+    releaseLabel: 12.1 'Snow Cone v2' (aka 12L)
     eol: false
     releaseDate: 2022-03-07
     link: https://developer.android.com/about/versions/12/12L
@@ -123,7 +123,7 @@ releases:
     releaseDate: 2009-02-09
 
 -   releaseCycle: "1.0"
-    releaseLabel: "Android __RELEASE_CYCLE__"
+    releaseLabel: "__RELEASE_CYCLE__"
     eol: true
     releaseDate: 2008-09-23
 

--- a/products/cakephp.md
+++ b/products/cakephp.md
@@ -1,14 +1,14 @@
 ---
 title: CakePHP
+category: framework
+iconSlug: cakephp
 permalink: /cakephp
 alternate_urls:
 -   /cake-php
 -   /cake
-category: framework
-iconSlug: cakephp
 releasePolicyLink: https://book.cakephp.org/4/en/release-policy.html
 changelogTemplate: https://github.com/cakephp/cakephp/releases/__LATEST__
-releaseLabel: "CakePHP __RELEASE_CYCLE__ __CODENAME__"
+releaseLabel: "__RELEASE_CYCLE__ __CODENAME__"
 releaseColumn: true
 releaseDateColumn: true
 activeSupportColumn: true
@@ -233,16 +233,16 @@ releases:
 > [CakePHP](https://cakephp.org/) is a free & open source PHP web development framework.  It follows the model–view–controller (MVC) approach and is written in PHP, modeled after the concepts of Ruby on Rails, and distributed under the [MIT License](https://en.wikipedia.org/wiki/MIT_License).
 
 Have a look at the [Bakery](https://bakery.cakephp.org/) for fresh [releases](https://bakery.cakephp.org/categories/release.html).
-  
+
 ## PHP Support
 
 Version    | Min PHP | Max PHP
 -----------|---------|--------
 4.4        | 7.4     | Latest
-4.0 - 4.3  | 7.2     | 
+4.0 - 4.3  | 7.2     |
 3.4 - 3.10 | 5.6     | 7.4
 3.2 - 3.3  | 5.5     |
 3.0 - 3.1  | 5.4     |
 2          | 5.4     | 7.4
- 
+
 See [Version map](https://github.com/cakephp/cakephp/wiki#version-map)

--- a/products/coldfusion.md
+++ b/products/coldfusion.md
@@ -1,15 +1,15 @@
 ---
 title: Adobe ColdFusion
 category: server-app
-permalink: /coldfusion
-releasePolicyLink: https://helpx.adobe.com/support/programs/eol-matrix.html
 iconSlug: adobe
+permalink: /coldfusion
+versionCommand: writeoutput(server.coldfusion.productversion);
+releasePolicyLink: https://helpx.adobe.com/support/programs/eol-matrix.html
 activeSupportColumn: false
 releaseColumn: false
 releaseDateColumn: true
 eolColumn: Core Support
-versionCommand: writeoutput(server.coldfusion.productversion);
-releaseLabel: "ColdFusion __RELEASE_CYCLE__"
+
 releases:
 -   releaseCycle: "2021"
     eol: 2025-11-10

--- a/products/cos.md
+++ b/products/cos.md
@@ -13,11 +13,11 @@ releaseDateColumn: true
 activeSupportColumn: false
 eolColumn: Support Status
 versionCommand: cat /etc/os-release /etc/lsb-release
+releaseLabel: "{{'__RELEASE_CYCLE__' | split:'-' | last}}"
 
-releaseLabel: |
-  m{{"__RELEASE_CYCLE__" | split:'-' | last}}
 auto:
 -   custom: true
+
 releases:
   # Active Milestones
 -   releaseCycle: "cos-101"

--- a/products/filemaker.md
+++ b/products/filemaker.md
@@ -1,13 +1,13 @@
 ---
-title: FileMaker
+title: FileMaker Platform
 category: app
+iconSlug: NA
 permalink: /filemaker
 releasePolicyLink: https://www.filemaker.com/support/product-availability.html
-iconSlug: "NA"
 activeSupportColumn: false
 releaseColumn: false
 eolColumn: Support Status
-releaseLabel: 'FileMaker Platform __RELEASE_CYCLE__'
+
 releases:
 -   releaseCycle: "19"
     eol: false
@@ -50,6 +50,8 @@ releases:
     releaseDate: 2004-03-01
 
 ---
+
+> FileMaker Platform is a cross-platform relational database application from Claris International.
 
 FileMaker has recently adopted a yearly release cycle, in May. Previously there was an 18-month release cycle.
 

--- a/products/mageia.md
+++ b/products/mageia.md
@@ -3,13 +3,12 @@ title: Mageia
 category: os
 iconSlug: NA
 permalink: /mageia
+versionCommand: cat /usr/lib/os-release
 releasePolicyLink: https://www.mageia.org/support/
+changelogTemplate: https://wiki.mageia.org/en/Mageia___RELEASE_CYCLE___Release_Notes
 releaseDateColumn: true
 releaseColumn: false
 eolColumn: Supported
-versionCommand: cat /usr/lib/os-release
-changelogTemplate: https://wiki.mageia.org/en/Mageia___RELEASE_CYCLE___Release_Notes
-releaseLabel: "mageia __RELEASE_CYCLE__"
 
 releases:
 -   releaseCycle: "8"

--- a/products/muleruntime.md
+++ b/products/muleruntime.md
@@ -8,12 +8,12 @@ alternate_urls:
   - /mulesoft-runtimes
   - /mule-runtimes
 releasePolicyLink: https://www.mulesoft.com/legal/versioning-back-support-policy#mule-runtimes
+changelogTemplate: https://docs.mulesoft.com/release-notes/mule-runtime/mule-__LATEST__-release-notes
 activeSupportColumn: Standard Support
 releaseColumn: true
 releaseDateColumn: true
 eolColumn: Extended Support
-changelogTemplate: https://docs.mulesoft.com/release-notes/mule-runtime/mule-__LATEST__-release-notes
-releaseLabel: "Mule Runtime (__RELEASE_CYCLE__)"
+
 releases:
   - releaseCycle: "4.4"
     eol: 2025-02-07
@@ -75,4 +75,4 @@ Each release gets:
 
 **Extended Support**: Technical support on and around the software for production environments, including troubleshooting, diagnosis and resolution of issues which do not require source code patches. Patches for Critical Security Vulnerabilities.
 
-**End-of-Life**: End-of-Life versions are not available or supported on CloudHub/Anypoint Studio. 
+**End-of-Life**: End-of-Life versions are not available or supported on CloudHub/Anypoint Studio.

--- a/products/opensuse.md
+++ b/products/opensuse.md
@@ -5,15 +5,15 @@ iconSlug: opensuse
 permalink: /opensuse
 alternate_urls:
 -   /opensuseleap
+versionCommand: cat /usr/lib/os-release
 releasePolicyLink: https://en.opensuse.org/Lifetime
+releaseImage: https://upload.wikimedia.org/wikipedia/en/timeline/qaub9pjgtzf5zjbrlbjruujp47jv6r5.png
+changelogTemplate: https://doc.opensuse.org/release-notes/x86_64/openSUSE/Leap/__RELEASE_CYCLE__/
+releaseLabel: "Leap __RELEASE_CYCLE__"
 activeSupportColumn: false
 releaseColumn: false
 releaseDateColumn: true
 eolColumn: End of Life
-versionCommand: cat /usr/lib/os-release
-releaseImage: https://upload.wikimedia.org/wikipedia/en/timeline/qaub9pjgtzf5zjbrlbjruujp47jv6r5.png
-changelogTemplate: https://doc.opensuse.org/release-notes/x86_64/openSUSE/Leap/__RELEASE_CYCLE__/
-releaseLabel: "openSUSE Leap __RELEASE_CYCLE__"
 
 releases:
 -   releaseCycle: "15.4"

--- a/products/openzfs.md
+++ b/products/openzfs.md
@@ -1,35 +1,35 @@
 ---
+title: OpenZFS
+category: app
+iconSlug: openzfs
 permalink: /openzfs
 alternate_urls:
 -   /zfs
-title: OpenZFS
-category: app
 versionCommand: zpool get version [zpool name]
 releasePolicyLink: https://github.com/openzfs/zfs/blob/master/RELEASES.md
-changelogTemplate: |
-  https://github.com/openzfs/zfs/releases/tag/zfs-__LATEST__
-# Ignore the 2.1.99 release, since that's a pre-release (See talk page)  
+changelogTemplate: https://github.com/openzfs/zfs/releases/tag/zfs-__LATEST__
+releaseDateColumn: true
+eolColumn: Critical bug fixes
+
+# Ignore the 2.1.99 release, since that's a pre-release (See talk page)
 auto:
 -   git: https://github.com/openzfs/zfs.git
     regex: ^zfs-(?<major>0|[1-9]\d*)\.(?<minor>0|[1-9]\d*)\.(?<patch>0|([1-9]|[1-8]\d|9[0-8]))$
-releaseDateColumn: true
-iconSlug: openzfs
-eolColumn: Critical bug fixes
-releaseLabel: "OpenZFS __RELEASE_CYCLE__"
+
 releases:
 -   releaseCycle: "2.1"
     eol: 2023-07-02
     lts: true
     latest: "2.1.7"
-
     latestReleaseDate: 2022-12-01
     releaseDate: 2021-07-02
+
 -   releaseCycle: "2.0"
     eol: 2021-12-23
     latest: "2.0.7"
-
     latestReleaseDate: 2021-12-23
     releaseDate: 2020-11-30
+
 -   releaseCycle: "0.8"
     eol: 2020-12-14
     latest: "0.8.6"
@@ -38,15 +38,15 @@ releases:
 
 ---
 
-> [OpenZFS](https://openzfs.github.io/openzfs-docs/) is an open-source storage platform that encompasses the functionality of traditional filesystems and volume manager. It includes protection against data corruption, support for high storage capacities, efficient data compression, snapshots and copy-on-write clones, continuous integrity checking and automatic repair, encryption, remote replication with ZFS send and receive, and RAID-Z. Linux and FreeBSD are officially supported, [with plans to support macOS in the future](https://github.com/openzfs/zfs/pull/12110).  
+> [OpenZFS](https://openzfs.github.io/openzfs-docs/) is an open-source storage platform that encompasses the functionality of traditional filesystems and volume manager. It includes protection against data corruption, support for high storage capacities, efficient data compression, snapshots and copy-on-write clones, continuous integrity checking and automatic repair, encryption, remote replication with ZFS send and receive, and RAID-Z. Linux and FreeBSD are officially supported, [with plans to support macOS in the future](https://github.com/openzfs/zfs/pull/12110).
 
 ## Release branches
 
-- **OpenZFS LTS** - A designated MAJOR.MINOR release with periodic PATCH releases that incorporate important changes backported from newer OpenZFS releases. This branch is intended for use by distributions which use an LTS, enterprise, or similarly managed kernel (RHEL, Ubuntu LTS, Debian). Minor changes to support these distribution kernels will be applied as needed. New kernel versions released after the OpenZFS LTS release are not supported unless there is not a newer current release. LTS releases will receive patches for at least 2 years. 
+- **OpenZFS LTS** - A designated MAJOR.MINOR release with periodic PATCH releases that incorporate important changes backported from newer OpenZFS releases. This branch is intended for use by distributions which use an LTS, enterprise, or similarly managed kernel (RHEL, Ubuntu LTS, Debian). Minor changes to support these distribution kernels will be applied as needed. New kernel versions released after the OpenZFS LTS release are not supported unless there is not a newer current release. LTS releases will receive patches for at least 2 years.
 
 - **OpenZFS current** - Tracks the newest MAJOR.MINOR release. This branch includes support for the latest OpenZFS features and recently releases kernels. When a new MINOR release is tagged the previous MINOR release will no longer be maintained (unless it is an LTS release). New MINOR releases are planned to occur roughly annually.
 
-## Officially supported distributions: 
+## Officially supported distributions:
 
 - [Fedora](https://openzfs.github.io/openzfs-docs/Getting%20Started/Fedora/index.html)
 - [RHEL-based distributions](https://openzfs.github.io/openzfs-docs/Getting%20Started/RHEL-based%20distro/index.html)

--- a/products/redhat.md
+++ b/products/redhat.md
@@ -1,8 +1,8 @@
 ---
 title: Red Hat Enterprise Linux
-permalink: /rhel
 category: os
 iconSlug: redhat
+permalink: /rhel
 alternate_urls:
 -   /redhat
 -   /redhatlinux
@@ -12,7 +12,7 @@ releasePolicyLink: https://access.redhat.com/support/policy/updates/errata
 LTSLabel: "<abbr title='Extended Life Cycle Support'>ELS</abbr>"
 activeSupportColumn: true
 releaseDateColumn: true
-releaseLabel: "RHEL __RELEASE_CYCLE__"
+
 releases:
 -   releaseCycle: "9"
     support: 2027-05-31
@@ -60,7 +60,6 @@ releases:
     releaseDate: 2005-02-15
     latestReleaseDate: 2011-02-16
     latest: '4.9'
-
 
 ---
 

--- a/products/rockylinux.md
+++ b/products/rockylinux.md
@@ -1,20 +1,21 @@
 ---
-releaseImage: https://global.discourse-cdn.com/standard14/uploads/rockylinux/original/2X/a/aa4ff9ead76ab2a0e52518e778a69cc666add4e9.png
 title: Rocky Linux
-permalink: /rocky-linux
 category: os
-versionCommand: cat /etc/os-release
 iconSlug: rockylinux
+permalink: /rocky-linux
 alternate_urls:
 -   /rocky
 -   /rockylinux
+versionCommand: cat /etc/os-release
 releasePolicyLink: https://forums.rockylinux.org/t/what-is-eol-of-rl8/3316/2
+releaseImage: https://global.discourse-cdn.com/standard14/uploads/rockylinux/original/2X/a/aa4ff9ead76ab2a0e52518e778a69cc666add4e9.png
 activeSupportColumn: true
 releaseDateColumn: true
-releaseLabel: "Rocky Linux __RELEASE_CYCLE__"
+
 auto:
 -   distrowatch: rocky
     regex: '^Distribution Release: Rocky Linux (?P<major>\d)\.(?P<minor>\d)$'
+
 releases:
 -   releaseCycle: "9"
     support: 2025-05-31

--- a/products/sles.md
+++ b/products/sles.md
@@ -1,21 +1,19 @@
 ---
 title: SUSE Linux Enterprise Server
 category: os
+iconSlug: suse
 permalink: /sles
 alternate_urls:
 -   /suseenterpriseserver
 -   /suseserver
 -   /suselinuxenterpriseserver
-iconSlug: suse
+versionCommand: cat /etc/os-release
 releasePolicyLink: https://www.suse.com/lifecycle
+changelogTemplate: https://www.suse.com/releasenotes/x86_64/SUSE-SLES/{{"__LATEST__"| replace:'SLES ','' | replace:' ','-'}}/
 activeSupportColumn: true
 releaseColumn: true
 releaseDateColumn: true
 LTSLabel: "<abbr title='Long Term Service Pack Support'>LTSS</abbr>"
-versionCommand: cat /etc/os-release
-changelogTemplate: https://www.suse.com/releasenotes/x86_64/SUSE-SLES/{{"__LATEST__"|
-  replace:'SLES ','' | replace:' ','-'}}/
-releaseLabel: "SUSE Linux Enterprise Server __RELEASE_CYCLE__"
 
 releases:
 -   releaseCycle: "15"


### PR DESCRIPTION
Updated :

- CakePHP
- Suse Linux Enterprise Server
- FileMaker
- FileMaker
- Red Hat Enterprise Linux
- Adobe ColdFusion
- OpenZFS
- Rocky Linux
- Mageia
- MuleSoft Runtime
- openSUSE
- Android
- COS