### PR TITLE
Make `iconSlug` explicit for all products

### DIFF
--- a/_auto/validate.py
+++ b/_auto/validate.py
@@ -3,7 +3,6 @@ import frontmatter
 from datetime import date
 from glob import glob
 from pathlib import Path
-from collections import OrderedDict
 from ruamel.yaml import YAML
 from ruamel.yaml import comments
 
@@ -42,6 +41,7 @@ def validate_product(name):
             assert isinstance(data["auto"], comments.CommentedSeq)
         assert data["category"] in VALID_CATEGORIES
         assert data["permalink"][0] == "/"
+        assert isinstance(data["iconSlug"], str)
         if "alternate_urls" in data:
             for url in data["alternate_urls"]:
                 assert url[0] == "/"

--- a/_layouts/product.html
+++ b/_layouts/product.html
@@ -2,10 +2,8 @@
 layout: default
 ---
 
-{% if page.iconSlug and page.iconSlug != "NA" %}
+{% if page.iconSlug != "NA" %}
 <img alt="{{page.title}} Logo" class=productlogo width=50 height=50 src="https://simpleicons.org/icons/{{page.iconSlug}}.svg" >
-{% elsif page.iconSlug != "NA" %}
-<img alt="{{page.title}} Logo" class=productlogo width=50 height=50 src="https://simpleicons.org/icons{{page.permalink}}.svg" >
 {% endif %}
 
 <div class="description">{{content | extract_element:'blockquote' | first }}</div>

--- a/products/android.md
+++ b/products/android.md
@@ -1,11 +1,12 @@
 ---
 title: Android OS
+category: os
+iconSlug: android
+permalink: /android
 alternate_urls:
 -   /aosp
 -   /androidos
-permalink: /android
 releasePolicyLink: https://developer.android.com/about/versions
-category: os
 activeSupportColumn: false
 releaseColumn: false
 releaseDateColumn: true

--- a/products/angular.md
+++ b/products/angular.md
@@ -1,11 +1,12 @@
 ---
-permalink: /angular
 title: Angular
+category: framework
+iconSlug: angular
+permalink: /angular
 versionCommand: ng version
 releasePolicyLink: https://angular.io/guide/releases
 activeSupportColumn: true
 releaseDateColumn: true
-category: framework
 changelogTemplate: https://github.com/angular/angular/releases/tag/__LATEST__
 purls:
 -   purl: pkg:npm/@angular/core

--- a/products/bootstrap.md
+++ b/products/bootstrap.md
@@ -1,7 +1,8 @@
 ---
 title: Bootstrap
-permalink: /bootstrap
 category: framework
+iconSlug: bootstrap
+permalink: /bootstrap
 activeSupportColumn: true
 changelogTemplate: https://github.com/twbs/bootstrap/releases/tag/v__LATEST__
 auto:

--- a/products/centos.md
+++ b/products/centos.md
@@ -1,7 +1,8 @@
 ---
-permalink: /centos
 title: CentOS
 category: os
+iconSlug: centos
+permalink: /centos
 versionCommand: lsb_release --release
 releasePolicyLink: https://wiki.centos.org/About/Product
 activeSupportColumn: true

--- a/products/debian.md
+++ b/products/debian.md
@@ -1,8 +1,9 @@
 ---
-permalink: /debian
 title: Debian
-versionCommand: cat /etc/os-release
 category: os
+iconSlug: debian
+permalink: /debian
+versionCommand: cat /etc/os-release
 releasePolicyLink: https://wiki.debian.org/DebianReleases
 activeSupportColumn: false
 releaseColumn: true

--- a/products/django.md
+++ b/products/django.md
@@ -1,7 +1,8 @@
 ---
 title: Django
-permalink: /django
 category: framework
+iconSlug: django
+permalink: /django
 releasePolicyLink: https://www.djangoproject.com/download/#supported-versions
 releaseImage: https://static.djangoproject.com/img/release-roadmap.3c7ece4f31b3.png
 changelogTemplate: https://docs.djangoproject.com/en/__RELEASE_CYCLE__/releases/__LATEST__/

