### PR TITLE
[samsungmobile] Add links and remove some models

### DIFF
--- a/products/samsungmobile.md
+++ b/products/samsungmobile.md
@@ -1,2141 +1,2533 @@
 ---
-permalink: /samsung-mobile
-alternate_urls:
--   /samsungmobile
 title: Samsung Mobile
 category: device
 iconSlug: samsung
+permalink: /samsung-mobile
+alternate_urls:
+-   /samsungmobile
 releasePolicyLink: https://security.samsungmobile.com/workScope.smsb
-discontinuedColumn: false
-activeSupportColumn: true
-eolColumn: Security Updates
 releaseColumn: false
 releaseDateColumn: true
+activeSupportColumn: true
+eolColumn: Security Updates
 
 # Models compatible with Android 12+ are considered fully supported.
+#
+# To find the link for a particular model :
+# 1. search the model numbers on https://www.gsmarena.com/ ("Models" entry in the "MISC" section),
+# 2. search on Google with the query : "<model_number> site:doc.samsungmobile.com",
+# 3. choose a page (preferably in english).
 releases:
 -   releaseCycle: "Galaxy A14 5G"
-    support: true
-    eol: false # https://doc.samsungmobile.com/SM-A146B/INS/doc.html
     releaseDate: 2023-01-12
+    support: true
+    eol: false
+    link: https://doc.samsungmobile.com/SM-A146B/INS/doc.html
 
 -   releaseCycle: "Galaxy F04"
-    support: true
-    eol: false # No associated page on https://doc.samsungmobile.com
     releaseDate: 2023-01-12
+    support: true
+    eol: false
+    link: null
 
 -   releaseCycle: "Galaxy M04"
-    support: true
-    eol: false # https://doc.samsungmobile.com/SM-M045F/INS/doc.html
     releaseDate: 2022-12-16
+    support: true
+    eol: false
+    link: https://doc.samsungmobile.com/SM-M045F/INS/doc.html
 
 -   releaseCycle: "Galaxy Tab A7 10.4 (2022)"
-    support: true
-    eol: false # https://doc.samsungmobile.com/SM-T509/ITV/doc.html
     releaseDate: 2022-11-21
+    support: true
+    eol: false
+    link: https://doc.samsungmobile.com/SM-T509/ITV/doc.html
 
 -   releaseCycle: "Galaxy A04e"
-    support: true
-    eol: false # https://doc.samsungmobile.com/SM-A042F/XXV/doc.html
     releaseDate: 2022-11-07
+    support: true
+    eol: false
+    link: https://doc.samsungmobile.com/SM-A042F/XXV/doc.html
 
 -   releaseCycle: "Galaxy A04s"
-    support: true
-    eol: false # https://doc.samsungmobile.com/SM-A047F/XXV/doc.html
     releaseDate: 2022-09-22
+    support: true
+    eol: false
+    link: https://doc.samsungmobile.com/SM-A047F/XXV/doc.html
 
 -   releaseCycle: "Galaxy A04"
-    support: true
-    eol: false # https://doc.samsungmobile.com/SM-A045F/XXV/doc.html
     releaseDate: 2022-10-10
-
--   releaseCycle: "Galaxy Tab Active 4 Pro"
     support: true
-    eol: false # https://doc.samsungmobile.com/SM-T636B/XSA/doc.html
-    releaseDate: 2022-09-13 # TODO: Verify date
+    eol: false
+    link: https://doc.samsungmobile.com/SM-A045F/XXV/doc.html
+
+-   releaseCycle: "Galaxy Tab Active4 Pro"
+    releaseDate: 2022-09-13
+    support: true
+    eol: false
+    link: https://doc.samsungmobile.com/SM-T636B/XSA/doc.html
 
 -   releaseCycle: "Galaxy A23 5G"
+    releaseDate: 2022-09-02
     support: true
     eol: false
-    releaseDate: 2022-09-02
+    link: https://doc.samsungmobile.com/SM-A236U/DSA/doc.html
 
 -   releaseCycle: "Galaxy Z Fold4"
-    support: true
-    eol: false # https://doc.samsungmobile.com/SM-F936U1/TMB/doc.html
     releaseDate: 2022-08-25
+    support: true
+    eol: false
+    link: https://doc.samsungmobile.com/SM-F936U1/TMB/doc.html
 
 -   releaseCycle: "Galaxy Z Flip4"
-    support: true
-    eol: false # https://doc.samsungmobile.com/SM-F721U1/XAR/doc.html
     releaseDate: 2022-08-25
+    support: true
+    eol: false
+    link: https://doc.samsungmobile.com/SM-F721U1/XAR/doc.html
 
 -   releaseCycle: "Galaxy Watch5 Pro"
-    support: true
-    eol: false # https://doc.samsungmobile.com/SM-R925F/ITV/doc.html
     releaseDate: 2022-08-26
+    support: true
+    eol: false
+    link: https://doc.samsungmobile.com/SM-R925F/ITV/doc.html
 
 -   releaseCycle: "Galaxy Watch5"
-    support: true
-    eol: false # https://doc.samsungmobile.com/SM-R905F/BTU/doc.html
     releaseDate: 2022-08-26
+    support: true
+    eol: false
+    link: https://doc.samsungmobile.com/SM-R905F/BTU/doc.html
 
 -   releaseCycle: "Galaxy M13 5G"
-    support: true
-    eol: false # https://doc.samsungmobile.com/SM-M136B/INS/doc.html
     releaseDate: 2022-07-23
+    support: true
+    eol: false
+    link: https://doc.samsungmobile.com/SM-M136B/INS/doc.html
 
 -   releaseCycle: "Galaxy M13 (India)"
-    support: true
-    eol: false # https://doc.samsungmobile.com/SM-M135FU/INS/doc.html
     releaseDate: 2022-07-23
+    support: true
+    eol: false
+    link: https://doc.samsungmobile.com/SM-M135FU/INS/doc.html
 
 -   releaseCycle: "Galaxy Xcover6 Pro"
-    support: true
-    eol: false # https://doc.samsungmobile.com/SM-G736B/XSA/doc.html
     releaseDate: 2022-07-13
+    support: true
+    eol: false
+    link: https://doc.samsungmobile.com/SM-G736B/XSA/doc.html
 
 -   releaseCycle: "Galaxy A13 (SM-A137)"
-    support: true
-    eol: false # TODO
     releaseDate: 2022-07-01 # Approximate to the month and year.
+    support: true
+    eol: false
+    link: https://doc.samsungmobile.com/SM-A137F/SFR/doc.html
 
 -   releaseCycle: "Galaxy F13"
-    support: true
-    eol: false # https://doc.samsungmobile.com/SM-E135F/INS/doc.html
     releaseDate: 2022-06-29
+    support: true
+    eol: false
+    link: https://doc.samsungmobile.com/SM-E135F/INS/doc.html
 
 -   releaseCycle: "Galaxy M13"
-    support: true
-    eol: false # TODO
     releaseDate: 2022-07-01
+    support: true
+    eol: false
+    link: https://doc.samsungmobile.com/SM-M135F/EUX/doc.html
 
 -   releaseCycle: "Galaxy Tab S6 Lite (2022)"
-    support: true
-    eol: false # https://doc.samsungmobile.com/SM-P619/ATO/doc.html
     releaseDate: 2022-05-23
+    support: true
+    eol: false
+    link: https://doc.samsungmobile.com/SM-P619/ATO/doc.html
 
 -   releaseCycle: "Galaxy M53"
-    support: true
-    eol: false # https://doc.samsungmobile.com/SM-M536B/SER/doc.html
     releaseDate: 2022-04-22
+    support: true
+    eol: false
+    link: https://doc.samsungmobile.com/SM-M536B/SER/doc.html
 
 -   releaseCycle: "Galaxy S20 FE 2022"
-    support: true
-    eol: false # TODO
     releaseDate: 2022-04-01
+    support: true
+    eol: false
+    link: https://doc.samsungmobile.com/sm-g781b/xeo/doc.html
 
 -   releaseCycle: "Galaxy A73 5G"
-    support: true
-    eol: false # https://doc.samsungmobile.com/SM-A736B/XSA/doc.html
     releaseDate: 2022-04-22
+    support: true
+    eol: false
+    link: https://doc.samsungmobile.com/SM-A736B/XSA/doc.html
 
 -   releaseCycle: "Galaxy A53 5G"
+    releaseDate: 2022-04-01
     support: true
     eol: false
-    releaseDate: 2022-04-01
+    link: https://doc.samsungmobile.com/SM-A536B/EUX/doc.html
 
 -   releaseCycle: "Galaxy A33 5G"
+    releaseDate: 2022-04-01
     support: true
     eol: false
-    releaseDate: 2022-04-01
+    link: https://doc.samsungmobile.com/sm-a336e/ins/doc.html
 
 -   releaseCycle: "Galaxy F23"
-    support: true
-    eol: false # https://doc.samsungmobile.com/SM-E236B/INS/doc.html
     releaseDate: 2022-03-16
+    support: true
+    eol: false
+    link: https://doc.samsungmobile.com/SM-E236B/INS/doc.html
 
 -   releaseCycle: "Galaxy M33"
-    support: true
-    eol: false # https://doc.samsungmobile.com/SM-M336BU/INS/doc.html
     releaseDate: 2022-04-08
+    support: true
+    eol: false
+    link: https://doc.samsungmobile.com/SM-M336BU/INS/doc.html
 
 -   releaseCycle: "Galaxy M23"
-    support: true
-    eol: false # https://doc.samsungmobile.com/SM-M236B/XXV/doc.html
     releaseDate: 2022-04-08
+    support: true
+    eol: false
+    link: https://doc.samsungmobile.com/SM-M236B/XXV/doc.html
 
 -   releaseCycle: "Galaxy A23"
-    support: true
-    eol: false # https://doc.samsungmobile.com/SM-A235M/PET/doc.html
     releaseDate: 2022-03-25
+    support: true
+    eol: false
+    link: https://doc.samsungmobile.com/SM-A235M/PET/doc.html
 
 -   releaseCycle: "Galaxy A13"
-    support: true
-    eol: false # https://doc.samsungmobile.com/SM-A135M/PET/doc.html
     releaseDate: 2022-03-23
+    support: true
+    eol: false
+    link: https://doc.samsungmobile.com/SM-A135M/PET/doc.html
 
 -   releaseCycle: "Galaxy S22 Ultra 5G"
-    support: true
-    eol: false # https://doc.samsungmobile.com/SM-S908E/VAU/doc.html
     releaseDate: 2022-02-25
+    support: true
+    eol: false
+    link: https://doc.samsungmobile.com/SM-S908E/VAU/doc.html
 
 -   releaseCycle: "Galaxy S22+ 5G"
-    support: true
-    eol: false # https://doc.samsungmobile.com/SM-S906E/XXV/doc.html
     releaseDate: 2022-02-25
+    support: true
+    eol: false
+    link: https://doc.samsungmobile.com/SM-S906E/XXV/doc.html
 
 -   releaseCycle: "Galaxy S22 5G"
-    support: true
-    eol: false # https://doc.samsungmobile.com/SM-S901E/XXV/doc.html
     releaseDate: 2022-02-25
+    support: true
+    eol: false
+    link: https://doc.samsungmobile.com/SM-S901E/XXV/doc.html
 
 -   releaseCycle: "Galaxy Tab S8 Ultra"
-    support: true
-    eol: false # https://doc.samsungmobile.com/SM-X906B/XXV/doc.html
     releaseDate: 2022-04-30
+    support: true
+    eol: false
+    link: https://doc.samsungmobile.com/SM-X906B/XXV/doc.html
 
 -   releaseCycle: "Galaxy Tab S8+"
-    support: true
-    eol: false # https://doc.samsungmobile.com/SM-X806B/XXV/doc.html
     releaseDate: 2022-04-14
+    support: true
+    eol: false
+    link: https://doc.samsungmobile.com/SM-X806B/XXV/doc.html
 
 -   releaseCycle: "Galaxy Tab S8"
-    support: true
-    eol: false # https://doc.samsungmobile.com/SM-X706B/SER/doc.html
     releaseDate: 2022-03-22
+    support: true
+    eol: false
+    link: https://doc.samsungmobile.com/SM-X706B/SER/doc.html
 
 -   releaseCycle: "Galaxy S21 FE 5G"
-    support: true
-    eol: false # https://doc.samsungmobile.com/SM-G990B2/SER/doc.html
     releaseDate: 2022-01-07
+    support: true
+    eol: false
+    link: https://doc.samsungmobile.com/SM-G990B2/SER/doc.html
 
 -   releaseCycle: "Galaxy Tab A8 10.5 (2021)"
-    support: true
-    eol: false # https://doc.samsungmobile.com/SM-X205/INS/doc.html
     releaseDate: 2022-01-17
+    support: true
+    eol: false
+    link: https://doc.samsungmobile.com/SM-X205/INS/doc.html
 
 -   releaseCycle: "Galaxy A03"
-    support: true
-    eol: false # https://doc.samsungmobile.com/SM-A035G/BTU/doc.html
     releaseDate: 2022-01-21
+    support: true
+    eol: false
+    link: https://doc.samsungmobile.com/SM-A035G/BTU/doc.html
 
 -   releaseCycle: "Galaxy A03 Core"
-    support: true
-    eol: false # https://doc.samsungmobile.com/SM-A032M/PET/doc.html
     releaseDate: 2021-12-06
+    support: true
+    eol: false
+    link: https://doc.samsungmobile.com/SM-A032M/PET/doc.html
 
 -   releaseCycle: "Galaxy A13 5G"
+    releaseDate: 2021-12-03
     support: true
     eol: false
-    releaseDate: 2021-12-03
+    link: https://doc.samsungmobile.com/SM-A136U/USC/doc.html
 
 -   releaseCycle: "Galaxy F42 5G"
+    releaseDate: 2021-10-03
     support: true
     eol: false
-    releaseDate: 2021-10-03
+    link: https://doc.samsungmobile.com/sm-e426b/ins/doc.html
 
 -   releaseCycle: "Galaxy M52 5G"
+    releaseDate: 2021-10-03
     support: true
     eol: false
-    releaseDate: 2021-10-03
+    link: https://doc.samsungmobile.com/SM-M526BR/ITV/doc.html
 
 -   releaseCycle: "Galaxy M22"
+    releaseDate: 2021-09-14 # Unclear date, defaulting to announcement date
     support: true
     eol: false
-    releaseDate: 2021-09-14 # Unclear date, defaulting to announcement date
+    link: https://doc.samsungmobile.com/sm-m225fv/zto/doc.html
 
 -   releaseCycle: "Galaxy M32 5G"
-    support: true
-    eol: false # https://doc.samsungmobile.com/SM-M326B/INS/doc.html
     releaseDate: 2021-09-02
+    support: true
+    eol: false
+    link: https://doc.samsungmobile.com/SM-M326B/INS/doc.html
 
 -   releaseCycle: "Galaxy A52s 5G"
-    support: true
-    eol: false # https://doc.samsungmobile.com/SM-A528B/BTU/doc.html
     releaseDate: 2021-09-01
-
--   releaseCycle: "Galaxy A52s"
     support: true
     eol: false
-    releaseDate: 2021-09-01
-
--   releaseCycle: "Galaxy Z Fold 3"
-    support: true
-    eol: false
-    releaseDate: 2021-08-27
+    link: https://doc.samsungmobile.com/SM-A528B/BTU/doc.html
 
 -   releaseCycle: "Galaxy Z Fold3 5G"
-    support: true
-    eol: false # https://doc.samsungmobile.com/SM-F926B/SER/doc.html
     releaseDate: 2021-08-27
+    support: true
+    eol: false
+    link: https://doc.samsungmobile.com/SM-F926B/SER/doc.html
 
 -   releaseCycle: "Galaxy Z Flip3 5G"
-    support: true
-    eol: false # https://doc.samsungmobile.com/SM-F711B/SER/doc.html
     releaseDate: 2021-08-27
+    support: true
+    eol: false
+    link: https://doc.samsungmobile.com/SM-F711B/SER/doc.html
 
 -   releaseCycle: "Galaxy Watch4 Classic"
