### PR TITLE
Improve homepage

### DIFF
--- a/_layouts/product.html
+++ b/_layouts/product.html
@@ -227,7 +227,7 @@ title="Click the Pencil, the link takes you directly to the correct page">on Git
 <p>
   A JSON version of this page is available at <a href="/api{{page.permalink}}.json">/api{{page.permalink}}.json</a>.
   See the <a href="/docs/api/">API Documentation</a> for more information.
-  You can subscribe to the icalendar feed at <a href="webcal://{{site.url | split: '://' | last}}/calendar{{page.permalink}}.ics">/calendar{{page.permalink}}.ics</a>.
+  You can subscribe to the iCalendar feed at <a href="webcal://{{site.url | split: '://' | last}}/calendar{{page.permalink}}.ics">/calendar{{page.permalink}}.ics</a>.
 </p>
 
 <p>

--- a/index.md
+++ b/index.md
@@ -21,7 +21,7 @@ Operating Systems     | [Windows][windows] | [Windows Server][windows-server] | 
 Frameworks            | [Angular][angular] | [Django][django] | [Ruby on Rails][rails] | [.NET][net]
 Desktop Applications  | [Firefox][firefox] | [Internet Explorer][ie] | [Godot][godot] | [Unity][unity]
 Server Applications   | [Nginx][nginx] | [Kubernetes][k8s] | [Tomcat][tomcat] | [HAProxy][haproxy]
-Cloud Services        | [Amazon EKS][eks] | [Google Kubernetes Engine][gke] | [Azure Kubernetes Service][aks]
+Cloud Services        | [Amazon<br>Elastic Kubernetes Service][eks] | [Google<br>Kubernetes Engine][gke] | [Azure<br>Kubernetes Service][aks]
 Standards             | [PCI-DSS][pci-dss]
 
 ## Contributing

--- a/index.md
+++ b/index.md
@@ -5,9 +5,14 @@ title: Home
 # This is the content for the website homepage (https://endoflife.date/)
 ---
 