--- a/products/dotnet.md
+++ b/products/dotnet.md
@@ -1,11 +1,12 @@
 ---
-permalink: /dotnet
+title: Microsoft .NET
 category: framework
+iconSlug: dotnet
+permalink: /dotnet
 alternate_urls:
 -   /.net
 -   /.netcore
 -   /dotnetcore
-title: Microsoft .NET
 versionCommand: dotnet --version
 releasePolicyLink: https://dotnet.microsoft.com/platform/support/policy/dotnet-core
 changelogTemplate: https://github.com/dotnet/core/blob/main/release-notes/{{"__LATEST__"|split:'.'|slice:0,2|join:'.'}}/__LATEST__/__LATEST__.md

--- a/products/drupal.md
+++ b/products/drupal.md
@@ -1,8 +1,9 @@
 ---
 title: Drupal
+category: server-app
+iconSlug: drupal
 permalink: /drupal
 releasePolicyLink: https://www.drupal.org/about/core/policies/core-release-cycles/schedule
-category: server-app
 changelogTemplate: https://www.drupal.org/project/drupal/releases/__LATEST__
 activeSupportColumn: true
 releaseDateColumn: true

--- a/products/elasticsearch.md
+++ b/products/elasticsearch.md
@@ -1,7 +1,8 @@
 ---
 title: Elasticsearch
-permalink: /elasticsearch
 category: db
+iconSlug: elasticsearch
+permalink: /elasticsearch
 releasePolicyLink: https://www.elastic.co/support/eol
 # Take the latest version, and drop the patch version to get MAJOR.MINOR
 changelogTemplate: >

--- a/products/elixir.md
+++ b/products/elixir.md
@@ -1,8 +1,9 @@
 ---
-permalink: /elixir
 title: Elixir
-versionCommand: elixir --version
 category: lang
+iconSlug: elixir
+permalink: /elixir
+versionCommand: elixir --version
 releasePolicyLink: https://hexdocs.pm/elixir/compatibility-and-deprecations.html
 changelogTemplate: https://github.com/elixir-lang/elixir/blob/v__RELEASE_CYCLE__/CHANGELOG.md
 activeSupportColumn: true

--- a/products/fedora.md
+++ b/products/fedora.md
@@ -1,16 +1,19 @@
 ---
-permalink: /fedora
 title: Fedora Linux
+category: os
+iconSlug: fedora
+permalink: /fedora
 releasePolicyLink: https://fedoraproject.org/wiki/End_of_life
 activeSupportColumn: false
 releaseDateColumn: true
 versionCommand: cat /etc/fedora-release
 changelogTemplate: https://fedoraproject.org/wiki/Releases/__RELEASE_CYCLE__/ChangeSet?rd=Releases/__RELEASE_CYCLE__
+
 auto:
 -   distrowatch: fedora
     regex: '^Distribution Release: Fedora (?P<version>\d{2})$'
     template: '{{version}}'
-category: os
+
 releases:
 -   releaseCycle: "37"
     latest: "37"

--- a/products/ffmpeg.md
+++ b/products/ffmpeg.md
@@ -1,8 +1,8 @@
 ---
 title: FFmpeg
-permalink: /ffmpeg
 category: framework
-icon: FFmpeg
+iconSlug: ffmpeg
+permalink: /ffmpeg
 releasePolicyLink: https://ffmpeg.org/
 changelogTemplate: https://ffmpeg.org/download.html#release_{{"__RELEASE_CYCLE__"}}
 versionCommand: ffmpeg -version

--- a/products/freebsd.md
+++ b/products/freebsd.md
@@ -1,7 +1,8 @@
 ---
-permalink: /freebsd
 title: FreeBSD
 category: os
+iconSlug: freebsd
+permalink: /freebsd
 releasePolicyLink: https://www.freebsd.org/security/#sup
 changelogTemplate: https://www.freebsd.org/releases/{{"__RELEASE_CYCLE__" | split:'/' | last}}R/
 activeSupportColumn: false

