### PR TITLE
[apple] Add active support column.

### DIFF
--- a/products/ios.md
+++ b/products/ios.md
@@ -19,67 +19,67 @@ releases:
     latest: "16.2"
 -   releaseCycle: "15"
     eol: false
-    support: false
+    support: 2022-09-12
     releaseDate: 2021-09-20
     latestReleaseDate: 2022-12-13
     latest: "15.7.2"
 -   releaseCycle: "14"
     eol: 2021-10-01
-    support: false
+    support: 2021-09-20
     releaseDate: 2020-09-16
     latestReleaseDate: 2021-10-26
     latest: "14.8.1"
 -   releaseCycle: "13"
     eol: 2020-09-16
-    support: false
+    support: 2020-09-16
     releaseDate: 2019-09-19
     latestReleaseDate: 2020-09-01
     latest: "13.7"
 -   releaseCycle: "12"
     eol: 2022-08-31
-    support: false
+    support: 2019-09-19
     releaseDate: 2018-09-17
     latestReleaseDate: 2022-08-31
     latest: "12.5.6"
 -   releaseCycle: "11"
     eol: 2018-10-08
-    support: false
+    support: 2018-09-17
     releaseDate: 2017-09-19
     latestReleaseDate: 2018-07-09
     latest: "11.4.1"
 -   releaseCycle: "10"
     eol: 2017-09-26
-    support: false
+    support: 2017-09-19
     releaseDate: 2016-09-13
     latestReleaseDate: 2019-07-22
     latest: "10.3.4"
 -   releaseCycle: "9"
     eol: 2016-09-13
-    support: false
+    support: 2016-09-13
     releaseDate: 2015-09-16
     latestReleaseDate: 2019-07-22
     latest: "9.3.6"
 -   releaseCycle: "8"
     eol: 2015-09-30
-    support: false
+    support: 2015-09-16
     releaseDate: 2014-09-17
     latestReleaseDate: 2015-08-13
     latest: "8.4.1"
 -   releaseCycle: "7"
     eol: 2014-10-20
-    support: false
+    support: 2014-09-17
     releaseDate: 2013-09-18
     latestReleaseDate: 2014-06-30
     latest: "7.1.2"
 -   releaseCycle: "6"
     eol: 2013-09-26
-    support: false
+    support: 2013-09-18
     releaseDate: 2012-09-19
     latestReleaseDate: 2014-02-21
     latest: "6.1.6"
 -   releaseCycle: "5"
     eol: 2012-11-01
-    support: false
+    support: 2012-09-19
     releaseDate: 2011-10-12
     latestReleaseDate: 2012-05-07
     latest: "5.1.1"

--- a/products/ios.md
+++ b/products/ios.md
@@ -5,69 +5,81 @@ category: os
 iconSlug: apple
 releasePolicyLink: https://en.wikipedia.org/wiki/IOS_version_history#Overview
 discontinuedColumn: false
-activeSupportColumn: false
+activeSupportColumn: true
 releaseColumn: true
 releaseDateColumn: true
 auto:
 -   custom: true
 releases:
 -   releaseCycle: "16"
+    support: true
     releaseDate: 2022-09-12
     eol: false
     latestReleaseDate: 2022-12-13
     latest: "16.2"
 -   releaseCycle: "15"
     eol: false
+    support: false
     releaseDate: 2021-09-20
     latestReleaseDate: 2022-12-13
     latest: "15.7.2"
 -   releaseCycle: "14"
     eol: 2021-10-01
+    support: false
     releaseDate: 2020-09-16
     latestReleaseDate: 2021-10-26
     latest: "14.8.1"
 -   releaseCycle: "13"
     eol: 2020-09-16
+    support: false
     releaseDate: 2019-09-19
     latestReleaseDate: 2020-09-01
     latest: "13.7"
 -   releaseCycle: "12"
     eol: 2022-08-31
+    support: false
     releaseDate: 2018-09-17
     latestReleaseDate: 2022-08-31
     latest: "12.5.6"
 -   releaseCycle: "11"
     eol: 2018-10-08
+    support: false
     releaseDate: 2017-09-19
     latestReleaseDate: 2018-07-09
     latest: "11.4.1"
 -   releaseCycle: "10"
     eol: 2017-09-26
+    support: false
     releaseDate: 2016-09-13
     latestReleaseDate: 2019-07-22
     latest: "10.3.4"
 -   releaseCycle: "9"
     eol: 2016-09-13
+    support: false
     releaseDate: 2015-09-16
     latestReleaseDate: 2019-07-22
     latest: "9.3.6"
 -   releaseCycle: "8"
     eol: 2015-09-30
+    support: false
     releaseDate: 2014-09-17
     latestReleaseDate: 2015-08-13
     latest: "8.4.1"
 -   releaseCycle: "7"
     eol: 2014-10-20
+    support: false
     releaseDate: 2013-09-18
     latestReleaseDate: 2014-06-30
     latest: "7.1.2"
 -   releaseCycle: "6"
     eol: 2013-09-26
+    support: false
     releaseDate: 2012-09-19
     latestReleaseDate: 2014-02-21
     latest: "6.1.6"
 -   releaseCycle: "5"
     eol: 2012-11-01
+    support: false
     releaseDate: 2011-10-12
     latestReleaseDate: 2012-05-07
     latest: "5.1.1"

--- a/products/ipados.md
+++ b/products/ipados.md
@@ -5,7 +5,7 @@ category: os
 iconSlug: apple
 releasePolicyLink: https://en.wikipedia.org/wiki/IOS_version_history#Overview
 discontinuedColumn: false
