### PR TITLE
[iphone] Mark iOS15 devices as supported

### DIFF
--- a/products/iphone.md
+++ b/products/iphone.md
@@ -1,7 +1,5 @@
 ---
 permalink: /iphone
-alternate_urls:
--   /ios
 title: Apple iPhone
 category: device
 iconSlug: apple
@@ -76,17 +74,20 @@ releases:
     discontinued: 2018-09-12
     eol: false
     releaseDate: 2017-09-12
+# iOS 15.7.2 was released on 13th Dec 2022
+# exclusively for 7/7+/SE1/6S/6S+
+# so these are marked as not yet dead devices.
 -   releaseCycle: "iPhone 7 / 7 Plus"
     discontinued: 2019-09-10
-    eol: 2022-09-12
+    eol: false
     releaseDate: 2016-09-16
 -   releaseCycle: "iPhone SE (1st generation)"
     discontinued: 2018-09-12
-    eol: 2022-09-12
+    eol: false
     releaseDate: 2016-03-31
 -   releaseCycle: "iPhone 6S / 6S Plus"
     discontinued: 2018-09-12
-    eol: 2022-09-12
+    eol: false
     releaseDate: 2015-09-25
 -   releaseCycle: "iPhone 6 / 6 Plus"
     discontinued: 2016-09-07


### PR DESCRIPTION
Seems like Apple is exclusively pushing fixes there still

Ref for 15.7.2: https://support.apple.com/en-us/HT213531