### PR TITLE
Add debian cpe identifiers

### DIFF
--- a/products/debian.md
+++ b/products/debian.md
@@ -11,6 +11,8 @@ releaseDateColumn: true
 releaseLabel: "__RELEASE_CYCLE__ (__CODENAME__)"
 identifiers:
 -   purl: pkg:os/debian
+-   cpe: cpe:2.3:o:debian:debian_linux
+-   cpe: cpe:/o:debian:debian_linux
 
 auto:
 -   custom: true

--- a/products/debian.md
+++ b/products/debian.md
@@ -10,7 +10,6 @@ releaseColumn: true
 releaseDateColumn: true
 releaseLabel: "__RELEASE_CYCLE__ (__CODENAME__)"
 identifiers:
--   purl: pkg:os/debian
 -   cpe: cpe:2.3:o:debian:debian_linux
 -   cpe: cpe:/o:debian:debian_linux
 


### PR DESCRIPTION
Removing pkg:os like we've done here: https://github.com/endoflife-date/endoflife.date/pull/2525

Pulling cpes from here: https://github.com/nexB/container-inspector/tree/main/tests/data/distro/os-release/debian