### PR TITLE
[office] Add links to release cycles

### DIFF
--- a/products/office.md
+++ b/products/office.md
@@ -1,47 +1,56 @@
 ---
 title: Microsoft Office
+category: app
+iconSlug: microsoftoffice
 permalink: /office
 alternate_urls:
 -   /msoffice
-iconSlug: microsoftoffice
-category: app
 releasePolicyLink: https://learn.microsoft.com/lifecycle/products/?terms=Office
 activeSupportColumn: true
 releaseColumn: false
 releaseDateColumn: true
+
 releases:
 -   releaseCycle: "365"
     support: true
     eol: false
     releaseDate: 2015-09-22
+
 -   releaseCycle: "2021"
     support: 2026-10-13
     eol: 2026-10-13
     releaseDate: 2021-10-05
+
 -   releaseCycle: "2019"
     support: 2023-10-10
     eol: 2025-10-14
     releaseDate: 2018-09-24
+
 -   releaseCycle: "2016"
     support: 2020-10-13
     eol: 2025-10-14
     releaseDate: 2015-09-22
+
 -   releaseCycle: "2013 SP1"
     support: 2018-04-10
     eol: 2023-04-11
     releaseDate: 2014-02-25
+
 -   releaseCycle: "2011 for Mac SP3"
     support: 2017-10-10
     eol: 2017-10-10
     releaseDate: 2013-01-29
+
 -   releaseCycle: "2010 SP2"
     support: 2015-10-13
     eol: 2020-10-13
     releaseDate: 2013-07-23
+
 -   releaseCycle: "2008 for Mac SP2"
     support: 2013-04-09
     eol: 2013-04-09
     releaseDate: 2009-10-18
+
 -   releaseCycle: "2007 SP3"
     support: 2012-10-09
     eol: 2017-10-10
@@ -49,6 +58,7 @@ releases:
 
 ---
 
-> Microsoft Office, or simply Office, is a family of client software, server software, and services developed by Microsoft.
+> Microsoft Office, or simply Office, is a family of client software, server software, and services
+> developed by Microsoft.
 
 Note that Microsoft Office 2019 for Mac is [only supported until 2023-10-10](https://learn.microsoft.com/lifecycle/products/microsoft-office-2019-for-mac).

--- a/products/office.md
+++ b/products/office.md
@@ -15,46 +15,55 @@ releases:
     support: true
     eol: false
     releaseDate: 2015-09-22
+    link: https://learn.microsoft.com/lifecycle/faq/office
 
 -   releaseCycle: "2021"
     support: 2026-10-13
     eol: 2026-10-13
     releaseDate: 2021-10-05
+    link: https://learn.microsoft.com/lifecycle/products/office-2021
 
 -   releaseCycle: "2019"
     support: 2023-10-10
     eol: 2025-10-14
     releaseDate: 2018-09-24
+    link: https://learn.microsoft.com/lifecycle/products/microsoft-office-2019
 
 -   releaseCycle: "2016"
     support: 2020-10-13
     eol: 2025-10-14
     releaseDate: 2015-09-22
+    link: https://learn.microsoft.com/lifecycle/products/microsoft-office-2016
 
 -   releaseCycle: "2013 SP1"
     support: 2018-04-10
     eol: 2023-04-11
     releaseDate: 2014-02-25
+    link: https://learn.microsoft.com/lifecycle/products/microsoft-office-2013
 
 -   releaseCycle: "2011 for Mac SP3"
     support: 2017-10-10
     eol: 2017-10-10
     releaseDate: 2013-01-29
+    link: https://learn.microsoft.com/lifecycle/products/microsoft-office-for-mac-2011
 
 -   releaseCycle: "2010 SP2"
     support: 2015-10-13
     eol: 2020-10-13
     releaseDate: 2013-07-23
+    link: https://learn.microsoft.com/lifecycle/products/microsoft-office-2010
 
 -   releaseCycle: "2008 for Mac SP2"
     support: 2013-04-09
     eol: 2013-04-09
     releaseDate: 2009-10-18
+    link: https://learn.microsoft.com/lifecycle/products/microsoft-office-2008-for-mac
 
 -   releaseCycle: "2007 SP3"
     support: 2012-10-09
     eol: 2017-10-10
     releaseDate: 2011-10-25
+    link: https://learn.microsoft.com/lifecycle/products/microsoft-office-2007
 
 ---
 


### PR DESCRIPTION
It is possible to use a `changelogTemplate`, but the template changed for Office 2021, and is not the same for Office 365 and all versions of Office for Mac. Moreover the fact that the service pack is stored in the release cycle name does not help. So it was more simple to specify each link.

This relates to #39, and I took the opportunity to normalize the page (#2124).