### PR TITLE
[redhat-satellite] reorganized file

### DIFF
--- a/products/satellite.md
+++ b/products/satellite.md
@@ -2,6 +2,17 @@
 title: Red Hat Satellite
 category: server-app
 changelogTemplate: "https://access.redhat.com/documentation/en-us/red_hat_satellite/__RELEASE_CYCLE__/html/release_notes/index"
+iconSlug: redhat
+permalink: /redhat-satellite
+alternate_urls:
+-   /rhsat
+releasePolicyLink: https://access.redhat.com/support/policy/updates/satellite
+releaseImage: https://access.redhat.com/sites/default/files/styles/XL%20-%20Extra%20Large/public/images/satellite_n-2_lifecycle_latest_v2.png
+activeSupportColumn: Full support
+activeSupportWarnThreshold: 30
+releaseDateColumn: General availability
+eolColumn: Maintenance support
+versionCommand: yum info satellite
 releases:
 -   releaseCycle: "6.12"
     eol: 2024-05-31
@@ -24,20 +35,9 @@ releases:
 -   releaseCycle: "6.9"
     eol: 2022-11-30
     support: 2021-11-30
-    releaseDate: 2021-04-16
+    releaseDate: 2021-04-21
     latest: "6.9.10"
     latestReleaseDate: 2022-11-17
-iconSlug: redhat
-permalink: /redhat-satellite
-alternate_urls:
--   /rhsat
-releasePolicyLink: https://access.redhat.com/support/policy/updates/satellite
-activeSupportColumn: Full support
-releaseColumn: true
-releaseDateColumn: true
-eolColumn: Maintenance support
-discontinuedColumn: false
-versionCommand: yum info satellite
 
 ---
 

--- a/products/satellite.md
+++ b/products/satellite.md
@@ -1,50 +1,54 @@
 ---
 title: Red Hat Satellite
 category: server-app
-changelogTemplate: "https://access.redhat.com/documentation/en-us/red_hat_satellite/__RELEASE_CYCLE__/html/release_notes/index"
 iconSlug: redhat
 permalink: /redhat-satellite
 alternate_urls:
 -   /rhsat
-releasePolicyLink: https://access.redhat.com/support/policy/updates/satellite
+versionCommand: yum info satellite
 releaseImage: https://access.redhat.com/sites/default/files/styles/XL%20-%20Extra%20Large/public/images/satellite_n-2_lifecycle_latest_v2.png
+releasePolicyLink: https://access.redhat.com/support/policy/updates/satellite
+changelogTemplate: "https://access.redhat.com/documentation/en-us/red_hat_satellite/__RELEASE_CYCLE__/html/release_notes/index"
+releaseDateColumn: General availability
 activeSupportColumn: Full support
 activeSupportWarnThreshold: 30
-releaseDateColumn: General availability
 eolColumn: Maintenance support
-versionCommand: yum info satellite
+
 releases:
 -   releaseCycle: "6.12"
+    releaseDate: 2022-11-16
     eol: 2024-05-31
     support: 2023-05-31
-    releaseDate: 2022-11-16
     latest: "6.12.2"
     latestReleaseDate: 2023-02-08
+
 -   releaseCycle: "6.11"
+    releaseDate: 2022-07-05
     eol: 2024-01-31
     support: 2022-11-30
-    releaseDate: 2022-07-05
     latest: "6.11.4.1"
     latestReleaseDate: 2022-11-17
+
 -   releaseCycle: "6.10"
+    releaseDate: 2021-11-16
     eol: 2023-05-31
     support: 2022-06-30
-    releaseDate: 2021-11-16
     latest: "6.10.7.2"
     latestReleaseDate: 2023-03-01
+
 -   releaseCycle: "6.9"
+    releaseDate: 2021-04-21
     eol: 2022-11-30
     support: 2021-11-30
-    releaseDate: 2021-04-21
     latest: "6.9.10"
     latestReleaseDate: 2022-11-17
 
 ---
 
-> [Red Hat Satellite](https://www.redhat.com/technologies/management/satellite) is an infrastructure management product 
-> specifically designed to keep Red Hat Enterprise Linux environments and other Red Hat infrastructure
-> running efficiently, with security, and compliant with various standards.
+> [Red Hat Satellite](https://www.redhat.com/technologies/management/satellite) is an infrastructure
+> management product specifically designed to keep Red Hat Enterprise Linux environments and other
+> Red Hat infrastructure running efficiently, with security, and compliant with various standards.
 
-A new release is made approximately every 6 months. Each release is actively supported for six months, 
-and followed by one year of maintenance support. Release Dates are published on the 
+A new release is made approximately every 6 months. Each release is actively supported for six
+months,  and followed by one year of maintenance support. Release Dates are published on the
 [Red Hat Customer Portal](https://access.redhat.com/articles/1365633).


### PR DESCRIPTION
Reorganized file, moved releases to the bottom.
Reduced activeSupportWarnTheshold to 30 days.
Added custom name for "Released" column.
Added releaseImage from releasePolicyLink Documentation.
Fixed Satellite 6.9 release date.
Removed unused Parameters.