### PR TITLE
[grafana] Add 9.4

### DIFF
--- a/products/grafana.md
+++ b/products/grafana.md
@@ -91,11 +91,9 @@ Grafana Cloud, the hosted Grafana offering from Grafana Labs has separate
 
 ## [Release Schedule](https://grafana.com/blog/2022/12/13/grafana-releases-new-2023-release-schedule/)
 
-Starting from January 2023, a monthly Grafana release cycle applies:
-
-- On even-numbered months (February, April, etc.) a minor version will be released with new
+- On even-numbered months (February, April, etc.) a minor version is released with new
   features, bug fixes, and security updates.
-- On odd-numbered months (March, May, etc.) patch releases will be made, which will only include bug
+- On odd-numbered months (March, May, etc.) patch releases are made, which will only include bug
   fixes and security updates.
 
 Release builds are cut a week in advance, to validate and prepare for each release internally.

--- a/products/grafana.md
+++ b/products/grafana.md
@@ -15,17 +15,26 @@ auto:
 # The policy before 9.0 release was to support 2 major versions. After 9.0, 2 latest minors are
 # supported, along with the last minor of the previous major. Hence, we break the latest series into
 # minors but only keep the previous major.
+# - support(x) = releaseDate(x+1)
+# - eol(x) = releaseDate(x+2)
 releases:
--   releaseCycle: "9.3"
-    eol: false
+-   releaseCycle: "9.4"
     support: true
+    eol: false
+    releaseDate: 2023-02-27
+    latest: "9.4.2"
+    latestReleaseDate: 2023-03-01
+
+-   releaseCycle: "9.3"
+    support: 2023-02-27
+    eol: false
     releaseDate: 2022-11-29
     latest: "9.3.8"
     latestReleaseDate: 2023-02-27
 
 -   releaseCycle: "9.2"
-    support: false
-    eol: false
+    support: 2022-11-29
+    eol: 2023-02-27
     releaseDate: 2022-10-11
     latest: "9.2.13"
     latestReleaseDate: 2023-02-27


### PR DESCRIPTION
See https://github.com/grafana/grafana/releases/tag/v9.4.1. Note that 9.4.1 is the first 9.4 release.

Also updated eol / support date for 9.2 and 9.3 following what was done for previous 9.x version. But the rule used for those versions does not seem consistent whith the description (there should be no active support column).