### PR TITLE
Update eol for Oracle Linux 8

### DIFF
--- a/products/oraclelinux.md
+++ b/products/oraclelinux.md
@@ -25,7 +25,7 @@ releases:
 -   releaseCycle: "8"
     releaseDate: 2019-07-19
     support: 2029-07-01
-    eol: 2029-07-01
+    eol: 2031-07-01
     latest: "8.7"
     latestReleaseDate: 2022-11-21
 -   releaseCycle: "7"


### PR DESCRIPTION
* Updating eol date for Oracle Linux 8.

As of [Oracle Linux ELSP Lifetime](https://www.oracle.com/a/ocom/docs/elsp-lifetime-069338.pdf). 
The mentioned Oracle Linux versions in the table refers to the value in _Extended Support Ends_ column, this is not the case for Oracle Linux 8.  
 