### PR TITLE
[VMware Horizon] Fix release cycles

### DIFF
--- a/products/vmware-horizon.md
+++ b/products/vmware-horizon.md
@@ -1,84 +1,83 @@
 ---
 title: VMware Horizon
+category: app
+iconSlug: vmware
 permalink: /horizon
 alternate_urls:
 -   /vmwarehorizon
 -   /vmware-horizon
-iconSlug: vmware
-category: app
 releasePolicyLink: https://lifecycle.vmware.com
+changelogTemplate: https://docs.vmware.com/en/VMware-Horizon/{{"__LATEST__"|replace_first:'.','-'}}/rn/vmware-horizon-{{"__LATEST__"|replace_first:'.','-'|replace:'.',''}}-release-notes/index.html
+LTSLabel: "<abbr title='Extended Service Branch'>ESB</abbr>"
 activeSupportColumn: Technical Guidance
 eolColumn: General Support
 releaseColumn: true
 releaseDateColumn: true
-releaseLabel: 'Horizon __RELEASE_CYCLE__ {{ "__LATEST__" | split: "." | first }}'
-changelogTemplate: https://docs.vmware.com/en/VMware-Horizon/__RELEASE_CYCLE__-__LATEST__/rn/vmware-horizon-__RELEASE_CYCLE__-{{"__LATEST__"|replace:'.',''}}-release-notes/index.html
-LTSLabel: "<abbr title='Extended Service Branch'>ESB</abbr>"
+
 releases:
--   releaseCycle: "8"
+-   releaseCycle: "8.2209"
     releaseDate: 2022-10-20
     eol: 2025-10-20
     support: 2026-10-20
-    latest: "2209"
+    latest: "8.2209"
     latestReleaseDate: 2022-10-20
 
--   releaseCycle: "8"
+-   releaseCycle: "8.2206"
     releaseDate: 2022-07-19
     eol: 2025-07-19
     support: 2026-07-19
-    latest: "2206"
+    latest: "8.2206"
     latestReleaseDate: 2022-07-19
 
--   releaseCycle: "8"
+-   releaseCycle: "8.2203"
     releaseDate: 2022-04-05
     eol: 2025-04-05
     support: 2026-04-05
-    latest: "2203"
+    latest: "8.2203"
     latestReleaseDate: 2022-04-05
 
--   releaseCycle: "8"
-    codename: "2111"
-    lts: true
+-   releaseCycle: "8.2111"
     releaseDate: 2021-11-30
     eol: 2024-11-30
     support: 2025-11-30
-    latest: "2111.1"
+    lts: true
+    latest: "8.2111.1"
     latestReleaseDate: 2022-11-08
 
--   releaseCycle: "8"
+-   releaseCycle: "8.2106"
     releaseDate: 2021-07-15
     eol: 2024-07-15
     support: 2025-07-15
-    latest: "2106"
+    latest: "8.2106"
     latestReleaseDate: 2021-07-05
     link: https://docs.vmware.com/en/VMware-Horizon/2106/rn/horizon-2106-release-notes.html
 
--   releaseCycle: "8"
+-   releaseCycle: "8.2103"
     releaseDate: 2021-03-23
     eol: 2024-03-23
     support: 2025-03-23
-    latest: "2103"
+    latest: "8.2103"
     latestReleaseDate: 2021-03-23
     link: https://docs.vmware.com/en/VMware-Horizon/2103/rn/horizon-2103-release-notes.html
 
--   releaseCycle: "8"
+-   releaseCycle: "8.2012"
     releaseDate: 2021-01-07
     eol: 2024-01-07
     support: 2025-01-07
-    latest: "2012"
+    latest: "8.2012"
     latestReleaseDate: 2021-01-07
     link: https://docs.vmware.com/en/VMware-Horizon/2012/rn/horizon-2012-release-notes.html
 
--   releaseCycle: "8"
+-   releaseCycle: "8.2006"
     releaseDate: 2020-08-11
     eol: 2025-08-11
     support: 2027-08-11
-    latest: "2006"
+    latest: "8.2006"
     latestReleaseDate: 2020-08-11
     link: https://docs.vmware.com/en/VMware-Horizon/2006/rn/horizon-2006-release-notes.html
 
 -   releaseCycle: "7"
-    releaseLabel: "Horizon 7.X NonLTS branch"
+    releaseLabel: "7.X NonLTS branch"
     releaseDate: 2016-03-22
     eol: 2022-10-15
     support: 2023-03-23
@@ -87,7 +86,7 @@ releases:
     link: https://docs.vmware.com/en/VMware-Horizon-7/7.13.2/rn/vmware-horizon-7-7132-release-notes/index.html
 
 -   releaseCycle: "7.10"
-    releaseLabel: "Horizon 7.10"
+    releaseLabel: "7.10"
     lts: true
     releaseDate: 2019-09-17
     eol: 2022-03-17
@@ -97,7 +96,7 @@ releases:
     link: ' '
 
 -   releaseCycle: "7.5"
-    releaseLabel: "Horizon 7.5"
+    releaseLabel: "7.5"
     lts: true
     releaseDate: 2018-05-29
     eol: 2020-11-30


### PR DESCRIPTION
Many release cycles on the horizon page had the name '8', which resulted in invalid data for the API (some files are named after the revision name).

Release label has been simplified too (following #2068).