### PR TITLE
[rails] Add severe security issue example

### DIFF
--- a/products/ruby-on-rails.md
+++ b/products/ruby-on-rails.md
@@ -61,7 +61,7 @@ releases:
 
 >[Ruby on Rails](https://rubyonrails.org/), or Rails, is a server-side web application framework written in Ruby.
 
-Only the latest Rails version gets bug fixes, and the version before that gets security fixes. Severe security issues (as judged by the core team) are backported further; e.g., v4.2.11.1 and v5.0.7.2 are [severe security fixes](https://rubyonrails.org/2019/3/13/Rails-4-2-5-1-5-1-6-2-have-been-released) that were created after v4.2 and v5.0 were no longer receiving (non-severe) security updates.
+Only the latest Rails version gets bug fixes, and the version before that gets security fixes. Severe security issues (as judged by the core team) are backported further; e.g., [v4.2.11.1 and v5.0.7.2](https://rubyonrails.org/2019/3/13/Rails-4-2-5-1-5-1-6-2-have-been-released) as well as [v5.2.8.1](https://rubyonrails.org/2022/7/12/Rails-Versions-7-0-3-1-6-1-6-1-6-0-5-1-and-5-2-8-1-have-been-released) were created after v4.2, v5.0, and v5.2, respectively, were no longer receiving (non-severe) security updates.
 
 A complete list of historic versions is available on [RubyGems](https://rubygems.org/gems/rails/versions). New releases are published on the [Rails blog](https://rubyonrails.org/category/releases).
 .

--- a/products/ruby-on-rails.md
+++ b/products/ruby-on-rails.md
@@ -61,7 +61,7 @@ releases:
 
 >[Ruby on Rails](https://rubyonrails.org/), or Rails, is a server-side web application framework written in Ruby.
 
-Only the latest Rails version gets bug fixes, and the version before that gets security fixes. Severe security issues (as judged by the core team) are backported further; e.g., [v4.2.11.1 and v5.0.7.2](https://rubyonrails.org/2019/3/13/Rails-4-2-5-1-5-1-6-2-have-been-released) as well as [v5.2.8.1](https://rubyonrails.org/2022/7/12/Rails-Versions-7-0-3-1-6-1-6-1-6-0-5-1-and-5-2-8-1-have-been-released) were created after v4.2, v5.0, and v5.2, respectively, were no longer receiving (non-severe) security updates.
+Only the latest Rails version gets bug fixes, and the version before that gets security fixes. Severe security issues (as judged by the core team) are backported further; e.g., v5.2.8.1 is a [severe security fix](https://rubyonrails.org/2022/7/12/Rails-Versions-7-0-3-1-6-1-6-1-6-0-5-1-and-5-2-8-1-have-been-released) that was created after v5.2 was no longer receiving (non-severe) security updates.
 
 A complete list of historic versions is available on [RubyGems](https://rubygems.org/gems/rails/versions). New releases are published on the [Rails blog](https://rubyonrails.org/category/releases).
 .


### PR DESCRIPTION
## Description

Include one other severe security fix example. Rails 5.2.8.1 was released after support for Rails 5.2 had ended.

I tried to preserve the original wording where possible while also providing a link to the [original release announcement for 5.2.8.1](https://rubyonrails.org/2022/7/12/Rails-Versions-7-0-3-1-6-1-6-1-6-0-5-1-and-5-2-8-1-have-been-released), but am **very** open to suggestions 😄