### PR TITLE
[debian] Separate EOL and EOL LTS

### DIFF
--- a/products/debian.md
+++ b/products/debian.md
@@ -24,7 +24,7 @@ releases:
     releaseDate: 2021-08-14
     eol: 2024-07-01
     extendedSupport: 2026-06-30
-    link: https://www.debian.org/News/2022/2022091002
+    link: https://www.debian.org/News/2022/20221217
     latest: "11.6"
     latestReleaseDate: 2022-12-17
 
@@ -42,7 +42,7 @@ releases:
     releaseDate: 2017-06-17
     eol: 2020-07-18
     extendedSupport: 2022-07-01
-    link: https://lists.debian.org/debian-announce/2020/msg00004.html
+    link: https://www.debian.org/News/2020/20200718
     latest: "9.13"
     latestReleaseDate: 2020-07-18
 
@@ -51,7 +51,7 @@ releases:
     releaseDate: 2015-04-25
     eol: 2018-06-17
     extendedSupport: 2020-06-30
-    link: https://www.debian.org/News/2015/20150426
+    link: https://www.debian.org/News/2018/20180623
     latest: "8.11"
     latestReleaseDate: 2018-06-23
 
@@ -60,7 +60,7 @@ releases:
     releaseDate: 2013-05-04
     eol: 2016-04-25
     extendedSupport: 2018-05-31
-    link: https://www.debian.org/News/2013/20130504
+    link: https://www.debian.org/News/2016/2016060402
     latest: "7.11"
     latestReleaseDate: 2016-06-04
 
@@ -69,7 +69,7 @@ releases:
     releaseDate: 2011-02-06
     eol: 2014-05-31
     extendedSupport: 2016-02-29
-    link: https://www.debian.org/News/2011/20110205a
+    link: https://www.debian.org/News/2014/20140719
     latest: "6.0.10"
     latestReleaseDate: 2014-07-19
 

--- a/products/debian.md
+++ b/products/debian.md
@@ -5,10 +5,11 @@ iconSlug: debian
 permalink: /debian
 versionCommand: cat /etc/os-release
 releasePolicyLink: https://wiki.debian.org/DebianReleases
-activeSupportColumn: false
+releaseLabel: "__RELEASE_CYCLE__ (__CODENAME__)"
 releaseColumn: true
 releaseDateColumn: true
-releaseLabel: "__RELEASE_CYCLE__ (__CODENAME__)"
+activeSupportColumn: false
+
 identifiers:
 -   cpe: cpe:2.3:o:debian:debian_linux
 -   cpe: cpe:/o:debian:debian_linux
@@ -25,6 +26,7 @@ releases:
     releaseDate: 2021-08-14
     lts: 2024-07-01
     latestReleaseDate: 2022-12-17
+
 -   releaseCycle: "10"
     codename: "Buster"
     eol: 2024-06-01
@@ -33,6 +35,7 @@ releases:
     lts: 2022-07-01
     releaseDate: 2019-07-06
     latestReleaseDate: 2022-09-10
+
 -   releaseCycle: "9"
     codename: "Stretch"
     eol: 2022-06-30
@@ -41,6 +44,7 @@ releases:
     link: https://lists.debian.org/debian-announce/2020/msg00004.html
     releaseDate: 2017-06-17
     latestReleaseDate: 2020-07-18
+
 -   releaseCycle: "8"
     codename: "Jessie"
     eol: 2020-06-30
@@ -49,6 +53,7 @@ releases:
     link: https://www.debian.org/News/2015/20150426
     releaseDate: 2015-04-25
     latestReleaseDate: 2018-06-23
+
 -   releaseCycle: "7"
     codename: "Wheezy"
     eol: 2018-05-31
@@ -57,6 +62,7 @@ releases:
     link: https://www.debian.org/News/2013/20130504
     releaseDate: 2013-05-04
     latestReleaseDate: 2016-06-04
+
 -   releaseCycle: "6"
     codename: "Squeeze"
     eol: 2016-02-29
@@ -68,10 +74,19 @@ releases:
 
 ---
 
