### PR TITLE
[Drupal] Update latest version for 7.x

### DIFF
--- a/products/drupal.md
+++ b/products/drupal.md
@@ -77,7 +77,7 @@ releases:
     support: 2015-11-19
     latestReleaseDate: 2022-06-01
     eol: 2023-11-01
-    latest: "7.90"
+    latest: "7.94"
     lts: true
     releaseDate: 2011-01-05
 

--- a/products/drupal.md
+++ b/products/drupal.md
@@ -75,7 +75,7 @@ releases:
     releaseDate: 2019-12-04
 -   releaseCycle: "7"
     support: 2015-11-19
-    latestReleaseDate: 2022-06-01
+    latestReleaseDate: 2022-12-14
     eol: 2023-11-01
     latest: "7.94"
     lts: true


### PR DESCRIPTION
This aims to resolve https://github.com/endoflife-date/endoflife.date/issues/2464

Looking at the history, cycle 7.x has been manually updated as `drupal/core` repo does not tag 7.x releases (unlike `drupal/drupal`) 

This change updates the latest version to `7.94` and the latestReleaseDate. [GIT: Drupal/Core 7.94](https://github.com/drupal/drupal/releases/tag/7.94) [Drupal: 7.94](https://www.drupal.org/project/drupal/releases/7.94)

The eol date remains the same as per [this page](https://www.drupal.org/project/drupal)