### PR TITLE
[Elasticsearch] Update page

### DIFF
--- a/products/elasticsearch.md
+++ b/products/elasticsearch.md
@@ -3,26 +3,30 @@ title: Elasticsearch
 category: db
 iconSlug: elasticsearch
 permalink: /elasticsearch
-releasePolicyLink: https://www.elastic.co/support/eol
-# Take the latest version, and drop the patch version to get MAJOR.MINOR
-changelogTemplate: >
-  https://www.elastic.co/guide/en/elasticsearch/reference/{{"__LATEST__"|split:"."|pop|join:'.'}}/release-notes-__LATEST__.html
 versionCommand: $ES_HOME/bin/elasticsearch -v
+releasePolicyLink: https://www.elastic.co/support_policy
+changelogTemplate: "https://www.elastic.co/guide/en/elasticsearch/reference/{{'__LATEST__'|split:'.'|pop|join:'.'}}/release-notes-__LATEST__.html"
+eolColumn: Support
+releaseDateColumn: true
+
 auto:
 -   git: https://github.com/elastic/elasticsearch.git
+
 releases:
 -   releaseCycle: "8"
+    # the longest between this date and 6 months after the 9.0.0
     eol: 2023-10-26
     latest: "8.5.3"
     latestReleaseDate: 2022-12-08
     releaseDate: 2022-02-10
-    # temporary fix until they publish 8.5.1's changelog
-    link: https://www.elastic.co/guide/en/elasticsearch/reference/8.5/release-notes-8.5.0.html
+
 -   releaseCycle: "7"
+    # Maintained until 9.0.0
     eol: 2023-08-01
     latest: "7.17.8"
     latestReleaseDate: 2022-12-08
     releaseDate: 2019-04-10
+
 -   releaseCycle: "6"
     eol: 2022-02-10
     latest: "6.8.23"
@@ -31,10 +35,19 @@ releases:
 
 ---
 
-> Elasticsearch is a search engine that provides a distributed, multitenant-capable full-text search engine with an HTTP web interface and schema-free JSON documents.
+> Elasticsearch is a search engine that provides a distributed, multitenant-capable full-text search
+> engine with an HTTP web interface and schema-free JSON documents.
 
-Each major release of all Elastic products is supported for at least 18 months from the General Availability date. The last minor release of the two most recent major branches of Elasticsearch (and compatible releases of Kibana, Beats, and Logstash) is maintained. The EOL date of a major release is usually bumped over time as additional minor versions are released.
+Elasticsearch is part of the [Elastic Stack](https://www.elastic.co/elastic-stack/), also known as the
+[ELK Stack](https://www.elastic.co/what-is/elk-stack). It shares the same support policy as the
+other products in the Elastic Stack (Kibana, Logstash, Beats...).
 
-Major versions will introduce features and break backwards compatibility. Minor versions, such as 7.1.0 and 7.2.0, will only introduce features. Maintenance releases, such as 7.1.1 and 7.1.2, will fix bugs only.
+Elastic Stack product releases follow [Semantic Versioning](https://semver.org/). Elastic provides
+maintenance for each major release series for the longest of 30 months after the GA date of the
+major release or 6 months after the GA date of the subsequent major release.
 
-Elasticsearch maintains the most recent minor release from the current major release stream and the most recent minor release from the prior major release stream. For example, Elasticsearch 6.8.x was maintained until the GA release of Elasticsearch 8.0.0.
+End of life dates for Elasticsearch can be found on the [Elastic product EOL dates page](https://www.elastic.co/support/eol).
+Support for various operating systems can also be found on the [Elastic support matrix page](https://www.elastic.co/support/matrix).
+
+*[GA]: General Availability
+*[EOL]: End Of Life


### PR DESCRIPTION
Update page to make it nearly identical to those of Kibana, Logstash and Beats (all those products share the same release cadence and versions).