### PR TITLE
Add cpe identifiers to OS products

### DIFF
--- a/products/almalinux.md
+++ b/products/almalinux.md
@@ -9,7 +9,8 @@ activeSupportColumn: true
 releaseDateColumn: true
 
 identifiers:
--   purl: pkg:os/almalinux
+-   cpe: cpe:/o:almalinux:almalinux
+-   cpe: cpe:2.3:o:almalinux:almalinux
 
 auto:
 -   distrowatch: alma

--- a/products/alpinelinux.md
+++ b/products/alpinelinux.md
@@ -12,7 +12,8 @@ activeSupportColumn: false
 releaseDateColumn: true
 
 identifiers:
--   purl: pkg:os/alpinelinux
+-   cpe: cpe:/o:alpinelinux:alpine_linux
+-   cpe: cpe:2.3:o:alpinelinux:alpine_linux
 
 auto:
 # upstream does not support filtering https://git.alpinelinux.org/aports

--- a/products/amazon-linux.md
+++ b/products/amazon-linux.md
@@ -11,7 +11,8 @@ eolColumn: Support
 releaseDateColumn: true
 
 identifiers:
--   purl: pkg:os/amazonlinux
+-   cpe: cpe:2.3:o:amazon:amazon_linux
+-   cpe: cpe:/o:amazon:amazon_linux
 -   purl: pkg:docker/library/amazonlinux
 
 auto:

--- a/products/centos.md
+++ b/products/centos.md
@@ -10,7 +10,8 @@ activeSupportColumn: true
 releaseDateColumn: true
 
 identifiers:
--   purl: pkg:os/centos
+-   cpe: cpe:/o:centos:centos
+-   cpe: cpe:2.3:o:centos:centos
 
 releases:
 -   releaseCycle: "9"

--- a/products/fedora.md
+++ b/products/fedora.md
@@ -14,6 +14,10 @@ auto:
     regex: '^Distribution Release: Fedora (?P<version>\d{2})$'
     template: '{{version}}'
 
+identifier:
+-   cpe: cpe:/o:fedoraproject:fedora
+-   cpe: cpe:2.3:o:fedoraproject:fedora
+
 releases:
 -   releaseCycle: "37"
     latest: "37"

--- a/products/fedora.md
+++ b/products/fedora.md
@@ -14,7 +14,7 @@ auto:
     regex: '^Distribution Release: Fedora (?P<version>\d{2})$'
     template: '{{version}}'
 
-identifier:
+identifiers:
 -   cpe: cpe:/o:fedoraproject:fedora
 -   cpe: cpe:2.3:o:fedoraproject:fedora
 

--- a/products/linuxkernel.md
+++ b/products/linuxkernel.md
@@ -17,6 +17,10 @@ auto:
 -   git: https://github.com/gregkh/linux.git
     regex: ^v(?<major>0|[1-9]\d*)\.(?<minor>0|[1-9]\d*)(\.(?<patch>0|[1-9]\d*))?$
 
+identifier:
+-   cpe: cpe:/o:linux:linux_kernel
+-   cpe: cpe:2.3:o:linux:linux_kernel
+
 releases:
 -   releaseCycle: "6.1"
     eol: 2026-12-31

--- a/products/linuxkernel.md
+++ b/products/linuxkernel.md
@@ -17,7 +17,7 @@ auto:
 -   git: https://github.com/gregkh/linux.git
     regex: ^v(?<major>0|[1-9]\d*)\.(?<minor>0|[1-9]\d*)(\.(?<patch>0|[1-9]\d*))?$
 
-identifier:
+identifiers:
 -   cpe: cpe:/o:linux:linux_kernel
 -   cpe: cpe:2.3:o:linux:linux_kernel
 

--- a/products/opensuse.md
+++ b/products/opensuse.md
@@ -15,6 +15,10 @@ releaseColumn: false
 releaseDateColumn: true
 eolColumn: End of Life
 
+identifiers:
+-   cpe: cpe:/o:opensuse:leap
+-   cpe: cpe:2.3:o:opensuse:leap
+
 releases:
 -   releaseCycle: "15.4"
     eol: 2023-12-01

--- a/products/oraclelinux.md
+++ b/products/oraclelinux.md
@@ -17,6 +17,10 @@ auto:
     regex: '^Distribution Release: Oracle( Enterprise| Unbreakable)? Linux R?(?P<major>\d)(-U|\.|
       Update )?(?P<minor>\d+)?$'
 
