### PR TITLE
Add nixos cpes

### DIFF
--- a/products/nixos.md
+++ b/products/nixos.md
@@ -12,6 +12,9 @@ activeSupportColumn: false
 releaseColumn: true
 releaseDateColumn: true
 releaseLabel: "__RELEASE_CYCLE__ '__CODENAME__'"
+identifiers:
+-   cpe: cpe:/o:nixos:nixos
+-   cpe: cpe:2.3:o:nixos:nixos
 releases:
 -   releaseCycle: "22.11"
     codename: "Raccoon"


### PR DESCRIPTION
Pulling CPEs from here: https://github.com/nexB/container-inspector/tree/main/tests/data/distro/os-release/nixos

EDIT: this might actually be incorrect. Not sure if it's `cpe:2.3:o:nixos:nix` or `cpe:2.3:o:nixos:nixos` right now.

EDIT2: `cpe:2.3:o:nixos:nix` seems to be the package manager. There's a CVE that mentions version 2.3, which is a version of the Nix pkg manager.  `cpe:2.3:o:nixos:nixos` is for the OS https://nvd.nist.gov/vuln/detail/CVE-2017-7412