### PR TITLE
[watchos] Add changelogTemplate and links

### DIFF
--- a/products/watchos.md
+++ b/products/watchos.md
@@ -4,6 +4,9 @@ category: os
 iconSlug: apple
 permalink: /watchos
 releasePolicyLink: https://en.wikipedia.org/wiki/WatchOS#Version_history
+# Release notes are not published for all minor or patch versions, so using only the major version.
+# Other release notes are easily accessible from that page, if available.
+changelogTemplate: "https://developer.apple.com/documentation/watchos-release-notes/watchos-__RELEASE_CYCLE__-release-notes"
 discontinuedColumn: false
 activeSupportColumn: true
 releaseColumn: true
@@ -54,6 +57,7 @@ releases:
     eol: 2018-09-27
     latestReleaseDate: 2018-07-09
     latest: '4.3.2'
+    link: https://support.apple.com/HT208071
 
 -   releaseCycle: "3"
     releaseDate: 2016-09-13
@@ -61,6 +65,7 @@ releases:
     eol: 2017-10-04
     latestReleaseDate: 2017-07-19
     latest: '3.2.3'
+    link: https://support.apple.com/kb/DL1894
 
 ---
 

--- a/products/watchos.md
+++ b/products/watchos.md
@@ -1,61 +1,70 @@
 ---
-permalink: /watchos
 title: Apple watchOS
 category: os
 iconSlug: apple
+permalink: /watchos
 releasePolicyLink: https://en.wikipedia.org/wiki/WatchOS#Version_history
 discontinuedColumn: false
 activeSupportColumn: true
 releaseColumn: true
 releaseDateColumn: true
+
 auto:
 -   custom: true
+
 releases:
 -   releaseCycle: "9"
-    eol: false
-    support: true
     releaseDate: 2022-09-12
+    support: true
+    eol: false
     latestReleaseDate: 2023-02-13
     latest: '9.3.1'
+
 -   releaseCycle: "8"
-    eol: 2022-09-22
-    support: 2022-09-12
     releaseDate: 2021-09-20
+    support: 2022-09-12
+    eol: 2022-09-22
     latestReleaseDate: 2022-08-17
     latest: '8.7.1'
+
 -   releaseCycle: "7"
-    eol: 2021-10-11
-    support: 2021-09-20
     releaseDate: 2020-09-16
+    support: 2021-09-20
+    eol: 2021-10-11
     latestReleaseDate: 2021-09-13
     latest: '7.6.2'
+
 -   releaseCycle: "6"
-    eol: 2020-09-16
-    support: 2020-09-16
     releaseDate: 2019-09-19
+    support: 2020-09-16
+    eol: 2020-09-16
     latestReleaseDate: 2020-12-14
     latest: '6.3'
+
 -   releaseCycle: "5"
-    eol: 2019-09-30
-    support: 2019-09-19
     releaseDate: 2018-09-17
+    support: 2019-09-19
+    eol: 2019-09-30
     latestReleaseDate: 2020-11-05
     latest: '5.3.9'
+
 -   releaseCycle: "4"
-    eol: 2018-09-27
-    support: 2018-09-17
     releaseDate: 2017-09-19
+    support: 2018-09-17
+    eol: 2018-09-27
     latestReleaseDate: 2018-07-09
     latest: '4.3.2'
+
 -   releaseCycle: "3"
-    eol: 2017-10-04
-    support: 2017-09-19
     releaseDate: 2016-09-13
+    support: 2017-09-19
+    eol: 2017-10-04
     latestReleaseDate: 2017-07-19
     latest: '3.2.3'
 
 ---
 
-> [watchOS](https://www.apple.com/watchos/) is Apple's mobile operating system for its Apple Watches. It is based on iOS, and introduced in 2015.
+> [watchOS](https://www.apple.com/watchos/) is Apple's mobile operating system for its Apple
+> Watches. It is based on iOS, and introduced in 2015.
 
 Major versions of watchOS are released annually, with the previous major version losing support.


### PR DESCRIPTION
Relates to #39. Release notes are not published for all minor or patch versions, so using only the major version. Other release notes are easily accessible from that page, if available.

Also took the opportunity to normalize page (#2124).
