### PR TITLE
[end-of-life-filters] improve performance for .0 droping

### DIFF
--- a/_plugins/end-of-life-filters.rb
+++ b/_plugins/end-of-life-filters.rb
@@ -54,7 +54,7 @@ module EndOfLifeFilter
   # {{ '2.1.0' | drop_zero_patch }} => '2.1'
   # {{ '2.1.1' | drop_zero_patch }} => '2.1.1'
   def drop_zero_patch(input)
-    input.end_with?(".0") ? input[0, input.length - 2] : input
+    input.delete_suffix(".0")
   end
 end
 


### PR DESCRIPTION
* Improves performance
* Improves readability
```
                     user     system      total        real
chomp            0.949823   0.001025   0.950848 (  0.951941)
range            1.874237   0.001472   1.875709 (  1.876820)
delete_suffix    0.721699   0.000945   0.722644 (  0.723410)
```