### PR TITLE
Reformat README and fix 'powered by Jekyll' badge link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,19 +1,33 @@
 # endoflife.date
 
-[![Netlify Status](https://api.netlify.com/api/v1/badges/92f7a2a9-3cca-4916-a75e-f9db4ec39d48/deploy-status)](https://app.netlify.com/sites/endoflife-date/deploys) [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](https://opensource.guide/how-to-contribute/#opening-a-pull-request) ![powered by Jekyll](https://img.shields.io/badge/powered_by-Jekyll-blue.svg) [![Website shields.io](https://img.shields.io/website-up-down-green-red/https/endoflife.date.svg)](https://endoflife.date/) [![made-with-Markdown](https://img.shields.io/badge/Made%20with-Markdown-1f425f.svg)](https://commonmark.org/) [![Contributor Covenant](https://img.shields.io/badge/Contributor%20Covenant-2.0-4baaaa.svg)](CODE-OF-CONDUCT.md) [![Gitter](https://badges.gitter.im/endoflife-date/community.svg)](https://gitter.im/endoflife-date/community) [![Twitter Follow Badge](https://img.shields.io/twitter/url.svg?label=@endoflife_date&style=social&url=https%3A%2F%2Ftwitter.com%2Fendoflife_date)](https://twitter.com/endoflife_date)
+[![Netlify Status](https://api.netlify.com/api/v1/badges/92f7a2a9-3cca-4916-a75e-f9db4ec39d48/deploy-status)](https://app.netlify.com/sites/endoflife-date/deploys)
+[![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](https://opensource.guide/how-to-contribute/#opening-a-pull-request)
+[![powered by Jekyll](https://img.shields.io/badge/powered_by-Jekyll-blue.svg)](https://jekyllrb.com/)
+[![Website shields.io](https://img.shields.io/website-up-down-green-red/https/endoflife.date.svg)](https://endoflife.date/)
+[![made-with-Markdown](https://img.shields.io/badge/Made%20with-Markdown-1f425f.svg)](https://commonmark.org/)
+[![Contributor Covenant](https://img.shields.io/badge/Contributor%20Covenant-2.0-4baaaa.svg)](CODE-OF-CONDUCT.md)
+[![Gitter](https://badges.gitter.im/endoflife-date/community.svg)](https://gitter.im/endoflife-date/community)
+[![Twitter Follow Badge](https://img.shields.io/twitter/url.svg?label=@endoflife_date&style=social&url=https%3A%2F%2Ftwitter.com%2Fendoflife_date)](https://twitter.com/endoflife_date)
 
-Keep track of various End of Life dates and support lifecycles for various products. Visit <https://endoflife.date> for a list of supported products. This information is very often [hard to track or badly presented](https://twitter.com/captn3m0/status/1110504412064239617). This project collates this data and presents it in an easily accessible format, with URLs that are easy to guess and remember.
+Keep track of various End of Life dates and support lifecycles for various products.
+Visit <https://endoflife.date> for a list of supported products.
+This information is very often [hard to track or badly presented](https://twitter.com/captn3m0/status/1110504412064239617).
+This project collates this data and presents it in an easily accessible format, with URLs that are
+easy to guess and remember.
 
-If you maintain release information (end-of-life dates, or support information) for a product, we have a [set of recommendations](https://endoflife.date/recommendations) along with a checklist on some best practices for publishing this information.
+If you maintain release information (end-of-life dates, or support information) for a product,
+we have a [set of recommendations](https://endoflife.date/recommendations) along with a checklist on
+some best practices for publishing this information.
 
 ## Contributing
 
-Please see [CONTRIBUTING.md](CONTRIBUTING.md) for details. 
+Please see [CONTRIBUTING.md](CONTRIBUTING.md) for details.
 While participating in the project, you must abide by its [Code of Conduct](CODE-OF-CONDUCT.md).
 
 ## API
 
-An API is available for integration with CI platforms. API documentation is available at https://endoflife.date/docs/api.
+An API is available for integration with CI platforms.
+API documentation is available at https://endoflife.date/docs/api.
 The API is currently in Alpha, and breaking changes can happen.
 
 ## License
@@ -24,17 +38,19 @@ Licensed under the [MIT License](LICENSE).
 
 endoflife.date is relying on various amazing software and components :
 
-- [GitHub](https://github.com/), an Internet hosting service for software development and version control,
+- [GitHub](https://github.com/), an Internet hosting service for software development and version
+  control,
 - [Jekyll](https://jekyllrb.com/), a static site generator.
-- [Ruby](https://jekyllrb.com/), a dynamic and open source programming language with a focus on simplicity and
-  productivity.
+- [Ruby](https://jekyllrb.com/), a dynamic and open source programming language with a focus on
+  simplicity and productivity.
 - [Just the Docs](https://github.com/just-the-docs/just-the-docs), a documentation theme for Jekyll.
-- [Stoplight Elements](https://stoplight.io/open-source/elements), a collection of UI components for displaying
-  beautiful developer documentation from any OpenAPI document.
+- [Stoplight Elements](https://stoplight.io/open-source/elements), a collection of UI components for
+  displaying beautiful developer documentation from any OpenAPI document.
 - [Simple Icons](https://simpleicons.org/), free SVG icons for popular brands.
 - Our icon is derived from [Hourglass icon (orange)](https://commons.wikimedia.org/wiki/File:Hourglass_icon_%28orange%29.svg)
   by David Abián and Serhio Magpie on the English Wikipedia. Remixed under the CC-BY-SA-4.0 license.
 - [RealFaviconGenerator](https://realfavicongenerator.net/), a favicon Generator, for real.
 - [Netlify](https://www.netlify.com/), an all-in-one platform for automating modern web projects.
-- Product descriptions are adapted from the [English Wikipedia](https://en.wikipedia.org/), 
-  under [CC BY-SA 3.0](https://en.wikipedia.org/wiki/Wikipedia:Text_of_Creative_Commons_Attribution-ShareAlike_3.0_Unported_License) license.
+- Product descriptions are adapted from the [English Wikipedia](https://en.wikipedia.org/),
+  under [CC BY-SA 3.0](https://en.wikipedia.org/wiki/Wikipedia:Text_of_Creative_Commons_Attribution-ShareAlike_3.0_Unported_License)
+  license.


### PR DESCRIPTION
The 'powered by Jekyll' badge was missing a link, this PR adds one.

Badges were reformatted so there is only one per line. Text was also reformatted.