### PR TITLE
Simplify `product.html` template

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -102,30 +102,31 @@ releaseLabel: "MoM Timeturner __RELEASE_CYCLE__ (__CODENAME__)"
 # Prefer using an HTML abbr tag, if possible.
 LTSLabel: "<abbr title='Extra Long Support'>ELS</abbr>"
 
-# The name of the End of Life column (optional, default = Security Support).
-eolColumn: Service Status
+# Whether the "End of Life" column should be displayed (optional, default = true).
+# The value of this property can be set to any string to override the default column label.
+eolColumn: Security Support
 
-# Whether to display the "Active Support" column (optional, default = false).
-# You can also set this variable with a text label if you want to change the column name:
-#   activeSupportColumn: Customer Support
-activeSupportColumn: false
+# Whether the "Active Support" column should be displayed (optional, default = false).
+# The value of this property can be set to any string to override the default column label.
+activeSupportColumn: Active Support
 
-# Whether to display the "Latest" column (optional, default = true).
-# If the product doesn't have patch releases, set this to false.
-releaseColumn: true
+# Whether the "Latest" column should be displayed (optional, default = true).
+# The value of this property can be set to any string to override the default column label.
+releaseColumn: Latest
 
-# Whether to show the "Released" column (optional, default = false).
-releaseDateColumn: true
+# Whether the "Released" column should be displayed (optional, default = false).
+# The value of this property can be set to any string to override the default column label.
+releaseDateColumn: Released
 
-# Whether to show the discontinued column (optional, default = false).
-# Set to true if you're tracking a device.
-# This usually means the device is no longer available for sale or is no longer being manufactured.
-discontinuedColumn: false
+# Whether the "Discontinued" column should be displayed (optional, default = false).
+# Set to true if you're tracking a device. This usually means the device is no longer available for
+# sale or is no longer being manufactured.
+# The value of this property can be set to any string to override the default column label.
+discontinuedColumn: Discontinued
 
-# Whether to display the "Extended Support" column (optional, default = false).
-# You can also set this variable with a text label if you want to change the column name:
-#   extendedSupportColumn: Commercial Support
-extendedSupportColumn: false
+# Whether the "Extended Support" column should be displayed (optional, default = false).
+# The value of this property can be set to any string to override the default column label.
+extendedSupportColumn: Extended Support
 
 # Auto-update release configuration (optional).
 # This is used for automatically updating `releaseDate`, `latest`, and `latestReleaseDate` for every release.

--- a/_config.yml
+++ b/_config.yml
@@ -63,5 +63,17 @@ defaults:
       path: "products"
     values:
       layout: product
-      LTSLabel: <abbr title="Long Term Support">LTS</abbr>
+      releaseColumn: true
+      releaseColumnLabel: 'Latest'
+      releaseDateColumn: false
+      releaseDateColumnLabel: 'Released'
+      discontinuedColumn: false
+      discontinuedColumnLabel: 'Discontinued'
+      activeSupportColumn: false
+      activeSupportColumnLabel: 'Active Support'
+      eolColumn: true
+      eolColumnLabel: 'Security Support'
+      extendedSupportColumn: false
+      extendedSupportColumnLabel: 'Extended Support'
+      LTSLabel: '<abbr title="Long Term Support">LTS</abbr>'
 encoding: utf-8

--- a/_layouts/product.html
+++ b/_layouts/product.html
@@ -18,30 +18,12 @@ layout: default
   <thead>
     <tr>
       <th>Release</th>
