### PR TITLE
[windows][windowsserver] Add Build ID

### DIFF
--- a/_plugins/product-data-enricher.rb
+++ b/_plugins/product-data-enricher.rb
@@ -92,6 +92,7 @@ module Jekyll
           label = template.gsub('__RELEASE_CYCLE__', cycle['releaseCycle'] || '')
           label.gsub!('__CODENAME__', cycle['codename'] || '')
           label.gsub!('__LATEST__', cycle['latest'] || '')
+          label.gsub!('__BUILDID__', cycle['buildID'] || '')
           cycle['label'] = Liquid::Template.parse(label).render(@context)
         else
           cycle['label'] = cycle['releaseCycle']

--- a/products/windows.md
+++ b/products/windows.md
@@ -5,6 +5,7 @@ iconSlug: windows
 permalink: /windows
 versionCommand: winver
 releasePolicyLink: https://learn.microsoft.com/lifecycle/products/?terms=Windows
+releaseLabel: "__RELEASE_CYCLE__ (__BUILDID__)"
 
 activeSupportColumn: true
 releaseColumn: false

--- a/products/windowsServer.md
+++ b/products/windowsServer.md
@@ -7,7 +7,7 @@ alternate_urls:
   - /windowsserver
 versionCommand: winver
 releasePolicyLink: https://learn.microsoft.com/lifecycle/products/?terms=Windows%20Server
-releaseLabel: 'Windows Server __RELEASE_CYCLE__ (__BUILDID__)'
+releaseLabel: 'Windows Server __RELEASE_CYCLE__ (build __BUILDID__)'
 activeSupportColumn: true
 releaseColumn: false
 releaseDateColumn: true

--- a/products/windowsServer.md
+++ b/products/windowsServer.md
@@ -7,7 +7,7 @@ alternate_urls:
   - /windowsserver
 versionCommand: winver
 releasePolicyLink: https://learn.microsoft.com/lifecycle/products/?terms=Windows%20Server
-releaseLabel: 'Windows Server __RELEASE_CYCLE__'
+releaseLabel: 'Windows Server __RELEASE_CYCLE__ (__BUILDID__)'
 activeSupportColumn: true
 releaseColumn: false
 releaseDateColumn: true


### PR DESCRIPTION
This PR adds the Windows build ID to release names (i.e., _Windows Server 2022 (**10.0.20348**)_), by adding the `__BUILDID__` option to the releaseLabel template.

This makes it easier to lookup Windows versions and improve search results, as many system tools use the build ID instead of the `version \w{4}` shortname.