### PR TITLE
Hide oldest unmaintained releases cycles by default

### DIFF
--- a/_layouts/product.html
+++ b/_layouts/product.html
@@ -19,18 +19,20 @@ layout: default
 <table class="lifecycle">
   <thead>
     <tr>
-      <th>Release</th>
-      {% if page.releaseDateColumn %}<th>{{ page.releaseDateColumnLabel }}</th>{% endif %}
-      {% if page.discontinuedColumn %}<th>{{ page.releaseDateColumnLabel }}</th>{% endif %}
-      {% if page.activeSupportColumn %}<th>{{ page.activeSupportColumnLabel }}</th>{% endif %}
-      {% if page.eolColumn %}<th>{{ page.eolColumnLabel }}</th>{% endif %}
-      {% if page.extendedSupportColumn %}<th>{{ page.extendedSupportColumnLabel }}</th>{% endif %}
-      {% if page.releaseColumn %}<th>{{ page.releaseColumnLabel }}</th>{% endif %}
+      <th>Release</th>{% assign colCount = 1 %}
+      {% if page.releaseDateColumn %}<th>{{ page.releaseDateColumnLabel }}</th>{% assign colCount = colCount | plus:1 %}{% endif %}
+      {% if page.discontinuedColumn %}<th>{{ page.releaseDateColumnLabel }}</th>{% assign colCount = colCount | plus:1 %}{% endif %}
+      {% if page.activeSupportColumn %}<th>{{ page.activeSupportColumnLabel }}</th>{% assign colCount = colCount | plus:1 %}{% endif %}
+      {% if page.eolColumn %}<th>{{ page.eolColumnLabel }}</th>{% assign colCount = colCount | plus:1 %}{% endif %}
+      {% if page.extendedSupportColumn %}<th>{{ page.extendedSupportColumnLabel }}</th>{% assign colCount = colCount | plus:1 %}{% endif %}
+      {% if page.releaseColumn %}<th>{{ page.releaseColumnLabel }}</th>{% assign colCount = colCount | plus:1 %}{% endif %}
     </tr>
   </thead>
 
 {% for r in page.releases %}
-  <tr>
+{%- assign hideClass = '' %}
+{%- if r.can_be_hidden %}{% assign hideClass = 'd-none' %}{% endif %}
+  <tr class="release {{ hideClass }}">
     <td>
       {% comment %}Only put a link in the version column if the release column is not shown{% endcomment %}
       {% if page.releaseColumn == false and r.link and r.daysTowardEol > 0  %}
@@ -124,6 +126,17 @@ layout: default
     {% endif %}
   </tr>
 {% endfor %}
+{% assign can_be_hidden_releases_count = page.releases | where: 'can_be_hidden', true | size %}
+{% if can_be_hidden_releases_count > 0 %}
+  <tr id="show-more-row">
+    <td colspan="{{ colCount }}" class="text-center">
+      <button id="show-hidden-releases-button" class="btn">
+        Show more unmaintained releases
+      </button>
+    </td>
+  </tr>
+  <script type="text/javascript" src="assets/register-show-hidden-releases-handler.js" defer></script>
+{% endif %}
 </table>
 
 <div class="policytext">

--- a/_plugins/product-data-enricher.rb
+++ b/_plugins/product-data-enricher.rb
@@ -78,7 +78,7 @@ module Jekyll
         set_cycle_link(page, cycle)
         set_cycle_label(page, cycle)
         add_lts_label_to_cycle_label(page, cycle)
-        compute_days_toward_now_for_all_dates(page, cycle)
+        compute_days_toward_now_for_all_dates(cycle)
       end
 
       # Build the cycle id from the permalink.
@@ -133,7 +133,7 @@ module Jekyll
 
       # Compute the number of days toward now for all cycle's dates (support, eol...), and add those
       # values to the cycle's data in new fields (daysTowardSupport, daysTowardEol...).
-      def compute_days_toward_now_for_all_dates(page, cycle)
+      def compute_days_toward_now_for_all_dates(cycle)
         for field in ['support', 'eol', 'discontinued', 'extendedSupport']
           next if not cycle.has_key?(field)
 

--- a/_plugins/product-data-enricher.rb
+++ b/_plugins/product-data-enricher.rb
@@ -60,14 +60,14 @@ module Jekyll
 
       # Set properly the column presence/label if it was overridden.
       def set_overridden_columns_label(page)
