### PR TITLE
:mag_right:  Add missing legacy Perl releases

### DIFF
--- a/products/perl.md
+++ b/products/perl.md
@@ -72,7 +72,76 @@ releases:
     latest: "5.26.3"
     latestReleaseDate: 2018-11-28
     releaseDate: 2017-05-30
+    
+-   releaseCycle: "5.24"
+    support: 
+    eol: 
+    latest: "5.24.0"
+    latestReleaseDate: 2016-05-08
+    releaseDate: 2016-05-08
 
+-   releaseCycle: "5.22"
+    support: 
+    eol: 
+    latest: "5.22.0"
+    latestReleaseDate: 2015-06-01
+    releaseDate: 2015-06-01
+
+-   releaseCycle: "5.20"
+    support: 
+    eol: 
+    latest: "5.20.0"
+    latestReleaseDate: 2014-05-27
+    releaseDate: 2014-05-27
+
+-   releaseCycle: "5.18"
+    support: 
+    eol: 
+    latest: "5.18.0"
+    latestReleaseDate: 2013-05-18
+    releaseDate: 2013-05-18
+
+-   releaseCycle: "5.16"
+    support: 
+    eol: 
+    latest: "5.16.0"
+    latestReleaseDate: 2012-05-20
+    releaseDate: 2012-05-20
+
+-   releaseCycle: "5.14"
+    support: 
+    eol: 
+    latest: "5.14.0"
+    latestReleaseDate: 2011-05-14
+    releaseDate: 2011-05-14
+
+-   releaseCycle: "5.12"
+    support: 
+    eol: 
+    latest: "5.12.0"
+    latestReleaseDate: 2010-05-12
+    releaseDate: 2010-05-12
+
+-   releaseCycle: "5.10"
+    support: 
+    eol: 
+    latest: "5.10.0"
+    latestReleaseDate: 2007-12-18
+    releaseDate: 2007-12-18
+
+-   releaseCycle: "5.8"
+    support: 
+    eol: 
+    latest: "5.8.0"
+    latestReleaseDate: 2002-07-18
+    releaseDate: 2002-07-18
+    
+-   releaseCycle: "5.6"
+    support: 
+    eol: 
+    latest: "5.6.0 "
+    latestReleaseDate: 2000-03-22
+    releaseDate: 2000-03-22
 ---
 
 > [Perl](https://www.perl.org/) is a highly capable, feature-rich programming language with over 30

--- a/products/perl.md
+++ b/products/perl.md
@@ -95,8 +95,8 @@ releases:
     releaseDate: 2014-05-27
 
 -   releaseCycle: "5.18"
-    support: 
-    eol: 
+    support: 2015-01-26
+    eol: 2015-01-26
     latest: "5.18.0"
     latestReleaseDate: 2013-05-18
     releaseDate: 2013-05-18

--- a/products/perl.md
+++ b/products/perl.md
@@ -123,8 +123,8 @@ releases:
     releaseDate: 2010-05-12
 
 -   releaseCycle: "5.10"
-    support: 
-    eol: 
+    support: 2011-12-20
+    eol: 2011-12-20
     latest: "5.10.0"
     latestReleaseDate: 2011-12-20
     releaseDate: 2007-12-18

--- a/products/perl.md
+++ b/products/perl.md
@@ -74,8 +74,8 @@ releases:
     releaseDate: 2017-05-30
     
 -   releaseCycle: "5.24"
-    support: 
-    eol: 
+    support: 2017-09-12
+    eol: 2017-09-12
     latest: "5.24.0"
     latestReleaseDate: 2016-05-08
     releaseDate: 2016-05-08

--- a/products/perl.md
+++ b/products/perl.md
@@ -81,8 +81,8 @@ releases:
     releaseDate: 2016-05-08
 
 -   releaseCycle: "5.22"
-    support: 
-    eol: 
+    support: 2016-09-05
+    eol: 2016-09-05
     latest: "5.22.0"
     latestReleaseDate: 2015-06-01
     releaseDate: 2015-06-01

--- a/products/perl.md
+++ b/products/perl.md
@@ -116,8 +116,8 @@ releases:
     releaseDate: 2011-05-14
 
 -   releaseCycle: "5.12"
-    support: 
-    eol: 
+    support: 2012-07-29
+    eol: 2012-07-29
     latest: "5.12.0"
     latestReleaseDate: 2010-05-12
     releaseDate: 2010-05-12

--- a/products/perl.md
+++ b/products/perl.md
@@ -109,8 +109,8 @@ releases:
     releaseDate: 2012-05-20
 
 -   releaseCycle: "5.14"
-    support: 
-    eol: 
+    support: 2013-05-14
+    eol: 2013-05-14
     latest: "5.14.0"
     latestReleaseDate: 2011-05-14
     releaseDate: 2011-05-14

--- a/products/perl.md
+++ b/products/perl.md
@@ -137,8 +137,8 @@ releases:
     releaseDate: 2002-07-18
     
 -   releaseCycle: "5.6"
-    support: 
-    eol: 
+    support: 2004-12-31
+    eol: 2004-12-31
     latest: "5.6.0 "
     latestReleaseDate: 2000-03-22
     releaseDate: 2000-03-22

--- a/products/perl.md
+++ b/products/perl.md
@@ -88,8 +88,8 @@ releases:
     releaseDate: 2015-06-01
 
 -   releaseCycle: "5.20"
-    support: 
-    eol: 
+    support: 2016-05-10
+    eol: 2016-05-10
     latest: "5.20.0"
     latestReleaseDate: 2014-05-27
     releaseDate: 2014-05-27

--- a/products/perl.md
+++ b/products/perl.md
@@ -130,8 +130,8 @@ releases:
     releaseDate: 2007-12-18
 
 -   releaseCycle: "5.8"
-    support: 
-    eol: 
+    support: 2008-05-29
+    eol: 2008-05-29
     latest: "5.8.0"
     latestReleaseDate: 
     releaseDate: 2002-07-18

--- a/products/perl.md
+++ b/products/perl.md
@@ -102,8 +102,8 @@ releases:
     releaseDate: 2013-05-18
 
 -   releaseCycle: "5.16"
-    support: 
-    eol: 
+    support: 2016-05-09
+    eol: 2016-05-09
     latest: "5.16.0"
     latestReleaseDate: 2012-05-20
     releaseDate: 2012-05-20
@@ -126,14 +126,14 @@ releases:
     support: 
     eol: 
     latest: "5.10.0"
-    latestReleaseDate: 2007-12-18
+    latestReleaseDate: 2011-12-20
     releaseDate: 2007-12-18
 
 -   releaseCycle: "5.8"
     support: 
     eol: 
     latest: "5.8.0"
-    latestReleaseDate: 2002-07-18
+    latestReleaseDate: 
     releaseDate: 2002-07-18
     
 -   releaseCycle: "5.6"


### PR DESCRIPTION
# :grey_question: 

Versions between [`5.6`, `5.24` ] are missing. 

This first PR is an attempt to fix this.

:point_up: Still have to be found : 

- `support`: 
- `eol`


# :tickets: Related issues

- https://github.com/endoflife-date/endoflife.date/issues/2526
