### PR TITLE
[ipados] Add links

### DIFF
--- a/products/ipados.md
+++ b/products/ipados.md
@@ -1,44 +1,50 @@
 ---
-permalink: /ipados
 title: Apple iPadOS
 category: os
 iconSlug: apple
+permalink: /ipados
 releasePolicyLink: https://en.wikipedia.org/wiki/IOS_version_history#Overview
 discontinuedColumn: false
 activeSupportColumn: true
 releaseColumn: true
 releaseDateColumn: true
+
 auto:
 -   custom: true
+
 releases:
 -   releaseCycle: "16"
-    eol: false
-    support: true
     releaseDate: 2022-10-24
+    support: true
+    eol: false
     latestReleaseDate: 2023-02-13
     latest: '16.3.1'
+
 -   releaseCycle: "15"
-    eol: false
-    support: 2022-10-24
     releaseDate: 2021-09-20
+    support: 2022-10-24
+    eol: false
     latestReleaseDate: 2023-01-23
     latest: '15.7.3'
+
 -   releaseCycle: "14"
-    eol: 2021-10-01
-    support: 2021-09-20
     releaseDate: 2020-09-16
+    support: 2021-09-20
+    eol: 2021-10-01
     latestReleaseDate: 2021-10-26
     latest: '14.8.1'
+
 -   releaseCycle: "13"
-    eol: 2020-09-16
-    support: 2020-09-16
     releaseDate: 2019-09-24
+    support: 2020-09-16
+    eol: 2020-09-16
     latestReleaseDate: 2020-07-15
     latest: '13.6'
 
 ---
 
-> [iPadOS](https://www.apple.com/ipados/) is a mobile operating system created by Apple for its iPad line of devices. It is a rebranded variant of iOS, and introduced in 2019 as iPadOS 13.
+> [iPadOS](https://www.apple.com/ipados/) is a mobile operating system created by Apple for its iPad
+> line of devices. It is a rebranded variant of iOS, and introduced in 2019 as iPadOS 13.
 
 Major versions of iPadOS are released annually, and might lag behind corresponding iOS releases.
 

--- a/products/ipados.md
+++ b/products/ipados.md
@@ -19,6 +19,7 @@ releases:
     eol: false
     latestReleaseDate: 2023-02-13
     latest: '16.3.1'
+    link: https://developer.apple.com/documentation/ios-ipados-release-notes/ipados-16-release-notes
 
 -   releaseCycle: "15"
     releaseDate: 2021-09-20
@@ -26,6 +27,7 @@ releases:
     eol: false
     latestReleaseDate: 2023-01-23
     latest: '15.7.3'
+    link: https://developer.apple.com/documentation/ios-ipados-release-notes/ios-ipados-15-release-notes
 
 -   releaseCycle: "14"
     releaseDate: 2020-09-16
@@ -33,6 +35,7 @@ releases:
     eol: 2021-10-01
     latestReleaseDate: 2021-10-26
     latest: '14.8.1'
+    link: https://developer.apple.com/documentation/ios-ipados-release-notes/ios-ipados-14-release-notes
 
 -   releaseCycle: "13"
     releaseDate: 2019-09-24
@@ -40,6 +43,7 @@ releases:
     eol: 2020-09-16
     latestReleaseDate: 2020-07-15
     latest: '13.6'
+    link: https://developer.apple.com/documentation/ios-ipados-release-notes/ios-ipados-13_1-release-notes
 
 ---
 


### PR DESCRIPTION
Relates to #39. Release notes are not published for all minor or patch versions, so using only the major version. Other release notes are easily accessible from that page, if available.

Also took the opportunity to normalize page (#2124).