### PR TITLE
linux 6.1 is lts and update eol of 5.15 from kernel releases page

### DIFF
--- a/products/linuxkernel.md
+++ b/products/linuxkernel.md
@@ -19,9 +19,10 @@ auto:
 
 releases:
 -   releaseCycle: "6.1"
-    eol: false
-    latest: "6.1.9"
-    latestReleaseDate: 2023-02-01
+    eol: 2026-12-31
+    lts: true
+    latest: "6.1.10"
+    latestReleaseDate: 2023-02-06
     releaseDate: 2022-12-11
 
 -   releaseCycle: "6.0"
@@ -55,7 +56,7 @@ releases:
     releaseDate: 2022-01-09
 
 -   releaseCycle: "5.15"
-    eol: 2023-10-31
+    eol: 2026-10-31
     lts: true
     latest: "5.15.91"
     latestReleaseDate: 2023-02-01

--- a/products/linuxkernel.md
+++ b/products/linuxkernel.md
@@ -58,8 +58,8 @@ releases:
 -   releaseCycle: "5.15"
     eol: 2026-10-31
     lts: true
-    latest: "5.15.91"
-    latestReleaseDate: 2023-02-01
+    latest: "5.15.92"
+    latestReleaseDate: 2023-02-06
     releaseDate: 2021-10-31
 
 -   releaseCycle: "5.10"


### PR DESCRIPTION
- Linux kernel 6.1 gets lts and new eol date
- Linux kernel 5.15 have new eol date

all resources is from https://www.kernel.org/category/releases.html