### PR TITLE
[CakePHP] Fix product releases

### DIFF
--- a/products/cakephp.md
+++ b/products/cakephp.md
@@ -39,22 +39,22 @@ releases:
     eol: true
     support: 2021-10-24
     releaseDate: 2020-12-20
-
     latestReleaseDate: 2023-01-06
+
 -   releaseCycle: "4.1"
     latest: "4.1.7"
     eol: true
     support: 2020-12-21
     releaseDate: 2020-07-04
-
     latestReleaseDate: 2020-12-12
+
 -   releaseCycle: "4.0"
     latest: "4.0.10"
     eol: true
     support: 2020-07-05
     releaseDate: 2019-12-15
-
     latestReleaseDate: 2020-12-07
+
 -   releaseCycle: "3.10"
     latest: "3.10.5"
     eol: 2022-12-15
@@ -68,71 +68,71 @@ releases:
     eol: true
     support: 2021-06-20
     releaseDate: 2020-06-20
-
     latestReleaseDate: 2021-05-30
+
 -   releaseCycle: "3.8"
     latest: "3.8.13"
     eol: true
     support: 2020-06-21
     releaseDate: 2019-06-26
-
     latestReleaseDate: 2020-06-19
+
 -   releaseCycle: "3.7"
     latest: "3.7.9"
     eol: true
     support: 2019-06-27
     releaseDate: 2018-12-08
-
     latestReleaseDate: 2019-06-19
+
 -   releaseCycle: "3.6"
     latest: "3.6.15"
     eol: true
     support: 2018-12-09
     releaseDate: 2018-04-14
-
     latestReleaseDate: 2019-04-23
+
 -   releaseCycle: "3.5"
     latest: "3.5.18"
     eol: true
     support: 2018-04-15
     releaseDate: 2017-08-18
-
     latestReleaseDate: 2019-04-23
+
 -   releaseCycle: "3.4"
     latest: "3.4.14"
     eol: true
     support: 2017-08-19
     releaseDate: 2017-02-12
-
     latestReleaseDate: 2018-05-20
+
 -   releaseCycle: "3.3"
     latest: "3.3.16"
     eol: true
     support: 2017-02-13
     releaseDate: 2016-08-12
-
     latestReleaseDate: 2017-04-06
+
 -   releaseCycle: "3.2"
     latest: "3.2.14"
     eol: true
     support: 2016-08-13
     releaseDate: 2016-01-29
-
     latestReleaseDate: 2016-08-12
+
 -   releaseCycle: "3.1"
     latest: "3.1.14"
     eol: 2017-02-13
     support: 2016-01-16
     releaseDate: 2015-09-19
-
     latestReleaseDate: 2016-11-25
+
 -   releaseCycle: "3.0"
     latest: "3.0.19"
     eol: true
     support: 2015-09-20
     releaseDate: 2015-03-22
-
     latestReleaseDate: 2016-11-25
+
 -   releaseCycle: "2.10"
     latest: "2.10.24"
     eol: true
@@ -230,7 +230,9 @@ releases:
 
 ---
 
-> [CakePHP](https://cakephp.org/) is a free & open source PHP web development framework.  It follows the model–view–controller (MVC) approach and is written in PHP, modeled after the concepts of Ruby on Rails, and distributed under the [MIT License](https://en.wikipedia.org/wiki/MIT_License).
+> [CakePHP](https://cakephp.org/) is a free & open source PHP web development framework.  It follows
+> the model–view–controller (MVC) approach and is written in PHP, modeled after the concepts of Ruby
+> on Rails, and distributed under the [MIT License](https://en.wikipedia.org/wiki/MIT_License).
 
 Have a look at the [Bakery](https://bakery.cakephp.org/) for fresh [releases](https://bakery.cakephp.org/categories/release.html).
 

--- a/products/cakephp.md
+++ b/products/cakephp.md
@@ -18,6 +18,8 @@ versionCommand: php bin/cake.php version
 auto:
 -   git: https://github.com/cakephp/cakephp.git
 
+# support(X) = releaseDate(X+1) + 1 day
+# For a given major version, the last three minor versions have security support.
 releases:
 -   releaseCycle: "4.4"
     eol: false
@@ -28,15 +30,15 @@ releases:
     codename: Strawberry
 
 -   releaseCycle: "4.3"
-    eol: true
-    support: true
+    eol: false
+    support: 2022-06-07
     releaseDate: 2021-10-23
     latest: "4.3.11"
     latestReleaseDate: 2023-01-05
 
 -   releaseCycle: "4.2"
     latest: "4.2.12"
-    eol: true
+    eol: false
     support: 2021-10-24
     releaseDate: 2020-12-20
     latestReleaseDate: 2023-01-06
@@ -135,8 +137,8 @@ releases:
 
 -   releaseCycle: "2.10"
     latest: "2.10.24"
-    eol: true
-    support: 2019-12-16
+    eol: 2021-06-15
+    support: 2020-12-15
     releaseDate: 2017-07-22
     latestReleaseDate: 2020-12-15
     link: https://bakery.cakephp.org/2020/12/15/cakephp_21024_released.html
@@ -222,8 +224,8 @@ releases:
 
 -   releaseCycle: "1.3"
     latest: "1.3.21"
-    eol: true
-    support: false
+    eol: 2015-11-01
+    support: 2015-11-01
     releaseDate: 2010-04-25
     latestReleaseDate: 2015-10-31
     link: https://bakery.cakephp.org/2015/11/01/cakephp_1_3_21_released.html


### PR DESCRIPTION
- fix `eol` for 4.2 and 4.3 : those releases still receive security support,
- set `support` for 4.3 (= `releaseDate(4.4.0) + 1 day`),
- set `eol` / `support` for 2.10 (last 2.x minor version) using information from https://github.com/cakephp/cakephp/wiki,
- set `eol` / `support` for 1.3 (last 1.x minor version) using information from https://bakery.cakephp.org/2015/11/01/cakephp_1_3_21_released.html.

I also took the opportunity to normalize the file (see #2124).