### PR TITLE
Hide oldest unmaintained releases cycles using javascript

### DIFF
--- a/_layouts/product.html
+++ b/_layouts/product.html
@@ -30,9 +30,9 @@ layout: default
   </thead>
 
 {% for r in page.releases %}
-{%- assign hideClass = '' %}
-{%- if r.can_be_hidden %}{% assign hideClass = 'd-none' %}{% endif %}
-  <tr class="release {{ hideClass }}">
+{%- assign releaseClasses = 'release' %}
+{%- if r.can_be_hidden %}{% assign releaseClasses = 'release can-be-hidden' %}{% endif %}
+  <tr class="{{ releaseClasses }}">
     <td>
       {% comment %}Only put a link in the version column if the release column is not shown{% endcomment %}
       {% if page.releaseColumn == false and r.link and r.daysTowardEol > 0  %}
@@ -128,7 +128,7 @@ layout: default
 {% endfor %}
 {% assign can_be_hidden_releases_count = page.releases | where: 'can_be_hidden', true | size %}
 {% if can_be_hidden_releases_count > 0 %}
-  <tr id="show-more-row">
+  <tr id="show-more-row" class="d-none">
     <td colspan="{{ colCount }}" class="text-center">
       <button id="show-hidden-releases-button" class="btn">
         Show more unmaintained releases

--- a/assets/register-show-hidden-releases-handler.js
+++ b/assets/register-show-hidden-releases-handler.js
@@ -1,12 +1,23 @@
+function showHideOldReleases(show) {
+  const showMoreRow = document.getElementById("show-more-row");
+  const releases = document.querySelectorAll(".release.can-be-hidden");
+
+  if(show) {
+    showMoreRow.classList.add('d-none');
+    releases.forEach((r) => r.classList.remove('d-none'));
+  } else {
+    showMoreRow.classList.remove('d-none');
+    releases.forEach((r) => r.classList.add('d-none'));
+  }
+}
+
 function registerShowHiddenReleasesHandler() {
   document.getElementById('show-hidden-releases-button').addEventListener("click",
     (event) => {
       event.preventDefault();
-      document.getElementById("show-more-row").classList.add('d-none');
-      document.querySelectorAll(".release.d-none").forEach(
-        (c) => c.classList.remove('d-none')
-      );
+      showHideOldReleases(true);
     }, false);
 }
 
+showHideOldReleases(false);
 registerShowHiddenReleasesHandler();


### PR DESCRIPTION
I don't know if it makes things more accessible, but at least people that disabled JavaScript on their browser can now see all release cycles.

A small glitch can sometime be observed on page load (for example on API Platform page) but that's not systematic and I didn't consider that to be an issue.

This PR relates to #50.