### PR TITLE
[New Product] Add RDS Postgres

### DIFF
--- a/products/amazon-rds-mysql.md
+++ b/products/amazon-rds-mysql.md
@@ -4,7 +4,6 @@ category: service
 iconSlug: amazonaws
 permalink: /amazon-rds-mysql
 releasePolicyLink: https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/MySQL.Concepts.VersionMgmt.html
-
 releaseDateColumn: true
 
 # Auto updates are possible using a custom script.

--- a/products/amazon-rds-postgresql.md
+++ b/products/amazon-rds-postgresql.md
@@ -1,78 +1,79 @@
 ---
 title: Amazon RDS for PostgreSQL
-category: db
-iconSlug: postgresql
+category: service
+iconSlug: amazonaws
 permalink: /amazon-rds-postgresql
-releasePolicyLink: >-
-  https://docs.aws.amazon.com/AmazonRDS/latest/PostgreSQLReleaseNotes/postgresql-release-calendar.html
+releasePolicyLink: https://docs.aws.amazon.com/AmazonRDS/latest/PostgreSQLReleaseNotes/postgresql-release-calendar.html
+releaseDateColumn: true
+
+# Auto updates are possible using a custom script.
+# Releases and their date are documented on https://docs.aws.amazon.com/AmazonRDS/latest/PostgreSQLReleaseNotes/postgresql-release-calendar.html
+
 releases:
-  - latest: "15.2"
-    releaseCycle: "15"
-    releaseDate: 2023-02-27
+-   releaseCycle: "15"
+    releaseDate: 2023-02-28
     eol: 2027-11-01
+    latest: "15.2"
     latestReleaseDate: 2023-02-28
-  - latest: "14.6"
-    releaseCycle: "14"
+
+-   releaseCycle: "14"
     releaseDate: 2022-02-03
     eol: 2026-11-01
-    latestReleaseDate: 2023-01-24
-  - latest: "13.9"
-    releaseCycle: "13"
+    latest: "14.7"
+    latestReleaseDate: 2023-03-07
+
+-   releaseCycle: "13"
     releaseDate: 2021-02-24
     eol: 2025-11-01
-    latestReleaseDate: 2023-01-24
-  - latest: "12.13"
-    releaseCycle: "12"
+    latest: "13.10"
+    latestReleaseDate: 2023-03-07
+
+-   releaseCycle: "12"
     releaseDate: 2020-03-31
     eol: 2024-11-01
-    latestReleaseDate: 2023-01-24
-  - latest: "11.18"
-    releaseCycle: "11"
+    latest: "12.14"
+    latestReleaseDate: 2023-03-07
+
+-   releaseCycle: "11"
     releaseDate: 2019-03-13
     eol: 2023-11-01
-    latestReleaseDate: 2023-01-24
-  - latest: "10.23"
-    releaseCycle: "10"
+    latest: "11.19"
+    latestReleaseDate: 2023-03-07
+
+-   releaseCycle: "10"
     releaseDate: 2018-02-27
     eol: 2023-04-01
+    latest: "10.23"
     latestReleaseDate: 2023-01-24
-  - latest: "unknown"
-    releaseCycle: "9.6"
+
+-   releaseCycle: "9.6"
     releaseDate: 2016-11-11
     eol: 2022-04-30
+    # https://docs.aws.amazon.com/AmazonRDS/latest/PostgreSQLReleaseNotes/postgresql-versions.html#postgresql-versions-version96
+    latest: "9.6.24"
 
 ---
 
