### PR TITLE
MariaDB 10.11 LTS

### DIFF
--- a/products/mariadb.md
+++ b/products/mariadb.md
@@ -35,6 +35,7 @@ releases:
 -   releaseCycle: "10.11"
     eol: 2028-02-16
     latest: "10.11.2"
+    lts: true
     releaseDate: 2023-02-16
     latestReleaseDate: 2023-02-16
 -   releaseCycle: "10.10"


### PR DESCRIPTION
Missing flag for making MariaDB 10.11 an LTS version.
https://mariadb.org/mariadb-10-11-is-lts/