### PR TITLE
Symfony: fix the command to show the version

### DIFF
--- a/products/symfony.md
+++ b/products/symfony.md
@@ -5,7 +5,7 @@ iconSlug: symfony
 permalink: /symfony
 releasePolicyLink: https://symfony.com/releases
 activeSupportColumn: true
-versionCommand: composer show symfony/symfony | grep versions
+versionCommand: composer show | grep "symfony/"
 changelogTemplate: |
   https://symfony.com/blog/symfony-{{"__LATEST__" | replace:'.','-'}}-released
 releaseDateColumn: true


### PR DESCRIPTION
Symfony is split in a lot of packages that can be installed in different versions. Plus, using Symfony does not mean necessarily we use the framework directly (we can be using a framework that depends on it, like Sylius, Laravel or API Platform do), or we can even make a website using Symfony's components without the framework.

The new command proposal allows to check all the components versions at once.