-      {% if page.releaseDateColumn%}<th>Released</th>{% endif %}
-      {% if page.discontinuedColumn%}<th>Discontinued</th>{% endif %}
-      {% if page.activeSupportColumn%}
-        <th>
-          {% if page.activeSupportColumn == true %}
-            Active Support
-          {%else%}
-            {{page.activeSupportColumn}}
-          {%endif%}
-        </th>
-      {% endif %}
-      {% if page.eolColumn != false %}
-      <th>{{ page.eolColumn | default: "Security Support" }}</th>
-      {% endif %}
-      {% if page.extendedSupportColumn%}
-      <th>
-        {% if page.extendedSupportColumn == true %}
-        Extended Support
-        {%else%}
-        {{page.extendedSupportColumn}}
-        {%endif%}
-      </th>
-      {% endif %}
-      {% if page.releaseColumn != false %}<th>Latest</th>{% endif %}
+      {% if page.releaseDateColumn %}<th>{{ page.releaseDateColumnLabel }}</th>{% endif %}
+      {% if page.discontinuedColumn %}<th>{{ page.releaseDateColumnLabel }}</th>{% endif %}
+      {% if page.activeSupportColumn %}<th>{{ page.activeSupportColumnLabel }}</th>{% endif %}
+      {% if page.eolColumn %}<th>{{ page.eolColumnLabel }}</th>{% endif %}
+      {% if page.extendedSupportColumn %}<th>{{ page.extendedSupportColumnLabel }}</th>{% endif %}
+      {% if page.releaseColumn %}<th>{{ page.releaseColumnLabel }}</th>{% endif %}
     </tr>
   </thead>
 

--- a/_layouts/product.html
+++ b/_layouts/product.html
@@ -28,200 +28,131 @@ layout: default
   </thead>
 
 {% for r in page.releases %}
-{% assign support =r.support | date: '%s' | plus:0 %}
-{% assign securityFixes = r.eol | date: '%s' | plus:0 %}
-{% assign extendedSupport = r.extendedSupport | date: '%s' | plus:0 %}
+  <tr>
+    <td>
+      {% comment %}Only put a link in the version column if the release column is not shown{% endcomment %}
+      {% if page.releaseColumn == false and r.link and r.daysTowardEol > 0  %}
+        <a href="{{ r.link }}" title="Release Notes / Changelog for {{ r.label | strip_html }}">{{ r.label }}</a>
+      {% else %}
+        {{ r.label }}
+      {% endif %}
+    </td>
 
-
-{% comment %}
-diff is the number of days towards EoL. Positive is in the future. Negative is in the past.
-In case we don't have an exact date, we use boolean values (true/false) instead. In such
-cases diff is set to -1 for true (EoL has been reached)
-or +1 (EoL is in the future)
-{% endcomment %}
-{% if r.eol == true %}
-{% assign diff = -1 %}
-{% elsif r.eol == false %}
-{% assign diff = 1 %}
-{% elsif r.eol == nil %}
-{% assign diff = 1 %}
-{% else %}
-{% assign diff = r.eol | date: '%s' | plus:0 | minus:now %}
-{% endif %}
-
-{% assign diffSupport = support | minus:now %}
-{% assign diffExtendedSupport = extendedSupport | minus:now %}
-{% assign diffSecurity6  = diff | minus:10651938 %}
-{% assign diffSupport6  = diffSupport | minus:10651938 %}
-{% assign diffExtendedSupport6  = diffExtendedSupport | minus:10651938 %}
-
-<!-- Main Row starts here -->
-<tr>
-  <td>
-    {% comment %}Only put a link in the version column if the release column is not shown{% endcomment %}
-    {% if r.link and diff > 0 and page.releaseColumn == false %}
-      <a href="{{ r.link }}" title="Release Notes / Changelog for {{ r.label | strip_html }}">{{ r.label }}</a>
-    {% else %}
-      {{ r.label }}
+    {% if page.releaseDateColumn %}
+    <td>{{ r.releaseDate | timeago }} <div>({{ r.releaseDate | date_to_string }})</div></td>
     {% endif %}
-  </td>
 
