### PR TITLE
[SonarQube] Declare 9 as the new LTS version and add eol date for 8

### DIFF
--- a/products/sonarqube.md
+++ b/products/sonarqube.md
@@ -21,14 +21,14 @@ releases:
     releaseDate: 2021-07-02
     support: true
     eol: false
+    lts: 2023-02-07
     latest: "9.9.0"
     latestReleaseDate: 2023-02-06
 
 -   releaseCycle: "8"
     releaseDate: 2020-05-08
     support: 2021-07-05
-    # Should be 2022-11-04 as per the policy, but is now in the past
-    eol: false
+    eol: 2023-02-07
     lts: 2021-05-04
     latest: "8.9.10"
     latestReleaseDate: 2022-12-19

--- a/products/sonarqube.md
+++ b/products/sonarqube.md
@@ -23,7 +23,8 @@ releases:
     eol: false
     lts: 2023-02-07
     latest: "9.9.0"
-    latestReleaseDate: 2023-02-06
+    latestReleaseDate: 2023-02-07
+    link: https://www.sonarsource.com/products/sonarqube/downloads/lts/9-9-lts/
 
 -   releaseCycle: "8"
     releaseDate: 2020-05-08


### PR DESCRIPTION
See https://www.sonarsource.com/blog/sonarqube-9-9-lts/ :

> Given the release of SQ 9.9 LTS, we will now phase out our support of the previous LTS (8.9 version) –  which means that bug fixes will not be patched on the older releases and we recommend you upgrade to the latest. 