### PR TITLE
Rename purl to identifiers

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -183,6 +183,26 @@ auto:
   # The value must always be `true`.
   - custom: true
 
+# A list of identifiers that can be used to detect this product as being used,
+# especially by SBOM tooling
+identifiers:
+  # Each identifier is a way of linking this product to various methods of installing it
+
+  # This is a shorthand to use repology as the source data
+  # https://repology.org/project/:package-name-/versions
+  # should return a valid list of packages linked to this product.
+  - repology: package-name
+
+  # See the PURL spec https://github.com/package-url/purl-spec
+  # for details, and avoid packages that are already mentioned on
+  # the repology page
+  # Common examples would be to use
+  # - pkg:os to document operating systems (https://github.com/package-url/purl-spec/pull/161)
+  # - pkg:github to link to github pages
+  # - pkg:golang/pypi/gem/maven/npm etc for common package managers
+  # - pkg:docker for linking to docker images on Docker Hub
+  - purl: pkg:package-manager/package-name
+
 # A list of releases, supported or not (mandatory).
 # Releases must be sort from the newest (on top of the list) to the lowest.
 # Do not add releases that are not considered "stable" (such as RC/Alpha/Beta/Nightly).

--- a/products/almalinux.md
+++ b/products/almalinux.md
@@ -7,7 +7,7 @@ releasePolicyLink: https://blog.cloudlinux.com/announcing-open-sourced-community
 activeSupportColumn: true
 releaseDateColumn: true
 changelogTemplate: https://wiki.almalinux.org/release-notes/__LATEST__.html
-purls:
+identifiers:
 -   purl: pkg:os/almalinux
 auto:
 -   distrowatch: alma

--- a/products/alpinelinux.md
+++ b/products/alpinelinux.md
@@ -10,7 +10,7 @@ changelogTemplate: https://alpinelinux.org/posts/Alpine-__LATEST__-released.html
 activeSupportColumn: false
 versionCommand: cat /etc/alpine-release
 releaseDateColumn: true
-purls:
+identifiers:
 -   purl: pkg:os/alpinelinux
 auto:
   # upstream does not support filtering https://git.alpinelinux.org/aports

--- a/products/amazon-linux.md
+++ b/products/amazon-linux.md
@@ -8,7 +8,7 @@ activeSupportColumn: false
 versionCommand: cat /etc/system-release
 eolColumn: Support
 releaseDateColumn: true
-purls:
+identifiers:
 -   purl: pkg:os/amazonlinux
 -   purl: pkg:docker/library/amazonlinux
 auto:

--- a/products/angular.md
+++ b/products/angular.md
@@ -8,7 +8,7 @@ releasePolicyLink: https://angular.io/guide/releases
 activeSupportColumn: true
 releaseDateColumn: true
 changelogTemplate: https://github.com/angular/angular/releases/tag/__LATEST__
-purls:
+identifiers:
 -   purl: pkg:npm/@angular/core
 -   purl: pkg:github/angular/angular
 auto:

--- a/products/ansible.md
+++ b/products/ansible.md
@@ -10,7 +10,7 @@ releaseDateColumn: true
 activeSupportColumn: false
 eolColumn: Supported
 iconSlug: ansible
-purls:
+identifiers:
 -   purl: pkg:pypi/ansible
 -   repology: ansible
 auto:

--- a/products/antixlinux.md
+++ b/products/antixlinux.md
@@ -11,7 +11,7 @@ versionCommand: cat /etc/os-release
 releaseColumn: true
 releaseDateColumn: true
 releaseLabel: "__RELEASE_CYCLE__ (__CODENAME__)"
-purls:
+identifiers:
 -   purl: pkg:os/antix
 auto:
 -   distrowatch: antix

--- a/products/apache-airflow.md
+++ b/products/apache-airflow.md
@@ -14,7 +14,7 @@ releaseColumn: true
 releaseDateColumn: true
 auto:
 -   pypi: apache-airflow
-purls:
+identifiers:
 -   purl: pkg:pypi/apache-airflow
 -   repology: apache-airflow
 releases:

--- a/products/apache-http-server.md
+++ b/products/apache-http-server.md
@@ -11,7 +11,7 @@ versionCommand: httpd -v
 releaseColumn: true
 releaseDateColumn: true
 
-purls:
+identifiers:
 -   repology: apache
 
 releases:

--- a/products/bootstrap.md
+++ b/products/bootstrap.md
@@ -7,7 +7,7 @@ activeSupportColumn: true
 changelogTemplate: https://github.com/twbs/bootstrap/releases/tag/v__LATEST__
 auto:
 -   git: https://github.com/twbs/bootstrap.git