-  {% if page.releaseDateColumn %}
-  <td>{{ r.releaseDate | timeago }} <div>({{ r.releaseDate | date_to_string }})</div></td>
-  {% endif %}
-
-  {% if page.discontinuedColumn %}
-  <td class="{% unless r.discontinued %}bg-green-000{% endunless %}">
-    {% if r.discontinued  == true %}
-    Discontinued
-    {% elsif r.discontinued  == false %}
-    In Production
+    {% if page.discontinuedColumn %}
+    {%- assign colorClass = 'bg-green-000' %}
+    {%- if r.daysTowardDiscontinued < 121 %}{% assign colorClass = 'bg-yellow-200' %}{% endif %}
+    {%- if r.daysTowardDiscontinued < 0 %}{% assign colorClass = 'bg-red-000' %}{% endif %}
+    <td class="{{ colorClass }}">
+    {% if r.discontinued == true %}
+      Discontinued
+    {% elsif r.discontinued == false %}
+      In Production
     {% else %}
-    {{ r.discontinued | timeago }} <div>({{ r.discontinued | date_to_string }})</div>
-    {% endif %}
-  </td>
-  {% endif %}
-
-  {% if page.activeSupportColumn %}
-    <td class=
-    {% if support > 5 %}
-      {% if diffSupport < 0 and r.support != false %}
-      "bg-red-000"
-      {% elsif diffSupport6 > 0 %}
-      "bg-green-000"
-      {% else %}
-      "bg-yellow-200"
-      {% endif %}
-    {% else %}
-      {% if r.support %}
-      "bg-green-000"
-      {% else %}
-      "bg-red-000"
-      {% endif %}
-    {% endif %}
-    title="{{r.support}}">
-    {% if support > 5 %}
-      {% if diffSupport < 0 %}
-        Ended
-      {% else %}
-        Ends
-      {% endif %}
-    {{r.support | timeago}} <div>({{r.support | date_to_string}})</div>
-    {% else %}
-      {% if r.support %}
-      Yes
-      {% else %}
-      No
-      {% endif %}
+      {{ r.discontinued | timeago }} <div>({{ r.discontinued | date_to_string }})</div>
     {% endif %}
     </td>
-  {% endif %}
-
-  {% if page.eolColumn != false %}
-  <td class=
-    {% if securityFixes > 5 %}
-      {% if diff < 0 %}
-      "bg-red-000"
-      {% elsif diffSecurity6 > 0 %}
-      "bg-green-000"
-      {% else %}
-      "bg-yellow-200"
-      {% endif %}
-    {% else %}
-      {% if r.eol %}
-      "bg-red-000"
-      {% else %}
-      "bg-green-000"
-      {% endif %}
     {% endif %}
-    {% if securityFixes > 5 %}
-      title="{{r.eol}}">
-      {% if diff < 0 %}
-        Ended
-      {% else %}
-        Ends
-      {% endif %}
-    {{r.eol | timeago}} <div>({{r.eol | date_to_string}})</div>
-    {% else %}
-      >
-      {% if r.eol %}
-      No
-      {% else %}
+
+    {% if page.activeSupportColumn %}
+    {%- assign colorClass = 'bg-green-000' %}
+    {%- if r.daysTowardSupport < 121 %}{% assign colorClass = 'bg-yellow-200' %}{% endif %}
+    {%- if r.daysTowardSupport < 0 %}{% assign colorClass = 'bg-red-000' %}{% endif %}
+    <td class="{{ colorClass }}">
+    {% if r.support == true %}
       Yes
+    {% elsif r.support == false %}
+      No
+    {% else %}
+      {% if r.daysTowardSupport < 0 %}Ended{% else %}Ends{% endif %}
+      {{ r.support | timeago }} <div>({{ r.support | date_to_string }})</div>
+    {% endif %}
+    </td>
+    {% endif %}
+
+    {% if page.eolColumn != false %}
+    {%- assign colorClass = 'bg-green-000' %}
+    {%- if r.daysTowardEol < 121 %}{% assign colorClass = 'bg-yellow-200' %}{% endif %}
+    {%- if r.daysTowardEol < 0 %}{% assign colorClass = 'bg-red-000' %}{% endif %}
+    <td class="{{ colorClass }}">
+      {% if r.eol == true %}
+        No
+      {% elsif r.eol == false %}
+        Yes
+      {% else %}
+        {% if r.daysTowardEol < 0 %}Ended{% else %}Ends{% endif %}
+        {{ r.eol | timeago }} <div>({{ r.eol | date_to_string }})</div>
       {% endif %}
