### PR TITLE
[spring-framework] Improve Java support documentation

### DIFF
--- a/products/spring-framework.md
+++ b/products/spring-framework.md
@@ -20,6 +20,7 @@ auto:
 
 releases:
 -   releaseCycle: "6.0"
+    supportedJavaVersions: "17" # https://docs.spring.io/spring-framework/docs/current/reference/html/overview.html#overview
     eol: 2024-08-31
     extendedSupport: 2025-12-31
     latest: "6.0.4"
@@ -27,6 +28,7 @@ releases:
     releaseDate: 2022-11-16
 
 -   releaseCycle: "5.3"
+    supportedJavaVersions: "8, 11, 17" # https://github.com/spring-projects/spring-framework/wiki/Spring-Framework-Versions
     eol: 2024-12-31
     extendedSupport: 2026-12-31
     lts: true
@@ -35,6 +37,7 @@ releases:
     releaseDate: 2020-10-27
 
 -   releaseCycle: "5.2"
+    supportedJavaVersions: "8, 11" # https://docs.spring.io/spring-framework/docs/5.2.22.RELEASE/spring-framework-reference/overview.html#overview
     eol: 2021-12-31
     extendedSupport: 2023-12-31
     latest: "5.2.22"
@@ -42,6 +45,7 @@ releases:
     releaseDate: 2019-09-30
 
 -   releaseCycle: "5.1"
+    supportedJavaVersions: "8, 11" # https://docs.spring.io/spring-framework/docs/5.1.20.RELEASE/spring-framework-reference/overview.html#overview
     eol: 2020-12-31
     extendedSupport: 2022-12-31
     latest: "5.1.20"
@@ -49,6 +53,7 @@ releases:
     releaseDate: 2018-09-21
 
 -   releaseCycle: "5.0"
+    supportedJavaVersions: "8" # https://docs.spring.io/spring-framework/docs/5.0.20.RELEASE/spring-framework-reference/overview.html#overview
     eol: 2020-12-31
     extendedSupport: false
     latest: "5.0.20"
@@ -56,6 +61,7 @@ releases:
     releaseDate: 2017-09-28
 
 -   releaseCycle: "4.3"
+    supportedJavaVersions: "6, 7, 8" # https://docs.spring.io/spring-framework/docs/4.3.30.RELEASE/spring-framework-reference/html/new-in-4.0.html#_java_8_as_well_as_6_and_7
     eol: 2020-12-31
     extendedSupport: false
     latest: "4.3.30"
@@ -63,6 +69,7 @@ releases:
     releaseDate: 2016-06-10
 
 -   releaseCycle: "3.2"
+    supportedJavaVersions: "5, 6" # https://docs.spring.io/spring-framework/docs/3.2.18.RELEASE/spring-framework-reference/html/new-in-3.0.html#new-in-3.0
     eol: 2016-12-31
     extendedSupport: false
     latest: "3.2.18"
@@ -79,8 +86,14 @@ See [Spring Boot Milestones page](https://github.com/spring-projects/spring-fram
 for upcoming releases and [Spring Boot Support page](https://spring.io/projects/spring-framework#support)
 for more details about support roadmap.
 
-- Spring Framework 6.x requires **at least a Java 17 runtime**,
-- Spring Framework 5.3.x supports Java 19 while also remaining compatible with Java 11 and 8.
-
 Extended support is available
 [from VMWare](https://tanzu.vmware.com/content/blog/vmware-spring-runtime-extended-support).
+
+## Java Compatibility
+
+{%- assign collapsedCycles = page.releases | collapse_cycles:"supportedJavaVersions"," - " %}
+{% include table.html
+  labels="Release,Java (LTS)"
+  fields="releaseCycle,supportedJavaVersions"
+  types="string,string"
+  rows=collapsedCycles %}


### PR DESCRIPTION
Only documenting LTS Java version. Information about intermediate version is quite difficult to find.