### PR TITLE
[PAN Cortex XDR agent] Remove `latest` and `latestReleaseDate` fields

### DIFF
--- a/products/pan-cortex-xdr.md
+++ b/products/pan-cortex-xdr.md
@@ -18,128 +18,86 @@ releases:
 -   releaseCycle: "7.9"
     eol: 2023-09-11
     releaseDate: 2022-12-04
-    latestReleaseDate: 2022-12-04
-    latest: '7.9'
 
 -   releaseCycle: "7.8"
     eol: 2023-04-24
     releaseDate: 2022-07-24
-    latestReleaseDate: 2022-07-24
-    latest: '7.8'
 
 -   releaseCycle: "7.7"
     eol: 2022-12-27
     releaseDate: 2022-03-27
-    latestReleaseDate: 2022-03-27
-    latest: '7.7'
 
 -   releaseCycle: "7.5-ce"
     eol: 2024-03-06
     releaseDate: 2022-03-06
-    latestReleaseDate: 2022-03-06
-    latest: '7.5-ce'
 
 -   releaseCycle: "7.6"
     eol: 2022-09-05
     releaseDate: 2021-12-05
-    latestReleaseDate: 2021-12-05
-    latest: '7.6'
 
 -   releaseCycle: "7.5"
     eol: 2022-08-22
     releaseDate: 2021-08-22
-    latestReleaseDate: 2022-03-06
-    latest: '7.5-ce'
 
 -   releaseCycle: "7.4"
     eol: 2022-05-24
     releaseDate: 2021-05-24
-    latestReleaseDate: 2021-05-24
-    latest: '7.4'
 
 -   releaseCycle: "7.3"
     eol: 2022-02-01
     releaseDate: 2021-02-01
-    latestReleaseDate: 2021-02-01
-    latest: '7.3'
 
 -   releaseCycle: "7.2"
     eol: 2022-03-07
     releaseDate: 2020-09-07
-    latestReleaseDate: 2020-09-07
-    latest: '7.2'
 
 -   releaseCycle: "7.1"
     eol: 2021-06-04
     releaseDate: 2020-04-22
-    latestReleaseDate: 2020-04-22
-    latest: '7.1'
 
 -   releaseCycle: "7.0"
     eol: 2021-06-04
     releaseDate: 2019-12-04
-    latestReleaseDate: 2019-12-04
-    latest: '7.0'
 
 -   releaseCycle: "6.1"
     eol: 2022-07-01
     releaseDate: 2019-07-02
-    latestReleaseDate: 2019-07-02
-    latest: '6.1'
 
 -   releaseCycle: "6.0"
     eol: 2020-02-26
     releaseDate: 2019-02-26
-    latestReleaseDate: 2019-02-26
-    latest: '6.0'
 
 -   releaseCycle: "4.2"
     eol: 2022-03-01
     releaseDate: 2018-06-25
-    latestReleaseDate: 2018-06-25
-    latest: '4.2'
 
 -   releaseCycle: "5.0"
     eol: 2024-06-01
     releaseDate: 2018-03-19
-    latestReleaseDate: 2018-03-19
-    latest: '5.0'
 
 -   releaseCycle: "4.1"
     eol: 2019-09-15
     releaseDate: 2017-09-15
-    latestReleaseDate: 2017-09-15
-    latest: '4.1'
 
 -   releaseCycle: "4.0"
     eol: 2018-04-05
     releaseDate: 2017-04-05
-    latestReleaseDate: 2017-04-05
-    latest: '4.0'
 
 -   releaseCycle: "3.4"
     eol: 2019-08-21
     releaseDate: 2016-08-21
-    latestReleaseDate: 2016-08-21
-    latest: '3.4'
 
 -   releaseCycle: "3.3"
     eol: 2017-02-28
     releaseDate: 2015-11-10
-    latestReleaseDate: 2015-11-10
-    latest: '3.3'
 
 -   releaseCycle: "3.2"
     eol: 2016-03-31
     releaseDate: 2015-03-31
-    latestReleaseDate: 2015-03-31
-    latest: '3.2'
 
 -   releaseCycle: "3.1"
     eol: 2015-09-03
     releaseDate: 2014-09-03
-    latestReleaseDate: 2014-09-03
-    latest: '3.1'
 
 ---
 

--- a/products/pan-cortex-xdr.md
+++ b/products/pan-cortex-xdr.md
@@ -2,119 +2,139 @@
 title: Palo Alto Networks Cortex XDR agent
 category: app
 permalink: /cortex-xdr
-releasePolicyLink: https://www.paloaltonetworks.com/services/support/end-of-life-announcements/end-of-life-summary
-changelogTemplate: https://docs.paloaltonetworks.com/cortex/cortex-xdr/{{"__RELEASE_CYCLE__"
-  | remove:'-' | replace:'.','-'}}/cortex-xdr-agent-release-notes/cortex-xdr-agent-release-information
-activeSupportColumn: false
-releaseColumn: false
-releaseDateColumn: true
-eolColumn: Support Status
 alternate_urls:
 -   /pan-xdr
 -   /cortexxdr
 -   /xdr
 -   /pan-cortex-xdr
