### PR TITLE
Make warn threshold configurable per product and column

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -106,9 +106,17 @@ LTSLabel: "<abbr title='Extra Long Support'>ELS</abbr>"
 # The value of this property can be set to any string to override the default column label.
 eolColumn: Security Support
 
+# Threshold at which the background color of the cycle's "eol" cell changes to indicate
+# that the EOL date is approaching (optional, default = 121 days).
+eolWarnThreshold: 121
+
 # Whether the "Active Support" column should be displayed (optional, default = false).
 # The value of this property can be set to any string to override the default column label.
 activeSupportColumn: Active Support
+
+# Threshold at which the background color of the cycle's "activeSupport" cell changes to indicate
+# that the end of active support date is approaching (optional, default = 121 days).
+activeSupportWarnThreshold: 121
 
 # Whether the "Latest" column should be displayed (optional, default = true).
 # The value of this property can be set to any string to override the default column label.
@@ -124,9 +132,17 @@ releaseDateColumn: Released
 # The value of this property can be set to any string to override the default column label.
 discontinuedColumn: Discontinued
 
+# Threshold at which the background color of the cycle's "discontinued" cell changes to indicate
+# that the discontinued date is approaching (optional, default = 121 days).
+discontinuedWarnThreshold: 121
+
 # Whether the "Extended Support" column should be displayed (optional, default = false).
 # The value of this property can be set to any string to override the default column label.
 extendedSupportColumn: Extended Support
+
+# Threshold at which the background color of the cycle's "extendedSupport" cell changes to indicate
+# that the extended support date is approaching (optional, default = 121 days).
+extendedSupportWarnThreshold: 121
 
 # Auto-update release configuration (optional).
 # This is used for automatically updating `releaseDate`, `latest`, and `latestReleaseDate` for every release.

--- a/_config.yml
+++ b/_config.yml
@@ -69,11 +69,15 @@ defaults:
       releaseDateColumnLabel: 'Released'
       discontinuedColumn: false
       discontinuedColumnLabel: 'Discontinued'
+      discontinuedWarnThreshold: 121
       activeSupportColumn: false
       activeSupportColumnLabel: 'Active Support'
+      activeSupportWarnThreshold: 121
       eolColumn: true
       eolColumnLabel: 'Security Support'
+      eolWarnThreshold: 121
       extendedSupportColumn: false
       extendedSupportColumnLabel: 'Extended Support'
+      extendedSupportWarnThreshold: 121
       LTSLabel: '<abbr title="Long Term Support">LTS</abbr>'
 encoding: utf-8

--- a/_layouts/product.html
+++ b/_layouts/product.html
@@ -46,7 +46,7 @@ layout: default
 
     {% if page.discontinuedColumn %}
     {%- assign colorClass = 'bg-green-000' %}
-    {%- if r.daysTowardDiscontinued < 121 %}{% assign colorClass = 'bg-yellow-200' %}{% endif %}
+    {%- if r.daysTowardDiscontinued < page.discontinuedWarnThreshold %}{% assign colorClass = 'bg-yellow-200' %}{% endif %}
     {%- if r.daysTowardDiscontinued < 0 %}{% assign colorClass = 'bg-red-000' %}{% endif %}
     <td class="{{ colorClass }}">
     {% if r.discontinued == true %}
@@ -61,7 +61,7 @@ layout: default
 
     {% if page.activeSupportColumn %}
     {%- assign colorClass = 'bg-green-000' %}
-    {%- if r.daysTowardSupport < 121 %}{% assign colorClass = 'bg-yellow-200' %}{% endif %}
+    {%- if r.daysTowardSupport < page.activeSupportWarnThreshold %}{% assign colorClass = 'bg-yellow-200' %}{% endif %}
     {%- if r.daysTowardSupport < 0 %}{% assign colorClass = 'bg-red-000' %}{% endif %}
     <td class="{{ colorClass }}">
     {% if r.support == true %}
@@ -77,7 +77,7 @@ layout: default
 
     {% if page.eolColumn != false %}
     {%- assign colorClass = 'bg-green-000' %}
-    {%- if r.daysTowardEol < 121 %}{% assign colorClass = 'bg-yellow-200' %}{% endif %}
+    {%- if r.daysTowardEol < page.eolWarnThreshold %}{% assign colorClass = 'bg-yellow-200' %}{% endif %}
     {%- if r.daysTowardEol < 0 %}{% assign colorClass = 'bg-red-000' %}{% endif %}
     <td class="{{ colorClass }}">
       {% if r.eol == true %}
@@ -93,7 +93,7 @@ layout: default
 
     {% if page.extendedSupportColumn %}
     {%- assign colorClass = 'bg-green-000' %}
-    {%- if r.daysTowardExtendedSupport < 121 %}{% assign colorClass = 'bg-yellow-200' %}{% endif %}
+    {%- if r.daysTowardExtendedSupport < page.extendedSupportWarnThreshold %}{% assign colorClass = 'bg-yellow-200' %}{% endif %}
     {%- if r.daysTowardExtendedSupport < 0 %}{% assign colorClass = 'bg-red-000' %}{% endif %}
     {%- if r.extendedSupport == false %}{% assign colorClass = 'bg-grey-lt-100' %}{% endif %}
     <td class="{{ colorClass }}">

--- a/products/angular.md
+++ b/products/angular.md
@@ -6,8 +6,10 @@ permalink: /angular
 versionCommand: ng version
 releasePolicyLink: https://angular.io/guide/releases
 changelogTemplate: https://github.com/angular/angular/releases/tag/__LATEST__
-activeSupportColumn: true
 releaseDateColumn: true
+activeSupportColumn: true
+activeSupportWarnThreshold: 30
+eolWarnThreshold: 90
 
 identifiers:
 -   purl: pkg:npm/@angular/core


### PR DESCRIPTION
Until now, the threshold for changing the background color of a cycle's date to yellow (to indicate that date is approaching) was the same for all columns and products : 121 days (~ four months). This is not great for products :

- that have short release cycles and/or, because the warning happens immediatly or soon after the initial release date,
- or a very long extended support, such as OSes, because the warning happens too late (considering an OS upgrade is not a small and easy task).

This PR changes that by introducing four new variables allowing to update the threshold on a per-product / per-column (e.g. per date) basis : `discontinuedWarnThreshold`, `activeSupportWarnThreshold`, `eolWarnThreshold`, `extendedSupportWarnThreshold` (default value did not changed).

As an example the threshold has been changed for Angular, which have only 6 months of active support and 18 months of security support.