### PR TITLE
Add extended support column

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -122,6 +122,11 @@ releaseDateColumn: true
 # This usually means the device is no longer available for sale or is no longer being manufactured.
 discontinuedColumn: false
 
+# Whether to display the "Extended Support" column (optional, default = false).
+# You can also set this variable with a text label if you want to change the column name:
+#   extendedSupportColumn: Commercial Support
+extendedSupportColumn: false
+
 # Auto-update release configuration (optional).
 # This is used for automatically updating `releaseDate`, `latest`, and `latestReleaseDate` for every release.
 # Multiple configuration are allowed.
@@ -237,10 +242,18 @@ releases:
 
     # EOL date (mandatory).
     # This is where all support stops (including security support).
-    # In case there is extended/commercial support available, pick the date that would apply to the majority of users.
+    # In case there is extended/commercial support available, pick the date that would apply to the
+    # majority of users (and use the extendedSupport field if necessary).
     # Use valid dates, and do not add quotes around dates.
     # Alternatively, set to true|false the date has not been decided yet.
     eol: 2019-01-01
+
+    # End of extended/commercial support date (optional if extendedSupportColumn is false, else mandatory).
+    # Note that extended/commercial support is different from Long-Term Support. Extended/commercial
+    # support must be used only when additional support is available after EOL, usually against payment.
+    # Use valid dates, and do not add quotes around dates.
+    # Alternatively, set to true|false if the date has not been decided yet.
+    extendedSupport: 2020-01-01
 
     # Latest release for the release cycle (optional if releaseColumn is false, else mandatory).
     # Usually this is the release cycle's latest "patch" release.

--- a/_auto/validate.py
+++ b/_auto/validate.py
@@ -74,6 +74,12 @@ def validate_product(file):
             elif "support" in r:
                 warn_of_unnecessary_field('support', f"{file}/{r['releaseCycle']}")
 
+        if "extendedSupportColumn" in data:
+            if data["extendedSupportColumn"]:
+                assert_that_type_is((bool, date), r["extendedSupport"], 'extendedSupport', file)
+            elif "extendedSupport" in r:
+                warn_of_unnecessary_field('extendedSupport', f"{file}/{r['releaseCycle']}")
+
         if "discontinuedColumn" in data:
             if data["discontinuedColumn"]:
                 assert_that_type_is((bool, date), r["discontinued"], 'discontinued', file)

--- a/_layouts/product.html
+++ b/_layouts/product.html
@@ -32,6 +32,15 @@ layout: default
       {% if page.eolColumn != false %}
       <th>{{ page.eolColumn | default: "Security Support" }}</th>
       {% endif %}
+      {% if page.extendedSupportColumn%}
+      <th>
+        {% if page.extendedSupportColumn == true %}
+        Extended Support
+        {%else%}
+        {{page.extendedSupportColumn}}
+        {%endif%}
+      </th>
+      {% endif %}
       {% if page.releaseColumn != false %}<th>Latest</th>{% endif %}
     </tr>
   </thead>
@@ -39,6 +48,7 @@ layout: default
 {% for r in page.releases %}
 {% assign support =r.support | date: '%s' | plus:0 %}
 {% assign securityFixes = r.eol | date: '%s' | plus:0 %}
+{% assign extendedSupport = r.extendedSupport | date: '%s' | plus:0 %}
 
 
 {% comment %}
@@ -58,8 +68,10 @@ or +1 (EoL is in the future)
 {% endif %}
 
 {% assign diffSupport = support | minus:now %}
+{% assign diffExtendedSupport = extendedSupport | minus:now %}
 {% assign diffSecurity6  = diff | minus:10651938 %}
 {% assign diffSupport6  = diffSupport | minus:10651938 %}
+{% assign diffExtendedSupport6  = diffExtendedSupport | minus:10651938 %}
 {% assign latestVersionNumber = r.latest | liquify %}
 {% assign LTSLabel = page.LTSLabel | default: '<abbr title="Long Term Support">LTS</abbr>' %}
 
@@ -185,6 +197,41 @@ or +1 (EoL is in the future)
       {% else %}
       Yes
       {% endif %}
+    {% endif %}
+  </td>
+  {% endif %}
+
+  {% if page.extendedSupportColumn %}
+  <td class=
+        {% if extendedSupport > 5 %}
+    {% if diffExtendedSupport < 0 and r.extendedSupport != false %}
+    "bg-red-000"
+    {% elsif diffExtendedSupport6 > 0 %}
+    "bg-green-000"
+    {% else %}
+    "bg-yellow-200"
+    {% endif %}
+    {% else %}
+    {% if r.extendedSupport %}
+    "bg-green-000"
+    {% else %}
+    "bg-red-000"
+    {% endif %}
+    {% endif %}
+    title="{{r.extendedSupport}}">
+    {% if extendedSupport > 5 %}
+    {% if diffExtendedSupport < 0 %}
+    Ended
+    {% else %}
+    Ends
+    {% endif %}
+    {{r.extendedSupport | timeago}} <div>({{r.extendedSupport | date_to_string}})</div>
+    {% else %}
+    {% if r.extendedSupport %}
+    Yes
+    {% else %}
+    No
+    {% endif %}
     {% endif %}
   </td>
   {% endif %}

