### PR TITLE
Fix changelog links handling in product template

### DIFF
--- a/_auto/validate.py
+++ b/_auto/validate.py
@@ -36,6 +36,9 @@ def assert_that_in(values, value, name, file):
     assert value in values, f"{name} '{value}' is not valid in {file}, it must be in {values}"
 
 
+def assert_not_blank(value, name, file):
+    assert value.strip(), f"{name} must not be blank in {file}"
+
 def assert_that_starts_with(prefix, value, name, file):
     assert value.startswith(prefix), f"{name} '{value}' must start with {prefix} in {file}"
 
@@ -63,6 +66,9 @@ def validate_product(file):
     assert_that_type_is(comments.CommentedSeq, data["releases"], 'releases', file)
     for r in data["releases"]:
         assert_that_type_is(str, r["releaseCycle"], 'releaseCycle', file)
+
+        if "link" in r and r["link"] != None:
+            assert_not_blank(r["link"], 'link', file)
 
         if "releaseLabel" in r:
             assert_that_type_is(str, r["releaseLabel"], 'releaseLabel', file)

--- a/_layouts/product.html
+++ b/_layouts/product.html
@@ -208,7 +208,7 @@ or +1 (EoL is in the future)
 
   {% if page.releaseColumn != false %}
   <td {% if diff <= 0 %} class = "txt-linethrough" {% endif %} >      <!-- if the support finished add txt-linethrough class -->
-    {% if r.link != "" and diff > 0 %}
+    {% if r.link and diff > 0 %}
       <a href="{{ r.link }}" title="Release Notes / Changelog">{{ r.latest }}</a>
     {% else %}
       {{ r.latest }}

--- a/products/vmware-horizon.md
+++ b/products/vmware-horizon.md
@@ -100,7 +100,7 @@ releases:
     technicalGuidance: 2023-03-22
     latest: "7.10.3"
     latestReleaseDate: 2020-10-22
-    link: ' '
+    link: null
 
 -   releaseCycle: "7.5"
     lts: true
@@ -109,7 +109,7 @@ releases:
     technicalGuidance: 2023-03-22
     latest: "7.5.4"
     latestReleaseDate: 2019-12-19
-    link: ' '
+    link: null
 
 
 ---


### PR DESCRIPTION
Invalid links were generated on pages without `link`s and `changelogTemplates` (such as https://endoflife.date/ios).

Also added a check for blank links in `validate.py`.