### PR TITLE
[gitlab] Add details about docker images

### DIFF
--- a/products/gitlab.md
+++ b/products/gitlab.md
@@ -168,8 +168,13 @@ releases:
 > [GitLab](https://about.gitlab.com/) is a web-based DevOps lifecycle tool that provides a Git repository manager providing wiki, issue-tracking and continuous integration and deployment pipeline features, using an open-source license, developed by GitLab Inc.
 
 GitLab has a [well-defined versioning policy](https://docs.gitlab.com/ce/policy/maintenance.html) based on Semantic Versioning. New releases are announced on the [blog](https://about.gitlab.com/releases/categories/releases/), and you can subscribe to an [RSS Feed](https://about.gitlab.com/atom.xml) as well. A [tool is available](https://gitlab-com.gitlab.io/cs-tools/gitlab-cs-tools/what-is-new-since/?tab=features) to track new features since a given version.
+
+GitLab is distributed as [two disctinct flavors](https://about.gitlab.com/install/ce-or-ee/) public Docker images on [DockerHub](https://hub.docker.com/u/gitlab) : 
   
-Only the latest release is actively maintained. The previous two minor (monthly) releases get security fixes. Critical bug fixes can rarely be backported based on [a set criteria](https://docs.gitlab.com/ee/policy/maintenance.html#backporting-to-older-releases).
+- [Community Edition (`CE`)](https://gitlab.com/rluna-gitlab/gitlab-ce) : [`gitlab/gitlab-ce`](https://hub.docker.com/r/gitlab/gitlab-ce/)
+- [Enterprise Edition (`EE`)](https://about.gitlab.com/enterprise/) : [`gitlab/gitlab-ee`](https://hub.docker.com/r/gitlab/gitlab-ee/)
+  
+**Only the latest release is actively maintained.** The previous two minor (monthly) releases get security fixes. Critical bug fixes can rarely be backported based on [a set criteria](https://docs.gitlab.com/ee/policy/maintenance.html#backporting-to-older-releases).
 
 | Version Type | Description  | Cadence |
 |:-------------|:-------------|:--------|


### PR DESCRIPTION
# :grey_question: About
This morning, thanks to : 

- https://github.com/endoflife-date/endoflife.date/pull/2566#event-8593915123

I discovered that docker images were not detailed... which would be very useful for people using [`xeol`](https://github.com/noqcks/xeol) and [`grype`](https://github.com/anchore/grype)

# :dart: Why merge ?

By merging this PR, we'll get infos about the cloud-native distrib of [Gitlab](https://endoflife.date/gitlab)