### PR TITLE
[layout] Move layout logic to ruby plugin

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -63,4 +63,39 @@ defaults:
       path: "products"
     values:
       layout: product
+      releaseCycleColumn: true
+      releaseDateColumn: false
+      discontinuedColumn: false
+      activesupportColumn: false
+      eolColumn: true
+      columns:
+        # The spaces before Yes/No
+        # are intentional to avoid the
+        # YAML norway problem
+        support:
+          if: activeSupportColumn
+          type: date
+          defaults:
+            on-true:
+              text: " Yes"
+              color: green
+            on-false:
+              text: " No"
+              color: red
+        eol:
+          if: eolColumn
+          type: date
+          defaults:
+            on-false:
+              text: " Yes"
+              color: green
+            on-true:
+              text: " No"
+              color: red
+
+      releaseColumn: true
 encoding: utf-8
+colorClass:
+  green: bg-green-000
+  red: bg-red-000
+  yellow: bg-yellow-200

--- a/_includes/date-element.html
+++ b/_includes/date-element.html
@@ -1,0 +1,15 @@
+{% assign f=include.field %}
+{% if include.enabled %}
+  {% assign d=include.r[f]%}
+
+  {% assign color=include.r.colors[f] %}
+  {% assign colorClass=site.colorClass[color] %}
+  <td class={{colorClass}} title="{{d}}">
+    {% if d == true or d==false %}
+      {{include.r.text[f]}}
+    {% else %}
+      {{include.r.text[f]}} {{d | timeago}}
+      <div>({{d | date_to_string}})</div>
+      {%endif%}
+  </td>
+{% endif %}

--- a/_includes/product-footer.html
+++ b/_includes/product-footer.html
@@ -1,0 +1,27 @@
+{% if include.releasePolicyLink and include.releasePolicyLink != "" %}
+<p>More information is available on the <a href="{{include.releasePolicyLink}}">{{include.title}} website</a>. </p>
+{% endif %}
+
+{% if include.releaseColumn != false %}<p>You should be running one of the supported release numbers listed above in the rightmost column.</p>{% endif %}
+
+{% if include.versionCommand %}<div id="version-command" class="card card-body bg-light">You can check the version that you are currently using by running: <pre>{{include.versionCommand}}</pre></div>{% endif %}
+
+<hr>
+
+  <a href="https://github.com/endoflife-date/endoflife.date/blob/master/{{include.path}}"
+    title="Click the Pencil, the link takes you directly to the correct page">[Edit]</a>|
+  <a title="Talk Page for {{include.title}}" href="https://github.com/endoflife-date/talk/wiki{{include.permalink}}">[Talk]</a> |
+  <a href="/api{{include.permalink}}.json">[JSON]</a> |
+  <a href="webcal://{{site.url | split: '://' | last}}/calendar{{include.permalink}}.ics">[ICS (Calendar)]</a>
+  {% if include.permalink != include.shortlink %}
+    | <a title="short memorable url ({{include.shortlink}})" href="{{include.shortlink}}">
+    endoflife.date{{include.shortlink}}</a>
+  {% endif %}
+</p>
+
+
+
+<p>
+This page was last updated on {{ include.last_modified_at | date_to_long_string }}.
+{%if include.auto %}Latest releases are automatically updated.{% endif %}
+</p>

--- a/_layouts/product.html
+++ b/_layouts/product.html
@@ -2,8 +2,9 @@
 layout: default
 ---
 
-{% if page.iconSlug %}
-<img alt="{{page.title}} Logo" class=productlogo width=50 height=50 src="https://simpleicons.org/icons/{{page.iconSlug}}.svg" >
+
+{% if page.iconUrl %}
+<img alt="{{page.title}} Logo" class=productlogo width=50 height=50 src="{{page.iconUrl}}" >
 {% endif %}
 
 <div class="description">{{content | extract_element:'blockquote' | first }}</div>
@@ -12,54 +13,17 @@ layout: default
 <img alt="Release Schedule Image Gantt Chart for {{page.title}}" src="{{page.releaseImage}}" />
 {% endif %}
 
-{% capture now %}{{ "now" | date: "%s" | plus:0 }}{% endcapture %}
-
 <table class="lifecycle">
   <thead>
     <tr>
-      <th>Release</th>
-      {% if page.releaseDateColumn%}<th>Released</th>{% endif %}
-      {% if page.discontinuedColumn%}<th>Discontinued</th>{% endif %}
-      {% if page.activeSupportColumn%}
-        <th>
-          {% if page.activeSupportColumn == true %}
-            Active Support
-          {%else%}
-            {{page.activeSupportColumn}}
-          {%endif%}
-        </th>
-      {% endif %}
-      {% if page.eolColumn != false %}
-      <th>{{ page.eolColumn | default: "Security Support" }}</th>
-      {% endif %}
-      {% if page.releaseColumn != false %}<th>Latest</th>{% endif %}
+      {% for h in page.headers %}
+      <th>{{h}}</th>
+      {% endfor %}
     </tr>
   </thead>
 
 {% for r in page.releases %}