--- a/products/go.md
+++ b/products/go.md
@@ -1,9 +1,10 @@
 ---
 title: Go
+category: lang
+iconSlug: go
 permalink: /go
 alternate_urls:
 -   /golang
-category: lang
 releasePolicyLink: https://go.dev/doc/devel/release#policy
 changelogTemplate: https://go.dev/doc/devel/release#go__RELEASE_CYCLE__.minor
 eolColumn: Supported

--- a/products/kubernetes.md
+++ b/products/kubernetes.md
@@ -1,7 +1,8 @@
 ---
-permalink: /kubernetes
 title: Kubernetes
 category: server-app
+iconSlug: kubernetes
+permalink: /kubernetes
 versionCommand: kubectl version
 releasePolicyLink: https://kubernetes.io/releases/patch-releases/
 releaseImage: https://upload.wikimedia.org/wikipedia/en/timeline/hwofyi7fnfgyjzfs6er9ha6mvxnakw7.png

--- a/products/laravel.md
+++ b/products/laravel.md
@@ -1,7 +1,8 @@
 ---
 title: Laravel
-permalink: /laravel
 category: framework
+iconSlug: laravel
+permalink: /laravel
 releasePolicyLink: https://laravel.com/docs/9.x/releases#support-policy
 changelogTemplate: https://laravel.com/docs/__RELEASE_CYCLE__.x/releases
 activeSupportColumn: true

--- a/products/macos.md
+++ b/products/macos.md
@@ -1,14 +1,24 @@
 ---
 title: Apple macOS
+category: os
+iconSlug: macos
+permalink: /macos
 alternate_urls:
 -   /mac
-category: os
+releasePolicyLink: https://developer.apple.com/documentation/macos-release-notes
+activeSupportColumn: false
+releaseColumn: true
+releaseDateColumn: true
+eolColumn: Service Status
+versionCommand: sw_vers
 releaseLabel: "macOS __RELEASE_CYCLE__ (__CODENAME__)"
+
 # Data: https://github.com/endoflife-date/release-data/blob/main/releases/macos.json
 # Source: https://support.apple.com/en-us/HT201222 (and older versions linked at bottom)
 # Script: https://github.com/endoflife-date/release-data/blob/main/src/apple.py
 auto:
 -   custom: true
+
 releases:
 -   releaseCycle: "13"
     codename: "Ventura"
@@ -77,13 +87,6 @@ releases:
     releaseDate: 2013-10-22
     latestReleaseDate: 2014-09-17
     latest: '10.9.5'
-permalink: /macos
-releasePolicyLink: https://developer.apple.com/documentation/macos-release-notes
-activeSupportColumn: false
-releaseColumn: true
-releaseDateColumn: true
-eolColumn: Service Status
-versionCommand: sw_vers
 
 ---
 

--- a/products/magento.md
+++ b/products/magento.md
@@ -1,7 +1,8 @@
 ---
 title: Magento
-permalink: /magento
 category: server-app
+iconSlug: magento
+permalink: /magento
 releasePolicyLink: https://magento.com/tech-resources/download
 changelogTemplate: https://devdocs.magento.com/guides/v{{"__RELEASE_CYCLE__" |split:'.'|slice:0,2|join:'.'
   }}/release-notes/open-source-{{"__LATEST__" | replace:'.','-'}}.html

--- a/products/mariadb.md
+++ b/products/mariadb.md
@@ -1,7 +1,8 @@
 ---
 title: MariaDB
-permalink: /mariadb
 category: db
+iconSlug: mariadb
+permalink: /mariadb
 releasePolicyLink: https://mariadb.org/about/#maintenance-policy
 changelogTemplate: https://mariadb.com/kb/en/mariadb-{{"__LATEST__" | replace:'.','-'}}-changelog/
 activeSupportColumn: false

--- a/products/mongodb.md
+++ b/products/mongodb.md
@@ -1,7 +1,8 @@
 ---
 title: MongoDB Server
