### PR TITLE
[perl] Remove odd releases and clarify description

### DIFF
--- a/products/perl.md
+++ b/products/perl.md
@@ -3,67 +3,74 @@ title: Perl
 category: lang
 iconSlug: perl
 permalink: /perl
-changelogTemplate: "https://perldoc.perl.org/__LATEST__/perldelta"
+versionCommand: perl -v
 releaseImage: https://www.versio.io/img/product-release-version-end-of-life/Perl_Foundation-Perl.jpg
 releasePolicyLink: https://perldoc.perl.org/perlpolicy#MAINTENANCE-AND-SUPPORT
+changelogTemplate: "https://perldoc.perl.org/__LATEST__/perldelta"
 activeSupportColumn: true
 releaseColumn: true
 releaseDateColumn: true
 eolColumn: Critical security patches
-versionCommand: perl -v
 
+# Using the default regex loses all releases before 5.10
+# Feel free to file a PR to fix this
 auto:
-  # Using the default regex loses all releases before 5.10
-  # Feel free to file a PR to fix this
 -   git: https://github.com/Perl/perl5.git
 
-releases:
 # eol dates are always releaseDate + 3 YEARS
 # support: true for latest 2 releases
 # support: releaseDate(R+2) for R-th release
 # So the support(5.34) = releaseDate(5.36)
+releases:
 -   releaseCycle: "5.37"
     eol: 2025-05-27
     support: true
     releaseDate: 2022-05-27
     latestReleaseDate: 2023-01-20
     latest: "5.37.8"
+
 -   releaseCycle: "5.36"
     eol: 2025-05-27
     support: true
     latest: "5.36.0"
     latestReleaseDate: 2022-05-27
     releaseDate: 2022-05-27
+
 -   releaseCycle: "5.35"
     releaseDate: 2021-05-20
     eol: 2024-05-20
     support: 2022-05-27
     latestReleaseDate: 2022-04-20
     latest: '5.35.11'
+
 -   releaseCycle: "5.34"
     eol: 2024-05-20
     support: 2022-05-27
     latest: "5.34.1"
     latestReleaseDate: 2022-03-12
     releaseDate: 2021-05-20
+
 -   releaseCycle: "5.32"
     eol: 2023-06-20
     support: 2022-05-27
     latest: "5.32.1"
     latestReleaseDate: 2021-01-23
     releaseDate: 2020-06-20
+
 -   releaseCycle: "5.30"
     eol: 2022-05-22
     support: 2021-05-20
     latest: "5.30.3"
     latestReleaseDate: 2020-05-29
     releaseDate: 2019-05-22
+
 -   releaseCycle: "5.28"
     eol: 2021-06-23
     support: 2020-06-20
     latest: "5.28.3"
     latestReleaseDate: 2020-05-29
     releaseDate: 2018-06-22
+
 -   releaseCycle: "5.26"
     eol: 2020-05-30
     support: 2019-05-22
@@ -73,8 +80,12 @@ releases:
 
 ---
 