-> [Amazon RDS for PostgreSQL](https://aws.amazon.com/rds/postgresql) is a PaaS offering from Amazon for
-> creating managed PostgreSQL Community Edition databases. RDS makes it easier to set up, operate, and
-> scale PostgreSQL deployments on AWS cloud.
+> [Amazon RDS for PostgreSQL](https://aws.amazon.com/rds/postgresql) is a PaaS offering from Amazon
+> for creating managed PostgreSQL databases. RDS makes it easier to set up, operate, and scale
+> PostgreSQL deployments on AWS cloud.
 
-**Running the latest version in RDS improves performance and security.
-However, keep in mind that there are risks attached and
-upgrades should be done carefully in production environments.**
+Version numbers on Amazon RDS for PostgreSQL are identical to those of [PostgreSQL](/postgresql).
+As a general guidance, new versions of the PostgreSQL engine become available on Amazon RDS within 5
+months of their general availability.
 
-- AWS will provide support for major releases **3 years** after their RDS release date.
+Major versions (`x` in Amazon RDS terminology for versions >= 10) are supported
+[until the PostgreSQL end of life](/postgresql), with a minimum of 3 years from their release date
+on Amazon RDS. Minor versions (`x.y` in Amazon RDS terminology for versions >= 10) are supported at
+least for 1 year after their release date on Amazon RDS. Note that in some cases Amazon may
+deprecate specific major or minor versions sooner, such as when there are security issues.
 
-- AWS will provide support for minor versions **1 year** after their RDS release date.
+Depending on the configuration, the kind of version (major or minor) and their deprecation status,
+[upgrades can be manual, automatic or forced](https://aws.amazon.com/rds/faqs/#How_do_I_control_if_and_when_the_engine_version_of_my_DB_instance_is_upgraded_to_new_supported_versions.3F).
+When a minor release is deprecated, users are expected to upgrade within a 3 months period. This
+period is increased to 6 months for major releases. Upgrades are performed during the configured
+scheduled maintenance windows. These windows are initially set automatically by AWS but can be
+overridden in the AWS console.
 
-By default instances with security and durability minor version upgrades available are
-automatically upgraded during maintenance windows.
-
-#### Deprecation
-
-> For the most current information surrounding deprecation read the AWS
-> [documentation](https://aws.amazon.com/rds/faqs/#What_happens_when_an_Amazon_RDS_DB_engine_version_is_deprecated.3F).
-
-- When a minor version of a database engine is deprecated in Amazon RDS,
-a client will have **3 months** before an automatic upgrade (if enabled).
-
-- When a major version of a database engine is deprecated in Amazon RDS,
-a client will have **6 months** before an automatic upgrade.
-
-Deprecated versions will have scheduled maintenance performed during their configured
-scheduled maintenance windows. 
-
-While maintenance windows have an end time please be aware that this is just an estimate and
-depending on the size, upgrades can take longer.
-
-These windows are set automatically by AWS but can be overridden within the AWS console.
+For the most up-to-date information about the Amazon RDS deprecation policy for PostgreSQL, see
+[Amazon RDS FAQs](http://aws.amazon.com/rds/faqs/).

--- a/products/amazon-rds-postgresql.md
+++ b/products/amazon-rds-postgresql.md
@@ -42,7 +42,7 @@ releases:
 
 -   releaseCycle: "10"
     releaseDate: 2018-02-27
-    eol: 2023-04-01
+    eol: 2023-04-17
     latest: "10.23"
     latestReleaseDate: 2023-01-24
 

--- a/products/amazon-rds-postgresql.md
+++ b/products/amazon-rds-postgresql.md
@@ -1,0 +1,78 @@
+---
+title: Amazon RDS for PostgreSQL
+category: db
+iconSlug: postgresql
+permalink: /amazon-rds-postgresql
+releasePolicyLink: >-
+  https://docs.aws.amazon.com/AmazonRDS/latest/PostgreSQLReleaseNotes/postgresql-release-calendar.html
+releases:
+  - latest: "15.2"
+    releaseCycle: "15"
+    releaseDate: 2023-02-27
+    eol: 2027-11-01
+    latestReleaseDate: 2023-02-28
+  - latest: "14.6"
+    releaseCycle: "14"
+    releaseDate: 2022-02-03
+    eol: 2026-11-01
+    latestReleaseDate: 2023-01-24
+  - latest: "13.9"
+    releaseCycle: "13"
+    releaseDate: 2021-02-24
+    eol: 2025-11-01
+    latestReleaseDate: 2023-01-24
+  - latest: "12.13"
+    releaseCycle: "12"
+    releaseDate: 2020-03-31
+    eol: 2024-11-01
+    latestReleaseDate: 2023-01-24
+  - latest: "11.18"
+    releaseCycle: "11"
+    releaseDate: 2019-03-13
+    eol: 2023-11-01
+    latestReleaseDate: 2023-01-24
+  - latest: "10.23"
+    releaseCycle: "10"
+    releaseDate: 2018-02-27
+    eol: 2023-04-01
+    latestReleaseDate: 2023-01-24
+  - latest: "unknown"
+    releaseCycle: "9.6"
+    releaseDate: 2016-11-11
+    eol: 2022-04-30
+
+---
+
+> [Amazon RDS for PostgreSQL](https://aws.amazon.com/rds/postgresql) is a PaaS offering from Amazon for
+> creating managed PostgreSQL Community Edition databases. RDS makes it easier to set up, operate, and
+> scale PostgreSQL deployments on AWS cloud.
+
+**Running the latest version in RDS improves performance and security.
+However, keep in mind that there are risks attached and
+upgrades should be done carefully in production environments.**
+
+- AWS will provide support for major releases **3 years** after their RDS release date.
+
+- AWS will provide support for minor versions **1 year** after their RDS release date.
+
+By default instances with security and durability minor version upgrades available are
+automatically upgraded during maintenance windows.
+
+#### Deprecation
+
+> For the most current information surrounding deprecation read the AWS
+> [documentation](https://aws.amazon.com/rds/faqs/#What_happens_when_an_Amazon_RDS_DB_engine_version_is_deprecated.3F).
+
+- When a minor version of a database engine is deprecated in Amazon RDS,
+a client will have **3 months** before an automatic upgrade (if enabled).
+
+- When a major version of a database engine is deprecated in Amazon RDS,
+a client will have **6 months** before an automatic upgrade.
+
+Deprecated versions will have scheduled maintenance performed during their configured
+scheduled maintenance windows. 
+
+While maintenance windows have an end time please be aware that this is just an estimate and
+depending on the size, upgrades can take longer.
+
+These windows are set automatically by AWS but can be overridden within the AWS console.


### PR DESCRIPTION
If you are wondering why you need another postgres release page. This proposed page would be for the AWS RDS releases. Which follow about a month behind and have their own end of life dates. 

There is no AWS API to get End of life dates for RDS databases.

I wrote [a script](https://github.com/CodaBool/scrape-rds-eol/blob/main/main.js) to scrape the dates on this [page](https://docs.aws.amazon.com/AmazonRDS/latest/PostgreSQLReleaseNotes/postgresql-release-calendar.html). 

I probably could improve the bottom markdown section after the front matter. So let me know if I'm missing something.


I also plan on scaping and adding a page for mysql 🙂