-purls:
+identifiers:
 -   repology: bootstrap
 -   purl: pkg:npm/bootstrap
 -   purl: pkg:nuget/bootstrap

--- a/products/centos.md
+++ b/products/centos.md
@@ -8,7 +8,7 @@ releasePolicyLink: https://wiki.centos.org/About/Product
 activeSupportColumn: true
 releaseDateColumn: true
 releaseLabel: "CentOS Stream __RELEASE_CYCLE__"
-purls:
+identifiers:
 -   purl: pkg:os/centos
 releases:
 -   releaseCycle: "9"

--- a/products/cfengine.md
+++ b/products/cfengine.md
@@ -8,7 +8,7 @@ activeSupportColumn: true
 eolColumn: Supported
 permalink: /cfengine
 releasePolicyLink: https://cfengine.com
-purls:
+identifiers:
 -   repology: cfengine
 -   purl: pkg:homebrew/cfengine
 releases:

--- a/products/composer.md
+++ b/products/composer.md
@@ -10,7 +10,7 @@ releaseDateColumn: true
 versionCommand: composer --version
 auto:
 -   git: https://github.com/composer/composer.git
-purls:
+identifiers:
 -   purl: pkg:composer/composer/composer
 -   repology: php:composer
 -   purl: pkg:docker/library/composer

--- a/products/consul.md
+++ b/products/consul.md
@@ -7,7 +7,7 @@ releasePolicyLink: https://support.hashicorp.com/hc/articles/360021185113
 changelogTemplate: https://github.com/hashicorp/consul/blob/v__LATEST__/CHANGELOG.md
 auto:
 -   git: https://github.com/hashicorp/consul.git
-purls:
+identifiers:
 -   repology: consul
 -   purl: pkg:brew/consul
 -   purl: pkg:docker/library/consul

--- a/products/couchbase-server.md
+++ b/products/couchbase-server.md
@@ -10,7 +10,7 @@ changelogTemplate: https://docs.couchbase.com/server/__RELEASE_CYCLE__/release-n
 auto:
 -   dockerhub: library/couchbase
     regex: ^(?<major>[1-9]\d*)\.(?<minor>0|[1-9]\d*)\.?(?<patch>0|[1-9]\d*)?$
-purls:
+identifiers:
 -   repology: couchbase-server-community
 -   purl: pkg:docker/library/couchbase
 -   purl: pkg:docker/couchbase/server

--- a/products/debian.md
+++ b/products/debian.md
@@ -9,7 +9,7 @@ activeSupportColumn: false
 releaseColumn: true
 releaseDateColumn: true
 releaseLabel: "__RELEASE_CYCLE__ (__CODENAME__)"
-purls:
+identifiers:
 -   purl: pkg:os/debian
 
 auto:

--- a/products/devuan.md
+++ b/products/devuan.md
@@ -8,7 +8,7 @@ activeSupportColumn: false
 releaseColumn: true
 releaseDateColumn: true
 releaseLabel: "__RELEASE_CYCLE__ (__CODENAME__)"
-purls:
+identifiers:
 -   purl: pkg:os/devuan
 auto:
 -   distrowatch: devuan

--- a/products/django.md
+++ b/products/django.md
@@ -11,7 +11,7 @@ versionCommand: python -c "import django; print(django.get_version())"
 releaseDateColumn: false
 auto:
 -   git: https://github.com/django/django.git
-purls:
+identifiers:
 -   repology: python:django
 -   purl: pkg:github/django/django
 -   purl: pkg:pypi/django

--- a/products/docker-engine.md
+++ b/products/docker-engine.md
@@ -14,7 +14,7 @@ versionCommand: docker version --format '{{.Server.Version}}'
 auto:
 -   git: https://github.com/moby/moby.git
     regex: ^v(?<major>0|[1-9]\d*)\.(?<minor>\d*)\.(?<patch>0|[1-9]\d*)(-ce)?$
-purls:
+identifiers:
 -   repology: docker
 -   repology: docker-ce
 releases:

--- a/products/drupal.md
+++ b/products/drupal.md
@@ -11,7 +11,7 @@ releaseColumn: true
 versionCommand: drush status
 auto:
 -   git: https://github.com/drupal/core.git
-purls:
+identifiers:
 -   purl: pkg:composer/drupal/core
 -   repology: php:drupal
 -   purl: pkg:docker/bitnami/drupal

--- a/products/drush.md
+++ b/products/drush.md
@@ -11,7 +11,7 @@ eolColumn: Support
 versionCommand: drush --version
 auto:
 -   git: https://github.com/drush-ops/drush.git
