### PR TITLE
:heavy_plus_sign:  Samsung Mobile > samsung-mobile > Adding Samsung Galaxy A23 5G

### DIFF
--- a/products/samsungmobile.md
+++ b/products/samsungmobile.md
@@ -11,6 +11,11 @@ releaseColumn: false
 releaseDateColumn: true
 releases:
 
+-   releaseCycle: "Samsung Galaxy A23 5G"
+    support: true
+    eol: false
+    releaseDate: 2022-09-02
+
 -   releaseCycle: "Galaxy A13 LTE"
     support: true
     eol: false


### PR DESCRIPTION
# :grey_question: Context

My girlfriend just got a `Samsung Galaxy A23 5G`... I wanted to show her her phone on `endoflife.date`... to talk about [Planned obsolescence](https://en.wikipedia.org/wiki/Planned_obsolescence) (eg. compare to [Apple iPhone](https://endoflife.date/iphone))

As I plan to use `endoflife.date` to talk about this subject and compare products, I needed to get some data... but just discovered this model was not listed :sweat_smile: 


# :dart: Details

[Samsung Galaxy A23 5G](https://en.wikipedia.org/wiki/Samsung_Galaxy_A23) was released as part of [Galaxy 23](https://en.wikipedia.org/wiki/Galaxy_23) on `2022, September 02` : 

![image](https://user-images.githubusercontent.com/5235127/213813619-3d7fcd58-69b0-424a-81fa-2e8c563e1572.png)


All details [here](https://www.gsmarena.com/samsung_galaxy_a23_5g-11736.php) 