-endoflife.date documents End-of-life dates, and support lifecycles of various products. This project collates this data and presents it in an easily accessible format, with URLs that are easy to guess and remember.
+End-of-life (EOL) and support information is [often hard to track, or very badly presented](https://twitter.com/captn3m0/status/1110504412064239617).
+endoflife.date documents EOL dates and support lifecycles for various products.
 
-Here's some of our most popular pages:
+endoflife.date aggregates data from various sources and presents it in an understandable and
+succinct manner. It also makes the data available using an [easily accessible API](https://endoflife.date/docs/api)
+and has iCalendar support.
+
+Here are some of our most popular pages:
 
 Programming           | [Python][python] | [Ruby][ruby] | [Java][java] | [PHP][php]
 Devices               | [iPhone][iphone] | [Android][android] | [Google Pixel][pixel] | [Nokia][nokia]
@@ -16,23 +21,36 @@ Operating Systems     | [Windows][windows] | [Windows Server][windows-server] | 
 Frameworks            | [Angular][angular] | [Django][django] | [Ruby on Rails][rails] | [.NET][net]
 Desktop Applications  | [Firefox][firefox] | [Internet Explorer][ie] | [Godot][godot] | [Unity][unity]
 Server Applications   | [Nginx][nginx] | [Kubernetes][k8s] | [Tomcat][tomcat] | [HAProxy][haproxy]
-Services              | [Amazon EKS][eks] | [Google Kubernetes Engine][gke]
+Cloud Services        | [Amazon EKS][eks] | [Google Kubernetes Engine][gke] | [Azure Kubernetes Service][aks]
 Standards             | [PCI-DSS][pci-dss]
 
-## Why this exists
+## Contributing
 
-- EOL and Support information is [often hard to track, or very badly presented](https://twitter.com/captn3m0/status/1110504412064239617).
-- All the data is made available using an [easily accessible API](https://endoflife.date/docs/api).
-- There are a few tools that use this API: [norwegianblue](https://github.com/hugovk/norwegianblue), [cicada](https://github.com/mcandre/cicada).
+Want to contribute? Great! We try to make it easy, and all contributions, even the smaller ones, are
+more than welcome. This includes
+[new product suggestion or addition](https://github.com/endoflife-date/endoflife.date/issues/new?assignees=&labels=request&template=new_product_suggestion.md&title=),
+[existing product updates](https://github.com/endoflife-date/endoflife.date/issues/new?assignees=&labels=bug&template=report_incorrect_details.md&title=),
+[feature request](https://github.com/endoflife-date/endoflife.date/issues/new?assignees=&labels=enhancement&template=feature_request.md&title=),
+bug reports, fixes... Take a look at [our contribution guide](https://github.com/endoflife-date/endoflife.date/blob/master/CONTRIBUTING.md)
+for more information.
 
-If you maintain release information (end-of-life dates, or support information) for a product, we have a [set of recommendations](/recommendations) along with a checklist on some best practices for publishing this information.
+If you maintain release information for a product (end-of-life dates or support information), we
+also have a [set of recommendations](/recommendations) along with a checklist on some best practices
+for publishing this information.
 
-[![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](https://opensource.guide/how-to-contribute/#opening-a-pull-request) ![powered by Jekyll](https://img.shields.io/badge/powered_by-Jekyll-blue.svg) [![Website shields.io](https://img.shields.io/website-up-down-green-red/https/endoflife.date.svg)](https://endoflife.date/) [![made-with-Markdown](https://img.shields.io/badge/Made%20with-Markdown-1f425f.svg)](https://commonmark.org) [![](https://img.shields.io/badge/Hacktoberfest-Welcome-green)][hacktoberfest] [![Gitter](https://img.shields.io/badge/chat%20on-gitter-green)](https://gitter.im/endoflife-date/community)
+And do not hesitate to [play with our API](https://endoflife.date/docs/api). Here are a few awesome
+tools that already did it: [norwegianblue](https://github.com/hugovk/norwegianblue),
+[end_of_life](https://github.com/MatheusRich/end_of_life), and
+[cicada](https://github.com/mcandre/cicada). Find more on
+[our Known Users page](https://github.com/endoflife-date/endoflife.date/wiki/Known-Users).
 
+[![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](https://opensource.guide/how-to-contribute/#opening-a-pull-request)
+[![powered by Jekyll](https://img.shields.io/badge/powered_by-Jekyll-blue.svg)](https://jekyllrb.com/)
+[![Website shields.io](https://img.shields.io/website-up-down-green-red/https/endoflife.date.svg)](https://endoflife.date/)
+[![made-with-Markdown](https://img.shields.io/badge/Made%20with-Markdown-1f425f.svg)](https://commonmark.org)
+[![](https://img.shields.io/badge/Hacktoberfest-Welcome-green)](https://github.com/endoflife-date/endoflife.date/issues/408)
+[![Gitter](https://img.shields.io/badge/chat%20on-gitter-green)](https://gitter.im/endoflife-date/community)
 [![Powered by Netlify](https://www.netlify.com/v3/img/components/netlify-light.svg)](https://www.netlify.com)
-
-[coc]: https://github.com/endoflife-date/endoflife.date/blob/master/CODE-OF-CONDUCT.md "Code of Conduct"
-[hacktoberfest]: https://github.com/endoflife-date/endoflife.date/issues/408
 
 [python]: /python
 [nodejs]: /nodejs
@@ -65,4 +83,5 @@ If you maintain release information (end-of-life dates, or support information) 
 [rails]: /rails
 [eks]: /eks
 [gke]: /gke
+[aks]: /azure-kubernetes-service
 [pci-dss]: /pci-dss


### PR DESCRIPTION
- update description (merging part of the 'Why this exists' section),
- mention iCalendar support in the description,
- rename Services to Cloud Services,
- add Azure Kubernetes Service,
- emphasises contribution.