### PR TITLE
[kdeplasma] Add 5.27

### DIFF
--- a/products/kdeplasma.md
+++ b/products/kdeplasma.md
@@ -17,7 +17,7 @@ auto:
 
 releases:
 -   releaseCycle: "5.27"
-    latest: "5.27.01"
+    latest: "5.27.0"
     support: true
     eol: false
     lts: true

--- a/products/kdeplasma.md
+++ b/products/kdeplasma.md
@@ -75,6 +75,6 @@ every other year. There is a [detailed schedule](https://community.kde.org/Sched
 future bug fix releases and major releases.
 
 ## Release Cadence
-* Plasma 5.24 (LTS) bug fix support will end once the first Plasma 6.0 feature release comes out.
+* Plasma 5.27 and 5.24 LTS critical bug fix support will end once the first Plasma 6.0 feature release comes out.
 * Bugfix tags/releases are made on Tuesdays in a [Fibonacci sequence of weeks](https://community.kde.org/Schedules/Plasma_5#Bugfix_versions)
   (1, 1, 2, 3, 5) after each previous release of the same series.

--- a/products/kdeplasma.md
+++ b/products/kdeplasma.md
@@ -75,6 +75,9 @@ every other year. There is a [detailed schedule](https://community.kde.org/Sched
 future bug fix releases and major releases.
 
 ## Release Cadence
-* Plasma 5.24 LTS will get critical bug fixes updates until start of Plasma 6 development (timetable unsure). The last Plasma 5 release will be version 5.27 LTS and the end of critical bug fixes is not yet announced.
+
+* Plasma 5.24 LTS will get critical bug fixes updates until the start of Plasma 6 development
+  (timetable unsure). The last Plasma 5 release will be version 5.27 LTS and the end of critical bug
+  fixes is not yet announced.
 * Bugfix tags/releases are made on Tuesdays in a [Fibonacci sequence of weeks](https://community.kde.org/Schedules/Plasma_5#Bugfix_versions)
   (1, 1, 2, 3, 5) after each previous release of the same series.

--- a/products/kdeplasma.md
+++ b/products/kdeplasma.md
@@ -16,10 +16,18 @@ auto:
 -   git: https://github.com/KDE/plasma-desktop.git
 
 releases:
+-   releaseCycle: "5.27"
+    latest: "5.27.01"
+    support: true
+    eol: false
+    lts: true
+    releaseDate: 2023-02-14
+    latestReleaseDate: 2023-02-14
+
 -   releaseCycle: "5.26"
     latest: "5.26.90"
-    support: 2023-02-14 # Scheduled release of 5.27
-    eol: 2023-02-14 # Scheduled release of 5.27
+    support: 2023-02-14
+    eol: 2023-02-14
     lts: false
     releaseDate: 2022-10-11
     latestReleaseDate: 2023-01-19

--- a/products/kdeplasma.md
+++ b/products/kdeplasma.md
@@ -75,6 +75,6 @@ every other year. There is a [detailed schedule](https://community.kde.org/Sched
 future bug fix releases and major releases.
 
 ## Release Cadence
-* Plasma 5.27 and 5.24 critical bug fix support will end once the first Plasma 6.0 feature release comes out.
+* Plasma 5.24 LTS will get critical bug fixes updates until start of Plasma 6 development (timetable unsure). The last Plasma 5 release will be version 5.27 LTS and the end of critical bug fixes is not yet announced.
 * Bugfix tags/releases are made on Tuesdays in a [Fibonacci sequence of weeks](https://community.kde.org/Schedules/Plasma_5#Bugfix_versions)
   (1, 1, 2, 3, 5) after each previous release of the same series.

--- a/products/kdeplasma.md
+++ b/products/kdeplasma.md
@@ -19,7 +19,7 @@ releases:
 -   releaseCycle: "5.27"
     latest: "5.27.0"
     support: true
-    eol: false
+    eol: false # Will end when Plasma 6 comes out
     lts: true
     releaseDate: 2023-02-14
     latestReleaseDate: 2023-02-14
@@ -75,6 +75,6 @@ every other year. There is a [detailed schedule](https://community.kde.org/Sched
 future bug fix releases and major releases.
 
 ## Release Cadence
-* Plasma 5.27 and 5.24 LTS critical bug fix support will end once the first Plasma 6.0 feature release comes out.
+* Plasma 5.27 and 5.24 critical bug fix support will end once the first Plasma 6.0 feature release comes out.
 * Bugfix tags/releases are made on Tuesdays in a [Fibonacci sequence of weeks](https://community.kde.org/Schedules/Plasma_5#Bugfix_versions)
   (1, 1, 2, 3, 5) after each previous release of the same series.


### PR DESCRIPTION
Release Notes https://kde.org/announcements/plasma/5/5.27.0/
Marked as LTS on https://community.kde.org/Schedules/Plasma_5
5.28 not yet planned on https://phabricator.kde.org/calendar/query/all/