-{% assign support =r.support | date: '%s' | plus:0 %}
-{% assign securityFixes = r.eol | date: '%s' | plus:0 %}
 
-
-{% comment %}
-diff is the number of days towards EoL. Positive is in the future. Negative is in the past.
-In case we don't have an exact date, we use boolean values (true/false) instead. In such
-cases diff is set to -1 for true (EoL has been reached)
-or +1 (EoL is in the future)
-{% endcomment %}
-{% if r.eol == true %}
-{% assign diff = -1 %}
-{% elsif r.eol == false %}
-{% assign diff = 1 %}
-{% elsif r.eol == nil %}
-{% assign diff = 1 %}
-{% else %}
-{% assign diff = r.eol | date: '%s' | plus:0 | minus:now %}
-{% endif %}
-
-{% assign diffSupport = support | minus:now %}
-{% assign diffSecurity6  = diff | minus:10651938 %}
-{% assign diffSupport6  = diffSupport | minus:10651938 %}
 {% assign latestVersionNumber = r.latest | liquify %}
 {% assign LTSLabel = page.LTSLabel | default: '<abbr title="Long Term Support">LTS</abbr>' %}
 
@@ -118,76 +82,17 @@ or +1 (EoL is in the future)
   </td>
   {% endif %}
 
-  {% if page.activeSupportColumn %}
-    <td class=
-    {% if support > 5 %}
-      {% if diffSupport < 0 and r.support != false %}
-      "bg-red-000"
-      {% elsif diffSupport6 > 0 %}
-      "bg-green-000"
-      {% else %}
-      "bg-yellow-200"
-      {% endif %}
-    {% else %}
-      {% if r.support %}
-      "bg-green-000"
-      {% else %}
-      "bg-red-000"
-      {% endif %}
-    {% endif %}
-    title="{{r.support}}">
-    {% if support > 5 %}
-      {% if diffSupport < 0 %}
-        Ended
-      {% else %}
-        Ends
-      {% endif %}
-    {{r.support | timeago}} <div>({{r.support | date_to_string}})</div>
-    {% else %}
-      {% if r.support %}
-      Yes
-      {% else %}
-      No
-      {% endif %}
-    {% endif %}
-    </td>
-  {% endif %}
+  {% include date-element.html
+    field='support'
+    enabled=page.activeSupportColumn
+    r=r
+  %}
 
-  {% if page.eolColumn != false %}
-  <td class=
-    {% if securityFixes > 5 %}
-      {% if diff < 0 %}
-      "bg-red-000"
-      {% elsif diffSecurity6 > 0 %}
-      "bg-green-000"
-      {% else %}
-      "bg-yellow-200"
-      {% endif %}
-    {% else %}
-      {% if r.eol %}
-      "bg-red-000"
-      {% else %}
-      "bg-green-000"
-      {% endif %}
-    {% endif %}
-    {% if securityFixes > 5 %}
-      title="{{r.eol}}">
-      {% if diff < 0 %}
-        Ended
-      {% else %}
-        Ends
-      {% endif %}
-    {{r.eol | timeago}} <div>({{r.eol | date_to_string}})</div>
-    {% else %}
-      >
-      {% if r.eol %}
-      No
-      {% else %}
-      Yes
-      {% endif %}
-    {% endif %}
-  </td>
-  {% endif %}
+  {% include date-element.html
+    field='eol'
+    enabled=page.eolColumn
+    r=r
+  %}
 
   {% if page.releaseColumn != false %}
   <td {% if diff <= 0 %} class = "txt-linethrough" {% endif %} >      <!-- if the support finished add txt-linethrough class -->
@@ -208,29 +113,15 @@ or +1 (EoL is in the future)
 <div class="policytext">
   {{content | remove_first_element:'blockquote'}}
 </div>
-{% if page.releasePolicyLink and page.releasePolicyLink != "" %}
-<p>More information is available on the <a href="{{page.releasePolicyLink}}">{{page.title}} website</a>. </p>
-{% endif %}
 
