### PR TITLE
[Samsung Mobile] Remove 'Samsung' from Galaxy A23 5G cycle name

### DIFF
--- a/products/samsungmobile.md
+++ b/products/samsungmobile.md
@@ -11,7 +11,7 @@ releaseColumn: false
 releaseDateColumn: true
 releases:
 
--   releaseCycle: "Samsung Galaxy A23 5G"
+-   releaseCycle: "Galaxy A23 5G"
     support: true
     eol: false
     releaseDate: 2022-09-02


### PR DESCRIPTION
Product name is usually not repeated in the cycle name.