### PR TITLE
[Red Hat] Add ELS date for RHEL 4

### DIFF
--- a/products/redhat.md
+++ b/products/redhat.md
@@ -64,7 +64,7 @@ releases:
 -   releaseCycle: "4"
     support: 2009-03-31
     eol: 2012-02-29
-    extendedSupport: false
+    extendedSupport: 2017-03-31
     releaseDate: 2005-02-15
     latestReleaseDate: 2011-02-16
     latest: '4.9'


### PR DESCRIPTION
According to the following article: https://access.redhat.com/articles/75653

> Red Hat Enterprise Linux 4 ELS is available through March 31, 2017 

Fairly unimportant, but technically correct to list it.