### PR TITLE
[ios] Add links to release cycles

### DIFF
--- a/products/ios.md
+++ b/products/ios.md
@@ -19,6 +19,7 @@ releases:
     eol: false
     latestReleaseDate: 2023-02-13
     latest: "16.3.1"
+    link: https://support.apple.com/HT213407
 
 -   releaseCycle: "15"
     eol: false
@@ -26,6 +27,7 @@ releases:
     releaseDate: 2021-09-20
     latestReleaseDate: 2023-01-23
     latest: "15.7.3"
+    link: https://support.apple.com/HT212788
 
 -   releaseCycle: "14"
     eol: 2021-10-01
@@ -33,6 +35,7 @@ releases:
     releaseDate: 2020-09-16
     latestReleaseDate: 2021-10-26
     latest: "14.8.1"
+    link: https://support.apple.com/HT211808
 
 -   releaseCycle: "13"
     eol: 2020-09-16
@@ -40,6 +43,7 @@ releases:
     releaseDate: 2019-09-19
     latestReleaseDate: 2020-09-01
     latest: "13.7"
+    link: https://support.apple.com/HT210393
 
 # iOS 12 is still getting updates
 -   releaseCycle: "12"
@@ -48,6 +52,7 @@ releases:
     releaseDate: 2018-09-17
     latestReleaseDate: 2023-01-23
     latest: "12.5.7"
+    link: https://support.apple.com/HT209084
 
 -   releaseCycle: "11"
     eol: 2018-10-08
@@ -55,6 +60,7 @@ releases:
     releaseDate: 2017-09-19
     latestReleaseDate: 2018-07-09
     latest: "11.4.1"
+    link: https://support.apple.com/HT208067
 
 -   releaseCycle: "10"
     eol: 2017-09-26
@@ -62,6 +68,7 @@ releases:
     releaseDate: 2016-09-13
     latestReleaseDate: 2019-07-22
     latest: "10.3.4"
+    link: https://support.apple.com/HT208011
 
 -   releaseCycle: "9"
     eol: 2016-09-13
@@ -69,6 +76,7 @@ releases:
     releaseDate: 2015-09-16
     latestReleaseDate: 2019-07-22
     latest: "9.3.6"
+    link: https://support.apple.com/HT208010
 
 -   releaseCycle: "8"
     eol: 2015-09-30
@@ -76,6 +84,7 @@ releases:
     releaseDate: 2014-09-17
     latestReleaseDate: 2015-08-13
     latest: "8.4.1"
+    link: https://support.apple.com/HT208000
 
 -   releaseCycle: "7"
     eol: 2014-10-20
@@ -83,6 +92,7 @@ releases:
     releaseDate: 2013-09-18
     latestReleaseDate: 2014-06-30
     latest: "7.1.2"
+    link: https://support.apple.com/HT207979
 
 -   releaseCycle: "6"
     eol: 2013-09-26
@@ -90,6 +100,7 @@ releases:
     releaseDate: 2012-09-19
     latestReleaseDate: 2014-02-21
     latest: "6.1.6"
+    link: https://support.apple.com/HT212584
 
 -   releaseCycle: "5"
     eol: 2012-11-01
@@ -97,6 +108,7 @@ releases:
     releaseDate: 2011-10-12
     latestReleaseDate: 2012-05-07
     latest: "5.1.1"
+    link: https://support.apple.com/HT212597
 
 ---
 

--- a/products/ios.md
+++ b/products/ios.md
@@ -1,15 +1,17 @@
 ---
-permalink: /ios
 title: Apple iOS
 category: os
 iconSlug: apple
+permalink: /ios
 releasePolicyLink: https://en.wikipedia.org/wiki/IOS_version_history#Overview
 discontinuedColumn: false
 activeSupportColumn: true
 releaseColumn: true
 releaseDateColumn: true
+
 auto:
 -   custom: true
+
 releases:
 -   releaseCycle: "16"
     support: true