-    support: true
-    eol: false # https://doc.samsungmobile.com/SM-R890/XAA/doc.html
     releaseDate: 2021-08-27
+    support: true
+    eol: false
+    link: https://doc.samsungmobile.com/SM-R890/XAA/doc.html
 
 -   releaseCycle: "Galaxy Watch4"
-    support: true
-    eol: false # https://doc.samsungmobile.com/SM-R870/XAA/doc.html
     releaseDate: 2021-08-27
+    support: true
+    eol: false
+    link: https://doc.samsungmobile.com/SM-R870/XAA/doc.html
 
 -   releaseCycle: "Galaxy A03s"
+    releaseDate: 2021-08-18
     support: true
     eol: false
-    releaseDate: 2021-08-18
+    link: https://doc.samsungmobile.com/SM-A037F/INS/doc.html
 
 -   releaseCycle: "Galaxy A12 (India)"
-    support: true
-    eol: false # https://doc.samsungmobile.com/SM-A127F/ATO/doc.html
     releaseDate: 2021-08-12
-
--   releaseCycle: "Galaxy Z Flip 3"
     support: true
     eol: false
-    releaseDate: 2021-08-11
+    link: https://doc.samsungmobile.com/SM-A127F/INS/doc.html
 
 -   releaseCycle: "Galaxy A12 Nacho"
-    support: true
-    eol: false # https://doc.samsungmobile.com/SM-A127F/ITV/doc.html
     releaseDate: 2021-08-09
+    support: true
+    eol: false
+    link: https://doc.samsungmobile.com/SM-A127F/ITV/doc.html
 
 -   releaseCycle: "Galaxy M21 2021"
-    support: 2022-10-01 # Approximate from here: https://9to5google.com/2022/10/04/samsung-android-12-update-rollout/
-    eol: false
     releaseDate: 2021-07-26
+    support: true
+    eol: false
+    link: https://doc.samsungmobile.com/sm-m215f/ins/doc.html
 
 -   releaseCycle: "Galaxy F22"
+    releaseDate: 2021-07-13
     support: true
     eol: false
-    releaseDate: 2021-07-13
+    link: https://doc.samsungmobile.com/SM-E225F/INS/doc.html
 
 -   releaseCycle: "Galaxy M32"
+    releaseDate: 2021-06-28
     support: true
     eol: false
-    releaseDate: 2021-06-28
+    link: https://doc.samsungmobile.com/sm-m325f/ins/doc.html
 
 -   releaseCycle: "Galaxy A22 5G"
+    releaseDate: 2021-06-24
     support: true
     eol: false
-    releaseDate: 2021-06-24
+    link: https://doc.samsungmobile.com/SM-A226B/XEH/doc.html
 
 -   releaseCycle: "Galaxy A22"
+    releaseDate: 2021-06-03
     support: true
     eol: false
-    releaseDate: 2021-06-03
+    link: https://doc.samsungmobile.com/SM-A225F/TUR/doc.html
 
 -   releaseCycle: "Galaxy F52 5G"
-    support: 2022-10-01 # Approximate from here: https://9to5google.com/2022/10/04/samsung-android-12-update-rollout/
-    eol: false # TODO
     releaseDate: 2021-06-01
+    support: true
+    eol: false
+    link: https://doc.samsungmobile.com/SM-E5260/CHC/doc.html
 
 -   releaseCycle: "Galaxy Tab A7 Lite"
-    support: true
-    eol: false # https://doc.samsungmobile.com/SM-T220/CHN/doc.html
     releaseDate: 2021-05-27
+    support: true
+    eol: false
+    link: https://doc.samsungmobile.com/SM-T220/CHN/doc.html
 
 -   releaseCycle: "Galaxy Tab S7 FE"
+    releaseDate: 2021-05-25
     support: true
     eol: false
-    releaseDate: 2021-05-25
+    link: https://doc.samsungmobile.com/SM-T730/KOO/doc.html
 
 -   releaseCycle: "Galaxy A82 5G"
-    support: 2022-10-01 # Approximate from here: https://9to5google.com/2022/10/04/samsung-android-12-update-rollout/
-    eol: false
     releaseDate: 2021-05-05
+    support: true
+    eol: false
+    link: https://doc.samsungmobile.com/sm-a528b/dbt/doc.html
 
 -   releaseCycle: "Galaxy M42 5G"
-    support: true
-    eol: false
     releaseDate: 2021-04-30
-
--   releaseCycle: "Galaxy A Quantum 2"
     support: true
     eol: false
+    link: https://doc.samsungmobile.com/SM-M426B/INS/doc.html
+
+-   releaseCycle: "Galaxy A Quantum2"
     releaseDate: 2021-04-23
+    support: true
+    eol: false
+    link: https://doc.samsungmobile.com/sm-a826s/skc/doc.html
 
 -   releaseCycle: "Galaxy F12"
-    support: true
-    eol: false # https://doc.samsungmobile.com/SM-F127G/017298210201/wel.html
     releaseDate: 2021-04-12
-
--   releaseCycle: "Galaxy F02s" #This loses active support with Android 12.
     support: true
     eol: false
+    link: https://doc.samsungmobile.com/SM-F127G/INS/doc.html
+
+-   releaseCycle: "Galaxy F02s"
     releaseDate: 2021-04-09
+    support: true
+    eol: false
+    link: https://doc.samsungmobile.com/SM-E025F/INS/doc.html
 
 -   releaseCycle: "Galaxy A52"
+    releaseDate: 2021-03-26
     support: true
     eol: false
-    releaseDate: 2021-03-26
+    link: https://doc.samsungmobile.com/SM-A525F/XID/doc.html
 
 -   releaseCycle: "Galaxy A72"
-    support: true
-    eol: false # https://doc.samsungmobile.com/SM-A725F/XEO/doc.html
     releaseDate: 2021-03-26
+    support: true
+    eol: false
+    link: https://doc.samsungmobile.com/SM-A725F/XEO/doc.html
 
 -   releaseCycle: "Galaxy M12 (India)"
-    support: 2022-10-01 # Approximate from here: https://9to5google.com/2022/10/04/samsung-android-12-update-rollout/
-    eol: false # https://doc.samsungmobile.com/SM-M127G/INS/doc.html
     releaseDate: 2021-03-18
+    support: true
+    eol: false
+    link: https://doc.samsungmobile.com/SM-M127G/INS/doc.html
 
 -   releaseCycle: "Galaxy A52 5G"
+    releaseDate: 2021-03-17
     support: true
     eol: false
-    releaseDate: 2021-03-17
+    link: https://doc.samsungmobile.com/sm-a526b/dbt/doc.html
 
 -   releaseCycle: "Galaxy Xcover 5"
+    releaseDate: 2021-03-12
     support: true
     eol: false
-    releaseDate: 2021-03-12
-
--   releaseCycle: "Galaxy Xcover 4"
-    support: false
-    eol: 2019-12-01
-    releaseDate: 2017-04-01
+    link: https://doc.samsungmobile.com/SM-G525N/KOO/doc.html
 
 -   releaseCycle: "Galaxy M62"
+    releaseDate: 2021-03-03
     support: true
     eol: false
-    releaseDate: 2021-03-03
+    link: https://doc.samsungmobile.com/SM-M625F/NPL/doc.html
 
 -   releaseCycle: "Galaxy A32"
-    support: true
-    eol: false # https://doc.samsungmobile.com/sm-a325f/ins/doc.html
     releaseDate: 2021-02-25
+    support: true
+    eol: false
+    link: https://doc.samsungmobile.com/sm-a325f/ins/doc.html
 
 -   releaseCycle: "Galaxy F62"
-    support: true
-    eol: false
     releaseDate: 2021-02-22
-
--   releaseCycle: "Galaxy M02" #This loses active support with Android 12.
     support: true
     eol: false
-    releaseDate: 2021-02-09
+    link: https://doc.samsungmobile.com/SM-E625F/INS/doc.html
 
--   releaseCycle: "Galaxy M31s" #This loses active support with Android 12.
+-   releaseCycle: "Galaxy M02"
+    releaseDate: 2021-02-09
     support: true
     eol: false
-    releaseDate: 2021-02-09
+    link: https://doc.samsungmobile.com/SM-M022F/XTC/doc.html
 
--   releaseCycle: "Galaxy A02" #This loses active support with Android 12.
-    support: 2022-10-01 # Approximate from here: https://9to5google.com/2022/10/04/samsung-android-12-update-rollout/
+-   releaseCycle: "Galaxy M31s"
+    releaseDate: 2021-02-09
+    support: true
     eol: false
+    link: https://doc.samsungmobile.com/sm-m317f/ins/doc.html
+
+-   releaseCycle: "Galaxy A02"
     releaseDate: 2021-01-27
+    support: true
+    eol: false
+    link: https://doc.samsungmobile.com/SM-A022F/XID/doc.html
 
 -   releaseCycle: "Galaxy S21 Ultra"
+    releaseDate: 2021-01-14
     support: true
     eol: false
-    releaseDate: 2021-01-14
+    link: https://doc.samsungmobile.com/sm-g998b/dbt/doc.html
 
 -   releaseCycle: "Galaxy S21+"
+    releaseDate: 2021-01-14
     support: true
     eol: false
-    releaseDate: 2021-01-14
-
--   releaseCycle: "Galaxy S21"
-    support: true
-    eol: false
-    releaseDate: 2021-01-14
+    link: https://doc.samsungmobile.com/SM-G996B/DBT/doc.html
 
 -   releaseCycle: "Galaxy A32 5G"
-    support: true
-    eol: false
     releaseDate: 2021-01-13
-
--   releaseCycle: "Galaxy M02s" #This loses active support with Android 12.
     support: true
     eol: false
+    link: https://doc.samsungmobile.com/sm-a326u/tmb/doc.html
+
+-   releaseCycle: "Galaxy M02s"
     releaseDate: 2021-01-07
-
--   releaseCycle: "Galaxy A02s" #This loses active support with Android 12.
     support: true
     eol: false
+    link: https://doc.samsungmobile.com/SM-M025F/SLK/doc.html
+
+-   releaseCycle: "Galaxy A02s"
     releaseDate: 2021-01-04
-
--   releaseCycle: "Galaxy A12" #This loses active support with Android 12.
     support: true
     eol: false
+    link: https://doc.samsungmobile.com/SM-A025G/XEF/doc.html
+
+-   releaseCycle: "Galaxy A12"
     releaseDate: 2020-11-24
+    support: true
+    eol: false
+    link: https://doc.samsungmobile.com/SM-A125F/XEF/doc.html
 
 -   releaseCycle: "Galaxy M12"
+    releaseDate: 2020-11-24
     support: true
     eol: false
-    releaseDate: 2020-11-24
+    link: https://doc.samsungmobile.com/SM-M127F/ARO/doc.html
 
 -   releaseCycle: "Galaxy A42 5G"
+    releaseDate: 2020-11-11
     support: true
     eol: false
-    releaseDate: 2020-11-11
+    link: https://doc.samsungmobile.com/SM-A426B/XEF/doc.html
 
 -   releaseCycle: "Galaxy M21s"
-    support: 2022-10-01 # Approximate from here: https://9to5google.com/2022/10/04/samsung-android-12-update-rollout/
-    eol: false
     releaseDate: 2020-11-06
+    support: true
+    eol: false
+    link: https://doc.samsungmobile.com/SM-F415F/INS/doc.html
 
--   releaseCycle: "W21 5G"
+-   releaseCycle: "Galaxy Z Fold2 5G"
+    releaseDate: 2020-11-04
     support: false
     eol: false
-    releaseDate: 2020-11-04
+    link: https://doc.samsungmobile.com/SM-F916B/XEH/doc.html
 
--   releaseCycle: "Galaxy M31 Prime" #This loses active support with Android 12.
-    support: true
-    eol: false
+-   releaseCycle: "Galaxy M31 Prime"
     releaseDate: 2020-10-17
-
--   releaseCycle: "Galaxy F41" #This loses active support with Android 12.
     support: true
     eol: false
+    link: https://doc.samsungmobile.com/sm-m315f/ins/doc.html
+
+-   releaseCycle: "Galaxy F41"
     releaseDate: 2020-10-16
+    support: true
+    eol: false
+    link: https://doc.samsungmobile.com/SM-F415F/INS/doc.html
 
 -   releaseCycle: "Galaxy S20 FE 5G"
-    support: true
-    eol: false # https://doc.samsungmobile.com/SM-G781B/BTU/doc.html
     releaseDate: 2020-10-02
+    support: true
+    eol: false
+    link: https://doc.samsungmobile.com/SM-G781B/BTU/doc.html
 
 -   releaseCycle: "Galaxy S20 FE"
-    support: true
-    eol: false # https://doc.samsungmobile.com/SM-G780G/BTU/doc.html
     releaseDate: 2020-10-02
+    support: true
+    eol: false
+    link: https://doc.samsungmobile.com/SM-G780G/BTU/doc.html
 
 -   releaseCycle: "Galaxy Tab Active3"
-    support: true
-    eol: false # https://doc.samsungmobile.com/SM-T575/XEF/doc.html
     releaseDate: 2020-09-28
+    support: true
+    eol: false
+    link: https://doc.samsungmobile.com/SM-T575/XEF/doc.html
 
 -   releaseCycle: "Galaxy Z Fold 2"
+    releaseDate: 2020-09-18
     support: true
     eol: false
-    releaseDate: 2020-09-18
+    link: https://doc.samsungmobile.com/SM-F916B/XEH/doc.html
 
 -   releaseCycle: "Galaxy Tab A7 10.4 (2020)"
-    support: true
-    eol: false # https://doc.samsungmobile.com/SM-T505/BTU/doc.html
     releaseDate: 2020-09-11
+    support: true
+    eol: false
+    link: https://doc.samsungmobile.com/SM-T505/BTU/doc.html
 
 -   releaseCycle: "Galaxy Note 20 Ultra 5G"
-    support: true
-    eol: false # https://doc.samsungmobile.com/SM-N986U1/VZW/doc.html
     releaseDate: 2020-08-21
+    support: true
+    eol: false
+    link: https://doc.samsungmobile.com/SM-N986U1/VZW/doc.html
 
 -   releaseCycle: "Galaxy Note 20 5G"
-    support: true
-    eol: false # https://doc.samsungmobile.com/SM-N981U1/VZW/doc.html
     releaseDate: 2020-08-21
+    support: true
+    eol: false
+    link: https://doc.samsungmobile.com/SM-N981U1/VZW/doc.html
 
 -   releaseCycle: "Galaxy A51 5G UW"
-    support: true
-    eol: false # TODO
     releaseDate: 2020-08-14
-
--   releaseCycle: "Galaxy Note 20 Ultra"
     support: true
     eol: false
+    link: https://doc.samsungmobile.com/SM-A516V/CHA/doc.html
+
+-   releaseCycle: "Galaxy Note20 Ultra"
     releaseDate: 2020-08-21
+    support: true
+    eol: false
+    link: https://doc.samsungmobile.com/SM-N985F/XNZ/doc.html
 
 -   releaseCycle: "Galaxy Tab S7"
-    support: true
-    eol: false # https://doc.samsungmobile.com/SM-T875/DBT/doc.html
     releaseDate: 2020-08-21
-
--   releaseCycle: "Galaxy Note 20"
     support: true
     eol: false
+    link: https://doc.samsungmobile.com/SM-T875/DBT/doc.html
+
+-   releaseCycle: "Galaxy Note20"
     releaseDate: 2020-08-21
+    support: true
+    eol: false
+    link: https://doc.samsungmobile.com/SM-N980F/XEO/doc.html
 
 -   releaseCycle: "Galaxy Z Flip 5G"
+    releaseDate: 2020-08-07
     support: true
     eol: false
-    releaseDate: 2020-08-07
+    link: https://doc.samsungmobile.com/SM-F707B/XEH/doc.html
 
 -   releaseCycle: "Galaxy A51 5G"
-    support: true
-    eol: false # https://doc.samsungmobile.com/SM-A516B/012784200623/nld.html
     releaseDate: 2020-08-07
