### PR TITLE
[JQuery] Add changelogTemplate

### DIFF
--- a/products/jquery.md
+++ b/products/jquery.md
@@ -1,32 +1,36 @@
 ---
 title: jQuery
 category: framework
+iconSlug: jquery
+permalink: /jquery
+changelogTemplate: "https://github.com/jquery/jquery/releases/tag/__LATEST__"
+activeSupportColumn: false
+releaseColumn: true
+releaseDateColumn: true
+
 auto:
 -   git: https://github.com/jquery/jquery.git
+
 releases:
 -   releaseCycle: "3"
     eol: false
     latest: "3.6.2"
-    link: https://blog.jquery.com/2022/08/26/jquery-3-6-1-maintenance-release/
     latestReleaseDate: 2022-12-13
     releaseDate: 2016-06-09
+
 -   releaseCycle: "2"
     eol: true
     latest: "2.2.4"
     link: https://blog.jquery.com/2016/05/20/jquery-1-12-4-and-2-2-4-released/
     latestReleaseDate: 2016-05-20
     releaseDate: 2013-04-18
+
 -   releaseCycle: "1"
     eol: true
     latest: "1.12.4"
     link: https://blog.jquery.com/2016/05/20/jquery-1-12-4-and-2-2-4-released/
     latestReleaseDate: 2016-05-20
     releaseDate: 2006-08-31
-iconSlug: jquery
-permalink: /jquery
-activeSupportColumn: false
-releaseColumn: true
-releaseDateColumn: true
 
 ---
 


### PR DESCRIPTION
It's not a good idea to put a custom link to the release post, since the latest version numbers are automatically updated by the bot, but the manual link is not.

Links for 2 and 1 were left as is, because unfortunately the corresponding tag pages on GitHub don't provide links to the release notes. But those releases are EOL so it does not matter that much.