### PR TITLE
[docker-engine] Add 23.0, EoL 20.10, Update changelogTemplate

### DIFF
--- a/products/docker-engine.md
+++ b/products/docker-engine.md
@@ -5,7 +5,7 @@ iconSlug: docker
 permalink: /docker-engine
 versionCommand: docker version --format '{{.Server.Version}}'
 releasePolicyLink: https://docs.docker.com/engine/release-notes/
-changelogTemplate: "https://docs.docker.com/engine/release-notes/#{{'__LATEST__'|replace:'.',''}}"
+changelogTemplate: "https://docs.docker.com/engine/release-notes/__RELEASE_CYCLE__/"
 activeSupportColumn: false
 releaseColumn: true
 releaseDateColumn: true
@@ -20,8 +20,14 @@ auto:
     regex: ^v(?<major>0|[1-9]\d*)\.(?<minor>\d*)\.(?<patch>0|[1-9]\d*)(-ce)?$
 
 releases:
--   releaseCycle: "20.10"
+-   releaseCycle: "23.0"
     eol: false
+    latest: "23.0.0"
+    latestReleaseDate: 2023-02-01
+    releaseDate: 2023-02-01
+
+-   releaseCycle: "20.10"
+    eol: 2023-03-01
     latest: "20.10.23"
     latestReleaseDate: 2023-01-20
     releaseDate: 2020-12-09


### PR DESCRIPTION
https://docs.docker.com/engine/release-notes/23.0/
calculated EoL for 20.10 based on the rule "...supported with patches as needed for one month after the next year-month general availability release..."