### PR TITLE
:link:  Ubuntu > Add missing links :penguin: 

### DIFF
--- a/products/ubuntu.md
+++ b/products/ubuntu.md
@@ -66,6 +66,7 @@ releases:
     support: 2021-07-22
     eol: 2021-07-22
     latest: "20.10"
+    link: https://old-releases.ubuntu.com/releases/20.10/
     releaseDate: 2020-10-22
     latestReleaseDate: 2020-10-22
     extendedSupport: false
@@ -76,6 +77,7 @@ releases:
     eol: 2025-04-02
     extendedSupport: 2030-04-02
     latest: "20.04.5"
+    link: https://old-releases.ubuntu.com/releases/20.04/
     releaseDate: 2020-04-23
     latestReleaseDate: 2022-09-01
 -   releaseCycle: "19.10"
@@ -83,6 +85,7 @@ releases:
     support: 2020-07-06
     eol: 2020-07-06
     latest: "19.10"
+    link: https://old-releases.ubuntu.com/releases/19.10/
     releaseDate: 2019-10-17
     latestReleaseDate: 2019-10-17
     extendedSupport: false
@@ -93,7 +96,7 @@ releases:
     eol: 2023-04-02
     extendedSupport: 2028-04-01
     latest: "18.04.6"
-    link: https://wiki.ubuntu.com/BionicBeaver/ReleaseNotes
+    link: https://old-releases.ubuntu.com/releases/19.10/
     releaseDate: 2018-04-26
     latestReleaseDate: 2021-09-17
 -   releaseCycle: "16.04"
@@ -103,6 +106,7 @@ releases:
     eol: 2021-04-02
     extendedSupport: 2026-04-02
     latest: "16.04.7"
+    link: https://releases.ubuntu.com/16.04/
     releaseDate: 2016-04-21
     latestReleaseDate: 2020-08-13
 -   releaseCycle: "14.04"
@@ -112,6 +116,7 @@ releases:
     eol: 2019-04-02
     extendedSupport: 2024-04-02
     latest: "14.04.6"
+    link: https://releases.ubuntu.com/14.04/
     releaseDate: 2014-04-17
     latestReleaseDate: 2019-03-07
 ---


### PR DESCRIPTION
# :grey_question: About

While making some reporting on `endoflife.date`, I discovered that some `links` were missing on Ubuntu : 

<pre><font color="#5FD700">❯</font> eol ubuntu
| cycle     |  release   | latest  | latest release |  support   |    eol     |     codename    | extendedSupport | link                                                 |
|:----------|:----------:|:--------|:--------------:|:----------:|:----------:|:---------------:|:---------------:|:-----------------------------------------------------|
| 22.10     | 2022-10-20 | 22.10   |   2022-10-20   | <font color="#C4A000">2023-07-20</font> | <font color="#C4A000">2023-07-20</font> |   Kinetic Kudu  |      False      | https://wiki.ubuntu.com/KineticKudu/ReleaseNotes/    |
| 22.04 LTS | 2022-04-21 | 22.04.1 |   2022-08-11   | <font color="#4E9A06">2024-09-30</font> | <font color="#4E9A06">2027-04-01</font> | Jammy Jellyfish |    2032-04-09   | https://wiki.ubuntu.com/JammyJellyfish/ReleaseNotes/ |
| 21.10     | 2021-10-14 | 21.10   |   2021-10-14   | <font color="#CC0000">2022-07-14</font> | <font color="#CC0000">2022-07-14</font> |   Impish Indri  |      False      | https://wiki.ubuntu.com/ImpishIndri/ReleaseNotes/    |
| 21.04     | 2021-04-22 | 21.04   |   2021-04-22   | <font color="#CC0000">2022-01-20</font> | <font color="#CC0000">2022-01-20</font> |  Hirsute Hippo  |      False      | https://wiki.ubuntu.com/HirsuteHippo/ReleaseNotes/   |
| 20.10     | 2020-10-22 | 20.10   |   2020-10-22   | <font color="#CC0000">2021-07-22</font> | <font color="#CC0000">2021-07-22</font> |  Groovy Gorilla |      False      |                                                      |
| 20.04 LTS | 2020-04-23 | 20.04.5 |   2022-09-01   | <font color="#CC0000">2022-10-01</font> | <font color="#4E9A06">2025-04-02</font> |   Focal Fossa   |    2030-04-02   |                                                      |
| 19.10     | 2019-10-17 | 19.10   |   2019-10-17   | <font color="#CC0000">2020-07-06</font> | <font color="#CC0000">2020-07-06</font> |   Karmic Koala  |      False      |                                                      |
| 18.04 LTS | 2018-04-26 | 18.04.6 |   2021-09-17   | <font color="#C4A000">2023-04-02</font> | <font color="#C4A000">2023-04-02</font> |  Bionic Beaver  |    2028-04-01   | https://wiki.ubuntu.com/BionicBeaver/ReleaseNotes    |
| 16.04 LTS | 2016-04-21 | 16.04.7 |   2020-08-13   | <font color="#CC0000">2021-04-02</font> | <font color="#CC0000">2021-04-02</font> |   Xenial Xerus  |    2026-04-02   |                                                      |
| 14.04 LTS | 2014-04-17 | 14.04.6 |   2019-03-07   | <font color="#CC0000">2019-04-02</font> | <font color="#CC0000">2019-04-02</font> |   Trusty Tahr   |    2024-04-02   |                                                      |</pre>

# :dart: Actions

:point_right: By merging this PR, all links will be setup.
:pray: Please let me know if the urls are looking good for you.
