### PR TITLE
[ansible][ansible-core] Improve compatibility tables

### DIFF
--- a/products/ansible-core.md
+++ b/products/ansible-core.md
@@ -16,44 +16,66 @@ eolColumn: Supported
 auto:
 -   git: https://github.com/ansible/ansible.git
 
+# For Python / Powershell versions, see https://docs.ansible.com/ansible/latest/reference_appendices/release_and_maintenance.html#support-life
 releases:
 -   releaseCycle: "2.15"
+    pythonVersionsControlNode: 3.9 - 3.11
+    pythonVersionsManagedNode: 2.7 / 3.5 - 3.11
+    powershellVersionsManagedNode: 3 - 5.1
     releaseDate: 2023-05-15
     eol: 2024-11-01
     latest: "2.15.2"
     latestReleaseDate: 2023-07-17
 
 -   releaseCycle: "2.14"
+    pythonVersionsControlNode: 3.9 - 3.11
+    pythonVersionsManagedNode: 2.7 / 3.5 - 3.11
+    powershellVersionsManagedNode: 3 - 5.1
     releaseDate: 2022-11-07
     eol: 2024-05-31
     latest: "2.14.8"
     latestReleaseDate: 2023-07-17
 
 -   releaseCycle: "2.13"
+    pythonVersionsControlNode: 3.8 - 3.10
+    pythonVersionsManagedNode: 2.7 / 3.5 - 3.10
+    powershellVersionsManagedNode: 3 - 5.1
     releaseDate: 2022-05-16
     eol: 2023-11-30
     latest: "2.13.11"
     latestReleaseDate: 2023-07-17
 
 -   releaseCycle: "2.12"
+    pythonVersionsControlNode: 3.8 - 3.10
+    pythonVersionsManagedNode: 2.6 - 2.7 / 3.5 - 3.10
+    powershellVersionsManagedNode: 3 - 5.1
     releaseDate: 2021-11-08
     eol: 2023-05-31
     latest: "2.12.10"
     latestReleaseDate: 2022-10-11
 
 -   releaseCycle: "2.11"
+    pythonVersionsControlNode: 2.7 / 3.5 - 3.9
+    pythonVersionsManagedNode: 2.6 - 2.7 / 3.5 - 3.9
+    powershellVersionsManagedNode: 3 - 5.1
     releaseDate: 2021-04-26
     eol: 2022-11-07
     latest: "2.11.12"
     latestReleaseDate: 2022-05-23
 
 -   releaseCycle: "2.10"
+    pythonVersionsControlNode: 2.7 / 3.5 - 3.9
+    pythonVersionsManagedNode: 2.6 - 2.7 / 3.5 - 3.9
+    powershellVersionsManagedNode: 3 - 5.1
     releaseDate: 2020-08-13
     eol: 2022-05-23
     latest: "2.10.17"
     latestReleaseDate: 2022-01-31
 
 -   releaseCycle: "2.9"
+    pythonVersionsControlNode: 2.7 / 3.5 - 3.8
+    pythonVersionsManagedNode: 2.6 - 2.7 / 3.5 - 3.8
+    powershellVersionsManagedNode: 3 - 5.1
     releaseDate: 2019-10-31
     eol: 2022-05-23
     latest: "2.9.27"
