### PR TITLE
Add slackware linux cpe

### DIFF
--- a/products/slackware.md
+++ b/products/slackware.md
@@ -13,7 +13,8 @@ releaseColumn: false
 releaseDateColumn: true
 releasePolicyLink: http://www.slackware.com/faq/do_faq.php?faq=general#4
 identifiers:
--   purl: pkg:os/slackwarelinux
+-   cpe: cpe:/o:slackware:slackware_linux
+-   cpe: cpe:2.3:o:slackware:slackware_linux
 auto:
 -   distrowatch: slackware
     regex: '^Distribution Release: Slackware (Linux )?(?P<major>\d+)\.(?P<minor>\d+)$'


### PR DESCRIPTION
Removing the pkg:os like we did [here](https://github.com/endoflife-date/endoflife.date/pull/2525)

Pulling cpes from here: https://github.com/nexB/container-inspector/tree/main/tests/data/distro/os-release/slackware