### PR TITLE
[airflow] Update latest version to 2.5.2

### DIFF
--- a/products/apache-airflow.md
+++ b/products/apache-airflow.md
@@ -21,7 +21,7 @@ releases:
 -   releaseCycle: "2"
     eol: false
     latest: "2.5.2"
-    latestReleaseDate: 2023-03-14
+    latestReleaseDate: 2023-03-15
     releaseDate: 2020-12-17
 -   releaseCycle: "1.10"
     eol: 2021-07-17


### PR DESCRIPTION
Hello,

Small PR to update the latest version available for Apache Airflow to 2.5.2.

https://airflow.apache.org/docs/apache-airflow/stable/release_notes.html#airflow-2-5-2-2023-03-15

(Version number was already updated by github actions, but the date is not accurate)