-purls:
+identifiers:
 -   purl: pkg:composer/drush/drush
 -   repology: drush
 -   purl: pkg:github/drush-ops/drush

--- a/products/gorilla.md
+++ b/products/gorilla.md
@@ -8,7 +8,7 @@ releaseDateColumn: false
 iconSlug: go
 eolColumn: Support
 releaseColumn: false
-purls:
+identifiers:
 
 -   repology: go:github-gorilla-context
 -   repology: go:github-gorilla-csrf

--- a/products/kotlin.md
+++ b/products/kotlin.md
@@ -8,7 +8,7 @@ alternate_urls:
 versionCommand: kotlinc-native -version
 releasePolicyLink: https://kotlinlang.org/docs/releases.html
 changelogTemplate: "https://github.com/JetBrains/kotlin/releases/tag/v__LATEST__"
-purls:
+identifiers:
 -   repology: kotlin
 auto:
 -   git: https://github.com/JetBrains/kotlin.git

--- a/products/laravel.md
+++ b/products/laravel.md
@@ -10,7 +10,7 @@ versionCommand: composer show laravel/framework|grep versions
 releaseDateColumn: true
 auto:
 -   git: https://github.com/laravel/framework.git
-purls:
+identifiers:
 -   purl: pkg:composer/laravel/laravel
 -   repology: php:laravel-framework
 -   purl: pkg:docker/bitnami/laravel

--- a/products/mariadb.md
+++ b/products/mariadb.md
@@ -7,7 +7,7 @@ releasePolicyLink: https://mariadb.org/about/#maintenance-policy
 changelogTemplate: https://mariadb.com/kb/en/mariadb-{{"__LATEST__" | replace:'.','-'}}-changelog/
 activeSupportColumn: false
 releaseDateColumn: true
-purls:
+identifiers:
 -   repology: mariadb
 -   purl: pkg:deb/debian/mariadb-server
 -   purl: pkg:deb/ubuntu/mariadb-server

--- a/products/mongodb.md
+++ b/products/mongodb.md
@@ -9,7 +9,7 @@ activeSupportColumn: false
 releaseDateColumn: true
 releaseLabel: "__RELEASE_CYCLE__{%if r.codename %} ({{r.codename}}){%endif%}"
 versionCommand: mongod --version
-purls:
+identifiers:
 -   purl: pkg:deb/debian/mongodb-org-server
 -   purl: pkg:deb/ubuntu/mongodb-org-server
 -   purl: pkg:rpm/amzn/mongodb-org-server

--- a/products/mxlinux.md
+++ b/products/mxlinux.md
@@ -13,7 +13,7 @@ versionCommand: cat /etc/os-release
 releaseColumn: false
 releaseDateColumn: true
 releaseLabel: "__RELEASE_CYCLE__ (__CODENAME__)"
-purls:
+identifiers:
 -   purl: pkg:os/mxlinux
 auto:
 -   distrowatch: mxlinux

--- a/products/nginx.md
+++ b/products/nginx.md
@@ -9,7 +9,7 @@ versionCommand: nginx -v
 releaseColumn: true
 releaseDateColumn: true
 changelogTemplate: https://nginx.org/en/CHANGES-__RELEASE_CYCLE__
-purls:
+identifiers:
 -   repology: nginx
 -   purl: pkg:deb/debian/nginx
 -   purl: pkg:deb/ubuntu/nginx

--- a/products/ruby.md
+++ b/products/ruby.md
@@ -14,7 +14,7 @@ auto:
   # The meaning of patch and tiny below is as per the new policy
     regex: ^v(?<major>0|[1-9]\d*)_(?<minor>0|[1-9]\d*)_(?<patch>\d{1,3})_?(?<tiny>\d+)?$
     template: '{{major}}.{{minor}}.{{patch}}{%if tiny %}p{{tiny}}{%endif%}'
-purls:
+identifiers:
 -   repology: ruby
 -   purl: pkg:docker/library/ruby
 releaseDateColumn: true

--- a/products/slackware.md
+++ b/products/slackware.md
@@ -12,7 +12,7 @@ versionCommand: cat /etc/os-release
 releaseColumn: false
 releaseDateColumn: true
 releasePolicyLink: http://www.slackware.com/faq/do_faq.php?faq=general#4
-purls:
+identifiers:
 -   purl: pkg:os/slackwarelinux
 auto:
 -   distrowatch: slackware

--- a/products/tomcat.md
+++ b/products/tomcat.md
@@ -55,7 +55,7 @@ releases:
     eol: 2012-09-30
     latest: "5.5.36"
     releaseDate: 2003-09-06