-
--   releaseCycle: "Galaxy M51" #This loses active support with Android 12.
     support: true
     eol: false
+    link: https://doc.samsungmobile.com/SM-A516B/012784200623/nld.html
+
+-   releaseCycle: "Galaxy M51"
     releaseDate: 2020-08-06
+    support: true
+    eol: false
+    link: https://doc.samsungmobile.com/SM-M515F/DBT/doc.html
 
 -   releaseCycle: "Galaxy Watch3"
-    support: true
-    eol: false # TODO
     releaseDate: 2020-08-06
+    support: true
+    eol: false
+    link: https://doc.samsungmobile.com/sm-r850/btu/doc.html
 
 -   releaseCycle: "Galaxy A01 Core"
+    releaseDate: 2020-08-06
     support: false
     eol: false
-    releaseDate: 2020-08-06
+    link: https://doc.samsungmobile.com/SM-A013F/SEK/doc.html
 
 -   releaseCycle: "Galaxy Tab S7+"
-    support: true
-    eol: false # https://doc.samsungmobile.com/SM-T970/XAR/doc.html
     releaseDate: 2020-08-05
+    support: true
+    eol: false
+    link: https://doc.samsungmobile.com/SM-T970/XAR/doc.html
 
 -   releaseCycle: "Galaxy M01 Core"
-    support: true
-    eol: false # https://doc.samsungmobile.com/SM-M013F/INS/doc.html
     releaseDate: 2020-07-29
+    support: true
+    eol: false
+    link: https://doc.samsungmobile.com/SM-M013F/INS/doc.html
 
 -   releaseCycle: "Galaxy M01s"
-    support: true
-    eol: false # https://doc.samsungmobile.com/SM-M017F/INS/doc.html
     releaseDate: 2020-07-16
+    support: true
+    eol: false
+    link: https://doc.samsungmobile.com/SM-M017F/INS/doc.html
 
 -   releaseCycle: "Galaxy A71 5G UW"
-    support: true
-    eol: false # TODO
     releaseDate: 2020-07-16
+    support: true
+    eol: false
+    link: https://doc.samsungmobile.com/SM-A716V/CCT/doc.html
 
--   releaseCycle: "Galaxy A21" #This loses active support with Android 12.
+-   releaseCycle: "Galaxy A21"
+    releaseDate: 2020-06-26
     support: true
     eol: false # Quarterly
-    releaseDate: 2020-06-26
+    link: https://doc.samsungmobile.com/sm-a215u/usc/doc.html
 
 -   releaseCycle: "Galaxy A71 5G"
+    releaseDate: 2020-06-15
     support: true
     eol: false
-    releaseDate: 2020-06-15
+    link: https://doc.samsungmobile.com/sm-a716u/spr/doc.html
 
 -   releaseCycle: "Galaxy S20 5G UW"
-    support: true
-    eol: false # TODO
     releaseDate: 2020-06-04
+    support: true
+    eol: false
+    link: https://doc.samsungmobile.com/sm-g981u1/xaa/doc.html
 
--   releaseCycle: "Galaxy A21s" #This loses active support with Android 12.
+-   releaseCycle: "Galaxy A21s"
+    releaseDate: 2020-06-02
     support: true
     eol: false # Quarterly
-    releaseDate: 2020-06-02
+    link: https://doc.samsungmobile.com/SM-A217F/XEF/doc.html
 
 -   releaseCycle: "Galaxy M01"
+    releaseDate: 2020-06-02
     support: true
     eol: false
-    releaseDate: 2020-06-02
+    link: https://doc.samsungmobile.com/SM-M015G/INS/doc.html
 
 -   releaseCycle: "Galaxy A Quantum"
+    releaseDate: 2020-05-22
     support: true
     eol: false
-    releaseDate: 2020-05-22
+    link: https://doc.samsungmobile.com/sm-a716s/skc/doc.html
 
 -   releaseCycle: "Galaxy Tab S6 Lite"
+    releaseDate: 2020-05-16
     support: true
     eol: false
-    releaseDate: 2020-05-16
+    link: https://doc.samsungmobile.com/SM-P610/XEH/doc.html
 
--   releaseCycle: "Galaxy A11" #This loses active support with Android 12.
+-   releaseCycle: "Galaxy A11"
+    releaseDate: 2020-05-15
     support: true
     eol: false # Quarterly
-    releaseDate: 2020-05-15
+    link: https://doc.samsungmobile.com/SM-A115F/XSG/doc.html
 
 -   releaseCycle: "Galaxy M11"
-    support: true
-    eol: false # TODO
     releaseDate: 2020-05-04
+    support: true
+    eol: false
+    link: https://doc.samsungmobile.com/SM-M115F/INS/doc.html
 
--   releaseCycle: "Galaxy A31" #This loses active support with Android 12.
+-   releaseCycle: "Galaxy A31"
+    releaseDate: 2020-04-27
     support: true
     eol: false # Quarterly
-    releaseDate: 2020-04-27
+    link: https://doc.samsungmobile.com/SM-A315F/MID/doc.html
 
 -   releaseCycle: "Galaxy J2 Core (2020)"
-    support: false # Android 8.1 Oreo (Go edition) is not supported anymore
-    eol: false # https://doc.samsungmobile.com/SM-J260FU/SER/doc.html
     releaseDate: 2020-04-27
+    support: false # Android 8.1 Oreo (Go edition) is not supported anymore
+    eol: false
+    link: https://doc.samsungmobile.com/SM-J260FU/SER/doc.html
 
 -   releaseCycle: "Galaxy Xcover FieldPro"
-    support: 2022-10-01 # Approximate from here: https://9to5google.com/2022/10/04/samsung-android-12-update-rollout/
-    eol: false # https://doc.samsungmobile.com/SM-G889YB/DBT/doc.html
     releaseDate: 2020-04-06
+    support: 2022-10-01 # Approximate from here: https://9to5google.com/2022/10/04/samsung-android-12-update-rollout/
+    eol: false
+    link: https://doc.samsungmobile.com/SM-G889YB/DBT/doc.html
 
 -   releaseCycle: "Galaxy Tab A 8.4 (2020)" # Yeah we need to specify the year here, multiple models from different years with the same name.
-    support: true #This loses active support with Android 12.
-    eol: false
     releaseDate: 2020-03-25
-
--   releaseCycle: "Galaxy M21" #This loses active support with Android 12.
-    support: 2022-10-01 # Approximate from here: https://9to5google.com/2022/10/04/samsung-android-12-update-rollout/
+    support: true
     eol: false
-    releaseDate: 2020-03-23
+    link: https://doc.samsungmobile.com/sm-t307u/glw/doc.html
 
--   releaseCycle: "Galaxy A41" #This loses active support with Android 12.
+-   releaseCycle: "Galaxy M21"
+    releaseDate: 2020-03-23
+    support: true
+    eol: false
+    link: https://doc.samsungmobile.com/sm-m215f/ins/doc.html
+
+-   releaseCycle: "Galaxy A41"
+    releaseDate: 2020-03-18
     support: true
     eol: false # Quarterly
-    releaseDate: 2020-03-18
+    link: https://doc.samsungmobile.com/SM-A415F/TMH/doc.html
 
 -   releaseCycle: "Galaxy S20 Ultra 5G"
-    support: true
-    eol: false # https://doc.samsungmobile.com/SM-G988B/ATO/doc.html
     releaseDate: 2020-03-06
+    support: true
+    eol: false
+    link: https://doc.samsungmobile.com/SM-G988B/ATO/doc.html
 
 -   releaseCycle: "Galaxy S20 5G"
-    support: true
-    eol: false # https://doc.samsungmobile.com/SM-G981B/ITV/doc.html
     releaseDate: 2020-03-06
+    support: true
+    eol: false
+    link: https://doc.samsungmobile.com/SM-G981B/ITV/doc.html
 
 -   releaseCycle: "Galaxy S20+ 5G"
-    support: true
-    eol: false # https://doc.samsungmobile.com/SM-G986B/XEF/doc.html
     releaseDate: 2020-03-06
+    support: true
+    eol: false
+    link: https://doc.samsungmobile.com/SM-G986B/XEF/doc.html
 
 -   releaseCycle: "Galaxy M31"
+    releaseDate: 2020-03-05
     support: true
     eol: false
-    releaseDate: 2020-03-05
+    link: https://doc.samsungmobile.com/sm-m315f/ins/doc.html
 
 -   releaseCycle: "Galaxy S20 Ultra"
+    releaseDate: 2020-02-21
     support: true
     eol: false
-    releaseDate: 2020-02-21
+    link: https://doc.samsungmobile.com/SM-G988B/DCO/doc.html
 
 -   releaseCycle: "Galaxy S20+"
+    releaseDate: 2020-02-21
     support: true
     eol: false
-    releaseDate: 2020-02-21
+    link: https://doc.samsungmobile.com/SM-G985F/XEH/doc.html
 
 -   releaseCycle: "Galaxy S20"
+    releaseDate: 2020-02-21
     support: true
     eol: false
-    releaseDate: 2020-02-21
+    link: https://doc.samsungmobile.com/SM-G980F/VDC/doc.html
 
 -   releaseCycle: "Galaxy Z Flip"
+    releaseDate: 2020-02-14
     support: true
     eol: false
-    releaseDate: 2020-02-14
+    link: https://doc.samsungmobile.com/SM-F700F/XEH/doc.html
 
 -   releaseCycle: "Galaxy Tab S6 5G"
-    support: 2022-10-01 # Approximate from here: https://9to5google.com/2022/10/04/samsung-android-12-update-rollout/
-    eol: false
     releaseDate: 2020-01-30
+    support: true
+    eol: false
+    link: https://doc.samsungmobile.com/sm-t866n/koo/doc.html
 
 -   releaseCycle: "Galaxy A71"
+    releaseDate: 2020-01-17
     support: true
     eol: false
-    releaseDate: 2020-01-17
+    link: https://doc.samsungmobile.com/sm-a715f/ins/doc.html
 
 -   releaseCycle: "Galaxy S10 Lite"
+    releaseDate: 2020-01-03
     support: true
     eol: false
-    releaseDate: 2020-01-03
+    link: https://doc.samsungmobile.com/sm-g770f/phe/doc.html
 
--   releaseCycle: "Galaxy Note 10 Lite"
+-   releaseCycle: "Galaxy Note10 Lite"
+    releaseDate: 2020-01-03
     support: true
     eol: false
-    releaseDate: 2020-01-03
+    link: https://doc.samsungmobile.com/sm-n770f/xef/doc.html
 
 -   releaseCycle: "Galaxy XCover Pro" # Unclear release date.
-    support: true #This loses active support with Android 12.
-    eol: false
     releaseDate: 2020-01-01
+    support: true
+    eol: false
+    link: https://doc.samsungmobile.com/SM-G715FN/XEH/doc.html
 
 -   releaseCycle: "Galaxy A51"
+    releaseDate: 2019-12-27
     support: true
     eol: false
-    releaseDate: 2019-12-27
+    link: https://doc.samsungmobile.com/SM-A515F/XEF/doc.html
 
--   releaseCycle: "Galaxy A01" #This loses active support with Android 12.
+-   releaseCycle: "Galaxy A01"
+    releaseDate: 2019-12-18
     support: true
     eol: false # Quarterly
-    releaseDate: 2019-12-18
-
--   releaseCycle: "W20 5G"
-    support: false
-    eol: false
-    releaseDate: 2019-11-20
-
--   releaseCycle: "Galaxy M30s"
-    support: false
-    eol: false
-    releaseDate: 2019-10-30
-
--   releaseCycle: "Galaxy A20s"
-    support: false
-    eol: false
-    releaseDate: 2019-10-05
-
--   releaseCycle: "Galaxy Tab Active Pro"
-    support: 2022-10-01 # Approximate from here: https://9to5google.com/2022/10/04/samsung-android-12-update-rollout/
-    eol: false
-    releaseDate: 2019-10-01
-
--   releaseCycle: "Galaxy A30s"
-    support: false
-    eol: false # https://doc.samsungmobile.com/SM-A307GN/XXV/doc.html
-    releaseDate: 2019-09-11
-
--   releaseCycle: "Galaxy Fold"
-    support: true
-    eol: false # https://doc.samsungmobile.com/SM-F900F/XEH/doc.html
-    releaseDate: 2019-09-06
-
--   releaseCycle: "Galaxy A90 5G" #This loses active support with Android 12.
-    support: true
-    eol: false # Quarterly Security Updates. This is a weird one. Getting 12 but not under the monthly security support branch.
-    releaseDate: 2019-09-03
-
--   releaseCycle: "Galaxy A70s"
-    support: false
-    eol: false
-    releaseDate: 2019-09-01
-
--   releaseCycle: "Galaxy A50s"
-    support: false
-    eol: false
-    releaseDate: 2019-09-01
-
--   releaseCycle: "Galaxy M10s"
-    support: false
-    eol: false
-    releaseDate: 2019-09-01
+    link: https://doc.samsungmobile.com/SM-A015F/THL/doc.html
 
 -   releaseCycle: "Galaxy Fold 5G"
+    releaseDate: 2019-11-20
+    support: false
+    eol: false
+    link: https://doc.samsungmobile.com/SM-F907B/AUT/doc.html
+
+-   releaseCycle: "Galaxy M30s"
+    releaseDate: 2019-10-30
+    support: false
+    eol: false
+    link: https://doc.samsungmobile.com/sm-m307f/ins/doc.html
+
+-   releaseCycle: "Galaxy A20s"
+    releaseDate: 2019-10-05
+    support: false
+    eol: false
+    link: https://doc.samsungmobile.com/SM-A207F/XEH/doc.html
+
+-   releaseCycle: "Galaxy Tab Active Pro"
+    releaseDate: 2019-10-01
+    support: 2022-10-01 # Approximate from here: https://9to5google.com/2022/10/04/samsung-android-12-update-rollout/
+    eol: false
+    link: https://doc.samsungmobile.com/SM-T540/XEH/doc.html
+
+-   releaseCycle: "Galaxy A30s"
+    releaseDate: 2019-09-11
+    support: false
+    eol: false
+    link: https://doc.samsungmobile.com/SM-A307GN/XXV/doc.html
+
+-   releaseCycle: "Galaxy Fold"
+    releaseDate: 2019-09-06
     support: true
-    eol: false # https://doc.samsungmobile.com/SM-F907B/BTU/doc.html
+    eol: false
+    link: https://doc.samsungmobile.com/SM-F900F/XEH/doc.html
+
+-   releaseCycle: "Galaxy A90 5G"
+    releaseDate: 2019-09-03
+    support: true
+    eol: false # Quarterly Security Updates. This is a weird one. Getting 12 but not under the monthly security support branch.
+    link: https://doc.samsungmobile.com/SM-A908B/009444191005/eng.html
+
+-   releaseCycle: "Galaxy A70s"
+    releaseDate: 2019-09-01
+    support: false
+    eol: false
+    link: https://doc.samsungmobile.com/sm-a707f/ins/doc.html
+
+-   releaseCycle: "Galaxy A50s"
+    releaseDate: 2019-09-01
+    support: false
+    eol: false
+    link: https://doc.samsungmobile.com/sm-a507fn/ins/doc.html
+
+-   releaseCycle: "Galaxy M10s"
+    releaseDate: 2019-09-01
+    support: false
+    eol: false
+    link: https://doc.samsungmobile.com/SM-M107F/INS/doc.html
+
+-   releaseCycle: "Galaxy Fold 5G"
     releaseDate: 2019-09-01 # Approximate to the month and year.
+    support: true
+    eol: false
+    link: https://doc.samsungmobile.com/SM-F907B/BTU/doc.html
 
 -   releaseCycle: "Galaxy Watch Active2"
-    support: true
-    eol: false # TODO
     releaseDate: 2019-09-01 # Approximate to the month and year.
+    support: true
+    eol: false
+    link: https://doc.samsungmobile.com/sm-r825f/dbt/doc.html
 
 -   releaseCycle: "Galaxy Watch Active2 Aluminum"
