### PR TITLE
[MySQL] Expend Premier Support from 2023-04 to 2025-04

### DIFF
--- a/products/mysql.md
+++ b/products/mysql.md
@@ -27,9 +27,9 @@ auto:
 releases:
 -   releaseCycle: "8.0"
     latest: '8.0.32'
-    support: 2023-04-30
+    support: 2025-04-30
     eol: 2026-04-30
-    latestReleaseDate: 2022-12-16
+    latestReleaseDate: 2023-01-17
     releaseDate: 2018-04-08
 
 -   releaseCycle: "5.7"


### PR DESCRIPTION
ref: https://www.oracle.com/us/support/library/lifetime-support-technology-069183.pdf with `Effective Date: January 26, 2023` in the footnote of the first page

And the release date that become `General Avalibility` for version `8.0.32` should be at `2023-01-17`: https://dev.mysql.com/doc/relnotes/mysql/8.0/en/news-8-0-32.html