### PR TITLE
CFEngine 3.21.0, 3.18.3, 3.15.7 released

### DIFF
--- a/products/cfengine.md
+++ b/products/cfengine.md
@@ -38,9 +38,9 @@ releases:
 -   releaseCycle: "3.18"
     lts: true
     latest: "3.18.3"
-    support: 2023-06-24
+    support: 2024-06-24
     link: https://github.com/cfengine/core/blob/3.18.3/ChangeLog
-    eol: 2023-06-24
+    eol: 2024-06-24
     releaseDate: 2021-06-24
     latestReleaseDate: 2022-11-14
 -   releaseCycle: "3.17"

--- a/products/cfengine.md
+++ b/products/cfengine.md
@@ -13,10 +13,18 @@ purls:
 -   repology: cfengine
 -   purl: pkg:homebrew/cfengine
 releases:
+-   releaseCycle: "3.21"
+    latest: "3.21.0"
+    lts: true
+    eol: 2025-12-21
+    support: 2025-12-21
+    link: https://github.com/cfengine/core/blob/3.21.0/ChangeLog
+    releaseDate: 2022-12-21
+    latestReleaseDate: 2022-12-21
 -   releaseCycle: "3.20"
     latest: "3.20.0"
-    eol: false
-    support: true
+    eol: true
+    support: false
     link: https://github.com/cfengine/core/blob/3.20.0/ChangeLog
     releaseDate: 2022-07-01
     latestReleaseDate: 2022-07-01
@@ -29,12 +37,12 @@ releases:
     latestReleaseDate: 2021-12-10
 -   releaseCycle: "3.18"
     lts: true
-    latest: "3.18.2"
+    latest: "3.18.3"
     support: 2023-06-24
-    link: https://github.com/cfengine/core/blob/3.18.2/ChangeLog
-    eol: false
+    link: https://github.com/cfengine/core/blob/3.18.3/ChangeLog
+    eol: 2023-06-24
     releaseDate: 2021-06-24
-    latestReleaseDate: 2022-06-29
+    latestReleaseDate: 2022-11-14
 -   releaseCycle: "3.17"
     latest: "3.17.0"
     eol: true
@@ -51,12 +59,12 @@ releases:
     latestReleaseDate: 2020-06-25
 -   releaseCycle: "3.15"
     lts: true
-    latest: "3.15.6"
-    eol: false
-    support: 2022-12-18
+    latest: "3.15.7"
+    eol: 2022-12-31
+    support: 2022-12-31
     link: https://github.com/cfengine/core/blob/3.15.6/ChangeLog
     releaseDate: 2019-12-18
-    latestReleaseDate: 2022-06-29
+    latestReleaseDate: 2022-11-14
 
 ---
 


### PR DESCRIPTION
CFEngine 3.21.0 released: https://cfengine.com/blog/2022/cfengine-3-21-lts-released-unification/

CFEngine 3.15.7, 3.18.3 released: https://cfengine.com/blog/2022/cfengine-3-15-7-and-3-18-3-released/