-    support: true
-    eol: false # TODO
     releaseDate: 2019-09-01 # Approximate to the month and year.
+    support: true
+    eol: false
+    link: https://doc.samsungmobile.com/SM-R830/XAR/doc.html
 
 -   releaseCycle: "Galaxy A10s"
+    releaseDate: 2019-08-27
     support: false
     eol: false
-    releaseDate: 2019-08-27
+    link: https://doc.samsungmobile.com/SM-A107F/SEK/doc.html
 
 -   releaseCycle: "Galaxy A10e"
+    releaseDate: 2019-08-27
     support: false
     eol: false
-    releaseDate: 2019-08-27
+    link: https://doc.samsungmobile.com/SM-A102U/DSH/doc.html
 
 -   releaseCycle: "Galaxy Note10+"
-    support: true
-    eol: false # https://doc.samsungmobile.com/SM-N975U/008579190821/fra.html
     releaseDate: 2019-08-23
+    support: true
+    eol: false
+    link: https://doc.samsungmobile.com/SM-N975U/008579190821/fra.html
 
 -   releaseCycle: "Galaxy Note10"
-    support: true
-    eol: false # https://doc.samsungmobile.com/SM-N970F/XEF/doc.html
     releaseDate: 2019-08-23
-
--   releaseCycle: "Galaxy Tab S6" #This loses active support with Android 12.
     support: true
     eol: false
+    link: https://doc.samsungmobile.com/SM-N970F/XEF/doc.html
+
+-   releaseCycle: "Galaxy Tab S6"
     releaseDate: 2019-08-01
+    support: true
+    eol: false
+    link: https://doc.samsungmobile.com/SM-T860/XAR/doc.html
 
 -   releaseCycle: "Galaxy Note10+ 5G"
-    support: true
-    eol: false # https://doc.samsungmobile.com/SM-N976B/SFR/doc.html
     releaseDate: 2019-08-01 # Approximate to the month and year.
+    support: true
+    eol: false
+    link: https://doc.samsungmobile.com/SM-N976B/SFR/doc.html
 
 -   releaseCycle: "Galaxy Note10 5G"
-    support: true
-    eol: false # https://doc.samsungmobile.com/sm-n971n/koo/doc.html
     releaseDate: 2019-08-01 # Approximate to the month and year.
+    support: true
+    eol: false
+    link: https://doc.samsungmobile.com/sm-n971n/koo/doc.html
 
 -   releaseCycle: "Galaxy Tab A 8.0 (2019)"
+    releaseDate: 2019-07-01
     support: false
     eol: false
-    releaseDate: 2019-07-01
+    link: https://doc.samsungmobile.com/SM-T290/008916190830/mlt.html
 
 -   releaseCycle: "Galaxy Xcover 4s"
-    support: 2022-10-01 # Approximate from here: https://9to5google.com/2022/10/04/samsung-android-12-update-rollout/
-    eol: false # https://doc.samsungmobile.com/SM-G398FN/ATO/doc.html
     releaseDate: 2019-07-01 # Approximate to the month and year.
+    support: 2022-10-01 # Approximate from here: https://9to5google.com/2022/10/04/samsung-android-12-update-rollout/
+    eol: false
+    link: https://doc.samsungmobile.com/SM-G398FN/ATO/doc.html
 
 -   releaseCycle: "Galaxy A60"
+    releaseDate: 2019-06-01
     support: false
     eol: false
-    releaseDate: 2019-06-01
+    link: https://doc.samsungmobile.com/SM-A6060/TGY/doc.html
 
 -   releaseCycle: "Galaxy M40"
-    support: true
-    eol: false # https://doc.samsungmobile.com/SM-M405F/INS/doc.html
     releaseDate: 2019-06-01 # Approximate to the month and year.
+    support: true
+    eol: false
+    link: https://doc.samsungmobile.com/SM-M405F/INS/doc.html
 
 -   releaseCycle: "Galaxy A80"
+    releaseDate: 2019-05-01
     support: false
     eol: false
-    releaseDate: 2019-05-01
+    link: https://doc.samsungmobile.com/SM-A805F/XEH/doc.html
 
 -   releaseCycle: "Galaxy A70"
+    releaseDate: 2019-05-01
     support: false
     eol: false
-    releaseDate: 2019-05-01
+    link: https://doc.samsungmobile.com/SM-A705F/XID/doc.html
 
 -   releaseCycle: "Galaxy A20e"
+    releaseDate: 2019-05-01
     support: false
     eol: false
-    releaseDate: 2019-05-01
+    link: https://doc.samsungmobile.com/SM-A202F/DBT/doc.html
 
 -   releaseCycle: "Galaxy A20"
+    releaseDate: 2019-04-05
     support: false
     eol: false
-    releaseDate: 2019-04-05
+    link: https://doc.samsungmobile.com/SM-A205F/AFR/doc.html
 
 -   releaseCycle: "Galaxy A40"
+    releaseDate: 2019-04-01
     support: 2022-10-01 # Approximate from here: https://9to5google.com/2022/10/04/samsung-android-12-update-rollout/
     eol: false
-    releaseDate: 2019-04-01
+    link: https://doc.samsungmobile.com/SM-A405FN/XEH/doc.html
 
 -   releaseCycle: "Galaxy Watch Active"
-    support: true
-    eol: false # TODO
     releaseDate: 2019-04-01 # Approximate to the month and year.
+    support: true
+    eol: false
+    link: https://doc.samsungmobile.com/sm-r500/xar/doc.html
 
 -   releaseCycle: "Galaxy Tab A 8.0 & S Pen (2019)"
-    support: true
-    eol: false # https://doc.samsungmobile.com/SM-P205/XXV/doc.html
     releaseDate: 2019-04-01 # Approximate to the month and year.
+    support: true
+    eol: false
+    link: https://doc.samsungmobile.com/SM-P205/XXV/doc.html
 
 -   releaseCycle: "Galaxy View2"
+    releaseDate: 2019-04-01
     support: false
     eol: 2021-12-31
-    releaseDate: 2019-04-01
+    link: null
 
 -   releaseCycle: "Galaxy Tab S5e"
+    releaseDate: 2019-04-01
     support: false
     eol: false
-    releaseDate: 2019-04-01
+    link: https://doc.samsungmobile.com/SM-T725/XEO/doc.html
 
 -   releaseCycle: "Galaxy Tab A 8.0 with S Pen (2019)"
+    releaseDate: 2019-04-01
     support: false
     eol: 2021-11-17
-    releaseDate: 2019-04-01
+    link: https://doc.samsungmobile.com/sm-p205/xtc/doc.html
 
 -   releaseCycle: "Galaxy Tab A 10.1 (2019)"
+    releaseDate: 2019-04-01
     support: false
     eol: false
-    releaseDate: 2019-04-01
+    link: https://doc.samsungmobile.com/SM-T515/TMZ/doc.html
 
 -   releaseCycle: "Galaxy A2 Core"
+    releaseDate: 2019-04-01
     support: false
     eol: 2021-10-01
-    releaseDate: 2019-04-01
+    link: https://doc.samsungmobile.com/SM-A260F/ECT/doc.html
 
 -   releaseCycle: "Galaxy A10"
+    releaseDate: 2019-03-19
     support: false
     eol: false
-    releaseDate: 2019-03-19
+    link: https://doc.samsungmobile.com/SM-A105F/AFR/doc.html
 
 -   releaseCycle: "Galaxy A50"
-    support: 2022-10-01 # Approximate from here: https://9to5google.com/2022/10/04/samsung-android-12-update-rollout/
-    eol: false # https://doc.samsungmobile.com/SM-A505G/CHL/doc.html
     releaseDate: 2019-03-18
+    support: 2022-10-01 # Approximate from here: https://9to5google.com/2022/10/04/samsung-android-12-update-rollout/
+    eol: false
+    link: https://doc.samsungmobile.com/SM-A505G/CHL/doc.html
 
 -   releaseCycle: "Galaxy A30"
+    releaseDate: 2019-03-01
     support: false
     eol: false
-    releaseDate: 2019-03-01
+    link: https://doc.samsungmobile.com/SM-A305F/AFR/doc.html
 
 -   releaseCycle: "Galaxy M30"
-    support: true
-    eol: false # https://doc.samsungmobile.com/SM-M305M/XXV/doc.html
     releaseDate: 2019-03-01 # Approximate to the month and year.
+    support: true
+    eol: false
+    link: https://doc.samsungmobile.com/SM-M305M/XXV/doc.html
 
 -   releaseCycle: "Galaxy S10 5G"
-    support: true
-    eol: false # https://doc.samsungmobile.com/SM-G977B/EVR/doc.html
     releaseDate: 2019-02-20
+    support: true
+    eol: false
+    link: https://doc.samsungmobile.com/SM-G977B/EVR/doc.html
 
 -   releaseCycle: "Galaxy S10"
-    support: true
-    eol: false # https://doc.samsungmobile.com/SM-G973F/XEF/doc.html
     releaseDate: 2019-02-20
+    support: true
+    eol: false
+    link: https://doc.samsungmobile.com/SM-G973F/XEF/doc.html
 
 -   releaseCycle: "Galaxy S10+"
-    support: true
-    eol: false # https://doc.samsungmobile.com/SM-G975F/XEF/doc.html
     releaseDate: 2019-02-20
+    support: true
+    eol: false
+    link: https://doc.samsungmobile.com/SM-G975F/XEF/doc.html
 
 -   releaseCycle: "Galaxy S10e"
-    support: true
-    eol: false # https://doc.samsungmobile.com/sm-g970f/dbt/doc.html
     releaseDate: 2019-02-20
+    support: true
+    eol: false
+    link: https://doc.samsungmobile.com/sm-g970f/dbt/doc.html
 
 -   releaseCycle: "Galaxy M20"
-    support: false
-    eol: false # https://doc.samsungmobile.com/SM-M205F/INS/doc.html
     releaseDate: 2019-02-01 # Approximate to the month and year.
-
--   releaseCycle: "Galaxy M10"
-    support: false
-    eol: false # https://doc.samsungmobile.com/SM-M105F/INS/doc.html
-    releaseDate: 2019-02-01 # Approximate to the month and year.
-
--   releaseCycle: "Galaxy A8s"
     support: false
     eol: false
+    link: https://doc.samsungmobile.com/SM-M205F/INS/doc.html
+
+-   releaseCycle: "Galaxy M10"
+    releaseDate: 2019-02-01 # Approximate to the month and year.
+    support: false
+    eol: false
+    link: https://doc.samsungmobile.com/SM-M105F/INS/doc.html
+
+-   releaseCycle: "Galaxy A8s"
     releaseDate: 2018-12-01
+    support: false
+    eol: false
+    link: https://doc.samsungmobile.com/SM-G8870/TGY/doc.html
 
 -   releaseCycle: "Galaxy Tab Advanced2"
-    support: false
-    eol: true # https://doc.samsungmobile.com/SM-T583/KOO/doc.html
     releaseDate: 2018-12-01 # Approximate to the month and year.
+    support: false
+    eol: true
+    link: https://doc.samsungmobile.com/SM-T583/KOO/doc.html
 
 -   releaseCycle: "Galaxy J4 Core"
+    releaseDate: 2018-11-01
     support: false
     eol: 2020-12-01
-    releaseDate: 2018-11-01
+    link: https://doc.samsungmobile.com/SM-J410F/AFR/doc.html
 
 -   releaseCycle: "Galaxy A6s"
-    support: false
-    eol: true # https://doc.samsungmobile.com/SM-A600FN/XEF/doc.html
     releaseDate: 2018-11-01 # Approximate to the month and year.
+    support: false
+    eol: true
+    link: https://doc.samsungmobile.com/SM-A600FN/XEF/doc.html
 
 -   releaseCycle: "Galaxy A9 (2018)"
+    releaseDate: 2018-11-01
     support: false
     eol: 2022-06-01
-    releaseDate: 2018-11-01
+    link: https://doc.samsungmobile.com/SM-A920F/XEO/doc.html
 
 -   releaseCycle: "Galaxy J6+"
+    releaseDate: 2018-10-01
     support: false
     eol: 2022-06-01
-    releaseDate: 2018-10-01
+    link: https://doc.samsungmobile.com/SM-J610FN/XEF/doc.html
 
 -   releaseCycle: "Galaxy J4+"
+    releaseDate: 2018-10-01
     support: false
     eol: 2020-12-01
-    releaseDate: 2018-10-01
+    link: https://doc.samsungmobile.com/SM-J415F/AFR/doc.html
 
 -   releaseCycle: "Galaxy A7 (2018)"
-    support: false
-    eol: 2022-07-01 # https://doc.samsungmobile.com/SM-A750GN/XXV/doc.html
     releaseDate: 2018-10-01
-
--   releaseCycle: "Galaxy Tab A 8.0 (2018)"
-    support: false
-    eol: true # https://doc.samsungmobile.com/SM-A530F/FTM/doc.html
-    releaseDate: 2018-09-01 # Approximate to the month and year.
-
--   releaseCycle: "Galaxy Note 9"
     support: false
     eol: 2022-07-01
+    link: https://doc.samsungmobile.com/SM-A750GN/XXV/doc.html
+
+-   releaseCycle: "Galaxy Tab A 8.0 (2018)"
+    releaseDate: 2018-09-01 # Approximate to the month and year.
+    support: false
+    eol: true
+    link: https://doc.samsungmobile.com/SM-A530F/FTM/doc.html
+
+-   releaseCycle: "Galaxy Note 9"
     releaseDate: 2018-08-24
+    support: false
+    eol: 2022-07-01
+    link: https://doc.samsungmobile.com/sm-n960f/dbt/doc.html
 
 -   releaseCycle: "Galaxy Tab S4 10.5"
+    releaseDate: 2018-08-01
     support: false
     eol: 2022-06-01
-    releaseDate: 2018-08-01
+    link: https://doc.samsungmobile.com/SM-T830/XAR/doc.html
 
 -   releaseCycle: "Galaxy Tab A 10.5 (2018)"
-    support: false
-    eol: 2022-06-01 # https://doc.samsungmobile.com/SM-T595/SER/doc.html
     releaseDate: 2018-08-01 # Approximate to the month and year.
+    support: false
+    eol: 2022-06-01
+    link: https://doc.samsungmobile.com/SM-T595/SER/doc.html
 
 -   releaseCycle: "Galaxy Watch"
-    support: false
-    eol: true # https://doc.samsungmobile.com/SM-R810/001398180827/fra.html
     releaseDate: 2018-08-01 # Approximate to the month and year.
+    support: false
+    eol: true
+    link: https://doc.samsungmobile.com/SM-R810/001398180827/fra.html
 
 -   releaseCycle: "Galaxy J2 Core"
+    releaseDate: 2018-08-01
     support: false
     eol: 2021-12-31
-    releaseDate: 2018-08-01
+    link: https://doc.samsungmobile.com/SM-J260M/COM/doc.html
 
 -   releaseCycle: "Galaxy J8"
+    releaseDate: 2018-07-01
     support: false
     eol: 2021-09-01
-    releaseDate: 2018-07-01
+    link: https://doc.samsungmobile.com/SM-J810G/INS/doc.html
 
 -   releaseCycle: "Galaxy On6"
-    support: false
-    eol: 2022-02-01 # TODO
     releaseDate: 2018-07-01 # Approximate to the month and year.
+    support: false
+    eol: 2022-02-01
+    link: https://doc.samsungmobile.com/SM-J600GF/INS/doc.html
 
 -   releaseCycle: "Galaxy J7 (2018)"
-    support: false
-    eol: 2021-12-01 # https://doc.samsungmobile.com/SM-J700F/023395220803/roh.html
     releaseDate: 2018-07-01 # Approximate to the month and year.
+    support: false
+    eol: 2021-12-01
+    link: https://doc.samsungmobile.com/SM-J700F/023395220803/roh.html
 
 -   releaseCycle: "Galaxy J7 Top"
-    support: false
-    eol: 2021-12-31 # https://doc.samsungmobile.com/SM-J737U/XAR/doc.html
     releaseDate: 2018-07-01
