### PR TITLE
[godot] Add 4.0

### DIFF
--- a/products/godot.md
+++ b/products/godot.md
@@ -1,87 +1,105 @@
 ---
 title: Godot
-permalink: /godot
 category: app
+iconSlug: godotengine
+permalink: /godot
 alternate_urls:
 -   /godotengine
-iconSlug: godotengine
 releasePolicyLink: https://docs.godotengine.org/en/latest/about/release_policy.html
 changelogTemplate: |
   https://godotengine.org/article/maintenance-release-godot-{{"__LATEST__" | replace:'.','-'}}
 eolColumn: Critical, Security and Platform support
 activeSupportColumn: true
 releaseDateColumn: true
+
 auto:
 -   git: https://github.com/godotengine/godot.git
     regex: ^(?<version>\d+(\.\d+){1,3})-stable$
     template: "{{version}}"
+
 releases:
 -   releaseCycle: "3.5"
+    releaseDate: 2022-08-05
     support: true
     eol: false
     latest: "3.5.1"
     latestReleaseDate: 2022-09-28
-    releaseDate: 2022-08-05
+
 -   releaseCycle: "3.4"
+    releaseDate: 2021-11-05
     support: false
     eol: false
     latest: "3.4.5"
     latestReleaseDate: 2022-08-01
-    releaseDate: 2021-11-05
+
 -   releaseCycle: "3.3"
+    releaseDate: 2021-04-21
     support: false
     eol: true
     latest: "3.3.4"
     latestReleaseDate: 2021-10-01
-    releaseDate: 2021-04-21
+
 -   releaseCycle: "3.2"
+    releaseDate: 2020-01-29
     support: false
     eol: true
     latest: "3.2.3"
     latestReleaseDate: 2020-09-16
-    releaseDate: 2020-01-29
+
 -   releaseCycle: "3.1"
+    releaseDate: 2019-03-13
     support: false
     eol: true
     latest: "3.1.2"
     latestReleaseDate: 2019-12-03
-    releaseDate: 2019-03-13
+
 -   releaseCycle: "3.0"
+    releaseDate: 2018-01-29
     support: false
     eol: true
     latest: "3.0.6"
     latestReleaseDate: 2018-07-31
-    releaseDate: 2018-01-29
+
 -   releaseCycle: "2.1"
-    eol: true
-    support: false
-    latest: "2.1.6"
     lts: true
-    latestReleaseDate: 2019-07-08
     releaseDate: 2016-08-09
+    support: false
+    eol: true
+    latest: "2.1.6"
+    latestReleaseDate: 2019-07-08
+
 -   releaseCycle: "2.0"
-    eol: true
-    support: false
-    latest: "2.0.4.1"
-    lts: false
-    link: https://godotengine.org/article/maintenance-release-godot-2-0-4
-    latestReleaseDate: 2016-07-10
     releaseDate: 2016-02-22
--   releaseCycle: "1.0"
-    eol: true
     support: false
-    latest: "1.0"
+    eol: true
+    latest: "2.0.4.1"
+    latestReleaseDate: 2016-07-10
+    link: https://godotengine.org/article/maintenance-release-godot-2-0-4
 
-
-    latestReleaseDate: 2014-12-15
+-   releaseCycle: "1.0"
     releaseDate: 2014-12-15
+    support: false
+    eol: true
+    latest: "1.0"
+    latestReleaseDate: 2014-12-15
 
 ---
 
->[Godot Engine](https://godotengine.org/) is a feature-packed, cross-platform game engine to create 2D and 3D games from a unified interface released under the MIT License. It provides a comprehensive set of common tools, so users can focus on making games without having to reinvent the wheel. Games can be exported in one click to a [number of platforms](https://docs.godotengine.org/en/stable/about/list_of_features.html#platforms).
+>[Godot Engine](https://godotengine.org/) is a feature-packed, cross-platform game engine to create
+> 2D and 3D games from a unified interface released under the MIT License. It provides a
+> comprehensive set of common tools, so users can focus on making games without having to reinvent
+> the wheel. Games can be exported in one click to a [number of platforms](https://docs.godotengine.org/en/stable/about/list_of_features.html#platforms).
 
-Each stable branch starts with a `major.minor` release (without the 0 for patch) and is further developed for maintenance releases. _Stable branches are supported at minimum until the next stable branch is released and has received its first patch update_. In practice, stable branches are supported on a best effort basis for as long as they have active users who need maintenance updates.
+Each stable branch starts with a `major.minor` release (without the 0 for patch) and is further
+developed for maintenance releases. _Stable branches are supported at minimum until the next stable
+branch is released and has received its first patch update_. In practice, stable branches are
+supported on a best effort basis for as long as they have active users who need maintenance updates.
 
-On a new major version release, the previous stable branch becomes a long-term supported release. This is the case for the 2.1 branch, and will be the case for the latest 3.x stable branch by the time Godot 4.0 is released.
+On a new major version release, the previous stable branch becomes a long-term supported release.
+This is the case for the 2.1 branch, and will be the case for the latest 3.x stable branch by the
+time Godot 4.0 is released.
 
-Starting with Godot 3.3, the planned development cycle aims for a new minor release every 3 to 6 months. The Godot release policy is a set of guidelines and "what will actually happen depends on the choices of core contributors, and the needs of the community at a given time". Godot loosely follows [Semantic Versioning](https://semver.org/).
+Starting with Godot 3.3, the planned development cycle aims for a new minor release every 3 to 6
+months. The Godot release policy is a set of guidelines and "what will actually happen depends on
+the choices of core contributors, and the needs of the community at a given time". Godot loosely
+follows [Semantic Versioning](https://semver.org/).

--- a/products/godot.md
+++ b/products/godot.md
@@ -108,7 +108,7 @@ On a new major version release, the previous stable branch becomes a long-term s
 This is the case for the 2.1 branch, and will be the case for the latest 3.x stable branch by the
 time Godot 4.0 is released.
 
-Starting with Godot 3.3, the planned development cycle aims for a new minor release every 3 to 6
+The development cycle aims for a new minor release every 3 to 6
 months. The Godot release policy is a set of guidelines and "what will actually happen depends on
 the choices of core contributors, and the needs of the community at a given time". Godot loosely
 follows [Semantic Versioning](https://semver.org/).

--- a/products/godot.md
+++ b/products/godot.md
@@ -17,7 +17,16 @@ auto:
     regex: ^(?<version>\d+(\.\d+){1,3})-stable$
     template: "{{version}}"
 
+# Do not forget to remove the link after the first patch release.
 releases:
+-   releaseCycle: "4.0"
+    releaseDate: 2023-03-01
+    support: true
+    eol: false
+    latest: "4.0"
+    latestReleaseDate: 2023-03-01
+    link: https://godotengine.org/article/godot-4-0-sets-sail/
+
 -   releaseCycle: "3.5"
     releaseDate: 2022-08-05
     support: true


### PR DESCRIPTION
See https://godotengine.org/article/godot-4-0-sets-sail/.
    
The next LTS will be 3.6, as seen in the announcement :
    
> As for Godot 3 users, needless to say, you’ll continue to receive a lot of care as we backport relevant features and bugfixes to the upcoming Godot 3.6. This is going to be our long-term support (LTS) release, that we plan to maintain for the foreseeable future to enable existing Godot 3 project. Throughout the development of Godot 4 we’ve been backporting a lot of compatible and relevant work, and you will notice a few of new features have already made it into Godot 3.4 and 3.5.

Also took the opportunity to normalize the page.
