### PR TITLE
Improve table.html template

### DIFF
--- a/_includes/table.html
+++ b/_includes/table.html
@@ -50,22 +50,16 @@ Parameters:
     {%- elsif type == "timeago" %}
       <td>{{ value | timeago }}</td>
     {%- elsif type == "end-date" %}
-      {%- if value == true %}
-      <td class="bg-green-000">Yes</td>
+      <td class="{{ row[field] | end_color }}">
+      {%- if value == true %}}
+        Yes
       {%- elsif value == false %}
-      <td class="bg-red-000">No</td>
+        No
       {%- else %}
-        {%- assign row_date = row[field] | date: '%s' %}
-        {%- assign site_date = site.time | date: '%s' %}
-        {%- assign days_between = row_date | minus: site_date | divided_by: 86400 %}
-        {%- if days_between < 0 %}
-      <td class="bg-red-000">Ended {{ row[field] | timeago }} <div>({{ row[field] | date_to_string }})</div></td>
-        {%- elsif days_between < 120 %}
-      <td class="bg-yellow-200">Ends {{ row[field] | timeago }} <div>({{ row[field] | date_to_string }})</div></td>
-        {%- else %}
-      <td class="bg-green-000">Ends {{ row[field] | timeago }} <div>({{ row[field] | date_to_string }})</div></td>
-        {%- endif %}
+        {{ row[field] | date_to_string }}
+        <div>({{ row[field] | timeago }})</div>
       {%- endif %}
+      </td>
     {%- else %}
       <td>{{ row[field] }}</td>
     {%- endif %}

--- a/_includes/table.html
+++ b/_includes/table.html
@@ -1,3 +1,27 @@
+{%- comment %}
+Render a table from the given rows.
+
+Considering a table with N column and M rows, the equivalent Markdown table will be :
+
+| labels[0]          | labels[1]          | ... | labels[N]          |
+|--------------------|--------------------|-----|--------------------|
+| rows[0][fields[0]] | rows[0][fields[1]] | ... | rows[0][fields[N]] |
+| rows[1][fields[0]] | rows[1][fields[1]] | ... | rows[1][fields[N]] |
+| ...                | ...                | ... | ...                |
+| rows[M][fields[0]] | rows[M][fields[1]] | ... | rows[M][fields[N]] |
+
+Parameters:
+- rows: Rows used to build the table.
+- fields: A comma-separated list of row field names.
+- labels: A comma-separated list of column labels.
+          The size of the list must be identical to the fields list size.
+- types: A comma-separated list of column types.
+         The size of the list must be identical to the fields list size.
+         Available type are :
+         - raw: display the value "as is". The raw type is also used when type is unknown.
+         - date: display the value using the date_to_string filter,
+                 see https://jekyllrb.com/docs/liquid/filters/#date-to-string.
+{% endcomment %}
 {%- assign labels = include.labels | split:',' %}
 {%- assign fields = include.fields | split:',' %}
 {%- assign types = include.types | split:',' %}
@@ -5,7 +29,7 @@
 <table>
   <thead>
     <tr>
-      {% for label in labels %}<th>{{ label }}</th>{% endfor %}
+      {%- for label in labels %}<th>{{ label }}</th>{% endfor %}
     </tr>
   </thead>
   <tbody>
@@ -14,11 +38,11 @@
   {%- for field in fields %}
     {%- if types[forloop.index0] == "date" %}
       <td>{{ row[field] | date_to_string }}</td>
-    {% else %}
+    {%- else %}
       <td>{{ row[field] }}</td>
-    {% endif %}
-  {% endfor %}
+    {%- endif %}
+  {%- endfor %}
     </tr>
-{% endfor %}
+{%- endfor %}
   </tbody>
 </table>

--- a/_includes/table.html
+++ b/_includes/table.html
@@ -21,6 +21,8 @@ Parameters:
          - raw: display the value "as is". The raw type is also used when type is unknown.
          - date: display the value using the date_to_string filter,
                  see https://jekyllrb.com/docs/liquid/filters/#date-to-string.
+         - timeago: display the value using the timeago filter,
+                 see https://github.com/markets/jekyll-timeago.
 {% endcomment %}
 {%- assign labels = include.labels | split:',' %}
 {%- assign fields = include.fields | split:',' %}
@@ -38,6 +40,8 @@ Parameters:
   {%- for field in fields %}
     {%- if types[forloop.index0] == "date" %}
       <td>{{ row[field] | date_to_string }}</td>
+    {%- elsif types[forloop.index0] == "timeago" %}
+      <td>{{ row[field] | timeago }}</td>
     {%- else %}
       <td>{{ row[field] }}</td>
     {%- endif %}