-        columnNames = [
+        date_column_names = [
           'releaseDateColumn', 'releaseColumn', 'discontinuedColumn',
           'activeSupportColumn', 'eolColumn', 'extendedSupportColumn'
         ]
-        for columnName in columnNames
-          if page.data[columnName].is_a? String
-            page.data[columnName + 'Label'] = page.data[columnName]
-            page.data[columnName] = true
+        for date_column in date_column_names
+          if page.data[date_column].is_a? String
+            page.data[date_column + 'Label'] = page.data[date_column]
+            page.data[date_column] = true
           end
         end
       end

--- a/_plugins/product-data-enricher.rb
+++ b/_plugins/product-data-enricher.rb
@@ -79,6 +79,7 @@ module Jekyll
         set_cycle_label(page, cycle)
         add_lts_label_to_cycle_label(page, cycle)
         compute_days_toward_now_for_all_dates(cycle)
+        set_is_maintained(cycle) # must be called after compute_days_toward_now_for_all_dates
       end
 
       # Build the cycle id from the permalink.
@@ -149,6 +150,26 @@ module Jekyll
             cycle[new_field_name] = field_value ? 4096 : -4096 # if support is true, then positive days
           end
         end
+      end
+
+      # Compute whether the cycle is still maintained and add the result to the cycle's data.
+      #
+      # A cycle is maintained if at least one of the active support / eol / discontinued / extended
+      # support dates is in the future or is true.
+      #
+      # This function must be executed after compute_days_toward_now_for_all_dates because it makes
+      # use of the fields injected by this function.
+      def set_is_maintained(cycle)
+        is_maintained = false
+
+        for daysTowardField in ['daysTowardSupport', 'daysTowardEol', 'daysTowardDiscontinued', 'daysTowardExtendedSupport']
+          if cycle.has_key?(daysTowardField) and cycle[daysTowardField] >= 0
+            is_maintained = true
+            break
+          end
+        end
+
+        cycle['is_maintained'] = is_maintained
       end
 
       private

--- a/_plugins/product-data-enricher.rb
+++ b/_plugins/product-data-enricher.rb
@@ -75,7 +75,6 @@ module Jekyll
       def enrich_release(page, cycle)
         set_cycle_id(cycle)
         set_cycle_lts(cycle)
-        set_cycle_discontinued(cycle)
         set_cycle_link(page, cycle)
         set_cycle_label(page, cycle)
         add_lts_label_to_cycle_label(page, cycle)
@@ -90,12 +89,6 @@ module Jekyll
       def set_cycle_lts(cycle)
         if !cycle['lts']
           cycle['lts'] = false
-        end
-      end
-
-      def set_cycle_discontinued(cycle)
-        if !cycle['discontinued']
-          cycle['discontinued'] = false
         end
       end
 

--- a/assets/register-show-hidden-releases-handler.js
+++ b/assets/register-show-hidden-releases-handler.js
@@ -1,0 +1,12 @@
+function registerShowHiddenReleasesHandler() {
+  document.getElementById('show-hidden-releases-button').addEventListener("click",
+    (event) => {
+      event.preventDefault();
+      document.getElementById("show-more-row").classList.add('d-none');
+      document.querySelectorAll(".release.d-none").forEach(
+        (c) => c.classList.remove('d-none')
+      );
+    }, false);
+}
+
+registerShowHiddenReleasesHandler();


### PR DESCRIPTION
Hide oldest unmaintained release cycles by default, letting the users display them if necessary.

In this version, a cycle can be hidden only if:

- it is not the first cycle,
- it is unmaintained (see set_is_maintained below),
- the previous cycle is still maintained,
- all next cycles are unmaintained.

This approach allows reducing the number of releases displayed on most pages, without concealing too much information.
This is also the first try at hiding releases: more approach has been discussed on #50, and we may want to test them in the future.

This PR also add or fix a few things :

- Inject the `is_maintained` field to release cycles : a release cycle is still maintained if at least one of the active support / eol / discontinued / extended support dates is in the future (or is true),
- Stop declaring discontinued for products without discontinued column in `product-data-enricher`,
- And some minor code enhancement in `product-data-enricher`.