### PR TITLE
[Jenkins] Remove activeSupportColumn

### DIFF
--- a/products/jenkins.md
+++ b/products/jenkins.md
@@ -5,7 +5,7 @@ iconSlug: jenkins
 permalink: /jenkins
 releasePolicyLink: https://www.jenkins.io/download/lts/
 changelogTemplate: https://github.com/jenkinsci/jenkins/releases/tag/jenkins-__LATEST__
-activeSupportColumn: true
+activeSupportColumn: false
 releaseDateColumn: true
 eolColumn: Bug and Security Fixes
 

--- a/products/jenkins.md
+++ b/products/jenkins.md
@@ -60,7 +60,7 @@ releases:
 The Jenkins project produces two release lines: Stable (LTS) and regular (Weekly).
 
 [Stable (LTS)](https://www.jenkins.io/download/lts/) releases are chosen every 12 weeks from the
-stream of regular releases, and patched every 4 weeks with bug and security fix backports.
+stream of regular releases, and patched every 4 weeks with bug, security fix, and minor feature backports.
 
 [Regular (Weekly)](https://www.jenkins.io/download/weekly/) releases deliver bug fixes and new
 features rapidly to users and plugin developers who need them.

--- a/products/jenkins.md
+++ b/products/jenkins.md
@@ -7,7 +7,7 @@ releasePolicyLink: https://www.jenkins.io/download/lts/
 changelogTemplate: https://github.com/jenkinsci/jenkins/releases/tag/jenkins-__LATEST__
 activeSupportColumn: false
 releaseDateColumn: true
-eolColumn: Bug and Security Fixes
+eolColumn: Support
 
 auto:
 -   git: https://github.com/jenkinsci/jenkins.git


### PR DESCRIPTION
## Remove activeSupportColumn for Jenkins

Correct the potential misperception by users that the most recent Jenkins long term support release is not supported.  Jenkins long term support releases are supported by the Jenkins project in much the same way that Alpine Linux and Debian Linux support their releases.  The most recent release (Alpine 3.17.2, Debian 11.6, Jenkins 2.375.3) is actively supported.

### Before

![before](https://user-images.githubusercontent.com/156685/218835207-8643a346-674c-47f6-becd-304d34090336.png)

### After


![after](https://user-images.githubusercontent.com/156685/218835234-5e6db2e5-fc58-4e70-a26f-58259d154e73.png)

### Alternative

As an alternative, could look for a way to apply the correction to the LTS row so that it would look more like the weekly row, showing that active support is available for Jenkins weekly and Jenkins LTS (as is shown for Apache Maven at https://endoflife.date/maven ).  It was easier for me to disable the "active support" column and look like Debian and Alpine than to resolve the issue that caused the "active support" column to be red and show an "ended" date.  Happy to use the other approach if someone is willing to guide me to the correct change.