-
--   releaseCycle: "Galaxy J3"
     support: false
     eol: 2021-12-31
-    releaseDate: 2018-06-01
+    link: https://doc.samsungmobile.com/SM-J737U/XAR/doc.html
 
 -   releaseCycle: "Galaxy J3 (2018)"
-    support: false
-    eol: 2021-11-01 # https://doc.samsungmobile.com/SM-J3300/CHC/doc.html
     releaseDate: 2018-06-01 # Approximate to the month and year.
+    support: false
+    eol: 2021-11-01
+    link: https://doc.samsungmobile.com/SM-J3300/CHC/doc.html
 
 -   releaseCycle: "Galaxy A8 Star"
-    support: false
-    eol: 2022-06-01 # https://doc.samsungmobile.com/SM-G885F/XXV/doc.html
     releaseDate: 2018-06-01
+    support: false
+    eol: 2022-06-01
+    link: https://doc.samsungmobile.com/SM-G885F/XXV/doc.html
 
 -   releaseCycle: "Galaxy J6"
+    releaseDate: 2018-05-01
     support: false
     eol: 2022-02-01
-    releaseDate: 2018-05-01
+    link: https://doc.samsungmobile.com/SM-J600G/INS/doc.html
 
 -   releaseCycle: "Galaxy J4"
+    releaseDate: 2018-05-01
     support: false
     eol: 2022-02-01
-    releaseDate: 2018-05-01
+    link: https://doc.samsungmobile.com/SM-J400G/BRI/doc.html
 
 -   releaseCycle: "Galaxy S Light Luxury"
-    support: false
-    eol: true # TODO
     releaseDate: 2018-05-01 # Approximate to the month and year.
+    support: false
+    eol: true
+    link: https://doc.samsungmobile.com/SM-G8750/000773180601/zho-cn.html
 
 -   releaseCycle: "Galaxy A6+ (2018)"
-    support: false
-    eol: 2021-12-01 # https://doc.samsungmobile.com/SM-A605G/XXV/doc.html
     releaseDate: 2018-05-01 # Approximate to the month and year.
+    support: false
+    eol: 2021-12-01
+    link: https://doc.samsungmobile.com/SM-A605G/XXV/doc.html
 
 -   releaseCycle: "Galaxy A6 (2018)"
-    support: false
-    eol: 2022-03-01 # https://doc.samsungmobile.com/SM-A600U/XAR/doc.html
     releaseDate: 2018-05-01 # Approximate to the month and year.
+    support: false
+    eol: 2022-03-01
+    link: https://doc.samsungmobile.com/SM-A600U/XAR/doc.html
 
 -   releaseCycle: "Galaxy J7 Prime 2"
+    releaseDate: 2018-04-01
     support: false
     eol: 2021-12-31
-    releaseDate: 2018-04-01
+    link: null
 
 -   releaseCycle: "Galaxy J7 Duo"
+    releaseDate: 2018-04-01
     support: false
     eol: 2021-12-31
-    releaseDate: 2018-04-01
+    link: null
 
 -   releaseCycle: "Galaxy S9+"
+    releaseDate: 2018-03-09
     support: false
     eol: 2022-04-05
-    releaseDate: 2018-03-09
+    link: https://doc.samsungmobile.com/sm-g965f/dbt/doc.html
 
 -   releaseCycle: "Galaxy S9"
+    releaseDate: 2018-03-09
     support: false
     eol: 2022-04-05
-    releaseDate: 2018-03-09
+    link: https://doc.samsungmobile.com/sm-g960f/dbt/doc.html
 
 -   releaseCycle: "Galaxy A8 (2018) Enterprise"
+    releaseDate: 2018-01-01
     support: false
     eol: 2021-12-31
-    releaseDate: 2018-01-01
+    link: null
 
 -   releaseCycle: "Galaxy A8+ (2018)"
-    support: false
-    eol: 2021-09-01 # https://doc.samsungmobile.com/SM-A730F/INS/doc.html
     releaseDate: 2018-01-01 # Approximate to the month and year.
+    support: false
+    eol: 2021-09-01
+    link: https://doc.samsungmobile.com/SM-A730F/INS/doc.html
 
 -   releaseCycle: "Galaxy A8 (2018)"
-    support: false
-    eol: 2022-01-01 # https://doc.samsungmobile.com/SM-A530F/CHL/doc.html
     releaseDate: 2018-01-01 # Approximate to the month and year.
+    support: false
+    eol: 2022-01-01
+    link: https://doc.samsungmobile.com/SM-A530F/CHL/doc.html
 
 -   releaseCycle: "Galaxy J2 Pro (2018)"
-    support: false
-    eol: 2019-10-01 # https://doc.samsungmobile.com/SM-J250Y/ITV/doc.html
     releaseDate: 2018-01-01 # Approximate to the month and year.
+    support: false
+    eol: 2019-10-01
+    link: https://doc.samsungmobile.com/SM-J250Y/ITV/doc.html
 
 -   releaseCycle: "Galaxy J2 (2017)"
-    support: false
-    eol: true # TODO
     releaseDate: 2017-10-01 # Approximate to the month and year.
+    support: false
+    eol: true
+    link: null
 
 -   releaseCycle: "Galaxy C7 (2017)"
-    support: false
-    eol: false # https://doc.samsungmobile.com/SM-C710F/XXV/doc.html
     releaseDate: 2017-10-01 # Approximate to the month and year.
+    support: false
+    eol: false
+    link: https://doc.samsungmobile.com/SM-C710F/XXV/doc.html
 
 -   releaseCycle: "Gear Sport"
-    support: false
-    eol: true # https://doc.samsungmobile.com/SM-R600/CHC/doc.html
     releaseDate: 2017-10-01 # Approximate to the month and year.
-
--   releaseCycle: "Galaxy Tab Active 2"
     support: false
-    eol: 2021-11-17
+    eol: true
+    link: https://doc.samsungmobile.com/SM-R600/CHC/doc.html
+
+-   releaseCycle: "Galaxy Tab Active2"
     releaseDate: 2017-10-20
-
--   releaseCycle: "Galaxy Note 8"
     support: false
     eol: 2021-11-17
+    link: https://doc.samsungmobile.com/SM-T395/DBT/doc.html
+
+-   releaseCycle: "Galaxy Note8"
     releaseDate: 2017-09-01
+    support: false
+    eol: 2021-11-17
+    link: https://doc.samsungmobile.com/sm-n950f/dbt/doc.html
 
 -   releaseCycle: "Galaxy Tab A 8.0 (2017)"
+    releaseDate: 2017-09-01
     support: false
     eol: 2021-11-17
-    releaseDate: 2017-09-01
-
--   releaseCycle: "Galaxy J7+"
-    support: false
-    eol: 2021-11-17
-    releaseDate: 2017-09-01
+    link: https://doc.samsungmobile.com/SM-T380/COO/doc.html
 
 -   releaseCycle: "Galaxy S8 Active"
+    releaseDate: 2017-08-01
     support: false
     eol: 2021-11-17
-    releaseDate: 2017-08-01
+    link: null
 
 -   releaseCycle: "Galaxy Note FE"
-    support: false
-    eol: 2019-03-01 # https://doc.samsungmobile.com/SM-N935F/XXV/doc.html
     releaseDate: 2017-07-01 # Approximate to the month and year.
+    support: false
+    eol: 2019-03-01
+    link: https://doc.samsungmobile.com/SM-N935F/XXV/doc.html
 
 -   releaseCycle: "Galaxy J7 (2017)"
-    support: false
-    eol: 2019-05-01 # https://doc.samsungmobile.com/SM-J730F/XEF/doc.html
     releaseDate: 2017-07-01 # Approximate to the month and year.
+    support: false
+    eol: 2019-05-01
+    link: https://doc.samsungmobile.com/SM-J730F/XEF/doc.html
 
 -   releaseCycle: "Galaxy J7 Pro"
-    support: false
-    eol: 2019-04-01 # https://doc.samsungmobile.com/SM-J730G/TNZ/doc.html
     releaseDate: 2017-07-01 # Approximate to the month and year.
+    support: false
+    eol: 2019-04-01
+    link: https://doc.samsungmobile.com/SM-J730G/TNZ/doc.html
 
 -   releaseCycle: "Galaxy J3 (2017)"
-    support: false
-    eol: 2019-07-01 # https://doc.samsungmobile.com/SM-J327U/XAR/doc.html
     releaseDate: 2017-07-01 # Approximate to the month and year.
+    support: false
+    eol: 2019-07-01
+    link: https://doc.samsungmobile.com/SM-J327U/XAR/doc.html
 
 -   releaseCycle: "Galaxy Folder2"
-    support: false
-    eol: true # https://doc.samsungmobile.com/SM-G160N/KOO/doc.html
     releaseDate: 2017-07-01 # Approximate to the month and year.
+    support: false
+    eol: true
+    link: https://doc.samsungmobile.com/SM-G160N/KOO/doc.html
 
 -   releaseCycle: "Galaxy J7 Neo"
-    support: false
-    eol: 2019-05-01 # https://doc.samsungmobile.com/SM-J701M/PET/doc.html
     releaseDate: 2017-07-01 # Approximate to the month and year.
+    support: false
+    eol: 2019-05-01
+    link: https://doc.samsungmobile.com/SM-J701M/PET/doc.html
 
 -   releaseCycle: "Galaxy J7 Max"
-    support: false
-    eol: 2019-03-01 # https://doc.samsungmobile.com/SM-G615FU/INS/doc.html
     releaseDate: 2017-06-01 # Approximate to the month and year.
+    support: false
+    eol: 2019-03-01
+    link: https://doc.samsungmobile.com/SM-G615FU/INS/doc.html
 
 -   releaseCycle: "Galaxy J5 (2017)"
-    support: false
-    eol: 2019-03-01 # https://doc.samsungmobile.com/SM-J530F/XEO/doc.html
     releaseDate: 2017-06-01 # Approximate to the month and year.
+    support: false
+    eol: 2019-03-01
+    link: https://doc.samsungmobile.com/SM-J530F/XEO/doc.html
 
 -   releaseCycle: "Z4"
-    support: false
-    eol: true # TODO
     releaseDate: 2017-06-01 # Approximate to the month and year.
+    support: false
+    eol: true
+    link: null
 
 -   releaseCycle: "Gear S3 classic LTE"
-    support: false
-    eol: false # https://doc.samsungmobile.com/SM-R770/BRI/doc.html
     releaseDate: 2017-05-01 # Approximate to the month and year.
+    support: false
+    eol: false
+    link: https://doc.samsungmobile.com/SM-R770/BRI/doc.html
 
 -   releaseCycle: "Galaxy S8"
-    support: false
-    eol: 2021-04-01 # https://doc.samsungmobile.com/SM-G950F/ITV/doc.html
     releaseDate: 2017-04-24
+    support: false
+    eol: 2021-04-01
+    link: https://doc.samsungmobile.com/SM-G950F/ITV/doc.html
 
 -   releaseCycle: "Galaxy S8+"
-    support: false
-    eol: 2021-04-01 # https://doc.samsungmobile.com/SM-G955F/SER/doc.html
     releaseDate: 2017-04-01 # Approximate to the month and year.
+    support: false
+    eol: 2021-04-01
+    link: https://doc.samsungmobile.com/SM-G955F/SER/doc.html
 
 -   releaseCycle: "Galaxy Xcover 4"
-    support: false
-    eol: 2019-06-01 # https://doc.samsungmobile.com/SM-G390F/ATO/doc.html
     releaseDate: 2017-04-01 # Approximate to the month and year.
+    support: false
+    eol: 2019-06-01
+    link: https://doc.samsungmobile.com/SM-G390F/ATO/doc.html
 
 -   releaseCycle: "Galaxy Tab S3 9.7"
-    support: false
-    eol: 2019-04-01 # https://doc.samsungmobile.com/SM-T825Y/XXV/doc.html
     releaseDate: 2017-04-01 # Approximate to the month and year.
+    support: false
+    eol: 2019-04-01
+    link: https://doc.samsungmobile.com/SM-T825Y/XXV/doc.html
 
 -   releaseCycle: "Galaxy J7 V"
-    support: false
-    eol: 2019-03-01 # https://doc.samsungmobile.com/SM-J727U/XAA/doc.html
     releaseDate: 2017-03-01 # Approximate to the month and year.
+    support: false
+    eol: 2019-03-01
+    link: https://doc.samsungmobile.com/SM-J727U/XAA/doc.html
 
 -   releaseCycle: "Galaxy C5 Pro"
-    support: false
-    eol: 2018-10-01 # https://doc.samsungmobile.com/SM-C5010/TGY/doc.html
     releaseDate: 2017-03-01 # Approximate to the month and year.
+    support: false
+    eol: 2018-10-01
+    link: https://doc.samsungmobile.com/SM-C5010/TGY/doc.html
 
 -   releaseCycle: "Galaxy C7 Pro"
-    support: false
-    eol: 2019-05-01 # https://doc.samsungmobile.com/SM-C701F/INS/doc.html
     releaseDate: 2017-02-01 # Approximate to the month and year.
+    support: false
+    eol: 2019-05-01
+    link: https://doc.samsungmobile.com/SM-C701F/INS/doc.html
 
 -   releaseCycle: "Galaxy J3 Emerge"
-    support: false
-    eol: 2019-08-01 # https://doc.samsungmobile.com/SM-J327T/TMB/doc.html
     releaseDate: 2017-01-01 # Approximate to the month and year.
+    support: false
+    eol: 2019-08-01
+    link: https://doc.samsungmobile.com/SM-J327T/TMB/doc.html
 
 -   releaseCycle: "Galaxy A7 (2017)"
-    support: false
-    eol: 2020-08-01 # https://doc.samsungmobile.com/SM-A720F/CHL/doc.html
     releaseDate: 2017-01-01 # Approximate to the month and year.
+    support: false
+    eol: 2020-08-01
+    link: https://doc.samsungmobile.com/SM-A720F/CHL/doc.html
 
 -   releaseCycle: "Galaxy A5 (2017)"
-    support: false
-    eol: 2019-04-01 # https://doc.samsungmobile.com/SM-A520F/XSA/doc.html
     releaseDate: 2017-01-01 # Approximate to the month and year.
+    support: false
+    eol: 2019-04-01
+    link: https://doc.samsungmobile.com/SM-A520F/XSA/doc.html
 
 -   releaseCycle: "Galaxy A3 (2017)"
-    support: false
-    eol: 2020-11-01 # https://doc.samsungmobile.com/SM-A320FL/ITV/doc.html
     releaseDate: 2017-01-01 # Approximate to the month and year.
+    support: false
+    eol: 2020-11-01
+    link: https://doc.samsungmobile.com/SM-A320FL/ITV/doc.html
 
 -   releaseCycle: "Galaxy J1 mini prime"
-    support: false
-    eol: true # TODO
     releaseDate: 2016-12-01 # Approximate to the month and year.
+    support: false
+    eol: true
+    link: null
 
 -   releaseCycle: "Galaxy J7 Prime"
-    support: false
-    eol: 2020-04-01 # https://doc.samsungmobile.com/SM-G610F/XXV/doc.html
     releaseDate: 2016-11-30
+    support: false
+    eol: 2020-04-01
+    link: https://doc.samsungmobile.com/SM-G610F/XXV/doc.html
 
 -   releaseCycle: "Galaxy Grand Prime Plus"
-    support: false
-    eol: true # TODO
     releaseDate: 2016-11-01 # Approximate to the month and year.
+    support: false
+    eol: true
+    link: null
 
 -   releaseCycle: "Galaxy J2 Prime"
-    support: false
-    eol: true # TODO
     releaseDate: 2016-11-01 # Approximate to the month and year.
+    support: false
+    eol: true
+    link: null
 
 -   releaseCycle: "Galaxy C9 Pro"
-    support: false
-    eol: 2019-07-01 # https://doc.samsungmobile.com/SM-C900F/INS/doc.html
     releaseDate: 2016-11-01 # Approximate to the month and year.
+    support: false
+    eol: 2019-07-01
+    link: https://doc.samsungmobile.com/SM-C900F/INS/doc.html
 
 -   releaseCycle: "Gear S3 classic"
