### PR TITLE
[Ubuntu] Update Ubuntu LTS release image

### DIFF
--- a/products/ubuntu.md
+++ b/products/ubuntu.md
@@ -19,7 +19,7 @@ identifiers:
 -   purl: pkg:os/ubuntu
 activeSupportColumn: true
 releaseDateColumn: true
-releaseImage: https://user-images.githubusercontent.com/44484725/135176160-a1d5dd88-fc56-44ee-9ce8-98d52a41da2b.png
+releaseImage: https://user-images.githubusercontent.com/10281587/210113332-7a65b33c-c900-429a-8e73-83cefcb4e684.png
 releaseLabel: "__RELEASE_CYCLE__ '__CODENAME__'"
 releases:
 -   releaseCycle: "22.10"


### PR DESCRIPTION
The current graphic for the Ubuntu page is out of date. (20.10, 21.04, and 21.10 are unsupported. 22.10 is missing.)

Rather than continually updating the graphic, sourcing the release graphic from the [Ubuntu Lifecycle page](https://ubuntu.com/about/release-cycle).

The alternative is to continually capture the releases, in which case this PR can be amended to use [this graphic](https://user-images.githubusercontent.com/10281587/210113332-7a65b33c-c900-429a-8e73-83cefcb4e684.png) instead.
