### PR TITLE
[slackware] Drop -current

### DIFF
--- a/products/slackware.md
+++ b/products/slackware.md
@@ -18,14 +18,9 @@ auto:
 -   distrowatch: slackware
     regex: '^Distribution Release: Slackware (Linux )?(?P<major>\d+)\.(?P<minor>\d+)$'
 releases:
--   releaseCycle: "current"
-    codename: "-current"
-    releaseLabel: Current
-    eol: false
-    link: http://www.slackware.com/changelog/current.php?cpu=i386
-    releaseDate: 1993-07-27
 -   releaseCycle: "15.0"
     codename: "stable"
+    releaseLabel: "15.0 (Stable)"
     eol: false
     releaseDate: 2022-02-03
     latestReleaseDate: 2022-02-03


### PR DESCRIPTION
-current is not meant for production systems, and is not a release as-such.