-    support: false
-    eol: false # https://doc.samsungmobile.com/SM-R770/BRI/doc.html
     releaseDate: 2016-11-01 # Approximate to the month and year.
+    support: false
+    eol: false
+    link: https://doc.samsungmobile.com/SM-R770/BRI/doc.html
 
 -   releaseCycle: "Gear S3 frontier"
-    support: false
-    eol: false # https://doc.samsungmobile.com/SM-R770/BRI/doc.html
     releaseDate: 2016-11-01 # Approximate to the month and year.
+    support: false
+    eol: false
+    link: https://doc.samsungmobile.com/SM-R770/BRI/doc.html
 
 -   releaseCycle: "Gear S3 frontier LTE"
-    support: false
-    eol: false # https://doc.samsungmobile.com/SM-R770/BRI/doc.html
     releaseDate: 2016-11-01 # Approximate to the month and year.
+    support: false
+    eol: false
+    link: https://doc.samsungmobile.com/SM-R770/BRI/doc.html
 
 -   releaseCycle: "Galaxy A8 (2016)"
-    support: false
-    eol: true # https://doc.samsungmobile.com/SM-A800IZ/000065170406/zho-tw.htmll
     releaseDate: 2016-10-01 # Approximate to the month and year.
+    support: false
+    eol: true
+    link: https://doc.samsungmobile.com/SM-A800IZ/000065170406/zho-tw.htmll
 
 -   releaseCycle: "Galaxy On8"
-    support: false
-    eol: 2019-01-01 # https://doc.samsungmobile.com/SM-J710FN/INS/doc.html
     releaseDate: 2016-10-01 # Approximate to the month and year.
+    support: false
+    eol: 2019-01-01
+    link: https://doc.samsungmobile.com/SM-J710FN/INS/doc.html
 
 -   releaseCycle: "Galaxy On7 (2016)"
-    support: false
-    eol: 2020-07-01 # https://doc.samsungmobile.com/SM-G6100/TGY/doc.html
     releaseDate: 2016-10-01 # Approximate to the month and year.
+    support: false
+    eol: 2020-07-01
+    link: https://doc.samsungmobile.com/SM-G6100/TGY/doc.html
 
 -   releaseCycle: "Galaxy J5 Prime"
-    support: false
-    eol: 2020-10-01 # https://doc.samsungmobile.com/SM-G570F/SER/doc.html
     releaseDate: 2016-10-01 # Approximate to the month and year.
-
--   releaseCycle: "Galaxy Note 7"
     support: false
-    eol: true # TODO
+    eol: 2020-10-01
+    link: https://doc.samsungmobile.com/SM-G570F/SER/doc.html
+
+-   releaseCycle: "Galaxy Note7"
     releaseDate: 2016-09-01 # Approximate to the month and year.
+    support: false
+    eol: true
+    link: null
 
 -   releaseCycle: "Z2"
-    support: false
-    eol: true # TODO
     releaseDate: 2016-08-01 # Approximate to the month and year.
+    support: false
+    eol: true
+    link: null
 
 -   releaseCycle: "Galaxy Note 7 (USA)"
-    support: false
-    eol: true # TODO
     releaseDate: 2016-08-01 # Approximate to the month and year.
+    support: false
+    eol: true
+    link: null
 
 -   releaseCycle: "Galaxy Tab J"
-    support: false
-    eol: true # TODO
     releaseDate: 2016-08-01 # Approximate to the month and year.
+    support: false
+    eol: true
+    link: null
 
 -   releaseCycle: "Galaxy J Max"
-    support: false
-    eol: true # TODO
     releaseDate: 2016-08-01 # Approximate to the month and year.
+    support: false
+    eol: true
+    link: null
 
 -   releaseCycle: "Galaxy On7 Pro"
-    support: false
-    eol: true # TODO
     releaseDate: 2016-07-01 # Approximate to the month and year.
+    support: false
+    eol: true
+    link: null
 
 -   releaseCycle: "Galaxy On5 Pro"
-    support: false
-    eol: true # TODO
     releaseDate: 2016-07-01 # Approximate to the month and year.
+    support: false
+    eol: true
+    link: null
 
 -   releaseCycle: "Galaxy J2 Pro (2016)"
-    support: false
-    eol: 2019-10-01 # https://doc.samsungmobile.com/SM-J250F/TUR/doc.html
     releaseDate: 2016-07-01 # Approximate to the month and year.
+    support: false
+    eol: 2019-10-01
+    link: https://doc.samsungmobile.com/SM-J250F/TUR/doc.html
 
 -   releaseCycle: "Galaxy J2 (2016)"
-    support: false
-    eol: 2018-08-01 # https://doc.samsungmobile.com/SM-J210F/INS/doc.html
     releaseDate: 2016-07-01 # Approximate to the month and year.
+    support: false
+    eol: 2018-08-01
+    link: https://doc.samsungmobile.com/SM-J210F/INS/doc.html
 
 -   releaseCycle: "Z3 Corporate"
-    support: false
-    eol: true # TODO
     releaseDate: 2016-06-01 # Approximate to the month and year.
+    support: false
+    eol: true
+    link: null
 
 -   releaseCycle: "Galaxy S7 active"
-    support: false
-    eol: true # TODO
     releaseDate: 2016-06-01 # Approximate to the month and year.
+    support: false
+    eol: true
+    link: null
 
 -   releaseCycle: "Galaxy J3 Pro"
-    support: false
-    eol: 2021-04-01 # https://doc.samsungmobile.com/SM-J330G/BRI/doc.html
     releaseDate: 2016-06-01 # Approximate to the month and year.
+    support: false
+    eol: 2021-04-01
+    link: https://doc.samsungmobile.com/SM-J330G/BRI/doc.html
 
 -   releaseCycle: "Galaxy C7"
-    support: false
-    eol: 2018-10-01 # https://doc.samsungmobile.com/SM-C7000/CHC/doc.html
     releaseDate: 2016-06-01 # Approximate to the month and year.
+    support: false
+    eol: 2018-10-01
+    link: https://doc.samsungmobile.com/SM-C7000/CHC/doc.html
 
 -   releaseCycle: "Galaxy C5"
-    support: false
-    eol: 2019-01-01 # https://doc.samsungmobile.com/sm-c5000/tgy/doc.html
     releaseDate: 2016-06-01 # Approximate to the month and year.
+    support: false
+    eol: 2019-01-01
+    link: https://doc.samsungmobile.com/sm-c5000/tgy/doc.html
 
 -   releaseCycle: "Galaxy A9 Pro (2016)"
-    support: false
-    eol: 2019-02-01 # https://doc.samsungmobile.com/SM-A910F/INS/doc.html
     releaseDate: 2016-05-01 # Approximate to the month and year.
+    support: false
+    eol: 2019-02-01
+    link: https://doc.samsungmobile.com/SM-A910F/INS/doc.html
 
 -   releaseCycle: "Galaxy Tab A 10.1 (2016)"
-    support: false
-    eol: 2020-04-01 # https://doc.samsungmobile.com/SM-T580/ATO/doc.html
     releaseDate: 2016-05-01 # Approximate to the month and year.
+    support: false
+    eol: 2020-04-01
+    link: https://doc.samsungmobile.com/SM-T580/ATO/doc.html
 
 -   releaseCycle: "Galaxy Xcover3 G389F"
-    support: false
-    eol: 2018-06-01 # https://doc.samsungmobile.com/SM-G389F/ATO/doc.html
     releaseDate: 2016-04-01 # Approximate to the month and year.
+    support: false
+    eol: 2018-06-01
+    link: https://doc.samsungmobile.com/SM-G389F/ATO/doc.html
 
 -   releaseCycle: "Galaxy J7 (2016)"
-    support: false
-    eol: 2019-11-01 # https://doc.samsungmobile.com/SM-J710F/INS/doc.html
     releaseDate: 2016-04-01 # Approximate to the month and year.
+    support: false
+    eol: 2019-11-01
+    link: https://doc.samsungmobile.com/SM-J710F/INS/doc.html
 
 -   releaseCycle: "Galaxy J5 (2016)"
-    support: false
-    eol: 2019-08-01 # https://doc.samsungmobile.com/SM-J510FN/ATO/doc.html
     releaseDate: 2016-04-01 # Approximate to the month and year.
+    support: false
+    eol: 2019-08-01
+    link: https://doc.samsungmobile.com/SM-J510FN/ATO/doc.html
 
 -   releaseCycle: "Gear S2 classic 3G"
-    support: false
-    eol: true # TODO
     releaseDate: 2016-04-01 # Approximate to the month and year.
+    support: false
+    eol: true
+    link: null
 
 -   releaseCycle: "Galaxy Express Prime"
-    support: false
-    eol: true # TODO
     releaseDate: 2016-04-01 # Approximate to the month and year.
+    support: false
+    eol: true
+    link: null
 
 -   releaseCycle: "Galaxy Tab A 7.0 (2016)"
-    support: false
-    eol: 2016-12-30 # https://doc.samsungmobile.com/SM-T280/KOO/doc.html
     releaseDate: 2016-03-01 # Approximate to the month and year.
+    support: false
+    eol: 2016-12-30
+    link: https://doc.samsungmobile.com/SM-T280/KOO/doc.html
 
 -   releaseCycle: "Galaxy S7 edge"
-    support: false
-    eol: 2019-03-01 # https://doc.samsungmobile.com/SM-G935F/AFR/doc.html
     releaseDate: 2016-03-01 # Approximate to the month and year.
+    support: false
+    eol: 2019-03-01
+    link: https://doc.samsungmobile.com/SM-G935F/AFR/doc.html
 
 -   releaseCycle: "Galaxy S7"
-    support: false
-    eol: 2019-06-01 # https://doc.samsungmobile.com/SM-G930F/CHL/doc.html
     releaseDate: 2016-03-11
+    support: false
+    eol: 2019-06-01
+    link: https://doc.samsungmobile.com/SM-G930F/CHL/doc.html
 
 -   releaseCycle: "Galaxy J3 (2016)"
-    support: false
-    eol: 2019-04-02 # https://doc.samsungmobile.com/SM-J320H/AFR/doc.html
     releaseDate: 2016-05-06
+    support: false
+    eol: 2019-04-02
+    link: https://doc.samsungmobile.com/SM-J320H/AFR/doc.html
 
 -   releaseCycle: "Galaxy J1 Nxt"
-    support: false
-    eol: true # TODO
     releaseDate: 2016-02-01 # Approximate to the month and year.
+    support: false
+    eol: true
+    link: null
 
 -   releaseCycle: "Galaxy J1 (2016)"
-    support: false
-    eol: true # TODO
     releaseDate: 2016-01-01 # Approximate to the month and year.
+    support: false
+    eol: true
+    link: null
 
 -   releaseCycle: "Galaxy A9 (2016)"
-    support: false
-    eol: true # TODO
     releaseDate: 2016-01-01 # Approximate to the month and year.
+    support: false
+    eol: true
+    link: null
 
 -   releaseCycle: "Galaxy Tab E 8.0"
-    support: false
-    eol: 2020-11-10 # https://doc.samsungmobile.com/SM-A710S/SKC/doc.html
     releaseDate: 2016-01-01
+    support: false
+    eol: 2020-11-10
+    link: https://doc.samsungmobile.com/SM-A710S/SKC/doc.html
 
 -   releaseCycle: "Galaxy A7 (2016)"
-    support: false
-    eol: 2018-11-01 # https://doc.samsungmobile.com/SM-A710F/INS/doc.html
     releaseDate: 2015-12-01 # Approximate to the month and year.
+    support: false
+    eol: 2018-11-01
+    link: https://doc.samsungmobile.com/SM-A710F/INS/doc.html
 
 -   releaseCycle: "Galaxy A5 (2016)"
-    support: false
-    eol: 2019-06-01 # https://doc.samsungmobile.com/SM-A510F/INS/doc.html
     releaseDate: 2015-12-01 # Approximate to the month and year.
+    support: false
+    eol: 2019-06-01
+    link: https://doc.samsungmobile.com/SM-A510F/INS/doc.html
 
 -   releaseCycle: "Galaxy A3 (2016)"
-    support: false
-    eol: 2018-06-01 # https://doc.samsungmobile.com/SM-A310F/BTU/doc.html
     releaseDate: 2015-12-01 # Approximate to the month and year.
+    support: false
+    eol: 2018-06-01
+    link: https://doc.samsungmobile.com/SM-A310F/BTU/doc.html
 
 -   releaseCycle: "Galaxy View"
-    support: false
-    eol: 2018-01-01 # https://doc.samsungmobile.com/SM-T810/XSA/doc.html
     releaseDate: 2015-11-01 # Approximate to the month and year.
+    support: false
+    eol: 2018-01-01
+    link: https://doc.samsungmobile.com/SM-T810/XSA/doc.html
 
 -   releaseCycle: "Galaxy On7"
-    support: false
-    eol: 2018-01-01 # https://doc.samsungmobile.com/SM-G600S/SKC/doc.html
     releaseDate: 2015-11-01 # Approximate to the month and year.
+    support: false
+    eol: 2018-01-01
+    link: https://doc.samsungmobile.com/SM-G600S/SKC/doc.html
 
 -   releaseCycle: "Galaxy On5"
-    support: false
-    eol: true # TODO
     releaseDate: 2015-11-01 # Approximate to the month and year.
+    support: false
+    eol: true
+    link: null
 
 -   releaseCycle: "Z3"
-    support: false
-    eol: true # TODO
     releaseDate: 2015-10-01 # Approximate to the month and year.
+    support: false
+    eol: true
+    link: null
 
 -   releaseCycle: "Galaxy J1 Ace"
-    support: false
-    eol: true # TODO
     releaseDate: 2015-10-01 # Approximate to the month and year.
+    support: false
+    eol: true
+    link: null
 
 -   releaseCycle: "Gear S2 classic"
-    support: false
-    eol: 2018-03-26 # https://doc.samsungmobile.com/SM-R720/CHC/doc.html
     releaseDate: 2015-10-01 # Approximate to the month and year.
+    support: false
+    eol: 2018-03-26
+    link: https://doc.samsungmobile.com/SM-R720/CHC/doc.html
 
 -   releaseCycle: "Gear S2"
-    support: false
-    eol: 2018-03-26 # https://doc.samsungmobile.com/SM-R720/CHC/doc.html
     releaseDate: 2015-10-01 # Approximate to the month and year.
+    support: false
+    eol: 2018-03-26
+    link: https://doc.samsungmobile.com/SM-R720/CHC/doc.html
 
 -   releaseCycle: "Gear S2 3G"
-    support: false
-    eol: 2018-03-26 # https://doc.samsungmobile.com/SM-R720/CHC/doc.html
     releaseDate: 2015-10-01 # Approximate to the month and year.
+    support: false
+    eol: 2018-03-26
+    link: https://doc.samsungmobile.com/SM-R720/CHC/doc.html
 
 -   releaseCycle: "Galaxy Tab S2 9.7"
-    support: false
-    eol: 2019-07-01 # https://doc.samsungmobile.com/SM-T819Y/INS/doc.html
     releaseDate: 2015-09-01 # Approximate to the month and year.
+    support: false
+    eol: 2019-07-01
+    link: https://doc.samsungmobile.com/SM-T819Y/INS/doc.html
 
 -   releaseCycle: "Galaxy Tab S2 8.0"
-    support: false
-    eol: 2019-07-01 # https://doc.samsungmobile.com/SM-T713/BTU/doc.html
     releaseDate: 2015-09-01 # Approximate to the month and year.
+    support: false
+    eol: 2019-07-01
+    link: https://doc.samsungmobile.com/SM-T713/BTU/doc.html
 
 -   releaseCycle: "Galaxy J2"
-    support: false
-    eol: true # TODO
     releaseDate: 2015-09-01 # Approximate to the month and year.
+    support: false
+    eol: true
+    link: null
 
 -   releaseCycle: "Galaxy Note 5 (USA)"
-    support: false
-    eol: true # TODO
     releaseDate: 2015-08-01 # Approximate to the month and year.
