### PR TITLE
[office] Transfer SP information to `releaseLabels`

### DIFF
--- a/products/office.md
+++ b/products/office.md
@@ -35,31 +35,36 @@ releases:
     releaseDate: 2015-09-22
     link: https://learn.microsoft.com/lifecycle/products/microsoft-office-2016
 
--   releaseCycle: "2013 SP1"
+-   releaseCycle: "2013"
+    releaseLabel: "2013 SP1"
     support: 2018-04-10
     eol: 2023-04-11
     releaseDate: 2014-02-25
     link: https://learn.microsoft.com/lifecycle/products/microsoft-office-2013
 
--   releaseCycle: "2011 for Mac SP3"
+-   releaseCycle: "2011-for-mac"
+    releaseLabel: "2011 for Mac SP3"
     support: 2017-10-10
     eol: 2017-10-10
     releaseDate: 2013-01-29
     link: https://learn.microsoft.com/lifecycle/products/microsoft-office-for-mac-2011
 
--   releaseCycle: "2010 SP2"
+-   releaseCycle: "2010"
+    releaseLabel: "2010 SP2"
     support: 2015-10-13
     eol: 2020-10-13
     releaseDate: 2013-07-23
     link: https://learn.microsoft.com/lifecycle/products/microsoft-office-2010
 
--   releaseCycle: "2008 for Mac SP2"
+-   releaseCycle: "2008-for-mac"
+    releaseLabel: "2008 for Mac SP2"
     support: 2013-04-09
     eol: 2013-04-09
     releaseDate: 2009-10-18
     link: https://learn.microsoft.com/lifecycle/products/microsoft-office-2008-for-mac
 
--   releaseCycle: "2007 SP3"
+-   releaseCycle: "2007"
+    releaseLabel: "2007 SP3"
     support: 2012-10-09
     eol: 2017-10-10
     releaseDate: 2011-10-25


### PR DESCRIPTION
`releaseCycle` should not be used to indicate the service pack, so moving that information to the `releaseLabel` (similar to what's being done on [mssqlserver](https://endoflife.date/mssqlserver)).

Moreover, `releaseCycle` is used in the API as the filename, so it's should not contain spaces. So ` for Mac` has been replaced by `-for-mac` (but kept as is in the `releaseLabel`).