### PR TITLE
[gke] Updated EOL dates and version infos

### DIFF
--- a/products/gke.md
+++ b/products/gke.md
@@ -40,7 +40,7 @@ releases:
 
 -   releaseCycle: "1.22"
     eol: 2023-04-30
-    support: 2023-02-30
+    support: 2023-02-28
     latest: '1.22.17-gke.1900'
     releaseDate: 2022-03-07
     latestReleaseDate: 2023-01-13

--- a/products/gke.md
+++ b/products/gke.md
@@ -21,36 +21,36 @@ releases:
     eol: 2024-02-29
     support: 2023-12-29
     releaseDate: 2022-12-14
-    latestReleaseDate: 2023-01-05
-    latest: '1.25.5-gke.1500'
+    latestReleaseDate: 2023-01-13
+    latest: '1.25.5-gke.2000'
 
 -   releaseCycle: "1.24"
     eol: 2023-10-31
     support: 2023-08-31
     releaseDate: 2022-06-23
-    latestReleaseDate: 2023-01-05
-    latest: '1.24.9-gke.1500'
+    latestReleaseDate: 2023-01-13
+    latest: '1.24.9-gke.2000'
 
 -   releaseCycle: "1.23"
     eol: 2023-07-31
     support: 2023-05-31
     releaseDate: 2022-05-03
-    latestReleaseDate: 2023-01-05
-    latest: '1.23.15-gke.1400'
+    latestReleaseDate: 2023-01-13
+    latest: '1.23.15-gke.1900'
 
 -   releaseCycle: "1.22"
-    eol: 2023-04-01
-    support: 2023-02-01
-    latest: '1.22.17-gke.1400'
+    eol: 2023-04-30
+    support: 2023-02-30
+    latest: '1.22.17-gke.1900'
     releaseDate: 2022-03-07
-    latestReleaseDate: 2023-01-05
+    latestReleaseDate: 2023-01-13
 
 -   releaseCycle: "1.21"
-    eol: 2023-03-01
-    support: 2023-01-01
-    latest: '1.21.14-gke.14100'
+    eol: 2023-01-31
+    support: 2022-11-01
+    latest: '1.21.14-gke.14600'
     releaseDate: 2021-10-01
-    latestReleaseDate: 2023-01-05
+    latestReleaseDate: 2023-01-13
 
 -   releaseCycle: "1.20"
     eol: 2022-08-01


### PR DESCRIPTION
Fixed some of the EOL dates and updated the versions to the latest release.

See https://cloud.google.com/kubernetes-engine/docs/release-schedule#schedule-for-release-channels for the latest EOL dates
See https://cloud.google.com/kubernetes-engine/docs/release-notes#January_13_2023 for the latest releases