--- a/_includes/table.html
+++ b/_includes/table.html
@@ -23,6 +23,11 @@ Parameters:
                  see https://jekyllrb.com/docs/liquid/filters/#date-to-string.
          - timeago: display the value using the timeago filter,
                  see https://github.com/markets/jekyll-timeago.
+         - end-date: display the value as an end of something date (such as support or EOL).
+                 This is the "classic" way do display end of support or EOL date on endoflife.date, with:
+                 - a background color as a visual indication,
+                 - the value displayed using both the date_to_string and timeago filters,
+                 - a support for both boolean and date values.
 {% endcomment %}
 {%- assign labels = include.labels | split:',' %}
 {%- assign fields = include.fields | split:',' %}
@@ -38,10 +43,29 @@ Parameters:
 {%- for row in rows %}
     <tr>
   {%- for field in fields %}
-    {%- if types[forloop.index0] == "date" %}
-      <td>{{ row[field] | date_to_string }}</td>
-    {%- elsif types[forloop.index0] == "timeago" %}
-      <td>{{ row[field] | timeago }}</td>
+    {%- assign type = types[forloop.index0] %}
+    {%- assign value = row[field] %}
+    {%- if type == "date" %}
+      <td>{{ value | date_to_string }}</td>
+    {%- elsif type == "timeago" %}
+      <td>{{ value | timeago }}</td>
+    {%- elsif type == "end-date" %}
+      {%- if value == true %}
+      <td class="bg-green-000">Yes</td>
+      {%- elsif value == false %}
+      <td class="bg-red-000">No</td>
+      {%- else %}
+        {%- assign row_date = row[field] | date: '%s' %}
+        {%- assign site_date = site.time | date: '%s' %}
+        {%- assign days_between = row_date | minus: site_date | divided_by: 86400 %}
+        {%- if days_between < 0 %}
+      <td class="bg-red-000">Ended {{ row[field] | timeago }} <div>({{ row[field] | date_to_string }})</div></td>
+        {%- elsif days_between < 120 %}
+      <td class="bg-yellow-200">Ends {{ row[field] | timeago }} <div>({{ row[field] | date_to_string }})</div></td>
+        {%- else %}
+      <td class="bg-green-000">Ends {{ row[field] | timeago }} <div>({{ row[field] | date_to_string }})</div></td>
+        {%- endif %}
+      {%- endif %}
     {%- else %}
       <td>{{ row[field] }}</td>
     {%- endif %}

--- a/_plugins/end-of-life-filters.rb
+++ b/_plugins/end-of-life-filters.rb
@@ -84,6 +84,49 @@ module EndOfLifeFilter
       }
       .map { |cycleRange, value| Hash['releaseCycle', cycleRange, field, value] }
   end
+
+  # Compute the number of days from now to the given date.
+  #
+  # Usage (assuming now is '2023-01-01'):
+  # {{ '2023-01-10' | days_from_now }} => 9
+  # {{ '2023-01-01' | days_from_now }} => 0
+  # {{ '2022-12-31' | days_from_now }} => -1
+  def days_from_now(from)
+    from_timestamp = Date.parse(from.to_s).to_time.to_i
+    to_timestamp = Date.today.to_time.to_i
+    return (from_timestamp - to_timestamp) / (60 * 60 * 24)
+  end
+
+  # Compute the color according to the given number of days until the end.
+  #
+  # Usage:
+  # {{ true | end_color }} => bg-green-000
+  # {{ false | end_color }} => bg-red-000
+  # {{ -1 | end_color }} => bg-green-000
+  # {{ 1 | end_color }} => bg-yellow-200
+  # {{ 365 | end_color }} => bg-red-000
+  # {{ '2025-01-01' | days_from_now | end_color }} => bg-green-000
+  # {{ '2023-01-02' | days_from_now | end_color }} => bg-yellow-200
+  # {{ '2021-01-01' | days_from_now | end_color }} => bg-red-000
+  # {{ '2025-01-01' | end_color }} => bg-green-000
+  def end_color(input)
+    if input == true
+      return 'bg-green-000'
+    elsif input == false
+      return 'bg-red-000'
+    elsif input.is_a? Integer
+      if input < 0
+        return 'bg-red-000'
+      elsif input < 120
+        return 'bg-yellow-200'
+      else
+        return 'bg-green-000'
+      end
+    else
+      # Assuming it's a date
+      return end_color(days_from_now(input))
+    end
+  end
 end
 
 Liquid::Template.register_filter(EndOfLifeFilter)

--- a/products/vmware-esxi.md
+++ b/products/vmware-esxi.md
@@ -87,5 +87,5 @@ support, server/client/guest OS updates, new security patches or bug fixes unles
 {% include table.html
 labels="Release,Technical Guidance Ends"
 fields="releaseCycle,technicalGuidance"
-types="string,date"
+types="raw,date"
 rows=page.releases %}

