### PR TITLE
[haproxy] Update 2.5 eol date

### DIFF
--- a/products/haproxy.md
+++ b/products/haproxy.md
@@ -1,17 +1,19 @@
 ---
 title: HAProxy
-permalink: /haproxy
 category: server-app
+permalink: /haproxy
+versionCommand: haproxy -v
 releasePolicyLink: https://www.haproxy.org/
 changelogTemplate: https://www.haproxy.org/download/__RELEASE_CYCLE__/src/CHANGELOG
 activeSupportColumn: false
-versionCommand: haproxy -v
 releaseDateColumn: true
+
 # Source: https://www.haproxy.org/download/
 # Data: https://github.com/endoflife-date/release-data/blob/main/releases/haproxy.json
 # Script: https://github.com/endoflife-date/release-data/blob/main/src/haproxy.py
 auto:
 -   custom: true
+
 releases:
 -   releaseCycle: "2.7"
     lts: false
@@ -19,54 +21,64 @@ releases:
     latest: "2.7.2"
     latestReleaseDate: 2023-01-20
     releaseDate: 2022-12-01
+
 -   releaseCycle: "2.6"
     lts: true
     eol: 2027-04-01
     latest: "2.6.8"
     latestReleaseDate: 2023-01-24
     releaseDate: 2022-05-31
+
 -   releaseCycle: "2.5"
-    eol: 2023-01-01
+    eol: 2023-05-23
     latest: "2.5.11"
     latestReleaseDate: 2023-01-24
     releaseDate: 2021-11-23
+
 -   releaseCycle: "2.4"
     lts: true
     eol: 2026-04-01
     latest: "2.4.21"
     latestReleaseDate: 2023-01-27
     releaseDate: 2021-05-14
+
 -   releaseCycle: "2.3"
     eol: 2022-01-01
     latest: "2.3.21"
     latestReleaseDate: 2022-07-27
     releaseDate: 2020-11-05
+
 -   releaseCycle: "2.2"
     lts: true
     eol: 2025-04-01
     latest: "2.2.27"
     latestReleaseDate: 2023-01-27
     releaseDate: 2020-07-07
+
 -   releaseCycle: "2.1"
     eol: 2021-03-18
     latest: "2.1.12"
     latestReleaseDate: 2021-03-18
     releaseDate: 2019-11-25
+
 -   releaseCycle: "2.0"
     eol: 2024-04-01
     latest: "2.0.30"
     latestReleaseDate: 2022-12-09
     releaseDate: 2019-06-16
+
 -   releaseCycle: "1.9"
     eol: 2020-07-31
     latest: "1.9.16"
     latestReleaseDate: 2020-07-31
     releaseDate: 2018-12-19
+
 -   releaseCycle: "1.8"
     eol: 2022-10-01
     latest: "1.8.31"
     latestReleaseDate: 2022-12-09
     releaseDate: 2017-11-26
+
 -   releaseCycle: "1.7"
     eol: 2021-10-01
     latest: "1.7.14"


### PR DESCRIPTION
haproxy 2.5 is still marked as maintained on https://www.haproxy.org/. According to the product description, odd branches EOL date is not decided in advance and should be maintained from 12 to 18 months, so EOL should be between May 23, 2022-12-23 and 2023-05-23.