-> [Perl](https://www.perl.org/) is a highly capable, feature-rich programming language with over 30 years of development.
+> [Perl](https://www.perl.org/) is a highly capable, feature-rich programming language with over 30
+> years of development.
 
-As detailed in the [perlpolicy](https://perldoc.perl.org/perlpolicy#MAINTENANCE-AND-SUPPORT) man page, the Perl community will, to the best of its ability, attempt to:
+As detailed in the [perlpolicy](https://perldoc.perl.org/perlpolicy#MAINTENANCE-AND-SUPPORT) man
+page, the Perl community will, to the best of its ability, attempt to:
+
 - Fix critical issues in the two most recent stable 5.x release series.
-- Provide critical security patches for any major version of Perl whose 5.x.0 release was within the past three years.
+- Provide critical security patches for any major version of Perl whose 5.x.0 release was within the
+  past three years.

--- a/products/perl.md
+++ b/products/perl.md
@@ -12,68 +12,63 @@ releaseColumn: true
 releaseDateColumn: true
 eolColumn: Critical security patches
 
-# Using the default regex loses all releases before 5.10
-# Feel free to file a PR to fix this
+# We split the regex into two to deal with differing policies, and tagging schemes before/after 5.26
+# - before 5.26 -> perl-x.00y, perl-x.00y_z, perl-x.00y.z, perl-x.00y.zabc
+# - after  5.26 -> vx.y.z
+#
+# This regex is returning 5.7.x and 5.9.x versions even if it shouldn't (odd versions are
+# 'development' version since 5.6). But considering those are not listed on
+# https://endoflife.date/perl it's an acceptable inconvenient.
+#
+# See https://rubular.com/r/CUbQrJOw8jlOeS
 auto:
 -   git: https://github.com/Perl/perl5.git
+    regex: '^(v(?<major>\d+)\.(?<minor>[1-9]*[02468])\.(?<patch>\d+)?|perl-(?<major>\d+)\.(?<minor>\d+))((\.|\_)(?<patch>\d?\w+))?$'
 
-# eol dates are always releaseDate + 3 YEARS
-# support: true for latest 2 releases
-# support: releaseDate(R+2) for R-th release
-# So the support(5.34) = releaseDate(5.36)
+# Development releases are not listed here, and:
+# - eol dates are always releaseDate + 3 YEARS
+# - support dates are:
+#   - true for the last 2 releases
+#   - releaseDate(R+2) for other releases (e.g. support(5.34) = releaseDate(5.36))
 releases:
--   releaseCycle: "5.37"
-    eol: 2025-05-27
-    support: true
-    releaseDate: 2022-05-27
-    latestReleaseDate: 2023-01-20
-    latest: "5.37.8"
-
 -   releaseCycle: "5.36"
-    eol: 2025-05-27
     support: true
+    eol: 2025-05-27
     latest: "5.36.0"
     latestReleaseDate: 2022-05-27
     releaseDate: 2022-05-27
 
--   releaseCycle: "5.35"
-    releaseDate: 2021-05-20
-    eol: 2024-05-20
-    support: 2022-05-27
-    latestReleaseDate: 2022-04-20
-    latest: '5.35.11'
-
 -   releaseCycle: "5.34"
-    eol: 2024-05-20
     support: 2022-05-27
+    eol: 2024-05-20
     latest: "5.34.1"
     latestReleaseDate: 2022-03-12
     releaseDate: 2021-05-20
 
 -   releaseCycle: "5.32"
-    eol: 2023-06-20
     support: 2022-05-27
+    eol: 2023-06-20
     latest: "5.32.1"
     latestReleaseDate: 2021-01-23
     releaseDate: 2020-06-20
 
 -   releaseCycle: "5.30"
-    eol: 2022-05-22
     support: 2021-05-20
+    eol: 2022-05-22
     latest: "5.30.3"
     latestReleaseDate: 2020-05-29
     releaseDate: 2019-05-22
 
 -   releaseCycle: "5.28"
-    eol: 2021-06-23
     support: 2020-06-20
+    eol: 2021-06-23
     latest: "5.28.3"
     latestReleaseDate: 2020-05-29
     releaseDate: 2018-06-22
 
 -   releaseCycle: "5.26"
-    eol: 2020-05-30
     support: 2019-05-22
+    eol: 2020-05-30
     latest: "5.26.3"
     latestReleaseDate: 2018-11-28
     releaseDate: 2017-05-30
@@ -83,9 +78,14 @@ releases:
 > [Perl](https://www.perl.org/) is a highly capable, feature-rich programming language with over 30
 > years of development.
 
-As detailed in the [perlpolicy](https://perldoc.perl.org/perlpolicy#MAINTENANCE-AND-SUPPORT) man
-page, the Perl community will, to the best of its ability, attempt to:
+Perl used the following policy since the 5.6 release of Perl:
 
-- Fix critical issues in the two most recent stable 5.x release series.
-- Provide critical security patches for any major version of Perl whose 5.x.0 release was within the
-  past three years.
+- Maintenance releases (ready for production use) are even numbers, such as 5.8, 5.10, 5.12.
+- Development releases are odd numbers, such as 5.9, 5.11, 5.13.
+
+This page only list maintenance releases. Moreover, as detailed in the
+[perlpolicy](https://perldoc.perl.org/perlpolicy#MAINTENANCE-AND-SUPPORT) man page, the Perl
+community will, to the best of its ability, attempt to:
+
+- Fix critical issues in the two most recent maintenance releases.
+- Provide critical security patches for any maintenance release within the past three years.


### PR DESCRIPTION
Odd releases are development releases and are not considered suitable for production.

Regex has been modified to skip odd releases too. The new regex has been tested locally, here are an extract of the diff after executing the `update.rb` script :

```diff
diff --git i/releases/perl.json w/releases/perl.json
index b0a7f89..7ae215e 100644
--- i/releases/perl.json
+++ w/releases/perl.json
@@ -1,208 +1,55 @@
 {
   "5.10.0": "2011-03-11",
   "5.10.1": "2019-05-08",
-  "5.11.0": "2009-10-02",
-  "5.11.1": "2009-10-20",
-  "5.11.2": "2009-11-20",
-  "5.11.3": "2009-12-20",
-  "5.11.4": "2010-01-20",
-  "5.11.5": "2010-02-20",
   "5.12.0": "2010-04-12",
   "5.12.1": "2010-05-16",
   "5.12.2": "2010-09-06",
   "5.12.3": "2011-01-21",
   "5.12.4": "2011-06-20",
   "5.12.5": "2012-11-10",
-  "5.13.0": "2010-04-20",
-  "5.13.1": "2010-05-20",
-  "5.13.10": "2011-02-20",
...
```

I also took the opportunity to normalize the page (#2124).