### PR TITLE
[ipad] Add links to release cycles

### DIFF
--- a/products/ipad.md
+++ b/products/ipad.md
@@ -10,132 +10,155 @@ eolColumn: Supported
 releaseDateColumn: true
 releaseColumn: false
 
+# Links send to the Technical Specifications of each model.
+# All links can be found on https://support.apple.com/en-us/HT201471.
 releases:
 -   releaseCycle: "10"
     releaseLabel: "iPad (10th generation)"
     releaseDate: 2022-10-26
     discontinued: false
     eol: false
+    link: https://support.apple.com/kb/SP884
 
 -   releaseCycle: "air-5"
     releaseLabel: "iPad Air (5th generation)"
     releaseDate: 2022-03-18
     discontinued: false
     eol: false
+    link: https://support.apple.com/kb/SP866
 
 -   releaseCycle: "9"
     releaseLabel: "iPad (9th generation)"
     releaseDate: 2021-09-24
     discontinued: false
     eol: false
+    link: https://support.apple.com/kb/SP849
 
 -   releaseCycle: "mini-6"
     releaseLabel: "iPad Mini (6th generation)"
     releaseDate: 2021-09-24
     discontinued: false
     eol: false
+    link: https://support.apple.com/kb/SP850
 
 -   releaseCycle: "8"
     releaseLabel: "iPad (8th generation)"
     releaseDate: 2020-09-18
     discontinued: 2021-09-14
     eol: false
+    link: https://support.apple.com/kb/SP822
 
 -   releaseCycle: "air-4"
     releaseLabel: "iPad Air (4th generation)"
     releaseDate: 2020-10-23
     discontinued: 2022-03-08
     eol: false
+    link: https://support.apple.com/kb/SP828
 
 -   releaseCycle: "7"
     releaseLabel: "iPad (7th generation)"
     releaseDate: 2019-09-25
     discontinued: 2020-09-15
     eol: false
+    link: https://support.apple.com/kb/SP807
 
 -   releaseCycle: "mini-5"
     releaseLabel: "iPad Mini (5th generation)"
     releaseDate: 2019-03-18
     discontinued: 2021-09-14
     eol: false
+    link: https://support.apple.com/kb/SP788
 
 -   releaseCycle: "air-3"
     releaseLabel: "iPad Air (3rd generation)"
     releaseDate: 2019-03-18
     discontinued: 2021-09-15
     eol: false
+    link: https://support.apple.com/kb/SP787
 
 -   releaseCycle: "6"
     releaseLabel: "iPad (6th generation)"
     releaseDate: 2018-03-27
     discontinued: 2019-09-10
     eol: false
+    link: https://support.apple.com/kb/SP774
 
 -   releaseCycle: "5"
     releaseLabel: "iPad (5th generation)"
     releaseDate: 2017-03-24
     discontinued: 2018-03-27
     eol: false
+    link: https://support.apple.com/kb/SP751
 
 -   releaseCycle: "mini-4"
     releaseLabel: "iPad Mini 4"
     releaseDate: 2015-09-09
     discontinued: 2019-03-18
     eol: false
+    link: https://support.apple.com/kb/SP725
 
 -   releaseCycle: "mini-3"
     releaseLabel: "iPad Mini 3"
     releaseDate: 2014-10-22
     discontinued: 2015-09-09
     eol: false
+    link: https://support.apple.com/kb/SP709
 
 -   releaseCycle: "air-2"
     releaseLabel: "iPad Air 2"
     releaseDate: 2014-10-22
     discontinued: 2017-03-21
     eol: false
+    link: https://support.apple.com/kb/SP708
 
 -   releaseCycle: "mini-2"
     releaseLabel: "iPad Mini 2"
     releaseDate: 2013-11-12
     discontinued: 2017-03-21
     eol: false
+    link: https://support.apple.com/kb/SP693
 
 -   releaseCycle: "air-1"
     releaseLabel: "iPad Air (1st generation)"
     releaseDate: 2013-11-01
     discontinued: 2016-03-21
     eol: false
+    link: https://support.apple.com/kb/SP692
 
 -   releaseCycle: "4"
     releaseLabel: "iPad (4th generation)"
     releaseDate: 2012-11-02
     discontinued: 2014-10-16
     eol: 2019-07-22
+    link: https://support.apple.com/kb/SP662
 
 -   releaseCycle: "3"
     releaseLabel: "iPad (3rd generation)"
     releaseDate: 2012-03-16
     discontinued: 2012-10-23
     eol: 2019-07-22
+    link: https://support.apple.com/kb/SP647
 
 -   releaseCycle: "mini-1"
     releaseLabel: "iPad Mini (1st generation)"
     releaseDate: 2012-11-02
     discontinued: 2015-06-19
     eol: 2019-07-22
+    link: https://support.apple.com/kb/SP661
 
 -   releaseCycle: "2"
     releaseLabel: "iPad 2"
     releaseDate: 2011-03-11
     discontinued: 2014-03-18
     eol: 2019-07-22
+    link: https://support.apple.com/kb/sp622
 
 -   releaseCycle: "1"
     releaseLabel: "iPad (1st generation)"
     releaseDate: 2010-04-03
     discontinued: 2011-03-02
     eol: 2012-09-19
+    link: https://support.apple.com/kb/SP580
 
 ---
 


### PR DESCRIPTION
Links are sending to the Technical Specifications of each model. All links can be found on https://support.apple.com/en-us/HT201471.