### PR TITLE
Change Firefox logo to the right one

### DIFF
--- a/products/firefox.md
+++ b/products/firefox.md
@@ -5,7 +5,7 @@ category: app
 releasePolicyLink: https://www.mozilla.org/firefox/
 releaseDateColumn: true
 releaseColumn: true
-iconSlug: firefox
+iconSlug: firefoxbrowser
 LTSLabel: "<abbr title='Extended Support Release'>ESR</abbr>"
 changelogTemplate: https://www.mozilla.org/firefox/__LATEST__/releasenotes/
 


### PR DESCRIPTION
Some people used this to indicate the Mozila Firefox browser. (slug: `firefox`)

<img src="https://simpleicons.org/icons/firefox.svg" width=100 />

This is not the right logo. That is for the Firefox family of products. This right one is this. (slug: `firefoxbrowser`)

<img src="https://simpleicons.org/icons/firefoxbrowser.svg" width=100 />

This PR fixes that.

See also: [Remain calm. The fox is still in the Firefox logo.](https://blog.mozilla.org/en/internet-culture/the-fox-is-still-in-the-firefox-logo/)