### PR TITLE
Add GitHub Action to generate offline dataset

### DIFF
--- a/.github/workflows/generate-offline-dataset.yaml
+++ b/.github/workflows/generate-offline-dataset.yaml
@@ -1,0 +1,32 @@
+name: Generate offline dataset
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+      - master
+
+jobs:
+  build-release-bundle:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: '3.0'  # Not needed with a .ruby-version file
+        bundler-cache: true  # runs 'bundle install' and caches installed gems automatically
+    # Generate .json files under ./api/
+    - run: bundle exec ruby ./_plugins/create-json-files.rb
+    # Generate a tar bundle from those files.
+    - run: (cd ./api/ && tar --mode='a+rw' -czvf ../dataset.tar.gz *.json)
+    # Publish the release
+    - uses: ncipollo/release-action@v1
+      with:
+        name: "Latest Offline Dataset"
+        body: "A simple offline dataset for programmatic use, without requiring one to query the public API and without using up the API quota."
+        tag: "latest-offline-dataset"
+        artifacts: "dataset.tar.gz"
+        allowUpdates: true
+        artifactErrorsFailBuild: true
+        makeLatest: true

--- a/.github/workflows/generate-offline-dataset.yaml
+++ b/.github/workflows/generate-offline-dataset.yaml
@@ -8,17 +8,17 @@ on:
       - master
 
 jobs:
-  build-release-bundle:
+  generate-offline-dataset:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
     - uses: ruby/setup-ruby@v1
       with:
-        ruby-version: '3.0'  # Not needed with a .ruby-version file
-        bundler-cache: true  # runs 'bundle install' and caches installed gems automatically
+        ruby-version: '3.0'
+        bundler-cache: true  # Runs 'bundle install' and caches installed gems
     # Generate .json files under ./api/
     - run: bundle exec ruby ./_plugins/create-json-files.rb
-    # Generate a tar bundle from those files.
+    # Generate a tar bundle from those files
     - run: (cd ./api/ && tar --mode='a+rw' -czvf ../dataset.tar.gz *.json)
     # Publish the release
     - uses: ncipollo/release-action@v1


### PR DESCRIPTION
Inspired by https://github.com/endoflife-date/endoflife.date/issues/2530#issuecomment-1439830897. I liked this proposed idea:

>Setting up GitHub releases on this, or a separate repository, where we publish the data regularly. If this is automated correctly, a link like https://github.com/endoflife-date/endoflife.date/releases/latest/dataset.tar.gz will always point to the latest version of the dataset, and that can be used for any programmatic usage.

This Action simply tars up the JSON files generated by `./_plugins/create-json-files.rb` and uploads them to a release with a static name, replacing it if it already exists.

This provides a simple offline dataset for programmatic use, without requiring one to query the public API and without using up the API quota.

It runs on every push to the `main` and `master` branches, and can also be triggered manually.

I'm happy to hear any feedback or thoughts on this!