### PR TITLE
Support variables in release cycle links

### DIFF
--- a/_plugins/product-data-enricher.rb
+++ b/_plugins/product-data-enricher.rb
@@ -76,23 +76,22 @@ module Jekyll
       end
 
       def set_cycle_link(page, cycle)
-        if !cycle.has_key?('link') && page['changelogTemplate']
-          link = page['changelogTemplate'].gsub('__RELEASE_CYCLE__', cycle['releaseCycle'] || '')
-          link.gsub!('__CODENAME__', cycle['codename'] || '')
-          link.gsub!('__LATEST__', cycle['latest'] || '')
-          link.gsub!('__LATEST_RELEASE_DATE__', cycle['latestReleaseDate'] ? cycle['latestReleaseDate'].iso8601 : '')
-          cycle['link'] = Liquid::Template.parse(link).render(@context)
+        if cycle.has_key?('link')
+          # null link means no changelog template
+          if cycle['link'] && cycle['link'].include?('__')
+            cycle['link'] = render_eol_template(cycle['link'], cycle)
+          end
+        else
+          if page['changelogTemplate']
+            cycle['link'] = render_eol_template(page['changelogTemplate'], cycle)
+          end
         end
       end
 
       def set_cycle_label(page, cycle)
         template = cycle['releaseLabel'] || page.data['releaseLabel']
-
         if template
-          label = template.gsub('__RELEASE_CYCLE__', cycle['releaseCycle'] || '')
-          label.gsub!('__CODENAME__', cycle['codename'] || '')
-          label.gsub!('__LATEST__', cycle['latest'] || '')
-          cycle['label'] = Liquid::Template.parse(label).render(@context)
+          cycle['label'] = render_eol_template(template, cycle)
         else
           cycle['label'] = cycle['releaseCycle']
         end
@@ -113,6 +112,16 @@ module Jekyll
             end
           end
         end
+      end
+
+      private
+
+      def render_eol_template(template, cycle)
+        link = template.gsub('__RELEASE_CYCLE__', cycle['releaseCycle'] || '')
+        link.gsub!('__CODENAME__', cycle['codename'] || '')
+        link.gsub!('__LATEST__', cycle['latest'] || '')
+        link.gsub!('__LATEST_RELEASE_DATE__', cycle['latestReleaseDate'] ? cycle['latestReleaseDate'].iso8601 : '')
+        cycle['link'] = Liquid::Template.parse(link).render(@context)
       end
     end
   end

--- a/products/scala.md
+++ b/products/scala.md
@@ -47,7 +47,7 @@ releases:
     eol: false
     latest: "2.13.10"
     latestReleaseDate: 2022-10-08
-    link: https://github.com/scala/scala/releases/tag/v2.13.10
+    link: https://github.com/scala/scala/releases/tag/v__LATEST__
 
 -   releaseCycle: "2.12"
     releaseDate: 2016-10-28
@@ -55,7 +55,7 @@ releases:
     eol: false
     latest: "2.12.17"
     latestReleaseDate: 2022-09-14
-    link: https://github.com/scala/scala/releases/tag/v2.12.17
+    link: https://github.com/scala/scala/releases/tag/v__LATEST__
 
 -   releaseCycle: "2.11"
     releaseDate: 2014-04-16
@@ -63,7 +63,7 @@ releases:
     eol: false
     latest: "2.11.12"
     latestReleaseDate: 2017-11-06
-    link: https://github.com/scala/scala/releases/tag/v2.11.12
+    link: https://github.com/scala/scala/releases/tag/v__LATEST__
 
 -   releaseCycle: "2.10"
     releaseDate: 2012-12-19
@@ -71,7 +71,7 @@ releases:
     eol: false
     latest: "2.10.7"
     latestReleaseDate: 2017-11-06
-    link: https://github.com/scala/scala/releases/tag/v2.10.7
+    link: https://github.com/scala/scala/releases/tag/v__LATEST__
 
 ---
 

--- a/products/vue.md
+++ b/products/vue.md
@@ -1,14 +1,15 @@
 ---
 title: Vue
+category: framework
+iconSlug: vuedotjs
 permalink: /vue
 alternate_urls:
 -   /vuejs
-category: framework
+
+versionCommand: npm list vue
 releasePolicyLink: https://vuejs.org/about/releases.html
 activeSupportColumn: true
-versionCommand: npm list vue
 releaseDateColumn: true
-iconSlug: vuedotjs
 
 auto:
 -   npm: vue
@@ -19,6 +20,7 @@ identifiers:
 -   purl: pkg:npm/vue
 -   purl: pkg:github/vuejs/vue
 -   purl: pkg:github/vuejs/core
+
 releases:
 -   releaseCycle: "3"
     support: true
@@ -27,6 +29,8 @@ releases:
     lts: false
     latestReleaseDate: 2023-02-02
     releaseDate: 2020-09-18
+    link: https://github.com/vuejs/core/blob/main/CHANGELOG.md
+
 -   releaseCycle: "2"
     support: 2022-03-18
     eol: 2023-12-31
@@ -34,6 +38,8 @@ releases:
     lts: false
     latestReleaseDate: 2022-11-09
     releaseDate: 2016-09-30
+    link: https://github.com/vuejs/vue/blob/main/CHANGELOG.md
+
 -   releaseCycle: "1"
     support: false
     eol: true
@@ -41,11 +47,21 @@ releases:
     lts: false
     latestReleaseDate: 2016-09-27
     releaseDate: 2015-10-27
+    link: https://github.com/vuejs/vue/releases/tag/v__LATEST_
 
 ---
 
-> [Vue](https://vuejs.org/) is a JavaScript framework for building user interfaces. It builds on top of standard HTML, CSS and JavaScript, and provides a declarative and component-based programming model to efficiently develop user interfaces.
+> [Vue](https://vuejs.org/) is a JavaScript framework for building user interfaces. It builds on top
+> of standard HTML, CSS and JavaScript, and provides a declarative and component-based programming
+> model to efficiently develop user interfaces.
 
-[Vue does not have a fixed release cycle](https://vuejs.org/about/releases.html). Patch releases are released as needed. Minor releases always contain new features, with a typical time frame of 3-6 months in between. Minor releases always go through a beta pre-release phase. Major releases will be announced ahead of time, and will go through an early discussion phase and alpha / beta pre-release phases.
+[Vue does not have a fixed release cycle](https://vuejs.org/about/releases.html). Patch releases are
+released as needed. Minor releases always contain new features, with a typical time frame of 3-6
+months in between. Minor releases always go through a beta pre-release phase. Major releases will be
+announced ahead of time, and will go through an early discussion phase and alpha / beta pre-release
+phases.
 
-Every time a new major is released, the last minor in the previous major automatically becomes LTS for 18 months, receiving bug fixes and security patches. Then it becomes maintenance mode (security patches only) for another 18 months before entering end of life. "2.7" is the planned LTS release for the v2 cycle.
+Every time a new major is released, the last minor in the previous major automatically becomes LTS
+for 18 months, receiving bug fixes and security patches. Then it becomes maintenance mode
+(security patches only) for another 18 months before entering end of life. "2.7" is the planned LTS
+release for the v2 cycle.


### PR DESCRIPTION
New feature tested with scala 2.x cycles: these links no longer have to be updated manually.