@@ -71,14 +93,10 @@ releases. For detailed information, see Ansible [Releases and maintenance](https
 See the [ansible-core Roadmap](https://docs.ansible.com/ansible-core/devel/roadmap/ansible_core_roadmap_index.html)
 for upcoming release details.
 
-## Python Compatibility
+## [Compatibility](https://docs.ansible.com/ansible/latest/reference_appendices/release_and_maintenance.html#support-life)
 
-| ansible-core Version | Minimum Python Version (controller) | Minimum Python Version (modules) |
-|----------------------|-------------------------------------|----------------------------------|
-| 2.9                  | 2.7 or 3.5                          | 2.6 or 3.5                       |
-| 2.10                 | 2.7 or 3.5                          | 2.6 or 3.5                       |
-| 2.11                 | 2.7 or 3.5                          | 2.6 or 3.5                       |
-| 2.12                 | 3.8                                 | 2.6 or 3.5                       |
-| 2.13                 | 3.8                                 | 2.7 or 3.5                       |
-| 2.14                 | 3.9                                 | 2.7 or 3.5                       |
-| 2.15                 | 3.9                                 | 2.7 or 3.5                       |
+{% include table.html
+labels="ansible-core,Control node Python,Managed node Python,Managed node PowerShell"
+fields="releaseCycle,pythonVersionsControlNode,pythonVersionsManagedNode,powershellVersionsManagedNode"
+types="string,string,string,string"
+rows=page.releases %}

--- a/products/ansible-core.md
+++ b/products/ansible-core.md
@@ -1,20 +1,21 @@
 ---
-permalink: /ansible-core
 title: Ansible-core
+category: framework
+iconSlug: ansible
+tags: python-runtime red-hat
+permalink: /ansible-core
 versionCommand: ansible --version
-releasePolicyLink: 
+releasePolicyLink:
   https://docs.ansible.com/ansible-core/devel/reference_appendices/release_and_maintenance.html
-changelogTemplate: 
+changelogTemplate:
   https://github.com/ansible/ansible/blob/stable-__RELEASE_CYCLE__/changelogs/CHANGELOG-v__RELEASE_CYCLE__.rst
 releaseDateColumn: true
-sortReleasesBy: "releaseDate"
 activeSupportColumn: false
 eolColumn: Supported
-iconSlug: ansible
-category: framework
-tags: python-runtime red-hat
+
 auto:
 -   git: https://github.com/ansible/ansible.git
+
 releases:
 -   releaseCycle: "2.15"
     releaseDate: 2023-05-15
@@ -60,14 +61,15 @@ releases:
 
 ---
 
-> [Ansible](https://www.ansible.com/) is an open-source software provisioning, configuration management and application-deployment tool enabling infrastructure as code. It runs on many Unix-like systems, and can configure both Unix-like systems and Microsoft Windows.
+> [Ansible](https://www.ansible.com/) is an open-source software provisioning, configuration
+> management and application-deployment tool enabling infrastructure as code. It runs on many
+> Unix-like systems, and can configure both Unix-like systems and Microsoft Windows.
 
-The `ansible-core` package has a graduated maintenance structure that extends to three major releases. For detailed information, see Ansible [Releases and maintenance][maintenance].
+The `ansible-core` package has a graduated maintenance structure that extends to three major
+releases. For detailed information, see Ansible [Releases and maintenance](https://docs.ansible.com/ansible/devel/reference_appendices/release_and_maintenance.html).
 
-See the [ansible-core Roadmap][roadmap] for upcoming release details.
-
-[roadmap]: https://docs.ansible.com/ansible-core/devel/roadmap/ansible_core_roadmap_index.html
-[maintenance]: https://docs.ansible.com/ansible/devel/reference_appendices/release_and_maintenance.html
+See the [ansible-core Roadmap](https://docs.ansible.com/ansible-core/devel/roadmap/ansible_core_roadmap_index.html)
+for upcoming release details.
 
 ## Python Compatibility
 

--- a/products/ansible.md
+++ b/products/ansible.md
@@ -6,9 +6,9 @@ iconSlug: ansible
 permalink: /ansible
 # The following command works from Ansible 6.0.0 on:
 versionCommand: ansible-community --version
-releasePolicyLink: 
+releasePolicyLink:
   https://docs.ansible.com/ansible/devel/reference_appendices/release_and_maintenance.html
-changelogTemplate: 
+changelogTemplate:
   https://github.com/ansible-community/ansible-build-data/blob/main/__RELEASE_CYCLE__/CHANGELOG-v__RELEASE_CYCLE__.rst
 releaseDateColumn: true
 activeSupportColumn: false
@@ -21,50 +21,84 @@ identifiers:
 auto:
 -   pypi: ansible
 
+# ansible-Core versions can be found on https://docs.ansible.com/ansible/latest/reference_appendices/release_and_maintenance.html#ansible-community-changelogs
+# For Python / Powershell versions, see https://docs.ansible.com/ansible/latest/reference_appendices/release_and_maintenance.html#support-life
 releases:
 -   releaseCycle: "8"
+    ansibleCoreVersion: "2.15"
+    pythonVersionsControlNode: 3.9 - 3.11
+    pythonVersionsManagedNode: 2.7 / 3.5 - 3.11
+    powershellVersionsManagedNode: 3 - 5.1
     releaseDate: 2023-05-30
     eol: false
     latest: "8.2.0"
     latestReleaseDate: 2023-07-18
 
 -   releaseCycle: "7"
+    ansibleCoreVersion: "2.14"
+    pythonVersionsControlNode: 3.9 - 3.11
+    pythonVersionsManagedNode: 2.7 / 3.5 - 3.11
+    powershellVersionsManagedNode: 3 - 5.1
     releaseDate: 2022-11-22
     eol: 2023-06-22
     latest: "7.7.0"
     latestReleaseDate: 2023-06-22
 
 -   releaseCycle: "6"
+    ansibleCoreVersion: "2.13"
+    pythonVersionsControlNode: 3.8 - 3.10
+    pythonVersionsManagedNode: 2.7 / 3.5 - 3.10
+    powershellVersionsManagedNode: 3 - 5.1
     releaseDate: 2022-06-21
     eol: 2022-12-06
     latest: "6.7.0"
     latestReleaseDate: 2022-12-06
 
 -   releaseCycle: "5"
+    ansibleCoreVersion: "2.12"
+    pythonVersionsControlNode: 3.8 - 3.10
+    pythonVersionsManagedNode: 2.6 - 2.7 / 3.5 - 3.10
+    powershellVersionsManagedNode: 3 - 5.1
     releaseDate: 2021-12-02
     eol: 2022-06-08
     latest: "5.10.0"
     latestReleaseDate: 2022-06-28
 
 -   releaseCycle: "4"
+    ansibleCoreVersion: "2.11"
+    pythonVersionsControlNode: 2.7 / 3.5 - 3.9
+    pythonVersionsManagedNode: 2.6 - 2.7 / 3.5 - 3.9
+    powershellVersionsManagedNode: 3 - 5.1
     releaseDate: 2021-05-18
     eol: 2021-12-14
     latest: "4.10.0"
     latestReleaseDate: 2021-12-14
 
 -   releaseCycle: "3"
+    ansibleCoreVersion: "2.10"
+    pythonVersionsControlNode: 2.7 / 3.5 - 3.9
+    pythonVersionsManagedNode: 2.6 - 2.7 / 3.5 - 3.9
+    powershellVersionsManagedNode: 3 - 5.1
     releaseDate: 2021-02-18
     eol: 2021-05-11
     latest: "3.4.0"
     latestReleaseDate: 2021-05-11
 
 -   releaseCycle: "2.10"
+    ansibleCoreVersion: "2.10"
+    pythonVersionsControlNode: 2.7 / 3.5 - 3.9
+    pythonVersionsManagedNode: 2.6 - 2.7 / 3.5 - 3.9
+    powershellVersionsManagedNode: 3 - 5.1
     releaseDate: 2020-09-22
     eol: 2021-02-09
     latest: "2.10.7"
     latestReleaseDate: 2021-02-09
 
 -   releaseCycle: "2.9"
+    ansibleCoreVersion: "2.9"
+    pythonVersionsControlNode: 2.7 / 3.5 - 3.8
+    pythonVersionsManagedNode: 2.6 - 2.7 / 3.5 - 3.8
+    powershellVersionsManagedNode: 3 - 5.1
     releaseDate: 2019-10-31
     eol: 2022-05-23
     latest: "2.9.27"
@@ -84,11 +118,10 @@ released every 4 weeks. Maintenance fixes are guaranteed for only the latest maj
 See the [Ansible Roadmap](https://docs.ansible.com/ansible/devel/roadmap/ansible_roadmap_index.html)
 for upcoming release details.
 
-## Python Compatibility
+## [Compatibility](https://docs.ansible.com/ansible/latest/reference_appendices/release_and_maintenance.html#ansible-community-changelogs)
 
-| Ansible Version | Minimum Python Version (controller) | Minimum Python Version (modules) |
-|-----------------|-------------------------------------|----------------------------------|
-| 8               | 3.9                                 | 2.7 or 3.5                       |
-| 7               | 3.9                                 | 2.7 or 3.5                       |
-| 5               | 3.8                                 | 2.7 or 3.5                       |
-| 2.9             | 2.7 or 3.5                          | 2.6 or 3.5                       |
+{% include table.html
+labels="Ansible,ansible-core,Control node Python,Managed node Python,Managed node PowerShell"
+fields="releaseCycle,ansibleCoreVersion,pythonVersionsControlNode,pythonVersionsManagedNode,powershellVersionsManagedNode"
+types="string,string,string,string,string"
+rows=page.releases %}


### PR DESCRIPTION
Use the information on https://docs.ansible.com/ansible/latest/reference_appendices/release_and_maintenance.html#ansible-community-changelogs and :
- On ansible-core : show min and max Python / Powershell versions.
- On ansible : show the corresponding ansible-core version as well as  min and max Python / Powershell versions.
    
I used table includes to better manage the tables. I also took the opportunity to normalize the ansible-core page (#2124).