### PR TITLE
[Azure Devops Server] Various product improvements

### DIFF
--- a/products/azure-devops.md
+++ b/products/azure-devops.md
@@ -1,12 +1,13 @@
 ---
-title: Azure DevOps
+title: Azure DevOps Server
 category: server-app
 iconSlug: azuredevops
-permalink: /azure-devops
+permalink: /azure-devops-server
 alternate_urls:
 -   /tfs
+-   /azure-devops
 -   /team-foundation-server
-releasePolicyLink: https://learn.microsoft.com/lifecycle/products/?terms=Azure%20DevOps
+releasePolicyLink: https://learn.microsoft.com/lifecycle/products/?terms=Azure%20DevOps%20Server
 activeSupportColumn: true
 releaseDateColumn: true
 
@@ -15,79 +16,92 @@ releases:
     releaseDate: 2022-12-06
     support: 2028-01-11
     eol: 2033-01-11
-    link: https://learn.microsoft.com/azure/devops/server/release-notes/azuredevops2022?view=azure-devops-2020#azure-devops-server-2022-release-date-december-6-2022
     latest: "2022.1.0"
+    latestReleaseDate: 2022-12-06
+    link: https://learn.microsoft.com/azure/devops/server/release-notes/azuredevops2022?view=azure-devops-2020#azure-devops-server-2022-release-date-december-6-2022
 
 -   releaseCycle: "2020"
+    releaseDate: 2020-08-25
     support: 2025-10-14
     eol: 2030-10-08
     latest: "2020.1.2patch4"
+    latestReleaseDate: 2022-12-13
     link: https://learn.microsoft.com/azure/devops/server/release-notes/azuredevops2020u1?view=azure-devops-2020#azure-devops-server-2020-update-12-patch-4-release-date-december-13-2022
-    releaseDate: 2020-08-25
 
 -   releaseCycle: "2019"
+    releaseDate: 2019-03-05
     support: 2024-04-09
     eol: 2029-04-10
     latest: "2019.1.2patch2"
+    latestReleaseDate: 2022-12-13
     link: https://learn.microsoft.com/azure/devops/server/release-notes/azuredevops2019u1?view=azure-devops-2020#azure-devops-server-2019-update-12-patch-2-release-date-december-13-2022
-    releaseDate: 2019-03-05
 
 -   releaseCycle: "2018"
+    releaseLabel: "TFS __RELEASE_CYCLE__"
+    releaseDate: 2017-11-15
     support: 2023-01-10
     eol: 2028-01-11
     latest: "2018.3.2patch17"
-    releaseLabel: "TFS __RELEASE_CYCLE__"
+    latestReleaseDate: 2022-05-17
     link: https://learn.microsoft.com/visualstudio/releasenotes/tfs2018-update3#team-foundation-server-2018-update-32-patch-17
-    releaseDate: 2017-11-15
 
 -   releaseCycle: "2017"
+    releaseLabel: "TFS __RELEASE_CYCLE__"
+    releaseDate: 2016-11-16
     support: 2022-01-11
     eol: 2027-01-11
     latest: "2017.3.1patch15"
-    releaseLabel: "TFS __RELEASE_CYCLE__"
+    latestReleaseDate: 2022-05-17
     link: https://learn.microsoft.com/visualstudio/releasenotes/tfs2017-update3#details-of-whats-new-in-team-foundation-server-2017-update-31-patch-15
-    releaseDate: 2016-11-16
 
 -   releaseCycle: "2015"
+    releaseLabel: "TFS __RELEASE_CYCLE__"
+    releaseDate: 2015-07-30
     support: 2020-10-13
     eol: 2025-10-14
     latest: "2015.4.2patch8"
-    releaseLabel: "TFS __RELEASE_CYCLE__"
+    latestReleaseDate: 2022-05-17
     link: https://learn.microsoft.com/visualstudio/releasenotes/tfs2015-update4-vs#details-of-whats-new-in-team-foundation-server-2015-update-42-patch-8
-    releaseDate: 2015-07-30
 
 -   releaseCycle: "2013"
+    releaseLabel: "TFS __RELEASE_CYCLE__"
+    releaseDate: 2014-01-15
     support: 2019-04-09
     eol: 2024-04-09
     latest: "2013.5"
-    releaseLabel: "TFS __RELEASE_CYCLE__"
+    latestReleaseDate: 2015-07-20
     link: https://learn.microsoft.com/visualstudio/releasenotes/vs2013-update5-vs
-    releaseDate: 2014-01-15
 
 -   releaseCycle: "2012"
+    releaseLabel: "TFS __RELEASE_CYCLE__"
+    releaseDate: 2012-10-31
     support: 2019-01-09
     eol: 2023-01-10
     latest: "2012.4"
-    releaseLabel: "TFS __RELEASE_CYCLE__"
+    latestReleaseDate: 2013-11-13
     link: https://learn.microsoft.com/troubleshoot/developer/visualstudio/installation/visual-studio-2012-update-4
-    releaseDate: 2012-10-31
 
 -   releaseCycle: "2010"
+    releaseLabel: "TFS __RELEASE_CYCLE__"
+    releaseDate: 2010-06-29
     support: 2015-07-14
     eol: 2020-07-14
     latest: "2010.SP1"
-    releaseLabel: "TFS __RELEASE_CYCLE__"
-    releaseDate: 2010-06-29
+    latestReleaseDate: 2011-03-08
+    link: https://devblogs.microsoft.com/bharry/vstfs-2010-sp1-and-tfs-project-server-integration-feature-pack-have-released/
 
 -   releaseCycle: "2005"
+    releaseLabel: "TFS __RELEASE_CYCLE__"
+    releaseDate: 2006-06-17
     support: 2011-07-12
     eol: 2016-07-12
     latest: "2005.SP2"
-    releaseLabel: "TFS __RELEASE_CYCLE__"
-    releaseDate: 2006-06-17
+    latestReleaseDate: 2007-03-21
+    link: https://devblogs.microsoft.com/bharry/tfs-2005-sql-server-2005-sp2/
 
 ---
 
-> [Azure DevOps Server](https://azure.microsoft.com/services/devops/), is a set of collaborative software development tools, hosted on-premises.
+> [Azure DevOps Server](https://azure.microsoft.com/products/devops/server/), is a set of
+> collaborative software development tools, hosted on-premises.
 
-Prior to 2019, Azure DevOps was known as [Team Foundation Server (TFS)](https://learn.microsoft.com/lifecycle/products/?terms=Team%20Foundation%20Server)
+Prior to 2019, Azure DevOps was known as [Team Foundation Server (TFS)](https://learn.microsoft.com/lifecycle/products/?terms=Team%20Foundation%20Server).


### PR DESCRIPTION
This product is not about the SaaS product _Azure DevOps Services_, which is managed by Microsoft, so:

- rename product from `Azure DevOps` to `Azure DevOps Server`,
- make `/azure-devops-server` the `permalink`,
- add the old `/azure-devops` permalink to `alternate_urls`,
- update `releasePolicyLink` to search against `Azure DevOps Server` instead of `Azure DevOps`

Other improvements :

- add a `latestReleaseDate` for all cycles,
- add a `link` for TFS 2005/2010.