--- a/_plugins/create-icalendar-files.rb
+++ b/_plugins/create-icalendar-files.rb
@@ -60,6 +60,8 @@ def notification_message(product, cycle, type)
     message += ' will end active development.'
   when 'release' then
     message += ' will be released.'
+  when 'extendedSupport' then
+    message += ' will end extended support.'
   end
 end
 
@@ -69,7 +71,7 @@ def process_product(product)
   cal = Icalendar::Calendar.new
   product.release_cycles.each do |cycle|
     cycle.fetch('data').each do |key, item|
-      next if !['release', 'support', 'eol'].include?(key) || !item.instance_of?(Date)
+      next if !['release', 'support', 'eol', 'extendedSupport'].include?(key) || !item.instance_of?(Date)
       event = cal.event
       event.dtstart = Icalendar::Values::Date.new(item)
       event.dtend = Icalendar::Values::Date.new(item + 1)

--- a/products/redhat.md
+++ b/products/redhat.md
@@ -10,13 +10,16 @@ versionCommand: cat /etc/redhat-release
 changelogTemplate: https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/__RELEASE_CYCLE__/html/__LATEST___release_notes/overview
 releasePolicyLink: https://access.redhat.com/support/policy/updates/errata
 LTSLabel: "<abbr title='Extended Life Cycle Support'>ELS</abbr>"
-activeSupportColumn: true
+activeSupportColumn: Full Support
+eolColumn: Maintenance Support
 releaseDateColumn: true
+extendedSupportColumn: Extended Life Cycle Support
 
 releases:
 -   releaseCycle: "9"
     support: 2027-05-31
     eol: 2032-05-31
+    extendedSupport: 2034-05-31
     latest: "9.1"
     releaseDate: 2022-05-17
     lts: 2032-05-31
@@ -25,6 +28,7 @@ releases:
 -   releaseCycle: "8"
     support: 2024-05-31
     eol: 2029-05-31
+    extendedSupport: 2031-05-31
     latest: "8.7"
     releaseDate: 2019-05-07
     lts: 2029-05-31
@@ -33,6 +37,7 @@ releases:
 -   releaseCycle: "7"
     support: 2019-12-31
     eol: 2024-06-30
+    extendedSupport: 2026-06-30
     latest: "7.9"
     releaseDate: 2013-12-11
     lts: 2024-06-30
@@ -41,6 +46,7 @@ releases:
 -   releaseCycle: "6"
     support: 2016-05-10
     eol: 2020-11-30
+    extendedSupport: 2024-06-30
     releaseDate: 2010-11-09
     lts: 2020-11-30
     latestReleaseDate: 2018-06-19
@@ -49,6 +55,7 @@ releases:
 -   releaseCycle: "5"
     support: 2013-01-08
     eol: 2017-03-31
+    extendedSupport: 2020-11-30
     releaseDate: 2007-03-15
     lts: 2017-03-31
     latestReleaseDate: 2014-09-16
@@ -57,6 +64,7 @@ releases:
 -   releaseCycle: "4"
     support: 2009-03-31
     eol: 2012-02-29
+    extendedSupport: false
     releaseDate: 2005-02-15
     latestReleaseDate: 2011-02-16
     latest: '4.9'
@@ -68,5 +76,3 @@ releases:
 Red Hat Enterprise Linux versions 5, 6, and 7 each deliver ten years of support in Full Support, Maintenance Support 1 and Maintenance Support 2 Phases followed by an Extended Life Phase. In addition, for Red Hat Enterprise Linux 5 and 6, customers may purchase annual Add-on subscriptions called Extended Life-cycle Support (ELS) to extend limited subscription services beyond the Maintenance Support 2 Phase.
 
 With the introduction of Red Hat Enterprise Linux version 8, Red Hat is simplifying the RHEL product phases from four to three: Full Support, Maintenance Support, and Extended Life Phase.
-
-The Security Support dates in the above table use "Maintenance Support" as the end of security support.

--- a/products/ubuntu.md
+++ b/products/ubuntu.md
@@ -17,7 +17,9 @@ auto:
     template: "{{v1}}{%if v2%}\n{{v2}}{%endif%}"
 identifiers:
 -   purl: pkg:os/ubuntu
-activeSupportColumn: true
+activeSupportColumn: Hardware and Maintenance Updates
+eol: Maintenance Updates
+extendedSupportColumn: Extended Security Maintenance
 releaseDateColumn: true
 releaseImage: https://user-images.githubusercontent.com/10281587/210113332-7a65b33c-c900-429a-8e73-83cefcb4e684.png
 releaseLabel: "__RELEASE_CYCLE__ '__CODENAME__'"
