### PR TITLE
[cakephp] Remove some releases link

### DIFF
--- a/products/cakephp.md
+++ b/products/cakephp.md
@@ -62,7 +62,6 @@ releases:
     support: 2021-12-15
     releaseDate: 2021-06-19
     latestReleaseDate: 2023-01-01
-    link: https://bakery.cakephp.org/2022/05/21/cakephp_3104_released.html
 
 -   releaseCycle: "3.9"
     latest: "3.9.10"
@@ -140,7 +139,6 @@ releases:
     support: 2020-12-15
     releaseDate: 2017-07-22
     latestReleaseDate: 2020-12-15
-    link: https://bakery.cakephp.org/2020/12/15/cakephp_21024_released.html
 
 -   releaseCycle: "2.9"
     latest: "2.9.9"
@@ -148,7 +146,6 @@ releases:
     support: false
     releaseDate: 2016-09-18
     latestReleaseDate: 2017-05-25
-    link: https://bakery.cakephp.org/2017/05/25/cakephp_299_released.html
 
 -   releaseCycle: "2.8"
     latest: "2.8.9"
@@ -156,7 +153,6 @@ releases:
     support: false
     releaseDate: 2016-02-06
     latestReleaseDate: 2016-09-18
-    link: https://bakery.cakephp.org/2016/09/18/cakephp_290_289_released.html
 
 -   releaseCycle: "2.7"
     latest: "2.7.11"
@@ -164,7 +160,6 @@ releases:
     support: false
     releaseDate: 2015-07-11
     latestReleaseDate: 2016-03-13
-    link: https://bakery.cakephp.org/2016/03/13/cakephp_2613_2711_282_3017_3112_325_released.html
 
 -   releaseCycle: "2.6"
     latest: "2.6.13"
@@ -172,7 +167,6 @@ releases:
     support: false
     releaseDate: 2014-12-23
     latestReleaseDate: 2016-03-13
-    link: https://bakery.cakephp.org/2016/03/13/cakephp_2613_2711_282_3017_3112_325_released.html
 
 -   releaseCycle: "2.5"
     latest: "2.5.9"
@@ -180,7 +174,6 @@ releases:
     support: false
     releaseDate: 2014-05-12
     latestReleaseDate: 2015-08-06
-    link: https://bakery.cakephp.org/2015/08/06/cakephp_2_5_9_2_6_10_2_7_2_released.html
 
 -   releaseCycle: "2.4"
     latest: "2.4.10"
@@ -188,7 +181,6 @@ releases:
     support: false
     releaseDate: 2013-08-30
     latestReleaseDate: 2014-05-17
-    link: https://bakery.cakephp.org/2014/05/18/CakePHP-2-4-10-and-2-5-1-released.html
 
 -   releaseCycle: "2.3"
     latest: "2.3.10"
@@ -203,7 +195,6 @@ releases:
     support: false
     releaseDate: 2012-07-01
     latestReleaseDate: 2013-07-17
-    link: https://bakery.cakephp.org/2012/07/14/Security-Release-CakePHP-2-1-5-2-2-1.html
 
 -   releaseCycle: "2.1"
     latest: "2.1.5"
@@ -227,7 +218,6 @@ releases:
     support: 2015-11-01
     releaseDate: 2010-04-25
     latestReleaseDate: 2015-10-31
-    link: https://bakery.cakephp.org/2015/11/01/cakephp_1_3_21_released.html
 
 ---
 


### PR DESCRIPTION
All those releases have their release notes on GitHub (such as https://github.com/cakephp/cakephp/releases/1.3.21), so it's better to use the `changelogTemplate` in those cases.

Links for 2.0.6 and 2.1.5 has been kept because there was no release notes on GitHub.