+releasePolicyLink: https://www.paloaltonetworks.com/services/support/end-of-life-announcements/end-of-life-summary
+changelogTemplate: "https://docs.paloaltonetworks.com/cortex/cortex-xdr/{{'__RELEASE_CYCLE__'|remove:'-'|replace:'.','-'}}/cortex-xdr-agent-release-notes/cortex-xdr-agent-release-information"
+activeSupportColumn: false
+releaseColumn: false
+releaseDateColumn: true
+eolColumn: Support Status
+
 releases:
 -   releaseCycle: "7.9"
     eol: 2023-09-11
     releaseDate: 2022-12-04
     latestReleaseDate: 2022-12-04
     latest: '7.9'
+
 -   releaseCycle: "7.8"
     eol: 2023-04-24
     releaseDate: 2022-07-24
     latestReleaseDate: 2022-07-24
     latest: '7.8'
+
 -   releaseCycle: "7.7"
     eol: 2022-12-27
     releaseDate: 2022-03-27
     latestReleaseDate: 2022-03-27
     latest: '7.7'
+
 -   releaseCycle: "7.5-ce"
     eol: 2024-03-06
     releaseDate: 2022-03-06
     latestReleaseDate: 2022-03-06
     latest: '7.5-ce'
+
 -   releaseCycle: "7.6"
     eol: 2022-09-05
     releaseDate: 2021-12-05
     latestReleaseDate: 2021-12-05
     latest: '7.6'
+
 -   releaseCycle: "7.5"
     eol: 2022-08-22
     releaseDate: 2021-08-22
     latestReleaseDate: 2022-03-06
     latest: '7.5-ce'
+
 -   releaseCycle: "7.4"
     eol: 2022-05-24
     releaseDate: 2021-05-24
     latestReleaseDate: 2021-05-24
     latest: '7.4'
+
 -   releaseCycle: "7.3"
     eol: 2022-02-01
     releaseDate: 2021-02-01
     latestReleaseDate: 2021-02-01
     latest: '7.3'
+
 -   releaseCycle: "7.2"
     eol: 2022-03-07
     releaseDate: 2020-09-07
     latestReleaseDate: 2020-09-07
     latest: '7.2'
+
 -   releaseCycle: "7.1"
     eol: 2021-06-04
     releaseDate: 2020-04-22
     latestReleaseDate: 2020-04-22
     latest: '7.1'
+
 -   releaseCycle: "7.0"
     eol: 2021-06-04
     releaseDate: 2019-12-04
     latestReleaseDate: 2019-12-04
     latest: '7.0'
+
 -   releaseCycle: "6.1"
     eol: 2022-07-01
     releaseDate: 2019-07-02
     latestReleaseDate: 2019-07-02
     latest: '6.1'
+
 -   releaseCycle: "6.0"
     eol: 2020-02-26
     releaseDate: 2019-02-26
     latestReleaseDate: 2019-02-26
     latest: '6.0'
+
 -   releaseCycle: "4.2"
     eol: 2022-03-01
     releaseDate: 2018-06-25
     latestReleaseDate: 2018-06-25
     latest: '4.2'
+
 -   releaseCycle: "5.0"
     eol: 2024-06-01
     releaseDate: 2018-03-19
     latestReleaseDate: 2018-03-19
     latest: '5.0'
+
 -   releaseCycle: "4.1"
     eol: 2019-09-15
     releaseDate: 2017-09-15
     latestReleaseDate: 2017-09-15
     latest: '4.1'
+
 -   releaseCycle: "4.0"
     eol: 2018-04-05
     releaseDate: 2017-04-05
     latestReleaseDate: 2017-04-05
     latest: '4.0'
+
 -   releaseCycle: "3.4"
     eol: 2019-08-21
     releaseDate: 2016-08-21
     latestReleaseDate: 2016-08-21
     latest: '3.4'
+
 -   releaseCycle: "3.3"
     eol: 2017-02-28
     releaseDate: 2015-11-10
     latestReleaseDate: 2015-11-10
     latest: '3.3'
+
 -   releaseCycle: "3.2"
     eol: 2016-03-31
     releaseDate: 2015-03-31
     latestReleaseDate: 2015-03-31
     latest: '3.2'
+
 -   releaseCycle: "3.1"
     eol: 2015-09-03
     releaseDate: 2014-09-03
@@ -123,5 +143,10 @@ releases:
 
 ---
 
-> [Palo Alto Networks](https://www.paloaltonetworks.com/) [Cortex XDR agent](https://docs.paloaltonetworks.com/cortex/cortex-xdr) protects endpoints by preventing known and unknown malware from running on those endpoints and by halting any attempts to leverage software exploits and vulnerabilities. The agent can be installed on a variety of operating systems including Windows, macOS, Android, and Linux.
+> [Palo Alto Networks](https://www.paloaltonetworks.com/)
+> [Cortex XDR agent](https://docs.paloaltonetworks.com/cortex/cortex-xdr) protects endpoints by
+> preventing known and unknown malware from running on those endpoints and by halting any attempts
+> to leverage software exploits and vulnerabilities. The agent can be installed on a variety of
+> operating systems including Windows, macOS, Android, and Linux.
+
 Software updates are provided as part of a valid support agreement.


### PR DESCRIPTION
Those information are not displayed on https://endoflife.date/cortex-xdr, and:

- `latest` is always equals to `releaseCycle`
- `latestReleaseDate` is always equal to `releaseDate`
    
Note that 7.5 cycle was an exception because it declared `latest`=`7.5-ce` and `latestReleaseDate`=`2022-03-06`. But considering 7.5-ce has its own entry this seems wrong.

I also took this opportunity to normalize the page (#2124).