-> [Debian](https://www.debian.org/) is a free operating system for your computer. The Debian stable branch is the most popular edition for personal computers and network servers, and is used as the basis for many other Linux distributions.
+> [Debian](https://www.debian.org/) is a free operating system for your computer. The Debian stable
+> branch is the most popular edition for personal computers and network servers, and is used as the
+> basis for many other Linux distributions.
 
-At any given time, there is one stable release of Debian, which has the support of the Debian security team. When a new stable version is released, the security team will usually cover the previous version for a year or so, while they also cover the new/current version. Only stable is recommended for production use.
+At any given time, there is one stable release of Debian, which has the support of the Debian
+security team. When a new stable version is released, the security team will usually cover the
+previous version for a year or so, while they also cover the new/current version. Only stable is
+recommended for production use.
 
-[Debian Long Term Support (LTS)](https://wiki.debian.org/LTS) is a project to extend the lifetime of all Debian stable releases to (at least) 5 years. Debian LTS will not be handled by the Debian security team, but by a separate group of volunteers and companies. Not all packages of the Debian archive are supported by LTS, the [debian-security-support](https://wiki.debian.org/LTS/Using#Check_for_unsupported_packages) package can check for unsupported packages.
+[Debian Long Term Support (LTS)](https://wiki.debian.org/LTS) is a project to extend the lifetime of
+all Debian stable releases to (at least) 5 years. Debian LTS will not be handled by the Debian
+security team, but by a separate group of volunteers and companies. Not all packages of the Debian
+archive are supported by LTS, the [debian-security-support](https://wiki.debian.org/LTS/Using#Check_for_unsupported_packages)
+package can check for unsupported packages.
 
 A commercial offering for [Extended Long Term Support](https://wiki.debian.org/LTS/Extended) is available.

--- a/products/debian.md
+++ b/products/debian.md
@@ -8,7 +8,8 @@ releasePolicyLink: https://wiki.debian.org/DebianReleases
 releaseLabel: "__RELEASE_CYCLE__ (__CODENAME__)"
 releaseColumn: true
 releaseDateColumn: true
-activeSupportColumn: false
+eolColumn: Debian Security Support
+extendedSupportColumn: Debian <abbr title="Long Term Support">LTS</abbr>
 
 identifiers:
 -   cpe: cpe:2.3:o:debian:debian_linux
@@ -20,56 +21,56 @@ auto:
 releases:
 -   releaseCycle: "11"
     codename: "Bullseye"
-    eol: 2026-08-15
-    latest: "11.6"
-    link: https://www.debian.org/News/2022/2022091002
     releaseDate: 2021-08-14
-    lts: 2024-07-01
+    eol: 2024-07-01
+    extendedSupport: 2026-06-30
+    link: https://www.debian.org/News/2022/2022091002
+    latest: "11.6"
     latestReleaseDate: 2022-12-17
 
 -   releaseCycle: "10"
     codename: "Buster"
-    eol: 2024-06-01
-    latest: "10.13"
-    link: https://www.debian.org/News/2022/20220910
-    lts: 2022-07-01
     releaseDate: 2019-07-06
+    eol: 2022-09-10
+    extendedSupport: 2024-06-30
+    link: https://www.debian.org/News/2022/20220910
+    latest: "10.13"
     latestReleaseDate: 2022-09-10
 
 -   releaseCycle: "9"
     codename: "Stretch"
-    eol: 2022-06-30
-    lts: 2020-06-06
-    latest: "9.13"
-    link: https://lists.debian.org/debian-announce/2020/msg00004.html
     releaseDate: 2017-06-17
+    eol: 2020-07-18
+    extendedSupport: 2022-07-01
+    link: https://lists.debian.org/debian-announce/2020/msg00004.html
+    latest: "9.13"
     latestReleaseDate: 2020-07-18
 
 -   releaseCycle: "8"
     codename: "Jessie"
-    eol: 2020-06-30
-    lts: 2018-06-17
-    latest: "8.11"
-    link: https://www.debian.org/News/2015/20150426
     releaseDate: 2015-04-25
+    eol: 2018-06-17
+    extendedSupport: 2020-06-30
+    link: https://www.debian.org/News/2015/20150426
+    latest: "8.11"
     latestReleaseDate: 2018-06-23
 
 -   releaseCycle: "7"
     codename: "Wheezy"
-    eol: 2018-05-31
-    lts: 2016-04-26
-    latest: "7.11"
-    link: https://www.debian.org/News/2013/20130504
     releaseDate: 2013-05-04
+    eol: 2016-04-25
+    extendedSupport: 2018-05-31
+    link: https://www.debian.org/News/2013/20130504
+    latest: "7.11"
     latestReleaseDate: 2016-06-04
 
 -   releaseCycle: "6"
     codename: "Squeeze"
-    eol: 2016-02-29
-    lts: true
-    latest: "6.0.10"
-    link: https://www.debian.org/News/2011/20110205a
     releaseDate: 2011-02-06
+    eol: 2014-05-31
+    extendedSupport: 2016-02-29
+    link: https://www.debian.org/News/2011/20110205a
+    latest: "6.0.10"
     latestReleaseDate: 2014-07-19
 
 ---
@@ -84,9 +85,13 @@ previous version for a year or so, while they also cover the new/current version
 recommended for production use.
 
 [Debian Long Term Support (LTS)](https://wiki.debian.org/LTS) is a project to extend the lifetime of
-all Debian stable releases to (at least) 5 years. Debian LTS will not be handled by the Debian
-security team, but by a separate group of volunteers and companies. Not all packages of the Debian
-archive are supported by LTS, the [debian-security-support](https://wiki.debian.org/LTS/Using#Check_for_unsupported_packages)
-package can check for unsupported packages.
+all Debian stable releases to (at least) 5 years on [a limited set of
+architectures](https://lts-team.pages.debian.net/wiki/FAQ.html#what-architectures-are-supported).
+Debian LTS will not be handled by the Debian security team, but by a separate group of volunteers
+and companies. Not all packages of the Debian archive are supported by LTS, the
+[debian-security-support](https://wiki.debian.org/LTS/Using#Check_for_unsupported_packages) package
+can check for unsupported packages.
 
-A commercial offering for [Extended Long Term Support](https://wiki.debian.org/LTS/Extended) is available.
+A commercial offering for [Extended Long Term Support (ELTS)](https://wiki.debian.org/LTS/Extended)
+is also available to further extend the lifetime of Debian releases to 10 years (5 supplementary
+years after the 5 years offered by the LTS project). It is not an official Debian project.


### PR DESCRIPTION
Until now the end of life date used for Debian was the Debian Long Term Support EOL date (aka EOL LTS) (https://wiki.debian.org/LTS). But sysadmins are usually more interested in the 'End of life date' (aka EOL date), so :
  
- the `eol` field now contains the Debian EOL date (as documented on https://wiki.debian.org/DebianReleases),
- the `extendedSupportColumn` has been added,
- the `extendedSupport` field now contains the Debian Long Term Support EOL date (as documented on https://wiki.debian.org/LTS).
  
Description has also been improved by :
  
- explaining what is Debian ELTS,
- mentioning not all architecture are supported during Debian LTS.

I also took the opportunity to normalize the page (#2124).