### PR TITLE
[OpenSUSE] Remove unused `support` fields

### DIFF
--- a/products/opensuse.md
+++ b/products/opensuse.md
@@ -17,102 +17,84 @@ eolColumn: End of Life
 
 releases:
 -   releaseCycle: "15.4"
-    support: 2023-12-01
     eol: 2023-12-01
     releaseDate: 2022-06-09
 
 -   releaseCycle: "15.3"
-    support: 2022-12-01
     eol: 2022-12-01
     releaseDate: 2021-06-02
 
 -   releaseCycle: "15.2"
-    support: 2021-12-01
     eol: 2021-12-01
     releaseDate: 2020-07-02
 
 -   releaseCycle: "15.1"
-    support: 2021-02-02
     eol: 2021-02-02
     releaseDate: 2019-05-22
 
 -   releaseCycle: "15.0"
-    support: 2019-12-03
     eol: 2019-12-03
     releaseDate: 2018-05-25
 
 -   releaseCycle: "42.3"
-    support: 2019-07-01
     eol: 2019-07-01
     releaseDate: 2017-07-26
 
 -   releaseCycle: "42.2"
-    support: 2018-01-26
     eol: 2018-01-26
     releaseDate: 2016-11-16
 
 -   releaseCycle: "42.1"
-    support: 2017-05-17
     eol: 2017-05-17
     releaseDate: 2015-11-04
 
 -   releaseCycle: "13.2"
     releaseLabel: "__RELEASE_CYCLE__"
-    support: 2017-01-17
     eol: 2017-01-17
     releaseDate: 2014-11-04
 
 -   releaseCycle: "13.1"
     releaseLabel: "__RELEASE_CYCLE__"
-    support: 2016-02-03
     eol: 2016-02-03
     releaseDate: 2014-01-08
 
 -   releaseCycle: "12.3"
     releaseLabel: "__RELEASE_CYCLE__"
-    support: 2015-01-29
     eol: 2015-01-29
     releaseDate: 2013-03-13
 
 -   releaseCycle: "12.2"
     releaseLabel: "__RELEASE_CYCLE__"
-    support: 2014-01-15
     eol: 2014-01-15
     releaseDate: 2012-09-05
 
 -   releaseCycle: "12.1"
     releaseLabel: "__RELEASE_CYCLE__"
-    support: 2013-05-15
     eol: 2013-05-15
     releaseDate: 2011-11-16
 
 -   releaseCycle: "11.4"
     releaseLabel: "__RELEASE_CYCLE__"
-    support: 2012-11-05
     eol: 2012-11-05
     releaseDate: 2011-03-10
 
 -   releaseCycle: "11.3"
     releaseLabel: "__RELEASE_CYCLE__"
-    support: 2012-01-20
     eol: 2012-01-20
     releaseDate: 2010-07-15
 
 -   releaseCycle: "11.2"
     releaseLabel: "__RELEASE_CYCLE__"
-    support: 2011-05-12
     eol: 2011-05-12
     releaseDate: 2009-11-12
 
 -   releaseCycle: "11.1"
     releaseLabel: "__RELEASE_CYCLE__"
-    support: 2011-01-14
     eol: 2011-01-14
     releaseDate: 2008-12-18
 
 -   releaseCycle: "11.0"
     releaseLabel: "__RELEASE_CYCLE__"
-    support: 2010-07-26
     eol: 2010-07-26
     releaseDate: 2008-06-19
 

--- a/products/opensuse.md
+++ b/products/opensuse.md
@@ -20,79 +20,96 @@ releases:
     support: 2023-12-01
     eol: 2023-12-01
     releaseDate: 2022-06-09
+
 -   releaseCycle: "15.3"
     support: 2022-12-01
     eol: 2022-12-01
     releaseDate: 2021-06-02
+
 -   releaseCycle: "15.2"
     support: 2021-12-01
     eol: 2021-12-01
     releaseDate: 2020-07-02
+
 -   releaseCycle: "15.1"
     support: 2021-02-02
     eol: 2021-02-02
     releaseDate: 2019-05-22
+
 -   releaseCycle: "15.0"
     support: 2019-12-03
     eol: 2019-12-03
     releaseDate: 2018-05-25
+
 -   releaseCycle: "42.3"
     support: 2019-07-01
     eol: 2019-07-01
     releaseDate: 2017-07-26