-permalink: /mongodb
 category: db
+iconSlug: mongodb
+permalink: /mongodb
 releasePolicyLink: https://www.mongodb.com/support-policy
 changelogTemplate: https://www.mongodb.com/docs/v__RELEASE_CYCLE__/release-notes/__RELEASE_CYCLE__/
 activeSupportColumn: false

--- a/products/mysql.md
+++ b/products/mysql.md
@@ -1,12 +1,14 @@
 ---
 title: MySQL
 category: db
+iconSlug: mysql
+permalink: /mysql
 changelogTemplate: https://dev.mysql.com/doc/relnotes/mysql/__RELEASE_CYCLE__/en/news-{{"__LATEST__"
   | replace:'.','-'}}.html
-# dates below are for:
-# support -> GA+5 years = Premier support
-# eol -> GA+8 years = Extended Support
-# We show Extended support dates since that match Community Edition timelines
+releasePolicyLink: https://www.oracle.com/us/support/library/lifetime-support-technology-069183.pdf
+activeSupportColumn: false
+releaseDateColumn: true
+versionCommand: mysqld --version
 
 # Regex takes into account the first GA release in each cycle (in parentheses)
 # https://docs.oracle.com/cd/E17952_01/mysql-5.5-relnotes-en/index.html (5.5.8)
@@ -17,6 +19,11 @@ auto:
 -   git: https://github.com/mysql/mysql-server.git
     regex: ^mysql-((?<c>5\.5)\.(?<v>([8-9]|\d{2}))|((?<c>5\.6)\.(?<v>\d{2}))|((?<c>5\.7)\.(?<v>([9]|\d{2})))|((?<c>8\.0)\.(?<v>(1[1-9]|[2-9]\d))))$
     template: "{{c}}.{{v}}"
+
+# dates below are for:
+# support -> GA+5 years = Premier support
+# eol -> GA+8 years = Extended Support
+# We show Extended support dates since that match Community Edition timelines
 releases:
 -   releaseCycle: "8.0"
     latest: '8.0.31'
@@ -42,11 +49,6 @@ releases:
     eol: 2018-12-31
     latestReleaseDate: 2018-12-21
     releaseDate: 2010-12-03
-permalink: /mysql
-releasePolicyLink: https://www.oracle.com/us/support/library/lifetime-support-technology-069183.pdf
-activeSupportColumn: false
-releaseDateColumn: true
-versionCommand: mysqld --version
 
 ---
 

--- a/products/netbsd.md
+++ b/products/netbsd.md
@@ -1,7 +1,8 @@
 ---
-permalink: /netbsd
 title: NetBSD
 category: os
+iconSlug: netbsd
+permalink: /netbsd
 versionCommand: uname -r
 activeSupportColumn: false
 releasePolicyLink: https://www.netbsd.org/releases/

--- a/products/nextcloud.md
+++ b/products/nextcloud.md
@@ -1,10 +1,10 @@
 ---
 title: Nextcloud
 category: server-app
+iconSlug: nextcloud
+permalink: /nextcloud
 releasePolicyLink: https://github.com/nextcloud/server/wiki/Maintenance-and-Release-Schedule
 changelogTemplate: "https://nextcloud.com/changelog/#latest__RELEASE_CYCLE__"
-permalink: /nextcloud
-icon: nextcloud
 releaseDateColumn: true
 versionCommand: su -m www -c 'php $WEBROOT/occ config:system:get version'
 

--- a/products/numpy.md
+++ b/products/numpy.md
@@ -1,7 +1,8 @@
 ---
 title: NumPy
-permalink: /numpy
 category: framework
+iconSlug: numpy
+permalink: /numpy
 releasePolicyLink: https://numpy.org/neps/nep-0029-deprecation_policy.html
 versionCommand: python -c "import numpy; print(numpy.__version__)"
 releaseDateColumn: true

--- a/products/openbsd.md
+++ b/products/openbsd.md
@@ -1,7 +1,8 @@
 ---
-permalink: /openbsd
 title: OpenBSD
 category: os
