### PR TITLE
[Samsung-Mobile] Update EOL date for devices

### DIFF
--- a/products/samsungmobile.md
+++ b/products/samsungmobile.md
@@ -411,7 +411,7 @@ releases:
     eol: false # Quarterly
     releaseDate: 2019-12-18
 
--   releaseCycle: "Samsung W20 5G"
+-   releaseCycle: "W20 5G"
     support: false
     eol: false
     releaseDate: 2019-11-20
@@ -483,7 +483,7 @@ releases:
 
 -   releaseCycle: "Galaxy Tab A 8.0 (2019)"
     support: false
-    eol: 2021-11-17
+    eol: false
     releaseDate: 2019-07-01
 
 -   releaseCycle: "Galaxy A60"
@@ -538,7 +538,7 @@ releases:
 
 -   releaseCycle: "Galaxy A2 Core"
     support: false
-    eol: false
+    eol: 2021-10-01
     releaseDate: 2019-04-01
 
 -   releaseCycle: "Galaxy A10"
@@ -578,22 +578,22 @@ releases:
 
 -   releaseCycle: "Galaxy J4 Core"
     support: false
-    eol: false
+    eol: 2020-12-01
     releaseDate: 2018-11-01
 
 -   releaseCycle: "Galaxy A9 (2018)"
     support: false
-    eol: false
+    eol: 2022-06-01
     releaseDate: 2018-11-01
 
 -   releaseCycle: "Galaxy J6+"
     support: false
-    eol: false
+    eol: 2022-06-01
     releaseDate: 2018-10-01
 
 -   releaseCycle: "Galaxy J4+"
     support: false
-    eol: false
+    eol: 2020-12-01
     releaseDate: 2018-10-01
 
 -   releaseCycle: "Galaxy A7"
@@ -603,17 +603,17 @@ releases:
 
 -   releaseCycle: "Galaxy Note 9"
     support: false
-    eol: false
+    eol: 2022-07-01
     releaseDate: 2018-08-24
 
 -   releaseCycle: "Galaxy Tab S4 10.5"
     support: false
-    eol: false
+    eol: 2022-06-01
     releaseDate: 2018-08-01
 
 -   releaseCycle: "Galaxy Tab A 10.5 (2018)"
     support: false
-    eol: false
+    eol: 2022-06-01
     releaseDate: 2018-08-01
 
 -   releaseCycle: "Galaxy J2 Core"
@@ -623,7 +623,7 @@ releases:
 
 -   releaseCycle: "Galaxy J8"
     support: false
-    eol: false
+    eol: 2021-09-01
     releaseDate: 2018-07-01
 
 -   releaseCycle: "Galaxy J7 Top"
@@ -638,27 +638,27 @@ releases:
 
 -   releaseCycle: "Galaxy A8 Star"
     support: false
-    eol: false
+    eol: 2022-06-01
     releaseDate: 2018-06-01
 
 -   releaseCycle: "Galaxy J6"
     support: false
-    eol: false
+    eol: 2022-02-01
     releaseDate: 2018-05-01
 
 -   releaseCycle: "Galaxy J4"
     support: false
-    eol: false
+    eol: 2022-02-01
     releaseDate: 2018-05-01
 
 -   releaseCycle: "Galaxy A6+"
     support: false
-    eol: false
+    eol: 2022-02-01
     releaseDate: 2018-05-01
 
 -   releaseCycle: "Galaxy A6"
     support: false
-    eol: false
+    eol: 2022-02-01
     releaseDate: 2018-05-01
 
 -   releaseCycle: "Galaxy J7 Prime 2"
@@ -668,17 +668,17 @@ releases:
 
 -   releaseCycle: "Galaxy J7 Duo"
     support: false
-    eol: false
+    eol: 2021-12-31
     releaseDate: 2018-04-01
 
 -   releaseCycle: "Galaxy S9+"
     support: false
-    eol: false
+    eol: 2022-04-05
     releaseDate: 2018-03-09
 
 -   releaseCycle: "Galaxy S9"
     support: false
-    eol: false
+    eol: 2022-04-05
     releaseDate: 2018-03-09
 
 -   releaseCycle: "Galaxy A8 (2018) Enterprise"

--- a/products/samsungmobile.md
+++ b/products/samsungmobile.md
@@ -598,7 +598,7 @@ releases:
 
 -   releaseCycle: "Galaxy A7"
     support: false
-    eol: false
+    eol: 2022-07-01
     releaseDate: 2018-10-01
 
 -   releaseCycle: "Galaxy Note 9"


### PR DESCRIPTION
Source for Galaxy S9 EOL date: https://www.xda-developers.com/samsung-ends-software-support-galaxy-s9-galaxy-s9-plus/

Source for Galaxy J7 Duo was based on a guess that carriers still as of 2023 are pushing updates released back in 2021: https://www.sammobile.com/samsung/galaxy-j7-duo/firmware/SM-J720F/XFE/download/J720FDDS7CUL1/1619458/

Similar case as above for the A6 and A6+: https://www.sammobile.com/samsung/galaxy-a6/firmware/SM-A600F/EGY/download/A600FJXU9CVB1/1644189/ 

Source for Galaxy J4 is: https://doc.samsungmobile.com/SM-J400F/EGY/doc.html

Source for J6: https://doc.samsungmobile.com/SM-J600FN/XEF/doc.html

Source for A8 Star: https://doc.samsungmobile.com/SM-G885F/XID/doc.html

Source for J8: https://doc.samsungmobile.com/SM-J810M/001912180928/eng.html

Source for Galaxy Tab A 10.5 (2018): https://doc.samsungmobile.com/SM-T590/DBT/doc.html

Source for Tab S4: https://doc.samsungmobile.com/SM-T835/XEF/doc.html

Source for Note9: https://doc.samsungmobile.com/sm-n960f/dbt/doc.html

Source for J4+: https://doc.samsungmobile.com/SM-J415F/AFR/doc.html

Source for J6+: https://doc.samsungmobile.com/SM-J610FN/FTM/doc.html

Source for A9 (2018): https://doc.samsungmobile.com/SM-A920F/XEO/doc.html

Source for J4 Core: https://doc.samsungmobile.com/SM-J410G/002840190130/mlt.html

Source for A2 Core: https://doc.samsungmobile.com/SM-A260G/007599190702/fra-ca.html

Fixes https://github.com/endoflife-date/endoflife.date/issues/2300

Note: When using the last security update as the EOL date, I went with the security patch level date instead of the release date of the patch, as the release date varies by carrier and region. 