+
 -   releaseCycle: "42.2"
     support: 2018-01-26
     eol: 2018-01-26
     releaseDate: 2016-11-16
+
 -   releaseCycle: "42.1"
     support: 2017-05-17
     eol: 2017-05-17
     releaseDate: 2015-11-04
+
 -   releaseCycle: "13.2"
     releaseLabel: "__RELEASE_CYCLE__"
     support: 2017-01-17
     eol: 2017-01-17
     releaseDate: 2014-11-04
+
 -   releaseCycle: "13.1"
     releaseLabel: "__RELEASE_CYCLE__"
     support: 2016-02-03
     eol: 2016-02-03
     releaseDate: 2014-01-08
+
 -   releaseCycle: "12.3"
     releaseLabel: "__RELEASE_CYCLE__"
     support: 2015-01-29
     eol: 2015-01-29
     releaseDate: 2013-03-13
+
 -   releaseCycle: "12.2"
     releaseLabel: "__RELEASE_CYCLE__"
     support: 2014-01-15
     eol: 2014-01-15
     releaseDate: 2012-09-05
+
 -   releaseCycle: "12.1"
     releaseLabel: "__RELEASE_CYCLE__"
     support: 2013-05-15
     eol: 2013-05-15
     releaseDate: 2011-11-16
+
 -   releaseCycle: "11.4"
     releaseLabel: "__RELEASE_CYCLE__"
     support: 2012-11-05
     eol: 2012-11-05
     releaseDate: 2011-03-10
+
 -   releaseCycle: "11.3"
     releaseLabel: "__RELEASE_CYCLE__"
     support: 2012-01-20
     eol: 2012-01-20
     releaseDate: 2010-07-15
+
 -   releaseCycle: "11.2"
     releaseLabel: "__RELEASE_CYCLE__"
     support: 2011-05-12
     eol: 2011-05-12
     releaseDate: 2009-11-12
+
 -   releaseCycle: "11.1"
     releaseLabel: "__RELEASE_CYCLE__"
     support: 2011-01-14
     eol: 2011-01-14
     releaseDate: 2008-12-18
+
 -   releaseCycle: "11.0"
     releaseLabel: "__RELEASE_CYCLE__"
     support: 2010-07-26
@@ -101,11 +118,20 @@ releases:
 
 ---
 
-> [openSUSE](https://www.opensuse.org/) is a linux distribution developed by the community-supported openSUSE Project and aimed at sysadmins, developers and desktop users.
+> [openSUSE](https://www.opensuse.org/) is a linux distribution developed by the community-supported
+> openSUSE Project and aimed at sysadmins, developers and desktop users.
 
-openSUSE Leap is the name for openSUSE's regular releases, which were previously known as just 'openSUSE' for versions 13.2 and earlier. A Leap Minor Release (42.1, 42.2, 15.1, 15.2, etc.) is expected to be released annually. Users are expected to upgrade to the latest minor release within 6 months of its availability, leading to a _maintenance life cycle of 18 months_. Support is defined as:
+openSUSE Leap is the name for openSUSE's regular releases, which were previously known as just
+'openSUSE' for versions 13.2 and earlier. A Leap Minor Release (42.1, 42.2, 15.1, 15.2, etc.) is
+expected to be released annually. Users are expected to upgrade to the latest minor release within 6
+months of its availability, leading to a _maintenance life cycle of 18 months_. Support is defined
+as:
 
 - security updates for all included packages
 - critical bugfix updates
 
-A Leap major release (15.x) is supported until the next major release. Leap 15's lifecycle fully aligns with SUSE Linux Enterprise. There is a projection as of March 2021 that Leap 15 will extend to Leap 15.5. The previous major version of Leap, 42, was supported more than 36 months, while the current major version of Leap, 15, now stands well beyond 36 months of security and maintenance support as stated above.
+A Leap major release (15.x) is supported until the next major release. Leap 15's lifecycle fully
+aligns with SUSE Linux Enterprise. There is a projection as of March 2021 that Leap 15 will extend
+to Leap 15.5. The previous major version of Leap, 42, was supported more than 36 months, while the
+current major version of Leap, 15, now stands well beyond 36 months of security and maintenance
+support as stated above.


### PR DESCRIPTION
`support` date is not displayed and is always equal to `eol`.

I also took this opportunity to normalize the page (#2124).