+    </td>
     {% endif %}
-  </td>
-  {% endif %}
 
-  {% if page.extendedSupportColumn %}
-  <td class=
-        {% if extendedSupport > 5 %}
-    {% if diffExtendedSupport < 0 and r.extendedSupport != false %}
-    "bg-red-000"
-    {% elsif diffExtendedSupport6 > 0 %}
-    "bg-green-000"
-    {% else %}
-    "bg-yellow-200"
+    {% if page.extendedSupportColumn %}
+    {%- assign colorClass = 'bg-green-000' %}
+    {%- if r.daysTowardExtendedSupport < 121 %}{% assign colorClass = 'bg-yellow-200' %}{% endif %}
+    {%- if r.daysTowardExtendedSupport < 0 %}{% assign colorClass = 'bg-red-000' %}{% endif %}
+    {%- if r.extendedSupport == false %}{% assign colorClass = 'bg-grey-lt-100' %}{% endif %}
+    <td class="{{ colorClass }}">
+      {% if r.extendedSupport == true %}
+        Yes
+      {% elsif r.extendedSupport == false %}
+        Unavailable
+      {% else %}
+        {% if r.daysTowardExtendedSupport < 0 %}Ended{% else %}Ends{% endif %}
+        {{ r.extendedSupport | timeago }} <div>({{ r.extendedSupport | date_to_string }})</div>
+      {% endif %}
+    </td>
     {% endif %}
-    {% else %}
-    {% if r.extendedSupport %}
-    "bg-green-000"
-    {% else %}
-    "bg-grey-lt-100"
-    {% endif %}
-    {% endif %}
-    title="{{r.extendedSupport}}">
-    {% if extendedSupport > 5 %}
-    {% if diffExtendedSupport < 0 %}
-    Ended
-    {% else %}
-    Ends
-    {% endif %}
-    {{r.extendedSupport | timeago}} <div>({{r.extendedSupport | date_to_string}})</div>
-    {% else %}
-    {% if r.extendedSupport %}
-    Yes
-    {% else %}
-    Unavailable
-    {% endif %}
-    {% endif %}
-  </td>
-  {% endif %}
 
-  {% if page.releaseColumn != false %}
-  <td {% if diff <= 0 %} class = "txt-linethrough" {% endif %} >      <!-- if the support finished add txt-linethrough class -->
-    {% if r.link and diff > 0 %}
-      <a href="{{ r.link }}" title="Release Notes / Changelog">{{ r.latest }}</a>
-    {% else %}
-      {{ r.latest }}
+    {% if page.releaseColumn != false %}
+    {%- assign releaseColumnClass = '' %}
+    {%- if r.daysTowardEol < 0 %}{% assign releaseColumnClass = 'txt-linethrough' %}{% endif %}
+    <td class="{{ releaseColumnClass }}">
+      {% if r.link and r.daysTowardEol > 0 %}
+        <a href="{{ r.link }}" title="Release Notes / Changelog">{{ r.latest }}</a>
+      {% else %}
+        {{ r.latest }}
+      {% endif %}
+      {% if r.daysTowardEol > 0 and r.latestReleaseDate %}
+        <div>({{ r.latestReleaseDate | date_to_string }})</div>
+      {% endif %}
+    </td>
     {% endif %}
-    {% if diff > 0 and r.latestReleaseDate %}
-    <div>({{ r.latestReleaseDate | date_to_string }})</div>
-    {% endif %}
-  </td>
-  {% endif %}
-</tr>
+  </tr>
 {% endfor %}
 </table>
 
 <div class="policytext">
-  {{content | remove_first_element:'blockquote'}}
+  {{ content | remove_first_element:'blockquote' }}
 </div>
