### PR TITLE
[COS] Fix changelogTemplate

### DIFF
--- a/products/cos.md
+++ b/products/cos.md
@@ -1,7 +1,7 @@
 ---
 title: Google Container-Optimized OS (COS)
 category: os
-changelogTemplate: "https://cloud.google.com/container-optimized-os/docs/release-notes/m__RELEASE_CYCLE__#__LATEST__"
+changelogTemplate: "https://cloud.google.com/container-optimized-os/docs/release-notes/m{{'__RELEASE_CYCLE__'|split:'-'|last}}"
 iconSlug: googlecloud
 permalink: /cos
 alternate_urls:


### PR DESCRIPTION
The anchor has been removed: the latest version is always at the top of the page.