### PR TITLE
[coldfusion] Add a changelogTemplate and the extended support column

### DIFF
--- a/products/coldfusion.md
+++ b/products/coldfusion.md
@@ -12,25 +12,34 @@ eolColumn: Core Support
 
 releases:
 -   releaseCycle: "2021"
-    eol: 2025-11-10
     releaseDate: 2020-11-11
+    eol: 2025-11-10
+
 -   releaseCycle: "2018"
-    eol: 2023-07-13
     releaseDate: 2018-07-12
+    eol: 2023-07-13
+
 -   releaseCycle: "2016"
-    eol: 2021-02-17
     releaseDate: 2016-02-16
+    eol: 2021-02-17
+
 -   releaseCycle: "11"
-    eol: 2019-04-30
     releaseDate: 2014-04-29
+    eol: 2019-04-30
+
 -   releaseCycle: "10"
-    eol: 2017-05-16
     releaseDate: 2012-05-15
+    eol: 2017-05-16
 
 ---
 
-> [Adobe ColdFusion](https://www.adobe.com/products/coldfusion-family.html) is Java-based commercial web application server and development platform from Adobe.
+> [Adobe ColdFusion](https://www.adobe.com/products/coldfusion-family.html) is Java-based commercial
+> web application server and development platform from Adobe.
 
-ColdFusion's lifecycle is typically 5 years after release, with new releases usually about every two years. Adobe has a [Support Lifecycle Policy](https://helpx.adobe.com/x-productkb/policy-pricing/policy_enterprise_lifecycle.html) page as well.
+ColdFusion's lifecycle is typically 5 years after release, with new releases usually about every two
+years. Adobe has a [Support Lifecycle Policy](https://helpx.adobe.com/x-productkb/policy-pricing/policy_enterprise_lifecycle.html)
+page as well.
 
-Adobe provides an "Extended maintenance and support" option with additional two year of Maintenance and support services after the end of Core Support Period for a 25% premium of the annual support for the current renewal term.
+Adobe provides an "Extended maintenance and support" option with additional two year of Maintenance
+and support services after the end of Core Support Period for a 25% premium of the annual support
+for the current renewal term.

--- a/products/coldfusion.md
+++ b/products/coldfusion.md
@@ -5,6 +5,7 @@ iconSlug: adobe
 permalink: /coldfusion
 versionCommand: writeoutput(server.coldfusion.productversion);
 releasePolicyLink: https://helpx.adobe.com/support/programs/eol-matrix.html
+changelogTemplate: https://helpx.adobe.com/coldfusion/kb/coldfusion-__RELEASE_CYCLE__-updates.html
 activeSupportColumn: false
 releaseColumn: false
 releaseDateColumn: true

--- a/products/coldfusion.md
+++ b/products/coldfusion.md
@@ -4,33 +4,39 @@ category: server-app
 iconSlug: adobe
 permalink: /coldfusion
 versionCommand: writeoutput(server.coldfusion.productversion);
-releasePolicyLink: https://helpx.adobe.com/support/programs/eol-matrix.html
+releasePolicyLink: https://helpx.adobe.com/x-productkb/policy-pricing/policy_enterprise_lifecycle.html
 changelogTemplate: https://helpx.adobe.com/coldfusion/kb/coldfusion-__RELEASE_CYCLE__-updates.html
 activeSupportColumn: false
 releaseColumn: false
 releaseDateColumn: true
 eolColumn: Core Support
+extendedSupportColumn: true
 
 releases:
 -   releaseCycle: "2021"
     releaseDate: 2020-11-11
     eol: 2025-11-10
+    extendedSupport: 2026-11-10
 
 -   releaseCycle: "2018"
     releaseDate: 2018-07-12
     eol: 2023-07-13
+    extendedSupport: 2024-07-13
 
 -   releaseCycle: "2016"
     releaseDate: 2016-02-16
     eol: 2021-02-17
+    extendedSupport: 2022-02-17
 
 -   releaseCycle: "11"
     releaseDate: 2014-04-29
     eol: 2019-04-30
+    extendedSupport: 2021-04-30
 
 -   releaseCycle: "10"
     releaseDate: 2012-05-15
     eol: 2017-05-16
+    extendedSupport: 2019-05-16
 
 ---
 
@@ -38,9 +44,8 @@ releases:
 > web application server and development platform from Adobe.
 
 ColdFusion's lifecycle is typically 5 years after release, with new releases usually about every two
-years. Adobe has a [Support Lifecycle Policy](https://helpx.adobe.com/x-productkb/policy-pricing/policy_enterprise_lifecycle.html)
-page as well.
+years. A list of all the releases with their dates can be seen on
+[Products and technical support periods](https://helpx.adobe.com/support/programs/eol-matrix.html).
 
-Adobe provides an "Extended maintenance and support" option with additional two year of Maintenance
-and support services after the end of Core Support Period for a 25% premium of the annual support
-for the current renewal term.
+Adobe also commercialize an "Extended maintenance and support" option with extra maintenance and
+support services after the end of the Core Support period.


### PR DESCRIPTION
`changelogTemplate` has been added for #39.

Extended support column has been added for #2246. In the corresponding commit you can also find that :
- `releasePolicyLink` has been updated to the more generic link https://helpx.adobe.com/x-productkb/policy-pricing/policy_enterprise_lifecycle.html.
- Description of the extended support offer has been simplified to be more generic because it was incorrect (extended support for latest ColdFusion versions is 1 year). Users can refer to the Adobe documentation to know more.

I also took the opportunity to normalize the page (#2124).