+identifiers:
+-   cpe: cpe:/o:oracle:linux
+-   cpe: cpe:2.3:o:oracle:linux
+
 releases:
 -   releaseCycle: "9"
     releaseDate: 2022-07-06

--- a/products/redhat.md
+++ b/products/redhat.md
@@ -15,6 +15,10 @@ eolColumn: Maintenance Support
 releaseDateColumn: true
 extendedSupportColumn: Extended Life Cycle Support
 
+identifiers:
+-   cpe: cpe:/o:redhat:enterprise_linux
+-   cpe: cpe:2.3:o:redhat:enterprise_linux
+
 releases:
 -   releaseCycle: "9"
     support: 2027-05-31

--- a/products/rockylinux.md
+++ b/products/rockylinux.md
@@ -16,6 +16,10 @@ auto:
 -   distrowatch: rocky
     regex: '^Distribution Release: Rocky Linux (?P<major>\d)\.(?P<minor>\d)$'
 
+idenfitiers:
+-   cpe: cpe:/o:rocky:rocky
+-   cpe: cpe:2.3:o:rocky:rocky
+
 releases:
 -   releaseCycle: "9"
     support: 2025-05-31

--- a/products/ubuntu.md
+++ b/products/ubuntu.md
@@ -15,8 +15,11 @@ auto:
     regex: '^Distribution Releases?: Ubuntu( Linux)? (?P<v1>\d+\.\d+\.?\d+)(, (?P<v2>\d+\.\d+\.?\d+))?(
       LTS|, Kubuntu.*)?$'
     template: "{{v1}}{%if v2%}\n{{v2}}{%endif%}"
+
 identifiers:
--   purl: pkg:os/ubuntu
+-   cpe: cpe:2.3:o:canonical:ubuntu_linux
+-   cpe: cpe:/o:canonical:ubuntu_linux
+
 activeSupportColumn: Hardware & Maintenance
 eolColumn: Maintenance & Security Support
 extendedSupportColumn: Extended Security Maintenance
@@ -139,7 +142,7 @@ Feature/Plan | Ubuntu LTS | Ubuntu Pro (Infra-Only) [^1] | Ubuntu Pro
 -----|------------|------------------------------|-----------
 Main repository | 5 years | 10 years             | 10 years
 Restricted repository | 5 years | 10 years[^2]   |10 years [^2]
-Universe repository | Best Effort[^6] | Best Effort | 10 years 
+Universe repository | Best Effort[^6] | Best Effort | 10 years
 Phone/Ticket Support | No | Yes | Yes
 Kernel Live Patching | No  | Yes | Yes
 [Security Certifications and Hardening](https://ubuntu.com/security/certifications)[^3] | No | Yes | Yes

--- a/products/windows.md
+++ b/products/windows.md
@@ -10,6 +10,10 @@ releaseColumn: true
 releaseDateColumn: true
 releaseLabel: "Windows __RELEASE_CYCLE__"
 
+identifiers:
+-   cpe: cpe:2.3:o:microsoft:windows
+-   cpe: cpe:/o:microsoft:windows
+
 releases:
 -   releaseCycle: "10, version 22H2 (E)"
     releaseDate: 2022-10-18


### PR DESCRIPTION
After the discussion in purl-spec around adding an `os` [candidate type was rejected](https://github.com/package-url/purl-spec/pull/161#issuecomment-1374249666), I went to thinking about what identifiers we could use to match OS releases. 

@captn3m0 mentioned using CPEs in [Integrate with the SBOM Ecosystem #763](https://github.com/endoflife-date/endoflife.date/issues/763#issuecomment-1057730512)

Steve Springett mentioned using the PURL `swid` type [in this comment](https://github.com/package-url/purl-spec/pull/161#issuecomment-1374249666)

I think that endoflife.date could support both. But the only thing to note about the `swid` type in the purl spec is that the qualifier `tag_id` is NOT optional. This is the only qualifier I'm aware of that's not optional. I think that because of this, matching on `swid` would be much more difficult than matching on CPEs, if we wanted to remain compliant with purl-spec (probably should).

So, in order to find some kind of path forward, I added this PR, which adds cpes 2.2 and 2.3 for different operating systems. Most of these CPEs [I grabbed from syft](https://github.com/anchore/syft/blob/09bf5b062ceb405950c2beaacdaf79c43e9c7ae8/syft/linux/identify_release_test.go#L72).

The identifier I added is like `- cpe: <cpe2.2>` or `- cpe: <cpe2.3>` but we could also namespace according to cpe version in the key such as `- cpe22` or `- cpe23`, looking for your feedback.
