### PR TITLE
[gke] Add 1.25

### DIFF
--- a/products/gke.md
+++ b/products/gke.md
@@ -4,9 +4,9 @@ category: service
 changelogTemplate: https://cloud.google.com/kubernetes-engine/docs/release-notes-nochannel
 releases:
 -   releaseCycle: "1.25"
-    eol: 2024-03-31
-    support: 2024-01-31
-    releaseDate: 2022-08-23
+    eol: 2024-02-29
+    support: 2023-12-29
+    releaseDate: 2022-12-14
     latestReleaseDate: 2022-12-14
     latest: '1.25.4-gke.2100'
 -   releaseCycle: "1.24"

--- a/products/gke.md
+++ b/products/gke.md
@@ -4,7 +4,7 @@ category: service
 changelogTemplate: https://cloud.google.com/kubernetes-engine/docs/release-notes-nochannel
 releases:
 -   releaseCycle: "1.25"
-    eol: 2024-03-30
+    eol: 2024-03-31
     support: 2024-01-31
     releaseDate: 2022-08-23
     latestReleaseDate: 2022-12-14

--- a/products/gke.md
+++ b/products/gke.md
@@ -3,6 +3,12 @@ title: Google Kubernetes Engine
 category: service
 changelogTemplate: https://cloud.google.com/kubernetes-engine/docs/release-notes-nochannel
 releases:
+-   releaseCycle: "1.25"
+    eol: 2024-03-30
+    support: 2024-01-31
+    releaseDate: 2022-08-23
+    latestReleaseDate: 2022-12-14
+    latest: '1.25.4-gke.2100'
 -   releaseCycle: "1.24"
     eol: 2023-10-31
     support: 2023-08-31


### PR DESCRIPTION
* https://cloud.google.com/kubernetes-engine/docs/release-notes-nochannel#December_14_2022
* support and eol calculated from regular channel available date in https://cloud.google.com/kubernetes-engine/docs/release-schedule#schedule-for-release-channels