### PR TITLE
[PCI-DSS] Update 4.0 cycle

### DIFF
--- a/products/pci-dss.md
+++ b/products/pci-dss.md
@@ -12,9 +12,8 @@ releaseDateColumn: true
 eolColumn: Acceptance
 
 releases:
--   releaseCycle: "4"
+-   releaseCycle: "4.0"
     eol: false
-    latest: "4.0"
     releaseDate: 2022-03-31
     link: https://blog.pcisecuritystandards.org/pci-dss-v4-0-resource-hub
 

--- a/products/pci-dss.md
+++ b/products/pci-dss.md
@@ -2,39 +2,49 @@
 title: PCI-DSS
 category: standard
 permalink: /pci-dss
-releasePolicyLink: https://blog.pcisecuritystandards.org/updated-pci-dss-v4.0-timeline
-releasePolicyImage: https://blog.pcisecuritystandards.org/hs-fs/hubfs/Development.png?width=750&name=Development.png
 alternate_urls:
 -   /pci
+releasePolicyLink: https://blog.pcisecuritystandards.org/updated-pci-dss-v4.0-timeline
+releasePolicyImage: https://blog.pcisecuritystandards.org/hs-fs/hubfs/Development.png?width=750&name=Development.png
 activeSupportColumn: false
 releaseColumn: false
 releaseDateColumn: true
 eolColumn: Acceptance
+
 releases:
 -   releaseCycle: "4"
     eol: false
     latest: "4.0"
     releaseDate: 2022-03-31
     link: https://blog.pcisecuritystandards.org/pci-dss-v4-0-resource-hub
+
 -   releaseCycle: "3.2.1"
     eol: 2024-03-31
     releaseDate: 2018-05-01
     link: https://docs-prv.pcisecuritystandards.org/PCI%20DSS/Standard/PCI_DSS_Summary_of_Changes_3-2-1.pdf
+
 -   releaseCycle: "3.2"
     eol: 2018-12-31
     releaseDate: 2016-04-01
+
 -   releaseCycle: "3.1"
     eol: 2016-10-31
     releaseDate: 2015-04-01
 
 ---
 
-> [PCI-DSS](https://www.pcisecuritystandards.org) is an information security standard for organizations that handle branded credit cards from the major card schemes.
+> [PCI-DSS](https://www.pcisecuritystandards.org) is an information security standard for
+> organizations that handle branded credit cards from the major card schemes.
 
-- PCI DSS v3.2.1 will remain active till March 2024. This provides organizations time to become familiar with the new version, and plan for and implement the changes needed. A [summary of changes](https://docs-prv.pcisecuritystandards.org/PCI%20DSS/Standard/PCI-DSS-v3-2-1-to-v4-0-Summary-of-Changes-r1.pdf) from v3.2.1 to v4.0 is available.
+- PCI DSS v3.2.1 will remain active till March 2024. This provides organizations time to become
+  familiar with the new version, and plan for and implement the changes needed. A
+  [summary of changes](https://docs-prv.pcisecuritystandards.org/PCI%20DSS/Standard/PCI-DSS-v3-2-1-to-v4-0-Summary-of-Changes-r1.pdf)
+  from v3.2.1 to v4.0 is available.
 
 - Future-dated new requirements introduced in v4.0 will become effective on 31st March 2025.
 
 - PCI DSS 3.2 remained valid till 31 December 2018 and was retired on 1 January 2019.
 
-- PCI DSS [3.1 retired on 31 October 2016](https://listings.pcisecuritystandards.org/pdfs/PCI_DSS_Resource_Guide_(003).pdf). The new requirements introduced in PCI DSS 3.2 were considered best practices until 31 January 2018. Starting 1 February 2018 they are effective as requirements and must be used.
+- PCI DSS [3.1 retired on 31 October 2016](https://listings.pcisecuritystandards.org/pdfs/PCI_DSS_Resource_Guide_(003).pdf).
+  The new requirements introduced in PCI DSS 3.2 were considered best practices until 31 January 2018.
+  Starting 1 February 2018 they are effective as requirements and must be used.


### PR DESCRIPTION
- Use 4.0 as the cycle name: it's more coherent with the other cycles.
- Remove latest: this field is not displayed.

I also took this opportunity to normalize the page (#2124).
