### PR TITLE
[sonarqube] Switch auto configuration from docker to git

### DIFF
--- a/products/sonarqube.md
+++ b/products/sonarqube.md
@@ -13,8 +13,8 @@ releaseDateColumn: true
 eolColumn: Bug and Security Fixes
 
 auto:
--   dockerhub: library/sonarqube
-    regex: ^(?<major>\d+)\.(?<minor>\d+)\.(?<patch>\d+)-community$
+-   git: https://github.com/SonarSource/sonarqube.git
+    regex: ^(?<major>\d+)\.(?<minor>\d+)(\.(?<patch>\d+))?(\.(?<build>\d+))?$
 
 releases:
 -   releaseCycle: "9"


### PR DESCRIPTION
Release dates are more precise with git tags, and we have access to more versions.