### PR TITLE
Rename discontinuedColumn for pixel product

### DIFF
--- a/products/pixel.md
+++ b/products/pixel.md
@@ -8,7 +8,7 @@ releasePolicyLink: https://support.google.com/nexus/answer/4457705
 releaseColumn: false
 releaseDateColumn: true
 activeSupportColumn: true
-discontinuedColumn: true
+discontinuedColumn: Discontinued
 eolColumn: Guaranteed Security Updates
 
 releases:


### PR DESCRIPTION
On the pixel page, both the columns for release date and discontinuation date are named "Released". I renamed the later to "Discontinued".