+    support: false
+    eol: true
+    link: null
 
 -   releaseCycle: "Galaxy Note 5"
-    support: false
-    eol: 2018-08-01 # https://doc.samsungmobile.com/SM-N920G/CHL/doc.html
     releaseDate: 2015-08-01 # Approximate to the month and year.
+    support: false
+    eol: 2018-08-01
+    link: https://doc.samsungmobile.com/SM-N920G/CHL/doc.html
 
 -   releaseCycle: "Galaxy Note 5 Duos"
-    support: false
-    eol: 2018-08-01 # https://doc.samsungmobile.com/SM-N920C/SER/doc.html
     releaseDate: 2015-08-01 # Approximate to the month and year.
+    support: false
+    eol: 2018-08-01
+    link: https://doc.samsungmobile.com/SM-N920C/SER/doc.html
 
 -   releaseCycle: "Galaxy S6 edge+ (USA)"
-    support: false
-    eol: true # TODO
     releaseDate: 2015-08-01 # Approximate to the month and year.
+    support: false
+    eol: true
+    link: null
 
 -   releaseCycle: "Galaxy S6 edge+"
-    support: false
-    eol: 2018-08-01 # https://doc.samsungmobile.com/SM-G928C/XXV/doc.html
     releaseDate: 2015-08-01 # Approximate to the month and year.
+    support: false
+    eol: 2018-08-01
+    link: https://doc.samsungmobile.com/SM-G928C/XXV/doc.html
 
 -   releaseCycle: "Galaxy S6 edge+ Duos"
-    support: false
-    eol: 2018-08-01 # https://doc.samsungmobile.com/SM-G928F/ITV/doc.html
     releaseDate: 2015-08-01 # Approximate to the month and year.
+    support: false
+    eol: 2018-08-01
+    link: https://doc.samsungmobile.com/SM-G928F/ITV/doc.html
 
 -   releaseCycle: "Galaxy S5 Neo"
-    support: false
-    eol: 2018-04-01 # https://doc.samsungmobile.com/SM-G903F/DBT/doc.html
     releaseDate: 2015-08-01 # Approximate to the month and year.
+    support: false
+    eol: 2018-04-01
+    link: https://doc.samsungmobile.com/SM-G903F/DBT/doc.html
 
 -   releaseCycle: "Galaxy A8 Duos"
-    support: false
-    eol: 2017-08-01 # https://doc.samsungmobile.com/SM-A800I/INS/doc.html
     releaseDate: 2015-08-01 # Approximate to the month and year.
+    support: false
+    eol: 2017-08-01
+    link: https://doc.samsungmobile.com/SM-A800I/INS/doc.html
 
 -   releaseCycle: "Galaxy A8"
-    support: false
-    eol: 2017-08-01 # https://doc.samsungmobile.com/SM-A800F/INS/doc.html
     releaseDate: 2015-08-01 # Approximate to the month and year.
+    support: false
+    eol: 2017-08-01
+    link: https://doc.samsungmobile.com/SM-A800F/INS/doc.html
 
 -   releaseCycle: "Galaxy J5"
-    support: false
-    eol: 2019-12-03 # https://doc.samsungmobile.com/SM-J500F/INS/doc.html
     releaseDate: 2015-07-28
+    support: false
+    eol: 2019-12-03
+    link: https://doc.samsungmobile.com/SM-J500F/INS/doc.html
 
 -   releaseCycle: "Galaxy J7"
-    support: false
-    eol: 2018-04-01 # https://doc.samsungmobile.com/SM-J700F/INS/doc.html
     releaseDate: 2015-07-16
+    support: false
+    eol: 2018-04-01
+    link: https://doc.samsungmobile.com/SM-J700F/INS/doc.html
 
 -   releaseCycle: "Galaxy Folder"
-    support: false
-    eol: true # TODO
     releaseDate: 2015-07-01 # Approximate to the month and year.
+    support: false
+    eol: true
+    link: null
 
 -   releaseCycle: "Galaxy V Plus"
-    support: false
-    eol: true # TODO
     releaseDate: 2015-07-01 # Approximate to the month and year.
+    support: false
+    eol: true
+    link: null
 
 -   releaseCycle: "Galaxy Tab E 9.6"
-    support: false
-    eol: true # TODO
     releaseDate: 2015-07-01 # Approximate to the month and year.
+    support: false
+    eol: true
+    link: null
 
 -   releaseCycle: "Galaxy Tab A 9.7 & S Pen"
-    support: false
-    eol: 2017-08-01 # https://doc.samsungmobile.com/SM-P555/XXV/doc.html
     releaseDate: 2015-07-01 # Approximate to the month and year.
+    support: false
+    eol: 2017-08-01
+    link: https://doc.samsungmobile.com/SM-P555/XXV/doc.html
 
 -   releaseCycle: "Galaxy S4 mini I9195I"
-    support: false
-    eol: true # TODO
     releaseDate: 2015-06-01 # Approximate to the month and year.
+    support: false
+    eol: true
+    link: null
 
 -   releaseCycle: "Galaxy S6 active"
-    support: false
-    eol: true # TODO
     releaseDate: 2015-06-01 # Approximate to the month and year.
+    support: false
+    eol: true
+    link: null
 
 -   releaseCycle: "Galaxy S6 Duos"
-    support: false
-    eol: true # TODO
     releaseDate: 2015-06-01 # Approximate to the month and year.
+    support: false
+    eol: true
+    link: null
 
 -   releaseCycle: "Galaxy Tab A 9.7"
-    support: false
-    eol: 2017-08-01 # https://doc.samsungmobile.com/SM-P550/XSA/doc.html
     releaseDate: 2015-05-01 # Approximate to the month and year.
+    support: false
+    eol: 2017-08-01
+    link: https://doc.samsungmobile.com/SM-P550/XSA/doc.html
 
 -   releaseCycle: "Galaxy Tab A 8.0 & S Pen (2015)"
-    support: false
-    eol: 2017-08-01 # https://doc.samsungmobile.com/SM-P355/XXV/doc.html
     releaseDate: 2015-05-01 # Approximate to the month and year.
+    support: false
+    eol: 2017-08-01
+    link: https://doc.samsungmobile.com/SM-P355/XXV/doc.html
 
 -   releaseCycle: "Galaxy Tab A 8.0 (2015)"
-    support: false
-    eol: 2017-08-01 # https://doc.samsungmobile.com/SM-T355/SER/doc.html
     releaseDate: 2015-05-01 # Approximate to the month and year.
+    support: false
+    eol: 2017-08-01
+    link: https://doc.samsungmobile.com/SM-T355/SER/doc.html
 
 -   releaseCycle: "Galaxy Tab 3 V"
-    support: false
-    eol: true # TODO
     releaseDate: 2015-04-01 # Approximate to the month and year.
+    support: false
+    eol: true
+    link: null
 
 -   releaseCycle: "Galaxy Xcover 3"
-    support: false
-    eol: true # TODO
     releaseDate: 2015-04-01 # Approximate to the month and year.
+    support: false
+    eol: true
+    link: null
 
 -   releaseCycle: "Galaxy S6 edge (USA)"
-    support: false
-    eol: true # TODO
     releaseDate: 2015-04-01 # Approximate to the month and year.
+    support: false
+    eol: true
+    link: null
 
 -   releaseCycle: "Galaxy S6 (USA)"
-    support: false
-    eol: 2018-03-01 # https://doc.samsungmobile.com/SM-G920T1/TMB/doc.html
     releaseDate: 2015-04-01 # Approximate to the month and year.
+    support: false
+    eol: 2018-03-01
+    link: https://doc.samsungmobile.com/SM-G920T1/TMB/doc.html
 
 -   releaseCycle: "Galaxy S6 edge"
-    support: false
-    eol: 2018-06-01 # https://doc.samsungmobile.com/SM-G925I/PET/doc.html
     releaseDate: 2015-04-01 # Approximate to the month and year.
+    support: false
+    eol: 2018-06-01
+    link: https://doc.samsungmobile.com/SM-G925I/PET/doc.html
 
 -   releaseCycle: "Galaxy S6"
-    support: false
-    eol: 2018-06-01 # https://doc.samsungmobile.com/SM-G920I/INS/doc.html
     releaseDate: 2015-04-01 # Approximate to the month and year.
+    support: false
+    eol: 2018-06-01
+    link: https://doc.samsungmobile.com/SM-G920I/INS/doc.html
 
 -   releaseCycle: "Galaxy J1 4G"
-    support: false
-    eol: true # TODO
     releaseDate: 2015-03-01 # Approximate to the month and year.
+    support: false
+    eol: true
+    link: null
 
 -   releaseCycle: "Galaxy Tab 3 Lite 7.0 VE"
-    support: false
-    eol: true # TODO
     releaseDate: 2015-03-01 # Approximate to the month and year.
+    support: false
+    eol: true
+    link: null
 
 -   releaseCycle: "Galaxy J1"
-    support: false
-    eol: true # TODO
     releaseDate: 2015-02-01 # Approximate to the month and year.
+    support: false
+    eol: true
+    link: null
 
 -   releaseCycle: "Galaxy A7 Duos"
-    support: false
-    eol: true # TODO
     releaseDate: 2015-02-01 # Approximate to the month and year.
+    support: false
+    eol: true
+    link: null
 
 -   releaseCycle: "Galaxy E7"
-    support: false
-    eol: true # TODO
     releaseDate: 2015-02-01 # Approximate to the month and year.
+    support: false
+    eol: true
+    link: null
 
 -   releaseCycle: "Galaxy E5"
-    support: false
-    eol: true # TODO
     releaseDate: 2015-02-01 # Approximate to the month and year.
+    support: false
+    eol: true
+    link: null
 
 -   releaseCycle: "Z1"
-    support: false
-    eol: true # TODO
     releaseDate: 2015-01-01 # Approximate to the month and year.
+    support: false
+    eol: true
+    link: null
 
 -   releaseCycle: "Galaxy Grand Max"
-    support: false
-    eol: true # TODO
     releaseDate: 2015-01-01 # Approximate to the month and year.
+    support: false
+    eol: true
+    link: null
 
 -   releaseCycle: "Galaxy A5"
-    support: false
-    eol: true # TODO
     releaseDate: 2014-12-01 # Approximate to the month and year.
+    support: false
+    eol: true
+    link: null
 
 -   releaseCycle: "Galaxy A3 Duos"
-    support: false
-    eol: true # TODO
     releaseDate: 2014-12-01 # Approximate to the month and year.
+    support: false
+    eol: true
+    link: null
 
 -   releaseCycle: "Galaxy A3"
-    support: false
-    eol: true # TODO
     releaseDate: 2014-12-01 # Approximate to the month and year.
+    support: false
+    eol: true
+    link: null
 
 -   releaseCycle: "Galaxy Tab Active LTE"
-    support: false
-    eol: true # TODO
     releaseDate: 2014-12-01 # Approximate to the month and year.
+    support: false
+    eol: true
+    link: null
 
 -   releaseCycle: "Galaxy Tab Active"
-    support: false
-    eol: true # TODO
     releaseDate: 2014-12-01 # Approximate to the month and year.
+    support: false
+    eol: true
+    link: null
 
 -   releaseCycle: "Galaxy Core Prime"
-    support: false
-    eol: true # TODO
     releaseDate: 2014-11-01 # Approximate to the month and year.
+    support: false
+    eol: true
+    link: null
 
 -   releaseCycle: "Galaxy A5 Duos"
-    support: false
-    eol: true # TODO
     releaseDate: 2014-11-01 # Approximate to the month and year.
+    support: false
+    eol: true
+    link: null
 
 -   releaseCycle: "Galaxy S5 Plus"
-    support: false
-    eol: true # TODO
     releaseDate: 2014-11-01 # Approximate to the month and year.
+    support: false
+    eol: true
+    link: null
 
 -   releaseCycle: "Galaxy Note Edge"
-    support: false
-    eol: true # TODO
     releaseDate: 2014-11-01 # Approximate to the month and year.
+    support: false
+    eol: true
+    link: null
 
 -   releaseCycle: "Galaxy Core LTE G386W"
-    support: false
-    eol: true # TODO
     releaseDate: 2014-11-01 # Approximate to the month and year.
+    support: false
+    eol: true
+    link: null
 
 -   releaseCycle: "Galaxy Grand Prime Duos TV"
-    support: false
-    eol: true # TODO
     releaseDate: 2014-10-01 # Approximate to the month and year.
+    support: false
+    eol: true
+    link: null
 
 -   releaseCycle: "Galaxy Grand Prime"
-    support: false
-    eol: true # TODO
     releaseDate: 2014-10-01 # Approximate to the month and year.
+    support: false
+    eol: true
+    link: null
 
 -   releaseCycle: "Galaxy Note 4 Duos"
-    support: false
-    eol: true # TODO
     releaseDate: 2014-10-01 # Approximate to the month and year.
+    support: false
+    eol: true
+    link: null
 
 -   releaseCycle: "Galaxy Note4"
-    support: false
-    eol: 2017-08-01 # https://doc.samsungmobile.com/SM-N910U/TNZ/doc.html
     releaseDate: 2014-10-01 # Approximate to the month and year.
+    support: false
+    eol: 2017-08-01
+    link: https://doc.samsungmobile.com/SM-N910U/TNZ/doc.html
 
 -   releaseCycle: "Gear S"
-    support: false
-    eol: true # TODO
     releaseDate: 2014-10-01 # Approximate to the month and year.
+    support: false
+    eol: true
+    link: null
 
 -   releaseCycle: "Galaxy Young 2"
-    support: false
-    eol: true # TODO
     releaseDate: 2014-10-01 # Approximate to the month and year.
+    support: false
+    eol: true
+    link: null
 
 -   releaseCycle: "Galaxy Pocket 2"
-    support: false
-    eol: true # TODO
     releaseDate: 2014-09-01 # Approximate to the month and year.
+    support: false
+    eol: true
+    link: null
 
 -   releaseCycle: "Galaxy V"
-    support: false
-    eol: true # TODO
     releaseDate: 2014-09-01 # Approximate to the month and year.
+    support: false
+    eol: true
+    link: null
 
 -   releaseCycle: "Galaxy Ace Style LTE G357"
-    support: false
-    eol: true # TODO
     releaseDate: 2014-09-01 # Approximate to the month and year.
+    support: false
+    eol: true
+    link: null
 
 -   releaseCycle: "Galaxy Mega 2"
-    support: false
-    eol: true # TODO
     releaseDate: 2014-09-01 # Approximate to the month and year.
+    support: false
+    eol: true
+    link: null
 
 -   releaseCycle: "Galaxy Alpha (S801)"
-    support: false
-    eol: true # TODO
     releaseDate: 2014-09-01 # Approximate to the month and year.
+    support: false
+    eol: true
+    link: null
 
 -   releaseCycle: "Galaxy Alpha"
-    support: false
-    eol: 2017-01-01 # https://doc.samsungmobile.com/SM-G850Y/XSA/doc.html
     releaseDate: 2014-09-01 # Approximate to the month and year.
+    support: false
+    eol: 2017-01-01
+    link: https://doc.samsungmobile.com/SM-G850Y/XSA/doc.html
 
 -   releaseCycle: "Galaxy W"
-    support: false
-    eol: true # TODO
     releaseDate: 2014-09-01 # Approximate to the month and year.
+    support: false
+    eol: true
+    link: null
 
 -   releaseCycle: "Galaxy S5 LTE-A G901F"
-    support: false
-    eol: true # TODO
     releaseDate: 2014-08-01 # Approximate to the month and year.
+    support: false
+    eol: true
+    link: null
 
 -   releaseCycle: "Galaxy S5 mini Duos"
-    support: false
-    eol: true # TODO
     releaseDate: 2014-08-01 # Approximate to the month and year.
+    support: false
+    eol: true
+    link: null
 
 -   releaseCycle: "Galaxy S Duos 3"
-    support: false
-    eol: true # TODO
     releaseDate: 2014-08-01 # Approximate to the month and year.
+    support: false
+    eol: true
+    link: null
 
 -   releaseCycle: "Galaxy Ace NXT"