+iconSlug: openbsd
+permalink: /openbsd
 versionCommand: uname -r
 activeSupportColumn: false
 releaseDateColumn: true

--- a/products/perl.md
+++ b/products/perl.md
@@ -1,12 +1,22 @@
 ---
 title: Perl
 category: lang
+iconSlug: perl
+permalink: /perl
 changelogTemplate: "https://perldoc.perl.org/__LATEST__/perldelta"
 releaseImage: https://www.versio.io/img/product-release-version-end-of-life/Perl_Foundation-Perl.jpg
+releasePolicyLink: https://perldoc.perl.org/perlpolicy#MAINTENANCE-AND-SUPPORT
+activeSupportColumn: true
+releaseColumn: true
+releaseDateColumn: true
+eolColumn: Critical security patches
+versionCommand: perl -v
+
 auto:
   # Using the default regex loses all releases before 5.10
   # Feel free to file a PR to fix this
 -   git: https://github.com/Perl/perl5.git
+
 releases:
 # eol dates are always releaseDate + 3 YEARS
 # support: true for latest 2 releases
@@ -60,13 +70,6 @@ releases:
     latest: "5.26.3"
     latestReleaseDate: 2018-11-28
     releaseDate: 2017-05-30
-permalink: /perl
-releasePolicyLink: https://perldoc.perl.org/perlpolicy#MAINTENANCE-AND-SUPPORT
-activeSupportColumn: true
-releaseColumn: true
-releaseDateColumn: true
-eolColumn: Critical security patches
-versionCommand: perl -v
 
 ---
 

--- a/products/php.md
+++ b/products/php.md
@@ -1,7 +1,8 @@
 ---
 title: PHP
-permalink: /php
 category: lang
+iconSlug: php
+permalink: /php
 releasePolicyLink: https://www.php.net/supported-versions.php
 changelogTemplate: |
   https://www.php.net/ChangeLog-{{ "__LATEST__" | split: "." | first }}.php#__LATEST__

--- a/products/postgresql.md
+++ b/products/postgresql.md
@@ -1,11 +1,12 @@
 ---
 title: PostgreSQL
+category: db
+iconSlug: postgresql
 permalink: /postgresql
 alternate_urls:
 -   /postgres
 -   /pg
 releasePolicyLink: https://www.postgresql.org/support/versioning/
-category: db
 changelogTemplate: https://www.postgresql.org/docs/release/__LATEST__/
 activeSupportColumn: false
 eolColumn: Support Status

--- a/products/powershell.md
+++ b/products/powershell.md
@@ -1,7 +1,8 @@
 ---
-permalink: /powershell
 category: app
 title: Microsoft PowerShell
+iconSlug: powershell
+permalink: /powershell
 versionCommand: pwsh -v
 releasePolicyLink: https://learn.microsoft.com/lifecycle/products/powershell
 changelogTemplate: https://github.com/PowerShell/PowerShell/blob/master/CHANGELOG/__RELEASE_CYCLE__.md#{{"__LATEST__"

--- a/products/python.md
+++ b/products/python.md
@@ -1,7 +1,8 @@
 ---
-permalink: /python
 title: Python
 category: lang
+iconSlug: python
+permalink: /python
 versionCommand: python --version
 releasePolicyLink: https://devguide.python.org/versions/
 changelogTemplate: |

--- a/products/qt.md
+++ b/products/qt.md
@@ -1,8 +1,9 @@
 ---
-releaseImage: https://www.qt.io/hs-fs/hubfs/subscription%20timeline.png
-permalink: /qt
-category: framework
 title: Qt
+category: framework
+iconSlug: qt
+permalink: /qt
+releaseImage: https://www.qt.io/hs-fs/hubfs/subscription%20timeline.png
 versionCommand: qmake --version
 releasePolicyLink: https://cdn2.hubspot.net/hubfs/149513/_Website_Blog/Qt%20offering%20change%20FAQ-2020-01-27.pdf
 changelogTemplate: "https://www.qt.io/blog/qt-{{'__LATEST__' | drop_zero_patch}}-released"