-{% if page.releasePolicyLink and page.releasePolicyLink != "" %}
-<p>More information is available on the <a href="{{page.releasePolicyLink}}">{{page.title}} website</a>. </p>
+
+{% if page.releasePolicyLink %}
+<p>More information is available on the <a href="{{page.releasePolicyLink}}">{{page.title}} website</a>.</p>
 {% endif %}
 
-{% if page.releaseColumn != false %}<p>You should be running one of the supported release numbers listed above in the rightmost column.</p>{% endif %}
+{% if page.releaseColumn %}
+<p>You should be running one of the supported release numbers listed above in the rightmost column.</p>
+{% endif %}
 
-{% if page.versionCommand %}<div id="version-command" class="card card-body bg-light">You can check the version that you are currently using by running: <pre>{{page.versionCommand}}</pre></div>{% endif %}
+{% if page.versionCommand %}
+<div id="version-command" class="card card-body bg-light">
+  You can check the version that you are currently using by running: <pre>{{page.versionCommand}}</pre>
+</div>
+{% endif %}
 
 <hr>
 
-<p>You can submit an improvement to this page
-<a href="https://github.com/endoflife-date/endoflife.date/blob/master/{{page.path}}"
-title="Click the Pencil, the link takes you directly to the correct page">on GitHub</a>
-<img class="emoji" title=":octocat:" alt=":octocat:" src="https://github.githubassets.com/images/icons/emoji/octocat.png" width="20" height="20">
-. This page has a corresponding <a title="Talk Page for {{page.title}}" href="https://github.com/endoflife-date/talk/wiki{{page.permalink}}">Talk Page</a>.</p>
+<p>
+  You can submit an improvement to this page
+  <a href="https://github.com/endoflife-date/endoflife.date/blob/master/{{page.path}}" title="Click the Pencil, the link takes you directly to the correct page">
+    on GitHub
+    <img class="emoji" title=":octocat:" alt=":octocat:" src="https://github.githubassets.com/images/icons/emoji/octocat.png" width="20" height="20">
+  </a>.
+  This page has a corresponding <a title="Talk Page for {{page.title}}" href="https://github.com/endoflife-date/talk/wiki{{page.permalink}}">
+  Talk Page</a>.
+</p>
 
 <p>
   A JSON version of this page is available at <a href="/api{{page.permalink}}.json">/api{{page.permalink}}.json</a>.

--- a/_plugins/product-data-enricher.rb
+++ b/_plugins/product-data-enricher.rb
@@ -12,6 +12,7 @@ module Jekyll
         set_id(page)
         set_icon_url(page)
         set_tags(page)
+        set_overridden_columns_label(page)
 
         page.data["releases"].each { |release| enrich_release(page, release) }
       end
@@ -47,6 +48,20 @@ module Jekyll
 
         tags << page.data['category']
         page.data['tags'] = tags
+      end
+
+      # Set properly the column presence/label if it was overridden.
+      def set_overridden_columns_label(page)
+        columnNames = [
+          'releaseDateColumn', 'releaseColumn', 'discontinuedColumn',
+          'activeSupportColumn', 'eolColumn', 'extendedSupportColumn'
+        ]
+        for columnName in columnNames
+          if page.data[columnName].is_a? String
+            page.data[columnName + 'Label'] = page.data[columnName]
+            page.data[columnName] = true
+          end
+        end
       end
 
       def enrich_release(page, cycle)


### PR DESCRIPTION
This PR simplifies the `product.html` template by adding enriching more products in `ProductDataEnricher` and by defining more default values in Jekyll config files.

- Move default value for column names and labels to Jekyll's `config.yml`.
- Make it possible to override the label for all columns except the 'Release' column, not just `eolColumn`, `activeSupportColumn` and `extendedSupportColumn`.
- Make available two variables for each column instead of one : one boolean `xxxColumn` and one string `xxxColumnLabel`. These are easier to work with in the template.
- Move date computation in `product-data-enricher.rb`, which allowed a lot of simplification in the product template.