### PR TITLE
[golang] Add identifiers

### DIFF
--- a/products/go.md
+++ b/products/go.md
@@ -1,4 +1,4 @@
--   purl: pkg:docker/-   purl: pkg:docker/---
+---
 title: Go
 category: lang
 iconSlug: go

--- a/products/go.md
+++ b/products/go.md
@@ -1,4 +1,4 @@
----
+-   purl: pkg:docker/-   purl: pkg:docker/---
 title: Go
 category: lang
 iconSlug: go
@@ -12,6 +12,10 @@ versionCommand: go version
 releaseDateColumn: true
 identifiers:
 -   purl: pkg:generic/go
+-   purl: pkg:docker/library/golang
+-   purl: pkg:docker/circleci/golang
+-   purl: pkg:docker/cimg/go
+-   purl: pkg:docker/bitnami/golang
 -   repology: go
 auto:
 -   git: https://github.com/golang/go.git

--- a/products/go.md
+++ b/products/go.md
@@ -10,6 +10,9 @@ changelogTemplate: https://go.dev/doc/devel/release#go__RELEASE_CYCLE__.minor
 eolColumn: Supported
 versionCommand: go version
 releaseDateColumn: true
+identifiers:
+-   purl: pkg:generic/go
+-   repology: go
 auto:
 -   git: https://github.com/golang/go.git
     regex: ^go(?<major>[1-9]\d*)\.(?<minor>0|[1-9]\d*)\.?(?<patch>0|[1-9]\d*)?$


### PR DESCRIPTION
`pkg:generic/go` is used by syft for go binaries

https://github.com/anchore/syft/blob/main/syft/pkg/cataloger/binary/default_classifiers.go#L38