### PR TITLE
[gradle] Add 8 and clarify support description

### DIFF
--- a/products/gradle.md
+++ b/products/gradle.md
@@ -1,16 +1,17 @@
 ---
 title: Gradle
-permalink: /gradle
 category: app
 iconSlug: gradle
+permalink: /gradle
+versionCommand: gradle --version
 releasePolicyLink: https://docs.gradle.org/current/userguide/feature_lifecycle.html#eol_support
 changelogTemplate: https://github.com/gradle/gradle/releases/tag/v__LATEST__
-auto:
--   git: https://github.com/gradle/gradle.git
 activeSupportColumn: true
 releaseDateColumn: true
 eolColumn: Bug and Security Fixes
-versionCommand: gradle --version
+
+auto:
+-   git: https://github.com/gradle/gradle.git
 
 releases:
 -   releaseCycle: "8"
@@ -36,16 +37,18 @@ releases:
 
 ---
 
-> [Gradle](https://gradle.org/) is a build tool with a focus on build automation and support for multi-language
-> development. If you are building, testing, publishing, and deploying software on any platform, Gradle offers a
-> flexible model that can support the entire development lifecycle from compiling and packaging code to publishing
-> websites.
+> [Gradle](https://gradle.org/) is a build tool with a focus on build automation and support for
+> multi-language development. If you are building, testing, publishing, and deploying software on
+> any platform, Gradle offers a flexible model that can support the entire development lifecycle
+> from compiling and packaging code to publishing websites.
 
-Only the latest release is supported. There is an exception for 6.9 which is still getting bug and security fixes.
+Only the latest release is supported. There is an exception for 6.9 which is still getting bug and
+security fixes.
 
 ## [Java Compatibility](https://docs.gradle.org/current/userguide/compatibility.html)
 
-A Java version between 8 and 19 is required to execute Gradle. Java 20 and later versions are not yet supported. Java 6 and 7 can still be used for compilation and forked test execution.
+A Java version between 8 and 19 is required to execute Gradle. Java 20 and later versions are not
+yet supported. Java 6 and 7 can still be used for compilation and forked test execution.
 
 Gradle itself is tested with the following versions:
 

--- a/products/gradle.md
+++ b/products/gradle.md
@@ -13,16 +13,23 @@ eolColumn: Bug and Security Fixes
 versionCommand: gradle --version
 
 releases:
--   releaseCycle: "7"
-    eol: false
+-   releaseCycle: "8"
     support: true
+    eol: false
+    latest: "8.0.0"
+    latestReleaseDate: 2023-02-13
+    releaseDate: 2023-02-13
+
+-   releaseCycle: "7"
+    support: false
+    eol: false
     latest: "7.6.0"
     latestReleaseDate: 2022-11-22
     releaseDate: 2021-04-09
 
 -   releaseCycle: "6"
-    eol: false
     support: false
+    eol: false
     latest: "6.9.3"
     latestReleaseDate: 2022-10-14
     releaseDate: 2019-11-08
@@ -44,5 +51,6 @@ Gradle itself is tested with the following versions:
 
 | Gradle                                                          | Java | Kotlin        | Groovy       | Android                           |
 |-----------------------------------------------------------------|------|---------------|--------------|-----------------------------------|
+| [8](https://docs.gradle.org/8.0/userguide/compatibility.html)   | 8-19 | 1.6.10-1.8.10 | 1.5.8-4.0.0  | 7.3, 7.4, 8.0                     |
 | [7](https://docs.gradle.org/7.6/userguide/compatibility.html)   | 8-19 | 1.3.72-1.7.10 | 1.5.8-4.0.0  | 4.1, 4.2, 7.0, 7.1, 7.2, 7.3, 7.4 |
 | [6](https://docs.gradle.org/6.9.3/userguide/compatibility.html) | 8-15 | 1.3.21-1.4.20 | 1.5.8-2.5.12 | 3.4, 3.5, 3.6, 4.0, 4.1, 4.2      |

--- a/products/gradle.md
+++ b/products/gradle.md
@@ -42,13 +42,15 @@ releases:
 > any platform, Gradle offers a flexible model that can support the entire development lifecycle
 > from compiling and packaging code to publishing websites.
 
-Only the latest release is supported. There is an exception for 6.9 which is still getting bug and
-security fixes.
+Gradle follows [Semantic Versioning](https://semver.org/). The support and EOL policy is not clearly
+defined, but [looking at the releases history](https://gradle.org/releases/) and
+[Feature Lifecycle page](https://docs.gradle.org/current/userguide/feature_lifecycle.html#eol_support):
+
+- only the latest release is receiving new features,
+- after 7, 6 started to receive bug and security fixes,
+- before 7, only the latest release were receiving bug and security fixes.
 
 ## [Java Compatibility](https://docs.gradle.org/current/userguide/compatibility.html)
-
-A Java version between 8 and 19 is required to execute Gradle. Java 20 and later versions are not
-yet supported. Java 6 and 7 can still be used for compilation and forked test execution.
 
 Gradle itself is tested with the following versions:
 
@@ -57,3 +59,5 @@ Gradle itself is tested with the following versions:
 | [8](https://docs.gradle.org/8.0/userguide/compatibility.html)   | 8-19 | 1.6.10-1.8.10 | 1.5.8-4.0.0  | 7.3, 7.4, 8.0                     |
 | [7](https://docs.gradle.org/7.6/userguide/compatibility.html)   | 8-19 | 1.3.72-1.7.10 | 1.5.8-4.0.0  | 4.1, 4.2, 7.0, 7.1, 7.2, 7.3, 7.4 |
 | [6](https://docs.gradle.org/6.9.3/userguide/compatibility.html) | 8-15 | 1.3.21-1.4.20 | 1.5.8-2.5.12 | 3.4, 3.5, 3.6, 4.0, 4.1, 4.2      |
+
+Java 6 and 7 can still be used for compilation and forked test execution.


### PR DESCRIPTION
Gradle 8 were released yesterday : https://github.com/gradle/gradle/releases/tag/v8.0.0.

Now that 8 has been release I also updated the product description to make it more clear that the [release policy is not documented](https://discuss.gradle.org/t/recommended-supported-versions/19916).

Also took the opportunity to normalize the page (#2124).