-activeSupportColumn: false
+activeSupportColumn: true
 releaseColumn: true
 releaseDateColumn: true
 auto:
@@ -13,28 +13,28 @@ auto:
 releases:
 -   releaseCycle: "16"
     eol: false
+    support: true
     releaseDate: 2022-10-24
     latestReleaseDate: 2022-12-13
     latest: '16.2'
 -   releaseCycle: "15"
     eol: false
+    support: false
     releaseDate: 2021-09-20
     latestReleaseDate: 2022-12-13
     latest: '15.7.2'
 -   releaseCycle: "14"
     eol: 2021-10-01
+    support: false
     releaseDate: 2020-09-16
     latestReleaseDate: 2021-10-26
     latest: '14.8.1'
 -   releaseCycle: "13"
     eol: 2020-09-16
+    support: false
     releaseDate: 2019-09-24
     latestReleaseDate: 2020-07-15
     latest: '13.6'
-
-
-
-
 
 ---
 
@@ -42,4 +42,4 @@ releases:
 
 Major versions of iPadOS are released annually, and might lag behind corresponding iOS releases.
 
-Support information for iPhone devices are available at [/iphone](/iphone).
+Support information for iPad devices are available at [/ipad](/ipad).

--- a/products/ipados.md
+++ b/products/ipados.md
@@ -19,19 +19,19 @@ releases:
     latest: '16.2'
 -   releaseCycle: "15"
     eol: false
-    support: false
+    support: 2022-10-24
     releaseDate: 2021-09-20
     latestReleaseDate: 2022-12-13
     latest: '15.7.2'
 -   releaseCycle: "14"
     eol: 2021-10-01
-    support: false
+    support: 2021-09-20
     releaseDate: 2020-09-16
     latestReleaseDate: 2021-10-26
     latest: '14.8.1'
 -   releaseCycle: "13"
     eol: 2020-09-16
-    support: false
+    support: 2020-09-16
     releaseDate: 2019-09-24
     latestReleaseDate: 2020-07-15
     latest: '13.6'

--- a/products/watchos.md
+++ b/products/watchos.md
@@ -19,37 +19,37 @@ releases:
     latest: '9.2'
 -   releaseCycle: "8"
     eol: 2022-09-22
-    support: false
+    support: 2022-09-12
     releaseDate: 2021-09-20
     latestReleaseDate: 2022-08-17
     latest: '8.7.1'
 -   releaseCycle: "7"
     eol: 2021-10-11
-    support: false
+    support: 2021-09-20
     releaseDate: 2020-09-16
     latestReleaseDate: 2021-09-13
     latest: '7.6.2'
 -   releaseCycle: "6"
     eol: 2020-09-16
-    support: false
+    support: 2020-09-16
     releaseDate: 2019-09-19
     latestReleaseDate: 2020-12-14
     latest: '6.3'
 -   releaseCycle: "5"
     eol: 2019-09-30
-    support: false
+    support: 2019-09-19
     releaseDate: 2018-09-17
     latestReleaseDate: 2020-11-05
     latest: '5.3.9'
 -   releaseCycle: "4"
     eol: 2018-09-27
-    support: false
+    support: 2018-09-17
     releaseDate: 2017-09-19
     latestReleaseDate: 2018-07-09
     latest: '4.3.2'
 -   releaseCycle: "3"
     eol: 2017-10-04
-    support: false
+    support: 2017-09-19
     releaseDate: 2016-09-13
     latestReleaseDate: 2017-07-19
     latest: '3.2.3'

--- a/products/watchos.md
+++ b/products/watchos.md
@@ -5,7 +5,7 @@ category: os
 iconSlug: apple
 releasePolicyLink: https://en.wikipedia.org/wiki/WatchOS#Version_history
 discontinuedColumn: false
-activeSupportColumn: false
+activeSupportColumn: true
 releaseColumn: true
 releaseDateColumn: true
 auto:
@@ -13,36 +13,43 @@ auto:
 releases:
 -   releaseCycle: "9"
     eol: false
+    support: true
     releaseDate: 2022-09-12
     latestReleaseDate: 2022-12-13
     latest: '9.2'
 -   releaseCycle: "8"
     eol: 2022-09-22
+    support: false
     releaseDate: 2021-09-20
     latestReleaseDate: 2022-08-17
     latest: '8.7.1'
 -   releaseCycle: "7"
     eol: 2021-10-11
+    support: false
     releaseDate: 2020-09-16
     latestReleaseDate: 2021-09-13
     latest: '7.6.2'
 -   releaseCycle: "6"
     eol: 2020-09-16
+    support: false
     releaseDate: 2019-09-19
     latestReleaseDate: 2020-12-14
     latest: '6.3'
 -   releaseCycle: "5"
     eol: 2019-09-30
+    support: false
     releaseDate: 2018-09-17
     latestReleaseDate: 2020-11-05
     latest: '5.3.9'
 -   releaseCycle: "4"
     eol: 2018-09-27
+    support: false
     releaseDate: 2017-09-19
     latestReleaseDate: 2018-07-09
     latest: '4.3.2'
 -   releaseCycle: "3"
     eol: 2017-10-04
+    support: false
     releaseDate: 2016-09-13
     latestReleaseDate: 2017-07-19
     latest: '3.2.3'


### PR DESCRIPTION
iOS15 is still getting security support, so diffentiate it cleanly from v16.

Linked the /ipados page to /ipad, since we have that almost ready in #2199