### PR TITLE
:pray:  Please add mn alias to micronaut

### DIFF
--- a/products/micronaut.md
+++ b/products/micronaut.md
@@ -4,6 +4,7 @@ category: framework
 permalink: /micronaut
 alternate_urls:
 -   /micronaut-framework
+-   /mn
 releasePolicyLink: https://micronaut.io/support-schedule/
 changelogTemplate: "https://github.com/micronaut-projects/micronaut-core/releases/tag/v__LATEST__"
 activeSupportColumn: Active Development


### PR DESCRIPTION
# :grey_question:  About

As Micronaut is called on `CLI` by `mn`, adding `mn` would be very convenient.

# :bulb: Examples

- `PostgreSQL' with `psql`
- `Maven` with `mvn`

![image](https://user-images.githubusercontent.com/5235127/215185552-c3845734-5cfd-4600-8620-9127afce6e07.png)