-    support: false
-    eol: true # TODO
     releaseDate: 2014-08-01 # Approximate to the month and year.
+    support: false
+    eol: true
+    link: null
 
 -   releaseCycle: "Galaxy Star 2 Plus"
-    support: false
-    eol: true # TODO
     releaseDate: 2014-08-01 # Approximate to the month and year.
+    support: false
+    eol: true
+    link: null
 
 -   releaseCycle: "Galaxy Ace 4 LTE G313"
-    support: false
-    eol: true # TODO
     releaseDate: 2014-08-01 # Approximate to the month and year.
+    support: false
+    eol: true
+    link: null
 
 -   releaseCycle: "Galaxy Ace 4"
-    support: false
-    eol: true # TODO
     releaseDate: 2014-08-01 # Approximate to the month and year.
+    support: false
+    eol: true
+    link: null
 
 -   releaseCycle: "Galaxy Star 2"
-    support: false
-    eol: true # TODO
     releaseDate: 2014-08-01 # Approximate to the month and year.
+    support: false
+    eol: true
+    link: null
 
 -   releaseCycle: "Gear Live"
-    support: false
-    eol: true # TODO
     releaseDate: 2014-07-01 # Approximate to the month and year.
+    support: false
+    eol: true
+    link: null
 
 -   releaseCycle: "Galaxy Avant"
-    support: false
-    eol: true # TODO
     releaseDate: 2014-07-01 # Approximate to the month and year.
+    support: false
+    eol: true
+    link: null
 
 -   releaseCycle: "Galaxy S5 mini"
-    support: false
-    eol: 2017-08-01 # https://doc.samsungmobile.com/SM-G800F/DBT/doc.html
     releaseDate: 2014-07-01 # Approximate to the month and year.
+    support: false
+    eol: 2017-08-01
+    link: https://doc.samsungmobile.com/SM-G800F/DBT/doc.html
 
 -   releaseCycle: "Galaxy Core II"
-    support: false
-    eol: true # TODO
     releaseDate: 2014-07-01 # Approximate to the month and year.
+    support: false
+    eol: true
+    link: null
 
 -   releaseCycle: "Galaxy S5 LTE-A G906S"
-    support: false
-    eol: 2017-01-04 # https://doc.samsungmobile.com/sm-g906s/skc/doc.html
     releaseDate: 2014-07-01 # Approximate to the month and year.
+    support: false
+    eol: 2017-01-04
+    link: https://doc.samsungmobile.com/sm-g906s/skc/doc.html
 
 -   releaseCycle: "Galaxy Tab S 8.4 LTE"
-    support: false
-    eol: 2016-12-01 # https://doc.samsungmobile.com/SM-T705/INS/doc.html
     releaseDate: 2014-07-01 # Approximate to the month and year.
+    support: false
+    eol: 2016-12-01
+    link: https://doc.samsungmobile.com/SM-T705/INS/doc.html
 
 -   releaseCycle: "Galaxy Tab S 8.4"
-    support: false
-    eol: 2017-08-01 # https://doc.samsungmobile.com/SM-T700/BTU/doc.html
     releaseDate: 2014-07-01 # Approximate to the month and year.
+    support: false
+    eol: 2017-08-01
+    link: https://doc.samsungmobile.com/SM-T700/BTU/doc.html
 
 -   releaseCycle: "Galaxy Tab S 10.5 LTE"
-    support: false
-    eol: 2016-12-01 # https://doc.samsungmobile.com/SM-T805/ATO/doc.html
     releaseDate: 2014-07-01 # Approximate to the month and year.
+    support: false
+    eol: 2016-12-01
+    link: https://doc.samsungmobile.com/SM-T805/ATO/doc.html
 
 -   releaseCycle: "Galaxy Tab S 10.5"
-    support: false
-    eol: 2017-08-01 # https://doc.samsungmobile.com/SM-T800/ATO/doc.html
     releaseDate: 2014-07-01 # Approximate to the month and year.
+    support: false
+    eol: 2017-08-01
+    link: https://doc.samsungmobile.com/SM-T800/ATO/doc.html
 
 -   releaseCycle: "Galaxy Beam2"
-    support: false
-    eol: true # TODO
     releaseDate: 2014-07-01 # Approximate to the month and year.
+    support: false
+    eol: true
+    link: null
 
 -   releaseCycle: "Galaxy S5 Sport"
-    support: false
-    eol: true # TODO
     releaseDate: 2014-06-01 # Approximate to the month and year.
+    support: false
+    eol: true
+    link: null
 
 -   releaseCycle: "Galaxy Core Lite LTE"
-    support: false
-    eol: true # TODO
     releaseDate: 2014-06-01 # Approximate to the month and year.
+    support: false
+    eol: true
+    link: null
 
 -   releaseCycle: "I9301I Galaxy S3 Neo"
-    support: false
-    eol: true # TODO
     releaseDate: 2014-06-01 # Approximate to the month and year.
+    support: false
+    eol: true
+    link: null
 
 -   releaseCycle: "Galaxy K zoom"
-    support: false
-    eol: true # TODO
     releaseDate: 2014-06-01 # Approximate to the month and year.
+    support: false
+    eol: true
+    link: null
 
 -   releaseCycle: "Galaxy Tab 4 8.0"
-    support: false
-    eol: true # TODO
     releaseDate: 2014-06-01 # Approximate to the month and year.
+    support: false
+    eol: true
+    link: https://doc.samsungmobile.com/SM-T330/KSA/doc.html
 
 -   releaseCycle: "Galaxy Tab 4 8.0 3G"
-    support: false
-    eol: true # TODO
     releaseDate: 2014-06-01 # Approximate to the month and year.
+    support: false
+    eol: true
+    link: null
 
 -   releaseCycle: "Galaxy Tab 4 8.0 LTE"
-    support: false
-    eol: true # TODO
     releaseDate: 2014-06-01 # Approximate to the month and year.
+    support: false
+    eol: true
+    link: null
 
 -   releaseCycle: "Galaxy Tab 4 10.1"
-    support: false
-    eol: true # TODO
     releaseDate: 2014-06-01 # Approximate to the month and year.
+    support: false
+    eol: true
+    link: https://doc.samsungmobile.com/SM-T530/KOO/doc.html
 
 -   releaseCycle: "Galaxy Tab 4 10.1 3G"
-    support: false
-    eol: true # TODO
     releaseDate: 2014-06-01 # Approximate to the month and year.
+    support: false
+    eol: true
+    link: null
 
 -   releaseCycle: "Galaxy Tab 4 10.1 LTE"
-    support: false
-    eol: true # TODO
     releaseDate: 2014-06-01 # Approximate to the month and year.
+    support: false
+    eol: true
+    link: null
 
 -   releaseCycle: "Galaxy S5 Duos"
-    support: false
-    eol: true # TODO
     releaseDate: 2014-06-01 # Approximate to the month and year.
+    support: false
+    eol: true
+    link: null
 
 -   releaseCycle: "Gear 2 Neo"
-    support: false
-    eol: true # TODO
     releaseDate: 2014-05-01 # Approximate to the month and year.
+    support: false
+    eol: true
+    link: null
 
 -   releaseCycle: "Galaxy S5 Active"
-    support: false
-    eol: true # TODO
     releaseDate: 2014-05-01 # Approximate to the month and year.
+    support: false
+    eol: true
+    link: null
 
 -   releaseCycle: "Galaxy Ace Style"
-    support: false
-    eol: true # TODO
     releaseDate: 2014-05-01 # Approximate to the month and year.
+    support: false
+    eol: true
+    link: null
 
 -   releaseCycle: "Galaxy Tab 4 7.0"
-    support: false
-    eol: true # TODO
     releaseDate: 2014-05-01 # Approximate to the month and year.
+    support: false
+    eol: true
+    link: null
 
 -   releaseCycle: "Galaxy Tab 4 7.0 3G"
-    support: false
-    eol: true # TODO
     releaseDate: 2014-05-01 # Approximate to the month and year.
+    support: false
+    eol: true
+    link: null
 
 -   releaseCycle: "Galaxy Tab 4 7.0 LTE"
-    support: false
-    eol: true # TODO
     releaseDate: 2014-05-01 # Approximate to the month and year.
+    support: false
+    eol: true
+    link: null
 
 -   releaseCycle: "Galaxy Core LTE"
-    support: false
-    eol: true # TODO
     releaseDate: 2014-05-01 # Approximate to the month and year.
+    support: false
+    eol: true
+    link: null
 
 -   releaseCycle: "Galaxy Star Trios S5283"
-    support: false
-    eol: true # TODO
     releaseDate: 2014-05-01 # Approximate to the month and year.
+    support: false
+    eol: true
+    link: null
 
 -   releaseCycle: "Galaxy Tab Pro 12.2 LTE"
-    support: false
-    eol: true # TODO
     releaseDate: 2014-05-01 # Approximate to the month and year.
+    support: false
+    eol: true
+    link: null
 
 -   releaseCycle: "Gear 2"
-    support: false
-    eol: true # TODO
     releaseDate: 2014-04-01 # Approximate to the month and year.
+    support: false
+    eol: true
+    link: null
 
 -   releaseCycle: "I9300I Galaxy S3 Neo"
-    support: false
-    eol: true # TODO
     releaseDate: 2014-04-01 # Approximate to the month and year.
+    support: false
+    eol: true
+    link: null
 
 -   releaseCycle: "ATIV SE"
-    support: false
-    eol: true # TODO
     releaseDate: 2014-04-01 # Approximate to the month and year.
+    support: false
+    eol: true
+    link: null
 
 -   releaseCycle: "Galaxy S5 (octa-core)"
-    support: false
-    eol: 2017-04-01 # https://doc.samsungmobile.com/SM-G900H/XXV/doc.html
     releaseDate: 2014-04-01 # Approximate to the month and year.
+    support: false
+    eol: 2017-04-01
+    link: https://doc.samsungmobile.com/SM-G900H/XXV/doc.html
 
 -   releaseCycle: "Galaxy S5"
-    support: false
-    eol: 2017-04-01 # https://doc.samsungmobile.com/SM-G900H/XXV/doc.html
     releaseDate: 2014-04-01 # Approximate to the month and year.
+    support: false
+    eol: 2017-04-01
+    link: https://doc.samsungmobile.com/SM-G900H/XXV/doc.html
 
 -   releaseCycle: "Galaxy Tab Pro 12.2 3G"
-    support: false
-    eol: true # TODO
     releaseDate: 2014-04-01 # Approximate to the month and year.
+    support: false
+    eol: true
+    link: null
 
 -   releaseCycle: "G3812B Galaxy S3 Slim"
-    support: false
-    eol: true # TODO
     releaseDate: 2014-03-01 # Approximate to the month and year.
+    support: false
+    eol: true
+    link: null
 
 -   releaseCycle: "I8200 Galaxy S III mini VE"
-    support: false
-    eol: true # TODO
     releaseDate: 2014-03-01 # Approximate to the month and year.
+    support: false
+    eol: true
+    link: null
 
 -   releaseCycle: "Galaxy Note Pro 12.2 LTE"
-    support: false
-    eol: true # TODO
     releaseDate: 2014-03-01 # Approximate to the month and year.
+    support: false
+    eol: true
+    link: null
 
 -   releaseCycle: "Galaxy Note Pro 12.2 3G"
-    support: false
-    eol: true # TODO
     releaseDate: 2014-03-01 # Approximate to the month and year.
+    support: false
+    eol: true
+    link: null
 
 -   releaseCycle: "Galaxy Tab Pro 12.2"
-    support: false
-    eol: true # TODO
     releaseDate: 2014-03-01 # Approximate to the month and year.
+    support: false
+    eol: true
+    link: null
 
 -   releaseCycle: "Galaxy Note 3 Neo Duos"
-    support: false
-    eol: true # TODO
     releaseDate: 2014-02-01 # Approximate to the month and year.
+    support: false
+    eol: true
+    link: null
 
 -   releaseCycle: "Galaxy Note 3 Neo"
-    support: false
-    eol: true # TODO
     releaseDate: 2014-02-01 # Approximate to the month and year.
+    support: false
+    eol: true
+    link: https://doc.samsungmobile.com/SM-N750K/KTC/doc.html
 
 -   releaseCycle: "Galaxy Tab 3 Lite 7.0 3G"
-    support: false
-    eol: true # TODO
     releaseDate: 2014-02-01 # Approximate to the month and year.
+    support: false
+    eol: true
+    link: null
 
 -   releaseCycle: "Galaxy Tab 3 Lite 7.0"
-    support: false
-    eol: true # TODO
     releaseDate: 2014-02-01 # Approximate to the month and year.
+    support: false
+    eol: true
+    link: null
 
 -   releaseCycle: "Galaxy Grand Neo"
-    support: false
-    eol: true # TODO
     releaseDate: 2014-02-01 # Approximate to the month and year.
+    support: false
+    eol: true
+    link: null
 
 -   releaseCycle: "Galaxy Note Pro 12.2"
-    support: false
-    eol: true # TODO
     releaseDate: 2014-02-01 # Approximate to the month and year.
+    support: false
+    eol: true
+    link: https://doc.samsungmobile.com/SM-P900/KOO/doc.html
 
 -   releaseCycle: "Galaxy Gear"
-    support: false
-    eol: true # TODO
     releaseDate: 2013-09-01 # Approximate to the month and year.
+    support: false
+    eol: true
+    link: null
 
 ---
 
-> Samsung Galaxy is a series of computing and mobile computing devices that are designed, manufactured and marketed by Samsung Electronics.
+> Samsung Galaxy is a series of computing and mobile computing devices that are designed,
+> manufactured and marketed by Samsung Electronics.
 
 # Security brackets
 
-Samsung devices usually have four support brackets in which a device receives support. Which bracket your device falls under [can be found here](https://security.samsungmobile.com/workScope.smsb).
+Samsung devices usually have four support brackets in which a device receives support. Which bracket
+your device falls under [can be found here](https://security.samsungmobile.com/workScope.smsb).
 
-* **Active Android support:** This bracket provides a device with new Android versions as they come out. This bracket also with limited exceptions provides monthly security updates. This covers a device for up to two years after launch, averaging a year.
+* **Active Android support:** This bracket provides a device with new Android versions as they come
+  out. This bracket also with limited exceptions provides monthly security updates. This covers a
+  device for up to two years after launch, averaging a year.
 
-* **Quarterly Security Updates**: This bracket provides a device with quarterly security update. This bracket takes over once monthly updates have ended, it usually lasts a year.
+* **Quarterly Security Updates**: This bracket provides a device with quarterly security update.
+  This bracket takes over once monthly updates have ended, it usually lasts a year.
 
-* **Biannual Security Updates**: This bracket provides a device with biannual security update. This bracket takes over once quarterly updates have ended, it usually lasts an additional year, or until four years have passed since the device has been released.
+* **Biannual Security Updates**: This bracket provides a device with biannual security update. This
+  bracket takes over once quarterly updates have ended, it usually lasts an additional year, or
+  until four years have passed since the device has been released.
 
-**Note**: Some dates are based on when support status was changed on the Samsung website - they might be approximate.
+**Note**: Some dates are based on when support status was changed on the Samsung website - they
+might be approximate.


### PR DESCRIPTION
Existing links in comment were moved the the link attribute and a lot of links has been added. The method to find the links has been documented in the front matter.
    
Some model were removed :

- Galaxy A52s : it does not exist, all models make mention of Galaxy A52s 5G (which is already listed)
- Galaxy Z Fold 3 : same as Galaxy A52s
- Galaxy Z Flip 3 : same as Galaxy A52s
- Galaxy S21 : never released according to https://www.gsmarena.com/samsung_galaxy_s21-10693.php
- Galaxy J3 : the J3 2016/2017/2018 models are already documented
- Galaxy J7+ : looks like that model does not exist
- Galaxy Xcover 4 : this model was duplicated (#2745)

Also :

- some support date were fixed,
- some model name were fixed,
- W21 5G has been renamed to Galaxy Z Fold2 5G (W21 5G is the indian name)
- took the opportunity to normalize the page (#2124)