### PR TITLE
[nexus] Remove iconSlug

### DIFF
--- a/products/nexus.md
+++ b/products/nexus.md
@@ -2,7 +2,6 @@
 title: Nexus Repository OSS
 category: server-app
 # https://github.com/simple-icons/simple-icons/issues/7924
-iconSlug: NA
 permalink: /nexus
 alternate_urls:
 -   /nexus-repository


### PR DESCRIPTION
`NA` is not a valid value for iconSlug.