--- a/products/vmware-esxi.md
+++ b/products/vmware-esxi.md
@@ -87,5 +87,5 @@ support, server/client/guest OS updates, new security patches or bug fixes unles
 {% include table.html
 labels="Release,Technical Guidance Ends"
 fields="releaseCycle,technicalGuidance"
-types="raw,timeago"
+types="raw,end-date"
 rows=page.releases %}

--- a/products/vmware-esxi.md
+++ b/products/vmware-esxi.md
@@ -87,5 +87,5 @@ support, server/client/guest OS updates, new security patches or bug fixes unles
 {% include table.html
 labels="Release,Technical Guidance Ends"
 fields="releaseCycle,technicalGuidance"
-types="raw,date"
+types="raw,timeago"
 rows=page.releases %}

--- a/products/vmware-horizon.md
+++ b/products/vmware-horizon.md
@@ -133,5 +133,5 @@ support, server/client/guest OS updates, new security patches or bug fixes unles
 {% include table.html
    labels="Release,Technical Guidance Ends"
    fields="releaseCycle,technicalGuidance"
-   types="raw,date"
+   types="raw,timeago"
    rows=page.releases %}

--- a/products/vmware-horizon.md
+++ b/products/vmware-horizon.md
@@ -133,5 +133,5 @@ support, server/client/guest OS updates, new security patches or bug fixes unles
 {% include table.html
    labels="Release,Technical Guidance Ends"
    fields="releaseCycle,technicalGuidance"
-   types="raw,timeago"
+   types="raw,end-date"
    rows=page.releases %}

--- a/products/vmware-horizon.md
+++ b/products/vmware-horizon.md
@@ -133,5 +133,5 @@ support, server/client/guest OS updates, new security patches or bug fixes unles
 {% include table.html
    labels="Release,Technical Guidance Ends"
    fields="releaseCycle,technicalGuidance"
-   types="string,date"
+   types="raw,date"
    rows=page.releases %}

--- a/products/vmware-srm.md
+++ b/products/vmware-srm.md
@@ -127,5 +127,5 @@ support, server/client/guest OS updates, new security patches or bug fixes unles
 {% include table.html
 labels="Release,Technical Guidance Ends"
 fields="releaseCycle,technicalGuidance"
-types="raw,date"
+types="raw,timeago"
 rows=page.releases %}

--- a/products/vmware-srm.md
+++ b/products/vmware-srm.md
@@ -127,5 +127,5 @@ support, server/client/guest OS updates, new security patches or bug fixes unles
 {% include table.html
 labels="Release,Technical Guidance Ends"
 fields="releaseCycle,technicalGuidance"
-types="raw,timeago"
+types="raw,end-date"
 rows=page.releases %}

--- a/products/vmware-srm.md
+++ b/products/vmware-srm.md
@@ -127,5 +127,5 @@ support, server/client/guest OS updates, new security patches or bug fixes unles
 {% include table.html
 labels="Release,Technical Guidance Ends"
 fields="releaseCycle,technicalGuidance"
-types="string,date"
+types="raw,date"
 rows=page.releases %}

--- a/products/vmware-vcenter.md
+++ b/products/vmware-vcenter.md
@@ -109,5 +109,5 @@ support, server/client/guest OS updates, new security patches or bug fixes unles
 {% include table.html
 labels="Release,Technical Guidance Ends"
 fields="releaseCycle,technicalGuidance"
-types="raw,timeago"
+types="raw,end-date"
 rows=page.releases %}

--- a/products/vmware-vcenter.md
+++ b/products/vmware-vcenter.md
@@ -109,5 +109,5 @@ support, server/client/guest OS updates, new security patches or bug fixes unles
 {% include table.html
 labels="Release,Technical Guidance Ends"
 fields="releaseCycle,technicalGuidance"
-types="raw,date"
+types="raw,timeago"
 rows=page.releases %}

--- a/products/vmware-vcenter.md
+++ b/products/vmware-vcenter.md
@@ -109,5 +109,5 @@ support, server/client/guest OS updates, new security patches or bug fixes unles
 {% include table.html
 labels="Release,Technical Guidance Ends"
 fields="releaseCycle,technicalGuidance"
-types="string,date"
+types="raw,date"
 rows=page.releases %}


### PR DESCRIPTION
- add documentation,
- remove unnecessary new lines in the rendered template,
- rename string type to raw (values are not necessarily strings),
- add `timeago` type (https://github.com/markets/jekyll-timeago),
- add `end-date` type (the "classic" way do display end of support or EOL date on endoflife.date).

Please do not squash the commits when merging this PR.