### PR TITLE
[NodeJs] Change category to framework

### DIFF
--- a/products/nodejs.md
+++ b/products/nodejs.md
@@ -3,7 +3,7 @@ permalink: /nodejs
 alternate_urls:
 -   /node
 -   /node.js
-category: lang
+category: framework
 title: Node.js
 iconSlug: nodedotjs
 releasePolicyLink: https://nodejs.org/about/releases/


### PR DESCRIPTION
Like [`Vuejs`](https://github.com/endoflife-date/endoflife.date/blob/master/products/vue.md) is a framework cf : 

- https://github.com/endoflife-date/endoflife.date/pull/940

![image](https://user-images.githubusercontent.com/5235127/216196898-93fc4a37-fb2c-4b2b-95f0-a719624309c5.png)


![image](https://user-images.githubusercontent.com/5235127/216196980-9a33adc4-0903-4f07-9741-482e2cffc3af.png)