-{% if page.releaseColumn != false %}<p>You should be running one of the supported release numbers listed above in the rightmost column.</p>{% endif %}
-
-{% if page.versionCommand %}<div id="version-command" class="card card-body bg-light">You can check the version that you are currently using by running: <pre>{{page.versionCommand}}</pre></div>{% endif %}
-
-<hr>
-
-<p>You can submit an improvement to this page
-<a href="https://github.com/endoflife-date/endoflife.date/blob/master/{{page.path}}"
-title="Click the Pencil, the link takes you directly to the correct page">on GitHub</a>
-<img class="emoji" title=":octocat:" alt=":octocat:" src="https://github.githubassets.com/images/icons/emoji/octocat.png" width="20" height="20">
-. This page has a corresponding <a title="Talk Page for {{page.title}}" href="https://github.com/endoflife-date/talk/wiki{{page.permalink}}">Talk Page</a>.</p>
-
-<p>
-  A JSON version of this page is available at <a href="/api{{page.permalink}}.json">/api{{page.permalink}}.json</a>.
-  See the <a href="/docs/api/">API Documentation</a> for more information.
-  You can subscribe to the icalendar feed at <a href="webcal://{{site.url | split: '://' | last}}/calendar{{page.permalink}}.ics">/calendar{{page.permalink}}.ics</a>.
-</p>
-
-<p>
-This page was last updated on {{ page.last_modified_at | date_to_long_string }}.
-{%if page.auto %}Latest releases are automatically updated.{% endif %}
-</p>
+{%
+  include product-footer.html
+  releasePolicyLink=page.releasePolicyLink
+  title=page.title
+  versionCommand=page.versionCommand
+  path=page.path
+  permalink=page.permalink
+  shortlink=page.shortlink
+  last_modified_at=page.last_modified_at
+  auto=page.auto
+%}

--- a/_plugins/eol.rb
+++ b/_plugins/eol.rb
@@ -1,0 +1,106 @@
+require 'jekyll'
+require 'date'
+require 'pp'
+
+# This plugin enriches the product pages
+# by parsing the YAML and setting some standard
+# fields that can be easily consumed by the API
+# and other layouts
+module Jekyll
+  class Product
+    class << self
+      def enrich(page)
+        if page['iconSlug']
+          page.data['iconUrl'] = "https://simpleicons.org/icons/#{page['iconSlug']}.svg"
+        end
+
+        set_defaults(page)
+        set_column_headers(page)
+        enrich_releases(page)
+      end
+
+      def set_defaults(page)
+        page.data['shortlink'] ||= find_shortlink(page)
+      end
+
+      def find_shortlink(page)
+        return page['permalink'] unless page['alternate_urls']
+        shortlink = page['permalink']
+        page['alternate_urls'].each do |u|
+          shortlink = u if u.size < shortlink.size
+        end
+        shortlink
+      end
+
+      def enrich_releases(page)
+        today = Date.today
+        page['releases'].each do |r|
+          r['text'] = {}
+          r['colors'] = {}
+          ['eol', 'support'].each do |x|
+            next unless r.has_key? x
+            defaults = page['columns'][x]['defaults']
+            if r[x]===true
+              r['colors'][x] = defaults['on-true']['color']
+              r['text'][x] = defaults['on-true']['text']
+            elsif r[x]===false
+              r['colors'][x] = defaults['on-false']['color']
+              r['text'][x] = defaults['on-false']['text']
+            elsif r[x].is_a? Date
+              diff = (r[x]-today).to_i
+              # If EOL is after 6 months
+              if diff > 6*30
+                r['colors'][x] = 'green'
+                r['text'][x] = 'Ends'
+              elsif diff >0 and diff <= 6*30
+                r['colors'][x] = 'yellow'
+                r['text'][x] = 'Ends'
+              elsif diff <= 0
+                r['colors'][x] = 'red'
+                r['text'][x] = 'Ended'
+              end
+            end
+          end
+        end
+      end
+
+      # TODO: Allow for changing order
+      def set_column_headers(page)
+        headers = []
+        defaults = [
+          {key: 'releaseCycleColumn', text: 'Release'},
+          {key: 'releaseDateColumn', text: 'Released'},
+          {key: 'discontinuedColumn', text: 'Discontinued'},
+          {key: 'activeSupportColumn', text: 'Active Support'},
+          {key: 'eolColumn', text: 'Security Support'},
+          {key: 'releaseColumn', text: 'Latest'},
+        ]
+        defaults.each do |column|
+          val = page[column[:key]]
+          if val === true
+            headers << column[:text]
+          elsif val
+            headers << val
+          end
+        end
+        page.data['headers'] = headers
+      end
+
+      def is_product?(doc)
+        doc.data['layout'] == 'product'
+      end
+
+      # def post_render(doc)
+      #   pp doc.output
+      # end
+    end
+  end
+end
+
+Jekyll::Hooks.register [:pages], :post_init do |doc|
+  Jekyll::Product.enrich(doc) if Jekyll::Product.is_product? doc
+end
+
+# Jekyll::Hooks.register [:documents], :post_render do |doc|
+#   Jekyll::Product.post_render(doc)
+# end


### PR DESCRIPTION
We enrich the data available to liquid, and avoid complex logic in Liquid this way.

Still WIP, will make columns a bit more modular, with our sane defaults. Will avoid any mass changes to product front-matter in this PR, and retain compatibility for now. We can take those up in a later PR, since that would include schema changes and require more discussion.

Intent is to use the plugin for any complex logic:

1. Deciding colors of columns
2. Column ordering
3. Default values of columns
4. Template rendering for some columns
5. Parse out the product description

Output of the above (such as rendered templates, description) should be available to the API directly as well.