-purls:
+identifiers:
 -   repology: tomcat
 -   purl: pkg:maven/org.apache.tomcat/tomcat
 

--- a/products/typo3.md
+++ b/products/typo3.md
@@ -51,7 +51,7 @@ releases:
     latest: "7.6.32"
     link: https://typo3.org/download/release-notes/typo3-v8-release-notes/
     latestReleaseDate: 2018-12-11
-purls:
+identifiers:
 -   repology: typo3
 -   purl: pkg:composer/typo3/cms
 iconSlug: typo3

--- a/products/ubuntu.md
+++ b/products/ubuntu.md
@@ -15,7 +15,7 @@ auto:
     regex: '^Distribution Releases?: Ubuntu( Linux)? (?P<v1>\d+\.\d+\.?\d+)(, (?P<v2>\d+\.\d+\.?\d+))?(
       LTS|, Kubuntu.*)?$'
     template: "{{v1}}{%if v2%}\n{{v2}}{%endif%}"
-purls:
+identifiers:
 -   purl: pkg:os/ubuntu
 activeSupportColumn: true
 releaseDateColumn: true

--- a/products/unrealircd.md
+++ b/products/unrealircd.md
@@ -8,7 +8,7 @@ releaseDateColumn: true
 versionCommand: ./unrealircd version
 changelogTemplate: https://github.com/unrealircd/unrealircd/blob/unreal{{"__LATEST__"|split:'.'|slice:0,2|join:''}}/doc/RELEASE-NOTES.md#unrealircd-{{'__LATEST__'
   | replace:'.',''}}
-purls:
+identifiers:
 -   repology: unrealircd
 -   purl: pkg:docker/bbriggs/unrealircd
 # Source: https://www.unrealircd.org/docwiki/index.php?title=History_of_UnrealIRCd_releases&action=raw

--- a/products/varnish.md
+++ b/products/varnish.md
@@ -8,7 +8,7 @@ versionCommand: varnishd -V
 auto:
 -   git: https://github.com/varnishcache/varnish-cache.git
     regex: ^varnish-(?<major>0|[1-9]\d*)\.(?<minor>0|[1-9]\d*)\.(?<patch>0|[1-9]\d*)$
-purls:
+identifiers:
 -   repology: varnish
 -   purl: pkg:brew/varnish
 -   purl: pkg:docker/library/varnish

--- a/products/vue.md
+++ b/products/vue.md
@@ -13,7 +13,7 @@ iconSlug: vuedotjs
 auto:
 -   npm: vue
 
-purls:
+identifiers:
 -   repology: vue.js
 -   repology: vue
 -   purl: pkg:npm/vue

--- a/products/wagtail.md
+++ b/products/wagtail.md
@@ -10,7 +10,7 @@ releaseDateColumn: true
 versionCommand: python -c "import wagtail; print(wagtail.__version__)"
 auto:
 -   git: https://github.com/wagtail/wagtail.git
-purls:
+identifiers:
 -   repology: python:wagtail
 -   purl: pkg:pypi/wagtail
 releases:

--- a/products/wordpress.md
+++ b/products/wordpress.md
@@ -168,7 +168,7 @@ releases:
 
 auto:
 -   git: https://github.com/WordPress/wordpress-develop.git
-purls:
+identifiers:
 -   repology: wordpress
 -   purl: pkg:docker/library/wordpress
 -   purl: pkg:docker/bitnami/wordpress

--- a/products/zabbix.md
+++ b/products/zabbix.md
@@ -10,7 +10,7 @@ auto:
 releaseDateColumn: true
 activeSupportColumn: true
 eolColumn: Security Support
-purls:
+identifiers:
 -   repology: zabbix
 -   purl: pkg:brew/zabbix
 -   purl: pkg:github/zabbix/zabbix

--- a/products/zookeeper.md
+++ b/products/zookeeper.md
@@ -10,7 +10,7 @@ changelogTemplate: https://zookeeper.apache.org/doc/r{{"__LATEST__"}}/releasenot
 activeSupportColumn: true
 releaseDateColumn: true
 releaseColumn: true
-purls:
+identifiers:
 -   repology: zookeeper
 -   purl: pkg:maven/org.apache.zookeeper/zookeeper
 -   purl: pkg:github/apache/zookeeper


### PR DESCRIPTION
`purls` wasn't a very descriptive key, so changed it to `identifiers`. Others that I considered were:

- `package-info`
- `package-identifiers`

But I wanted to avoid the `package` bit, as it doesn't work across all products (devices, services etc).