### PR TITLE
[nodejs] Add identifiers

### DIFF
--- a/products/nodejs.md
+++ b/products/nodejs.md
@@ -12,6 +12,10 @@ changelogTemplate: https://github.com/nodejs/node/blob/main/doc/changelogs/CHANG
 activeSupportColumn: true
 identifiers:
 - purl: pkg:generic/node
+- purl: pkg:docker/circleci/node
+- purl: pkg:docker/library/node
+- purl: pkg:docker/cimg/node
+- purl: pkg:docker/bitnami/node
 - repology: nodejs
 auto:
 -   git: https://github.com/nodejs/node.git

--- a/products/nodejs.md
+++ b/products/nodejs.md
@@ -10,6 +10,9 @@ releasePolicyLink: https://nodejs.org/about/releases/
 releaseImage: https://raw.githubusercontent.com/nodejs/Release/main/schedule.svg?sanitize=true
 changelogTemplate: https://github.com/nodejs/node/blob/main/doc/changelogs/CHANGELOG_V__RELEASE_CYCLE__.md#__LATEST__
 activeSupportColumn: true
+identifiers:
+- purl: pkg:generic/node
+- repology: nodejs
 auto:
 -   git: https://github.com/nodejs/node.git
 versionCommand: node --version


### PR DESCRIPTION
`pkg:generic/node` is used by syft for node binaries

https://github.com/anchore/syft/blob/main/syft/pkg/cataloger/binary/default_classifiers.go#L81