### PR TITLE
[Samsung Galaxy] fix naming for W20/21 5G

### DIFF
--- a/products/samsungmobile.md
+++ b/products/samsungmobile.md
@@ -416,7 +416,7 @@ releases:
     eol: false # Quarterly
     releaseDate: 2019-12-18
 
--   releaseCycle: "W20 5G"
+-   releaseCycle: Galaxy W20 5G"
     support: false
     eol: false
     releaseDate: 2019-11-20

--- a/products/samsungmobile.md
+++ b/products/samsungmobile.md
@@ -231,7 +231,7 @@ releases:
     eol: false
     releaseDate: 2020-11-06
 
--   releaseCycle: "Samsung W21 5G"
+-   releaseCycle: "Galaxy W21 5G"
     support: false
     eol: false
     releaseDate: 2020-11-04

--- a/products/samsungmobile.md
+++ b/products/samsungmobile.md
@@ -231,7 +231,7 @@ releases:
     eol: false
     releaseDate: 2020-11-06
 
--   releaseCycle: "Galaxy W21 5G"
+-   releaseCycle: "W21 5G"
     support: false
     eol: false
     releaseDate: 2020-11-04

--- a/products/samsungmobile.md
+++ b/products/samsungmobile.md
@@ -416,7 +416,7 @@ releases:
     eol: false # Quarterly
     releaseDate: 2019-12-18
 
--   releaseCycle: Galaxy W20 5G"
+-   releaseCycle: "Galaxy W20 5G"
     support: false
     eol: false
     releaseDate: 2019-11-20


### PR DESCRIPTION
# :grey_question: About

Rename [`Samsung Galaxy W21 5G`](https://www.kimovil.com/en/where-to-buy-samsung-galaxy-w21-5g) to `Galaxy W21 5G`

![image](https://user-images.githubusercontent.com/5235127/214170322-ce49bd7c-76e4-4044-accf-5bac6508cf10.png)

# :tickets: Related stuff

- https://github.com/endoflife-date/endoflife.date/pull/2353
- https://github.com/endoflife-date/endoflife.date/pull/2336
- https://github.com/endoflife-date/endoflife.date/pull/2156