### PR TITLE
Fix pages description

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,8 +1,9 @@
 ---
+layout: page
 nav_exclude: true
 title: Contributing
+description: Some information on how to contribute to https://endoflife.date.
 permalink: /contribute
-layout: page
 ---
 
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->

--- a/_includes/head_custom.html
+++ b/_includes/head_custom.html
@@ -1,13 +1,3 @@
-{% capture d %}
-{% if page.layout == 'post' %}
-Check End of Life, Support Schedule, and release timelines for {{page.title}}. {%if page.alternate_urls %}endoflife.date{{page.alternate_urls[0]}}{%endif%}. {{page.title}} release policy. {{page.title}} release schedule. {{page.title}} end of life.
-{% else %}
-Check End of Life, Support Schedule, and release timelines for  {% for page in site.pages%}{%if page.releases%}{{page.title}}, {%endif%}{% endfor %} etc at one place.
-{% endif %}
-{% endcapture %}
-<meta name="description" content="{{ d | strip }}" />
-<meta property="og:description" content="{{ d | strip }}" />
-
 {%- comment %}
 Favicons were generated from the SVG icons with https://realfavicongenerator.net.
 

--- a/_plugins/product-data-enricher.rb
+++ b/_plugins/product-data-enricher.rb
@@ -10,6 +10,7 @@ module Jekyll
         Jekyll.logger.debug TOPIC, "Enriching #{page.name}"
 
         set_id(page)
+        set_description(page)
         set_icon_url(page)
         set_tags(page)
         set_overridden_columns_label(page)
@@ -26,6 +27,13 @@ module Jekyll
       # Build the product id from the permalink.
       def set_id(page)
         page.data['id'] = page.data['permalink'][1..page.data['permalink'].length]
+      end
+
+      # Build the product description, if it's not already set in the product's front matter.
+      def set_description(page)
+        if !page.data['description']
+          page.data['description'] = "Check end-of-life, release policy and support schedule for #{page.data['title']}."
+        end
       end
 
       # Build the icon URL from the icon slug.

--- a/index.md
+++ b/index.md
@@ -2,6 +2,7 @@
 layout: page
 nav_exclude: true
 title: Home
+description: Check end-of-life, support schedule, and release timelines for more than 200 products at one place.
 # This is the content for the website homepage (https://endoflife.date/)
 ---
 

--- a/recommendations.md
+++ b/recommendations.md
@@ -3,6 +3,7 @@ layout: page
 nav_exclude: true
 permalink: /recommendations
 title: Recommendations for maintainers
+description: If you maintain a product that has some notion of support lifecycle and end-of-life, these are endoflife.date recommendations on how to best document this information for your users.
 alternate_urls:
   - /advise
   - /advice


### PR DESCRIPTION
Product pages description was broken since the introduction of the 'product' layout. Moreover, jekyll-seo-tag already handles `description` and `og:description` meta tags, so there is no need to override them using the head_custom template.

All pages descriptions were also simplified in the process.