--- a/products/rabbitmq.md
+++ b/products/rabbitmq.md
@@ -1,7 +1,8 @@
 ---
 title: RabbitMQ
-permalink: /rabbitmq
 category: server-app
+iconSlug: rabbitmq
+permalink: /rabbitmq
 releasePolicyLink: https://www.rabbitmq.com/versions.html
 changelogTemplate: https://github.com/rabbitmq/rabbitmq-server/releases/tag/v__LATEST__
 activeSupportColumn: General Support

--- a/products/redis.md
+++ b/products/redis.md
@@ -1,7 +1,8 @@
 ---
-permalink: /redis
 title: Redis
 category: db
+iconSlug: redis
+permalink: /redis
 releasePolicyLink: https://redis.io/docs/about/releases/
 changelogTemplate: https://raw.githubusercontent.com/antirez/redis/__RELEASE_CYCLE__/00-RELEASENOTES
 activeSupportColumn: false

--- a/products/ros.md
+++ b/products/ros.md
@@ -1,7 +1,8 @@
 ---
 title: ROS
-permalink: /ros
 category: os
+iconSlug: ros
+permalink: /ros
 releasePolicyLink: https://wiki.ros.org/Distributions
 activeSupportColumn: false
 releaseColumn: true

--- a/products/ruby.md
+++ b/products/ruby.md
@@ -1,6 +1,8 @@
 ---
-permalink: /ruby
 title: Ruby
+category: lang
+iconSlug: ruby
+permalink: /ruby
 versionCommand: ruby --version
 releasePolicyLink: https://www.ruby-lang.org/en/downloads/releases/
 changelogTemplate: |
@@ -15,7 +17,6 @@ auto:
 purls:
 -   repology: ruby
 -   purl: pkg:docker/library/ruby
-category: lang
 releaseDateColumn: true
 eolColumn: Support Status
 releases:

--- a/products/symfony.md
+++ b/products/symfony.md
@@ -1,5 +1,7 @@
 ---
 title: Symfony
+category: framework
+iconSlug: symfony
 permalink: /symfony
 releasePolicyLink: https://symfony.com/releases
 activeSupportColumn: true
@@ -9,7 +11,6 @@ changelogTemplate: |
 releaseDateColumn: true
 auto:
 -   git: https://github.com/symfony/symfony.git
-category: framework
 releases:
 -   releaseCycle: "6.2"
     releaseDate: 2022-11-30

--- a/products/ubuntu.md
+++ b/products/ubuntu.md
@@ -1,8 +1,9 @@
 ---
-permalink: /ubuntu
 title: Ubuntu
-versionCommand: lsb_release --release
 category: os
+iconSlug: ubuntu
+permalink: /ubuntu
+versionCommand: lsb_release --release
 releasePolicyLink: https://wiki.ubuntu.com/Releases
 changelogTemplate: |
   https://wiki.ubuntu.com/{{"__CODENAME__"|replace:' ',''}}/ReleaseNotes/ChangeSummary/__LATEST__/

--- a/products/wagtail.md
+++ b/products/wagtail.md
@@ -1,7 +1,8 @@
 ---
 title: Wagtail
-permalink: /wagtail
 category: framework
+iconSlug: wagtail
+permalink: /wagtail
 releasePolicyLink: https://github.com/wagtail/wagtail/wiki/Release-schedule
 changelogTemplate: https://docs.wagtail.org/en/stable/releases/__LATEST__.html
 activeSupportColumn: true

--- a/products/windows.md
+++ b/products/windows.md
@@ -1,8 +1,9 @@
 ---
 title: Microsoft Windows
+category: os
+iconSlug: windows
 permalink: /windows
 releasePolicyLink: https://learn.microsoft.com/lifecycle/products/?terms=Windows
-category: os
 activeSupportColumn: true
 releaseColumn: false
 releaseDateColumn: true


### PR DESCRIPTION
Being explicit is simpler (especially on API side, see #759) and causes less confusion.