### PR TITLE
Update style and text for cycles with no extended support

### DIFF
--- a/_layouts/product.html
+++ b/_layouts/product.html
@@ -185,7 +185,7 @@ or +1 (EoL is in the future)
     {% if r.extendedSupport %}
     "bg-green-000"
     {% else %}
-    "bg-red-000"
+    "bg-grey-lt-100"
     {% endif %}
     {% endif %}
     title="{{r.extendedSupport}}">
@@ -200,7 +200,7 @@ or +1 (EoL is in the future)
     {% if r.extendedSupport %}
     Yes
     {% else %}
-    No
+    Unavailable
     {% endif %}
     {% endif %}
   </td>

--- a/_sass/custom/custom.scss
+++ b/_sass/custom/custom.scss
@@ -3,7 +3,7 @@
 // The file path comes from what the upstream allows:
 // https://just-the-docs.github.io/just-the-docs/docs/customization/#override-and-completely-custom-styles
 
-.bg-red-000, .bg-green-000, .site-footer {
+.bg-red-000, .bg-yellow-200, .bg-green-000, .bg-grey-lt-100, .site-footer {
   color: #1c1c1c;
 }
 


### PR DESCRIPTION
The color is supposed to indicate something ended, but when there is no extended support nothing ends. To reflect that the background color has been changed from red to light grey and the text from 'No' to 'Unavailable'.