### PR TITLE
[drupal] Add 10.0, 9.5

### DIFF
--- a/products/drupal.md
+++ b/products/drupal.md
@@ -20,6 +20,18 @@ purls:
 -   purl: pkg:docker/bitnami/drupal-nginx
 -   purl: pkg:github/drupal/core
 releases:
+-   releaseCycle: "10.0"
+    support: 2023-12-13
+    eol: 2023-12-13
+    latest: "10.0.0"
+    latestReleaseDate: 2022-12-15
+    releaseDate: 2022-12-15
+-   releaseCycle: "9.5"
+    support: 2023-11-01
+    eol: 2023-11-01
+    latest: "9.5.0"
+    latestReleaseDate: 2022-12-15
+    releaseDate: 2022-12-15
 -   releaseCycle: "9.4"
     support: 2022-12-14
     eol: 2023-06-21
@@ -75,6 +87,10 @@ releases:
 > [Drupal](https://www.drupal.org/) is a free and open-source content management framework written in PHP and distributed under the GNU General Public License.
 
 Releases are fully supported for 2 minor versions from initial stable release. During this period, bugs and security issues that have been reported are fixed and are released during the [release windows on the first and third Wednesdays of each month](https://www.drupal.org/about/core/policies/core-release-cycles/schedule#windows) (US time). The final minor release in major release cycle is a long-term support (LTS) release and has extended security coverage.
+
+**Drupal 10.0** will receive security coverage until December 13, 2023 when Drupal 10.2.0 is [released](https://www.drupal.org/about/core/policies/core-release-cycles/schedule#next).
+
+**Drupal 9.5** is the final minor release of the 9.x series. It will be supported until November 2023.
 
 **Drupal 9.4** will receive security coverage until June 21, 2023 when Drupal 10.1.0 is [released](https://www.drupal.org/about/core/policies/core-release-cycles/schedule#next).
 

--- a/products/drupal.md
+++ b/products/drupal.md
@@ -20,13 +20,13 @@ purls:
 -   purl: pkg:github/drupal/core
 releases:
 -   releaseCycle: "10.0"
-    support: 2023-12-13
+    support: 2023-06-21
     eol: 2023-12-13
     latest: "10.0.0"
     latestReleaseDate: 2022-12-15
     releaseDate: 2022-12-15
 -   releaseCycle: "9.5"
-    support: 2023-11-01
+    support: 2023-06-21
     eol: 2023-11-01
     latest: "9.5.0"
     latestReleaseDate: 2022-12-15

--- a/products/drupal.md
+++ b/products/drupal.md
@@ -9,7 +9,6 @@ activeSupportColumn: true
 releaseDateColumn: true
 releaseColumn: true
 versionCommand: drush status
-releaseImage: https://www.drupal.org/files/2019_minor_release_schedule.png
 auto:
 -   git: https://github.com/drupal/core.git
 purls:

--- a/products/drupal.md
+++ b/products/drupal.md
@@ -93,7 +93,7 @@ Releases are fully supported for 2 minor versions from initial stable release. D
 
 **Drupal 9.4** will receive security coverage until June 21, 2023 when Drupal 10.1.0 is [released](https://www.drupal.org/about/core/policies/core-release-cycles/schedule#next).
 
-**Drupal 9.3** will receive security coverage until December 14, 2022 when Drupal 9.5.0 and 10.0.0 are [released](https://www.drupal.org/about/core/policies/core-release-cycles/schedule#current).
+**Drupal 9.3** received security coverage until December 15, 2022 when Drupal 9.5.0 and 10.0.0 were [released](https://www.drupal.org/about/core/policies/core-release-cycles/schedule#current).
 
 **Drupal 9.2** received security coverage until June 15, 2022 when Drupal 9.4.0 was released.
 


### PR DESCRIPTION
* https://www.drupal.org/project/drupal/releases/10.0.0
* https://www.drupal.org/project/drupal/releases/9.5.0
* Remove releaseImage because it is outdated even still used in https://www.drupal.org/about/core/policies/core-release-cycles/schedule#overview