### PR TITLE
[PAN GlobalProtect App] Remove `latest` and `latestReleaseDate` fields

### DIFF
--- a/products/pan-gp.md
+++ b/products/pan-gp.md
@@ -16,75 +16,55 @@ releases:
     eol: 2024-09-01
     support: 2024-09-01
     releaseDate: 2022-09-01
-    latestReleaseDate: 2022-09-01
-    latest: '6.1.0'
     link: https://docs.paloaltonetworks.com/globalprotect/6-1/globalprotect-app-release-notes
 
 -   releaseCycle: "6.0"
     eol: 2024-02-22
     support: 2024-02-22
     releaseDate: 2022-02-22
-    latestReleaseDate: 2022-02-22
-    latest: '6.0'
     link: https://docs.paloaltonetworks.com/globalprotect/6-0/globalprotect-app-release-notes
 
 -   releaseCycle: "5.3"
     eol: 2023-06-01
     support: 2022-12-01
     releaseDate: 2021-06-01
-    latestReleaseDate: 2021-06-01
-    latest: '5.3'
     link: https://docs.paloaltonetworks.com/globalprotect/5-3/globalprotect-app-release-notes/gp-app-release-information
 
 -   releaseCycle: "5.2"
     eol: 2023-02-28
     support: 2023-02-28
     releaseDate: 2020-07-30
-    latestReleaseDate: 2020-07-30
-    latest: '5.2'
     link: https://docs.paloaltonetworks.com/globalprotect/5-2/globalprotect-app-release-notes
 
 -   releaseCycle: "5.1"
     eol: 2022-12-12
     support: 2021-03-12
     releaseDate: 2019-12-12
-    latestReleaseDate: 2019-12-12
-    latest: '5.1'
 
 -   releaseCycle: "5.0"
     eol: 2021-02-12
     support: 2020-05-12
     releaseDate: 2019-02-12
-    latestReleaseDate: 2019-02-12
-    latest: '5.0'
 
 -   releaseCycle: "4.1"
     eol: 2020-03-01
     support: 2019-06-01
     releaseDate: 2018-03-01
-    latestReleaseDate: 2018-03-01
-    latest: '4.1'
 
 -   releaseCycle: "4.0"
     eol: 2019-01-30
     support: 2018-05-02
     releaseDate: 2017-01-30
-    latestReleaseDate: 2017-01-30
-    latest: '4.0'
 
 -   releaseCycle: "3.1"
     eol: 2018-06-23
     support: 2017-09-23
     releaseDate: 2016-06-23
-    latestReleaseDate: 2016-06-23
-    latest: '3.1'
 
 -   releaseCycle: "3.0"
     eol: 2018-02-15
     support: 2017-05-18
     releaseDate: 2016-02-16
-    latestReleaseDate: 2016-02-16
-    latest: '3.0'
 
 ---
 

--- a/products/pan-gp.md
+++ b/products/pan-gp.md
@@ -7,8 +7,10 @@ activeSupportColumn: true
 releaseColumn: false
 releaseDateColumn: true
 eolColumn: End-of-life Date
+
 auto:
 -   custom: true
+
 releases:
 -   releaseCycle: "6.1"
     eol: 2024-09-01
@@ -17,6 +19,7 @@ releases:
     latestReleaseDate: 2022-09-01
     latest: '6.1.0'
     link: https://docs.paloaltonetworks.com/globalprotect/6-1/globalprotect-app-release-notes
+
 -   releaseCycle: "6.0"
     eol: 2024-02-22
     support: 2024-02-22
@@ -24,6 +27,7 @@ releases:
     latestReleaseDate: 2022-02-22
     latest: '6.0'
     link: https://docs.paloaltonetworks.com/globalprotect/6-0/globalprotect-app-release-notes
+
 -   releaseCycle: "5.3"
     eol: 2023-06-01
     support: 2022-12-01
@@ -31,6 +35,7 @@ releases:
     latestReleaseDate: 2021-06-01
     latest: '5.3'
     link: https://docs.paloaltonetworks.com/globalprotect/5-3/globalprotect-app-release-notes/gp-app-release-information
+
 -   releaseCycle: "5.2"
     eol: 2023-02-28
     support: 2023-02-28
@@ -38,36 +43,42 @@ releases:
     latestReleaseDate: 2020-07-30
     latest: '5.2'
     link: https://docs.paloaltonetworks.com/globalprotect/5-2/globalprotect-app-release-notes
+
 -   releaseCycle: "5.1"
     eol: 2022-12-12
     support: 2021-03-12
     releaseDate: 2019-12-12
     latestReleaseDate: 2019-12-12
     latest: '5.1'
+
 -   releaseCycle: "5.0"
     eol: 2021-02-12
     support: 2020-05-12
     releaseDate: 2019-02-12
     latestReleaseDate: 2019-02-12
     latest: '5.0'
+
 -   releaseCycle: "4.1"
     eol: 2020-03-01
     support: 2019-06-01
     releaseDate: 2018-03-01
     latestReleaseDate: 2018-03-01
     latest: '4.1'
+
 -   releaseCycle: "4.0"
     eol: 2019-01-30
     support: 2018-05-02
     releaseDate: 2017-01-30
     latestReleaseDate: 2017-01-30
     latest: '4.0'
+
 -   releaseCycle: "3.1"
     eol: 2018-06-23
     support: 2017-09-23
     releaseDate: 2016-06-23
     latestReleaseDate: 2016-06-23
     latest: '3.1'
+
 -   releaseCycle: "3.0"
     eol: 2018-02-15
     support: 2017-05-18
@@ -75,8 +86,11 @@ releases:
     latestReleaseDate: 2016-02-16
     latest: '3.0'
 
-
 ---
 
-[Palo Alto Networks](https://www.paloaltonetworks.com/) [GlobalProtect App](https://docs.paloaltonetworks.com/globalprotect) is the software client for the VPN service on Palo Alto Networks PAN-OS firewalls and Prisma Access service. The app can be installed on a variety of operating systems including Windows, macOS, Android, iOS, and Linux.
+> [Palo Alto Networks](https://www.paloaltonetworks.com/) [GlobalProtect App](https://docs.paloaltonetworks.com/globalprotect)
+> is the software client for the VPN service on Palo Alto Networks PAN-OS firewalls and Prisma
+> Access service. The app can be installed on a variety of operating systems including Windows,
+> macOS, Android, iOS, and Linux.
+
 Software updates are provided as part of a valid support agreement.


### PR DESCRIPTION
Those information are not displayed on https://endoflife.date/pangp, and:
    
- `latest` is always equals to `releaseCycle`
- `latestReleaseDate` is always equal to `releaseDate`

I also took this opportunity to normalize the page (#2124).