### PR TITLE
[airflow] Update latest version to 2.5.1

### DIFF
--- a/products/apache-airflow.md
+++ b/products/apache-airflow.md
@@ -20,8 +20,8 @@ identifiers:
 releases:
 -   releaseCycle: "2"
     eol: false
-    latest: "2.5.0"
-    latestReleaseDate: 2022-12-02
+    latest: "2.5.1"
+    latestReleaseDate: 2023-01-20
     releaseDate: 2020-12-17
 -   releaseCycle: "1.10"
     eol: 2021-07-17


### PR DESCRIPTION
Hello,

Small PR to update the latest version available for Apache Airflow to 2.5.1.

https://airflow.apache.org/docs/apache-airflow/stable/release_notes.html#airflow-2-5-1-2023-01-20