### PR TITLE
Disable changelog links for EOL cycles

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -280,6 +280,8 @@ releases:
     # Use this if the link is not predictable (i.e. you can't use changelogTemplate),
     # or if the changelogTemplate generated link must be overridden.
     # Do not use a localized URL (such as one containing en-us) if possible.
+    # Use the special value 'null' (unquoted) if you want to disable link for a specific cycle of a
+    # product having a changelogTemplate.
     link: https://example.com/news/2021-12-25/release-1.2.3
 
 # In the following markdown section, ensure that all the above are present:

--- a/_layouts/product.html
+++ b/_layouts/product.html
@@ -77,7 +77,7 @@ or +1 (EoL is in the future)
 <tr>
   <td>
     {% comment %}Only put a link in the version column if the release column is not shown{% endcomment %}
-    {% if r.link and page.releaseColumn == false %}
+    {% if r.link and diff > 0 and page.releaseColumn == false %}
       <a href="{{ r.link }}" title="Release Notes / Changelog for {{ r.label | strip_html }}">{{ r.label }}</a>
     {% else %}
       {{ r.label }}
@@ -208,7 +208,7 @@ or +1 (EoL is in the future)
 
   {% if page.releaseColumn != false %}
   <td {% if diff <= 0 %} class = "txt-linethrough" {% endif %} >      <!-- if the support finished add txt-linethrough class -->
-    {% if r.link != "" %}
+    {% if r.link != "" and diff > 0 %}
       <a href="{{ r.link }}" title="Release Notes / Changelog">{{ r.latest }}</a>
     {% else %}
       {{ r.latest }}

--- a/_plugins/product-data-enricher.rb
+++ b/_plugins/product-data-enricher.rb
@@ -76,7 +76,7 @@ module Jekyll
       end
 
       def set_cycle_link(page, cycle)
-        if !cycle['link'] && page['changelogTemplate']
+        if !cycle.has_key?('link') && page['changelogTemplate']
           link = page['changelogTemplate'].gsub('__RELEASE_CYCLE__', cycle['releaseCycle'] || '')
           link.gsub!('__CODENAME__', cycle['codename'] || '')
           link.gsub!('__LATEST__', cycle['latest'] || '')

--- a/products/android.md
+++ b/products/android.md
@@ -88,61 +88,61 @@ releases:
     codename: Jelly Bean
     eol: true
     releaseDate: 2012-07-09
-    link: ''
+    link: null
 
 -   releaseCycle: "4"
     codename: Ice Cream Sandwich
     eol: true
     releaseDate: 2011-10-18
-    link: ''
+    link: null
 
 -   releaseCycle: "3"
     codename: Honeycomb
     eol: true
     releaseDate: 2011-02-22
-    link: ''
+    link: null
 
 -   releaseCycle: "2.3"
     codename: Gingerbread
     eol: true
     releaseDate: 2010-12-06
-    link: ''
+    link: null
 
 -   releaseCycle: "2.2"
     codename: Froyo
     eol: true
     releaseDate: 2010-05-20
-    link: ''
+    link: null
 
 -   releaseCycle: "2.0"
     codename: Eclair
     eol: true
     releaseDate: 2009-10-26
-    link: ''
+    link: null
 
 -   releaseCycle: "1.6"
     codename: Donut
     eol: true
     releaseDate: 2009-09-15
-    link: ''
+    link: null
 
 -   releaseCycle: "1.5"
     codename: Cupcake
     eol: true
     releaseDate: 2009-04-27
-    link: ''
+    link: null
 
 -   releaseCycle: "1.1"
     codename: Petit Four
     eol: true
     releaseDate: 2009-02-09
-    link: ''
+    link: null
 
 -   releaseCycle: "1.0"
     releaseLabel: "__RELEASE_CYCLE__"
     eol: true
     releaseDate: 2008-09-23
-    link: ''
+    link: null
 
 ---
 

--- a/products/freebsd.md
+++ b/products/freebsd.md
@@ -23,8 +23,7 @@ releases:
 -   releaseCycle: "stable/13"
     releaseDate: 2021-04-13
     eol: 2026-01-31
-    # prevent the link to be generated using the changelogTemplate
-    link: ""
+    link: null
 
 -   releaseCycle: "releng/12.4"
     releaseDate: 2022-12-05
@@ -49,8 +48,7 @@ releases:
 -   releaseCycle: "stable/12"
     releaseDate: 2018-12-11
     eol: 2023-12-31
-    # prevent the link to be generated using the changelogTemplate
-    link: ""
+    link: null
 
 -   releaseCycle: "releng/11.4"
     eol: 2021-09-30
@@ -59,7 +57,7 @@ releases:
 -   releaseCycle: "stable/11"
     releaseDate: 2016-10-10
     eol: 2021-09-30
-    link: ""
+    link: null
 
 -   releaseCycle: "releng/10.4"
     eol: 2018-10-31
@@ -84,7 +82,7 @@ releases:
 -   releaseCycle: "stable/10"
     releaseDate: 2014-01-20
     eol: 2018-10-31
-    link: ""
+    link: null
 
 -   releaseCycle: "releng/9.3"
     eol: 2016-12-31
@@ -105,7 +103,7 @@ releases:
 -   releaseCycle: "stable/9"
     releaseDate: 2012-01-10
     eol: 2016-12-31
-    link: ""
+    link: null
 
 -   releaseCycle: "releng/8.4"
     eol: 2015-08-01
@@ -130,7 +128,7 @@ releases:
 -   releaseCycle: "stable/8"
     releaseDate: 2009-11-25
     eol: 2015-08-01
-    link: ""
+    link: null
 
 -   releaseCycle: "releng/7.4"
     eol: 2013-02-28
@@ -155,7 +153,7 @@ releases:
 -   releaseCycle: "stable/7"
     releaseDate: 2008-02-27
     eol: 2013-02-28
-    link: ""
+    link: null
 
 -   releaseCycle: "releng/6.4"
     eol: 2010-11-30
@@ -180,7 +178,7 @@ releases:
 -   releaseCycle: "stable/6"
     releaseDate: 2005-11-04
     eol: 2010-11-30
-    link: ""
+    link: null
 
 -   releaseCycle: "releng/5.5"
     eol: 2008-05-31
@@ -197,7 +195,7 @@ releases:
 -   releaseCycle: "stable/5"
     releaseDate: 2004-11-06
     eol: 2008-05-31
-    link: ""
+    link: null
 
 -   releaseCycle: "releng/4.11"
     eol: 2007-01-31
@@ -206,7 +204,7 @@ releases:
 -   releaseCycle: "stable/4"
     releaseDate: 2000-03-14
     eol: 2007-01-31
-    link: ""
+    link: null
 
 ---
 


### PR DESCRIPTION
This was the case before for the latest column, but was broken by #2239.

I also :

- did the same for links in the 'Release' column (it was not done before),
- allowed to disable links using [`null`](https://yaml.org/spec/1.2.2/#10211-null) instead of an empty string.

