### PR TITLE
Add mongodb 6.0 cycle EOL date

### DIFF
--- a/products/mongodb.md
+++ b/products/mongodb.md
@@ -27,7 +27,7 @@ releases:
     codename: "rapid"
     eol: false
 -   releaseCycle: "6.0"
-    eol: false
+    eol: 2025-07-01
     latest: "6.0.3"
     latestReleaseDate: 2022-11-14
     releaseDate: 2022-07-05


### PR DESCRIPTION
Added: https://www.mongodb.com/support-policy/lifecycles