@@ -17,24 +19,28 @@ releases:
     eol: false
     latestReleaseDate: 2023-02-13
     latest: "16.3.1"
+
 -   releaseCycle: "15"
     eol: false
     support: 2022-09-12
     releaseDate: 2021-09-20
     latestReleaseDate: 2023-01-23
     latest: "15.7.3"
+
 -   releaseCycle: "14"
     eol: 2021-10-01
     support: 2021-09-20
     releaseDate: 2020-09-16
     latestReleaseDate: 2021-10-26
     latest: "14.8.1"
+
 -   releaseCycle: "13"
     eol: 2020-09-16
     support: 2020-09-16
     releaseDate: 2019-09-19
     latestReleaseDate: 2020-09-01
     latest: "13.7"
+
 # iOS 12 is still getting updates
 -   releaseCycle: "12"
     eol: false
@@ -42,42 +48,49 @@ releases:
     releaseDate: 2018-09-17
     latestReleaseDate: 2023-01-23
     latest: "12.5.7"
+
 -   releaseCycle: "11"
     eol: 2018-10-08
     support: 2018-09-17
     releaseDate: 2017-09-19
     latestReleaseDate: 2018-07-09
     latest: "11.4.1"
+
 -   releaseCycle: "10"
     eol: 2017-09-26
     support: 2017-09-19
     releaseDate: 2016-09-13
     latestReleaseDate: 2019-07-22
     latest: "10.3.4"
+
 -   releaseCycle: "9"
     eol: 2016-09-13
     support: 2016-09-13
     releaseDate: 2015-09-16
     latestReleaseDate: 2019-07-22
     latest: "9.3.6"
+
 -   releaseCycle: "8"
     eol: 2015-09-30
     support: 2015-09-16
     releaseDate: 2014-09-17
     latestReleaseDate: 2015-08-13
     latest: "8.4.1"
+
 -   releaseCycle: "7"
     eol: 2014-10-20
     support: 2014-09-17
     releaseDate: 2013-09-18
     latestReleaseDate: 2014-06-30
     latest: "7.1.2"
+
 -   releaseCycle: "6"
     eol: 2013-09-26
     support: 2013-09-18
     releaseDate: 2012-09-19
     latestReleaseDate: 2014-02-21
     latest: "6.1.6"
+
 -   releaseCycle: "5"
     eol: 2012-11-01
     support: 2012-09-19
@@ -87,9 +100,14 @@ releases:
 
 ---
 
-> [iOS](https://www.apple.com/ios/) is a mobile operating system created by Apple, and used in the company's mobile devices, including the iPhone. It is the world's second-most widely installed operating system, after Android.
+> [iOS](https://www.apple.com/ios/) is a mobile operating system created by Apple, and used in the
+> company's mobile devices, including the iPhone. It is the world's second-most widely installed
+> operating system, after Android.
 
-Major versions of iOS are released annually. Apple significantly extended the cycle of updates for iOS-supported devices over the years. Usually, only the latest iOS release is supported by Apple. Starting with iOS 15, Apple started to support [2 major versions of iOS](https://www.zdnet.com/article/still-running-ios-14-on-your-iphone-apple-brings-support-to-an-end/), for a short period of time.
+Major versions of iOS are released annually. Apple significantly extended the cycle of updates for
+iOS-supported devices over the years. Usually, only the latest iOS release is supported by Apple.
+Starting with iOS 15, Apple started to support [2 major versions of iOS](https://www.zdnet.com/article/still-running-ios-14-on-your-iphone-apple-brings-support-to-an-end/),
+for a short period of time.
 
 iOS 12 is [still receving security updates](https://support.apple.com/en-us/HT213597).
 


### PR DESCRIPTION
It is possible to add an anchor to the link to target the latest version, but it would complicate things unnecessarily : the latest version is always first displayed on the page (#39).

Also took the opportunity to normalize the page (#2124).