### PR TITLE
[New Product] Jira Software

### DIFF
--- a/products/jira.md
+++ b/products/jira.md
@@ -123,6 +123,6 @@ which receive security support and bug fixes for 2 years. Non-LTS releases are s
 6 months (there may be some exception). More information can be found in
 [this article](https://www.atlassian.com/blog/enterprise/introducing-enterprise-releases).
 
-Note that Atlassian will definitely end support for Jira Software Server
+Atlassian will end support for Jira Software Server
 [on February 15, 2024](https://www.atlassian.com/migration/assess/journey-to-cloud),
 but Jira Software Data Center will still be available.

--- a/products/jira.md
+++ b/products/jira.md
@@ -1,0 +1,128 @@
+---
+title: Jira Software
+category: server-app
+iconSlug: jirasoftware
+permalink: /jira-software
+alternate_urls:
+-   /jira
+-   /jira-core
+releasePolicyLink: https://confluence.atlassian.com/enterprise/atlassian-enterprise-releases-948227420.html#LongTermSupportreleases-Policyanddetails
+eolColumn: Support
+releaseColumn: true
+releaseDateColumn: true
+
+releases:
+-   releaseCycle: "9.5"
+    releaseDate: 2022-12-06
+    eol: 2023-06-06
+    latest: "9.5.0"
+    latestReleaseDate: 2022-12-06
+    link: https://confluence.atlassian.com/jirasoftware/jira-software-9-5-x-release-notes-1188764867.html
+
+-   releaseCycle: "9.4"
+    releaseDate: 2022-11-15
+    eol: 2024-11-15
+    lts: true
+    latest: "9.4.1"
+    latestReleaseDate: 2022-12-14
+    link: https://confluence.atlassian.com/jirasoftware/jira-software-9-4-x-release-notes-1178869757.html
+
+-   releaseCycle: "9.3"
+    releaseDate: 2022-09-29
+    eol: 2023-03-29
+    latest: "9.3.2"
+    latestReleaseDate: 2022-12-16
+    link: https://confluence.atlassian.com/jirasoftware/jira-software-9-3-x-release-notes-1168850570.html
+
+-   releaseCycle: "9.2"
+    releaseDate: 2022-08-25
+    eol: 2023-02-21
+    latest: "9.2.0"
+    latestReleaseDate: 2022-08-25
+    link: https://confluence.atlassian.com/jirasoftware/jira-software-9-2-x-release-notes-1163763245.html
+
+-   releaseCycle: "9.1"
+    releaseDate: 2022-07-19
+    eol: 2023-01-21
+    latest: "9.1.1"
+    latestReleaseDate: 2022-08-23
+    link: https://confluence.atlassian.com/jirasoftware/jira-software-9-1-x-release-notes-1142452845.html
+
+-   releaseCycle: "9.0"
+    releaseDate: 2022-06-21
+    eol: 2022-12-21
+    latest: "9.0.0"
+    latestReleaseDate: 2022-06-21
+    link: https://confluence.atlassian.com/jirasoftware/jira-software-9-0-x-release-notes-1142227613.html
+
+-   releaseCycle: "8.22"
+    releaseDate: 2022-02-16
+    eol: 2022-08-16
+    latest: "8.22.6"
+    latestReleaseDate: 2022-07-20
+    link: https://confluence.atlassian.com/jirasoftware/jira-software-8-22-x-release-notes-1115656979.html
+
+-   releaseCycle: "8.21"
+    releaseDate: 2021-12-09
+    eol: 2022-06-09
+    latest: "8.21.2"
+    latestReleaseDate: 2022-01-27
+    link: https://confluence.atlassian.com/jirasoftware/jira-software-8-21-x-release-notes-1095249705.html
+
+-   releaseCycle: "8.20"
+    releaseDate: 2021-10-19
+    eol: 2023-10-19
+    lts: true
+    latest: "8.20.16"
+    latestReleaseDate: 2022-12-15
+    link: https://confluence.atlassian.com/jirasoftware/jira-software-8-20-x-release-notes-1086411771.html
+
+-   releaseCycle: "8.13"
+    releaseDate: 2020-10-08
+    eol: 2022-11-08
+    lts: true
+    latest: "8.13.27"
+    latestReleaseDate: 2022-10-24
+    link: https://confluence.atlassian.com/jirasoftware/jira-software-8-13-x-release-notes-1018783360.html
+
+-   releaseCycle: "8.5"
+    releaseDate: 2019-10-21
+    eol: 2021-10-21
+    lts: true
+    latest: "8.5.19"
+    latestReleaseDate: 2021-09-16
+    link: https://confluence.atlassian.com/jirasoftware/jira-software-8-5-x-release-notes-975014654.html
+
+-   releaseCycle: "7.13"
+    releaseDate: 2018-11-28
+    eol: 2020-11-28
+    lts: true
+    latest: "7.13.18"
+    latestReleaseDate: 2020-10-12
+    link: https://confluence.atlassian.com/jirasoftware/jira-software-7-13-x-release-notes-957981568.html
+
+---
+
+> [Jira Software](https://www.atlassian.com/software/jira) is a proprietary issue tracking product
+> developed by Atlassian that allows bug tracking and agile project management.
+
+Jira Software is available both as SaaS and on-premises offer, with three editions:
+
+- Jira Software Cloud: Cloud edition, available through
+  [Atlassian Cloud](https://www.atlassian.com/licensing/cloud).
+- Jira Software Server: Self-hosted edition.
+- Jira Software Data Center: Self-hosted edition, targeted to enterprises (see [Jira Server and Data
+  Center feature comparison](https://confluence.atlassian.com/enterprise/jira-server-and-data-center-feature-comparison-953651628.html)
+  for more information).
+
+This page is **only** about Jira Software Server and Jira Software Data Center. Jira Software Cloud
+is a part of the Atlassian Cloud with [its own release cadence](https://confluence.atlassian.com/cloud/blog).
+
+Jira Software has both LTS and non-LTS releases. There is approximately one LTS release per year,
+which receive security support and bug fixes for 2 years. Non-LTS releases are supported for
+6 months (there may be some exception). More information can be found in
+[this article](https://www.atlassian.com/blog/enterprise/introducing-enterprise-releases).
+
+Note that Atlassian will definitely end support for Jira Software Server
+[on February 15, 2024](https://www.atlassian.com/migration/assess/journey-to-cloud),
+but Jira Software Data Center will still be available.


### PR DESCRIPTION
Note that Jira (aka Jira Core) is packaged in other products, such as Jira Work Management or Jira Service Management... Those products are not as popular as Jira Software (I think) and does not share the same [version numbers](https://confluence.atlassian.com/servicemanagement/jira-service-management-release-notes-780083086.html), so I choose not to talk about them in the product description.

Jira Core and Jira Software release cadence and versions are identical, so I choose to put the `/jira-core` `alternate_urls`. The `/jira` `alternate_urls` has been added because often, when people are mentioning Jira, they mean Jira Software.

All releases from the oldest supported LTS have been documented. Before that, only LTS releases have been documented.