@@ -30,10 +32,12 @@ releases:
     link: https://wiki.ubuntu.com/KineticKudu/ReleaseNotes/
     releaseDate: 2022-10-20
     latestReleaseDate: 2022-10-20
+    extendedSupport: false
 -   releaseCycle: "22.04"
     codename: "Jammy Jellyfish"
-    support: 2027-04-21
-    eol: 2032-04-01
+    support: 2024-09-30
+    eol: 2027-04-01
+    extendedSupport: 2032-04-09
     lts: true
     latest: "22.04.1"
     link: https://wiki.ubuntu.com/JammyJellyfish/ReleaseNotes/
@@ -47,6 +51,7 @@ releases:
     link: https://wiki.ubuntu.com/ImpishIndri/ReleaseNotes/
     releaseDate: 2021-10-14
     latestReleaseDate: 2021-10-14
+    extendedSupport: false
 -   releaseCycle: "21.04"
     codename: "Hirsute Hippo"
     support: 2022-01-20
@@ -55,6 +60,7 @@ releases:
     link: https://wiki.ubuntu.com/HirsuteHippo/ReleaseNotes/
     releaseDate: 2021-04-22
     latestReleaseDate: 2021-04-22
+    extendedSupport: false
 -   releaseCycle: "20.10"
     codename: "Groovy Gorilla"
     support: 2021-07-22
@@ -62,11 +68,13 @@ releases:
     latest: "20.10"
     releaseDate: 2020-10-22
     latestReleaseDate: 2020-10-22
+    extendedSupport: false
 -   releaseCycle: "20.04"
     codename: "Focal Fossa"
     lts: true
-    support: 2025-04-02
-    eol: 2030-04-01
+    support: 2022-10-01
+    eol: 2025-04-02
+    extendedSupport: 2030-04-02
     latest: "20.04.5"
     releaseDate: 2020-04-23
     latestReleaseDate: 2022-09-01
@@ -77,11 +85,13 @@ releases:
     latest: "19.10"
     releaseDate: 2019-10-17
     latestReleaseDate: 2019-10-17
+    extendedSupport: false
 -   releaseCycle: "18.04"
     codename: "Bionic Beaver"
     lts: true
     support: 2023-04-02
-    eol: 2028-04-01
+    eol: 2023-04-02
+    extendedSupport: 2028-04-01
     latest: "18.04.6"
     link: https://wiki.ubuntu.com/BionicBeaver/ReleaseNotes
     releaseDate: 2018-04-26
@@ -90,7 +100,8 @@ releases:
     codename: "Xenial Xerus"
     lts: true
     support: 2021-04-02
-    eol: 2026-04-01
+    eol: 2021-04-02
+    extendedSupport: 2026-04-02
     latest: "16.04.7"
     releaseDate: 2016-04-21
     latestReleaseDate: 2020-08-13
@@ -98,7 +109,8 @@ releases:
     codename: "Trusty Tahr"
     lts: true
     support: 2019-04-02
-    eol: 2024-04-01
+    eol: 2019-04-02
+    extendedSupport: 2024-04-02
     latest: "14.04.6"
     releaseDate: 2014-04-17
     latestReleaseDate: 2019-03-07
@@ -112,8 +124,10 @@ LTS releases are in "General Support" for 5 years and "Extended Security Mainten
 
 During the lifetime of an Ubuntu release, Canonical provides security maintenance. Basic Security Maintenance covers binary packages that reside in the `main` and `restricted` components of the Ubuntu archive, typically for a period of 5 years from LTS release.
 
-Extended Security Maintenance (ESM) provides security updates on Ubuntu LTS releases for additional 5 years. It is available with the Ubuntu Pro subscription or a Free subscription. Please see the [Ubuntu Website]({{page.link}}) for details.
+Extended Security Maintenance (ESM) provides security updates on Ubuntu LTS releases for additional 5 years. It is available with the Ubuntu Pro subscription or a Free subscription. Please see the [Ubuntu Website](https://ubuntu.com/pro) for details.
 
 The dates for active and security support are taken from [here](https://github.com/canonical-web-and-design/ubuntu.com/blob/master/static/js/src/chart-data.js) what is used for the graph rendering on the [Release Cycle Page](https://ubuntu.com/about/release-cycle).
+
+Ubuntu Pro offers security fixes for critical, high, and selected medium CVEs in the `main` and `universe` repositories. Ubuntu Pro (Infra-only) - previously known as Ubuntu Advantage - only guarantees security fixes for packages in the `main` repository - other packages are on a best-effort basis.
 
 For package specific support details, run the `ubuntu-security-status` command (`ubuntu-support-status` on versions before `20.04`).


### PR DESCRIPTION
This PR is used to test the addition of a new "Extended support" column (as seen in https://github.com/endoflife-date/endoflife.date/pull/1254/files#r884229115).

TODO :

- [x] Initial POC
- [x] Support extended support in Calendar
- [x] Document the new fields
- [x] Decide if EOLed cycles that are in the extended support phase must be disabled or not.