### PR TITLE
[mattermost] New releases and automation

### DIFF
--- a/products/mattermost.md
+++ b/products/mattermost.md
@@ -7,11 +7,21 @@ versionCommand: sudo -u mattermost /opt/mattermost/bin/mattermost version
 activeSupportColumn: false
 releaseDateColumn: true
 iconSlug: mattermost
+changelogTemplate: https://docs.mattermost.com/upgrade/version-archive.html
 auto:
 -   git: https://github.com/mattermost/mattermost-server.git
+# Last 3 releases are supported.
 releases:
+-   releaseCycle: "7.7"
+    eol: 2023-04-15
+    releaseDate: 2023-01-16
+
+-   releaseCycle: "7.5"
+    eol: 2023-03-15
+    releaseDate: 2022-11-15
+
 -   releaseCycle: "7.4"
-    eol: 2023-01-15
+    eol: 2023-02-15
     releaseDate: 2022-10-16
 
 -   releaseCycle: "7.3"

--- a/products/mattermost.md
+++ b/products/mattermost.md
@@ -8,6 +8,8 @@ activeSupportColumn: false
 releaseDateColumn: true
 releaseColumn: false
 iconSlug: mattermost
+auto:
+-   git: https://github.com/mattermost/mattermost-server.git
 releases:
 -   releaseCycle: "7.4"
     eol: 2023-01-15

--- a/products/mattermost.md
+++ b/products/mattermost.md
@@ -6,7 +6,6 @@ category: server-app
 versionCommand: sudo -u mattermost /opt/mattermost/bin/mattermost version
 activeSupportColumn: false
 releaseDateColumn: true
-releaseColumn: false
 iconSlug: mattermost
 auto:
 -   git: https://github.com/mattermost/mattermost-server.git

--- a/products/mattermost.md
+++ b/products/mattermost.md
@@ -17,11 +17,11 @@ releases:
     releaseDate: 2023-01-16
 
 -   releaseCycle: "7.5"
-    eol: 2023-03-15
+    eol: 2023-02-15
     releaseDate: 2022-11-15
 
 -   releaseCycle: "7.4"
-    eol: 2023-02-15
+    eol: 2023-01-15
     releaseDate: 2022-10-16
 
 -   releaseCycle: "7.3"


### PR DESCRIPTION
There's some confusion about 7.4 still being supported. I've raised it here: https://github.com/mattermost/mattermost-server/discussions/22095