### PR TITLE
Tag products

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -54,6 +54,23 @@ title: Timeturner
 # - server-app is for applications usually installed on the server-side.
 category: os
 
+# Tags of the product (optional).
+#
+# Tags :
+# - must match [a-z0-9\-]+,
+# - must be declared with a space-separated string,
+# - must be alphabetically ordered,
+# - must use singular (for example web-server, not web-servers),
+# - should be used at least twice,
+# - must be added for one of the following reasons :
+#   - set a product family such as linux-distribution, web-browser, mobile-phone or web-server,
+#   - set a product vendor such as adobe, amazon or apache,
+#   - set a runtime dependency such as java-runtime, javascript-runtime or php-runtime.
+#
+# Remember that no tag is better than useless tag. Also note that categories are automatically tags, but don't
+# use another category as a tag.
+tags: amazon linux
+
 # Simple Icons (https://simpleicons.org/) icon slug (optional).
 # Remove this property if the icon is not available on Simple Icons.
 # As an example, https://simpleicons.org/?q=codemagic links to https://simpleicons.org/icons/codemagic.svg ,

--- a/_auto/validate.py
+++ b/_auto/validate.py
@@ -1,3 +1,5 @@
+import re
+
 import sys
 import frontmatter
 from datetime import date
@@ -36,6 +38,8 @@ def load_product_data(file):
 def assert_that_in(values, value, name, file):
     assert value in values, f"{name} '{value}' is not valid in {file}, it must be in {values}"
 
+def assert_that_match(regex, value, name, file):
+    assert bool(re.fullmatch(regex, value)), f"{name} '{value}' does not match {regex} in {file}"
 
 def assert_not_blank(value, name, file):
     assert value.strip(), f"{name} must not be blank in {file}"
@@ -56,6 +60,9 @@ def validate_product(file):
 
     assert_that_in(VALID_CATEGORIES, data['category'], 'category', file)
     assert_that_starts_with('/', data['permalink'], 'permalink', file)
+
+    if "tags" in data:
+        assert_that_match("^[a-z0-9\-]+( [a-z0-9\-]+)*", data['tags'], 'tags', file)
 
     if "alternate_urls" in data:
         for url in data["alternate_urls"]:

--- a/_plugins/product-data-enricher.rb
+++ b/_plugins/product-data-enricher.rb
@@ -58,7 +58,7 @@ module Jekyll
         end
 
         tags << page.data['category']
-        page.data['tags'] = tags
+        page.data['tags'] = tags.sort
       end
 
       # Set properly the column presence/label if it was overridden.

--- a/products/alibaba-dragonwell.md
+++ b/products/alibaba-dragonwell.md
@@ -1,6 +1,7 @@
 ---
 title: Alibaba Dragonwell
 category: lang
+tags: alibaba java-distribution
 iconSlug: openjdk
 permalink: /alibaba-dragonwell
 

--- a/products/almalinux.md
+++ b/products/almalinux.md
@@ -1,6 +1,7 @@
 ---
 title: AlmaLinux OS
 category: os
+tags: linux-distribution
 permalink: /almalinux
 versionCommand: cat /etc/redhat-release
 releasePolicyLink: https://blog.cloudlinux.com/announcing-open-sourced-community-driven-rhel-fork-by-cloudlinux

--- a/products/alpinelinux.md
+++ b/products/alpinelinux.md
@@ -1,6 +1,7 @@
 ---
 title: Alpine Linux
 category: os
+tags: linux-distribution
 iconSlug: alpinelinux
 permalink: /alpine
 alternate_urls:

--- a/products/amazon-corretto.md
+++ b/products/amazon-corretto.md
@@ -1,6 +1,7 @@
 ---
 title: Amazon Corretto
 category: lang
+tags: amazon java-distribution
 iconSlug: openjdk
 permalink: /amazon-corretto
 alternate_urls:

--- a/products/amazon-linux.md
+++ b/products/amazon-linux.md
@@ -1,6 +1,7 @@
 ---
 title: Amazon Linux
 category: os
+tags: amazon linux-distribution
 iconSlug: amazonaws
 permalink: /amazon-linux
 versionCommand: cat /etc/system-release
@@ -192,9 +193,9 @@ AWS announced [Amazon Linux 2023][al2023] [^1] as a successor to
 Amazon Linux 2, which uses Fedora as the upstream. It reached
 GA (General Availability) in March 2023.
 
-Every major version release is supported by Standard Support for 2 years, 
+Every major version release is supported by Standard Support for 2 years,
 followed by a maintenance phase of 3 years. Quarterly minor releases will be made
-during the Standard Support phase and include security updates, 
+during the Standard Support phase and include security updates,
 bug fixes, and new features and packages. Minor releases do not
 break backward-compatibility.
 

--- a/products/amazon-rds-mysql.md
+++ b/products/amazon-rds-mysql.md
@@ -1,6 +1,7 @@
 ---
 title: Amazon RDS for MySQL
 category: service
+tags: amazon managed-mysql
 iconSlug: amazonaws
 permalink: /amazon-rds-mysql
 releasePolicyLink: https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/MySQL.Concepts.VersionMgmt.html

--- a/products/amazon-rds-postgresql.md
+++ b/products/amazon-rds-postgresql.md
@@ -1,6 +1,7 @@
 ---
 title: Amazon RDS for PostgreSQL
 category: service
+tags: amazon managed-postgresql
 iconSlug: amazonaws
 permalink: /amazon-rds-postgresql
 releasePolicyLink: https://docs.aws.amazon.com/AmazonRDS/latest/PostgreSQLReleaseNotes/postgresql-release-calendar.html

--- a/products/android.md
+++ b/products/android.md
@@ -1,6 +1,7 @@
 ---
 title: Android OS
 category: os
+tags: google
 iconSlug: android
 permalink: /android
 alternate_urls:

--- a/products/angular.md
+++ b/products/angular.md
@@ -1,6 +1,7 @@
 ---
 title: Angular
 category: framework
+tags: google javascript-runtime
 iconSlug: angular
 permalink: /angular
 versionCommand: ng version

--- a/products/ansible-core.md
+++ b/products/ansible-core.md
@@ -10,6 +10,7 @@ activeSupportColumn: false
 eolColumn: Supported
 iconSlug: ansible
 category: framework
+tags: python-runtime red-hat
 auto:
 -   git: https://github.com/ansible/ansible.git
 releases:

--- a/products/ansible.md
+++ b/products/ansible.md
@@ -1,6 +1,7 @@
 ---
 title: Ansible
 category: app
+tags: python-runtime red-hat
 iconSlug: ansible
 permalink: /ansible
 # The following command works from Ansible 6.0.0 on:

--- a/products/antixlinux.md
+++ b/products/antixlinux.md
@@ -1,6 +1,7 @@
 ---
 title: antiX Linux
 category: os
+tags: linux-distribution
 permalink: /antix
 alternate_urls:
 -   /antixlinux

--- a/products/apache-airflow.md
+++ b/products/apache-airflow.md
@@ -8,6 +8,7 @@ releasePolicyLink: https://github.com/apache/airflow#version-life-cycle
 changelogTemplate: https://airflow.apache.org/docs/apache-airflow/stable/release_notes.html#airflow-{{"__LATEST__"
   | replace:'.','-'}}-{{"__LATEST_RELEASE_DATE__"}}
 category: framework
+tags: apache python-runtime
 activeSupportColumn: false
 versionCommand: airflow version
 releaseColumn: true

--- a/products/apache-camel.md
+++ b/products/apache-camel.md
@@ -1,10 +1,11 @@
 ---
 title: Apache Camel
+category: framework
+tags: apache java-runtime
 permalink: /apache-camel
 alternate_urls:
 -   /camel
 -   /camel-lang
-category: framework
 releasePolicyLink: https://camel.apache.org/blog/2020/03/LTS-Release-Schedule/
 changelogTemplate: https://camel.apache.org/releases/release-__LATEST__/
 releaseColumn: true

--- a/products/apache-cassandra.md
+++ b/products/apache-cassandra.md
@@ -7,7 +7,8 @@ iconSlug: apachecassandra
 releaseDateColumn: true
 changelogTemplate: 'https://gitbox.apache.org/repos/asf?p=cassandra.git;a=blob_plain;f=NEWS.txt;hb=refs/tags/cassandra-__LATEST__'
 category: db
-releasePolicyLink: 
+tags: apache java-runtime
+releasePolicyLink:
   https://cassandra.apache.org/_/blog/Behind-the-scenes-of-an-Apache-Cassandra-Release.html
 auto:
 -   git: https://github.com/apache/cassandra.git

--- a/products/apache-groovy.md
+++ b/products/apache-groovy.md
@@ -5,6 +5,7 @@ alternate_urls:
 -   /groovy
 -   /groovy-lang
 category: lang
+tags: apache java-runtime
 iconSlug: apachegroovy
 releasePolicyLink: https://groovy.apache.org/versioning.html
 changelogTemplate: https://groovy-lang.org/changelogs/changelog-__LATEST__.html

--- a/products/apache-http-server.md
+++ b/products/apache-http-server.md
@@ -1,6 +1,7 @@
 ---
 title: Apache HTTP Server
 category: server-app
+tags: apache web-server
 iconSlug: apache
 permalink: /apache
 alternate_urls:

--- a/products/apache-kafka.md
+++ b/products/apache-kafka.md
@@ -1,6 +1,7 @@
 ---
 title: Apache Kafka
 category: server-app
+tags: apache java-runtime
 iconSlug: apachekafka
 permalink: /apache-kafka
 alternate_urls:

--- a/products/apache-maven.md
+++ b/products/apache-maven.md
@@ -1,6 +1,7 @@
 ---
 title: Apache Maven
 category: app
+tags: apache java-runtime
 versionCommand: mvn --version
 permalink: /maven
 alternate_urls:

--- a/products/api-platform.md
+++ b/products/api-platform.md
@@ -1,6 +1,7 @@
 ---
 title: API Platform
 category: framework
+tags: php-runtime
 permalink: /api-platform
 versionCommand: composer show api-platform/core | grep versions
 releasePolicyLink: https://api-platform.com/docs/extra/releases/

--- a/products/azul-zulu.md
+++ b/products/azul-zulu.md
@@ -1,6 +1,7 @@
 ---
 title: Azul Zulu
 category: lang
+tags: azul java-distribution
 iconSlug: openjdk
 permalink: /azul-zulu
 alternate_urls:

--- a/products/azure-devops.md
+++ b/products/azure-devops.md
@@ -1,6 +1,7 @@
 ---
 title: Azure DevOps Server
 category: server-app
+tags: microsoft
 iconSlug: azuredevops
 permalink: /azure-devops-server
 alternate_urls:

--- a/products/azure-kubernetes-service.md
+++ b/products/azure-kubernetes-service.md
@@ -1,6 +1,7 @@
 ---
 title: Azure Kubernetes Service
 category: service
+tags: managed-kubernetes microsoft
 iconSlug: microsoftazure
 permalink: /azure-kubernetes-service
 alternate_urls:

--- a/products/beats.md
+++ b/products/beats.md
@@ -1,6 +1,7 @@
 ---
 title: Elastic Beats
 category: server-app
+tags: elastic
 iconSlug: beats
 permalink: /beats
 alternate_urls:

--- a/products/bellsoft-liberica.md
+++ b/products/bellsoft-liberica.md
@@ -1,6 +1,7 @@
 ---
 title: Bellsoft Liberica JDK
 category: lang
+tags: bellsoft java-distribution
 iconSlug: openjdk
 permalink: /bellsoft-liberica
 alternate_urls:

--- a/products/bootstrap.md
+++ b/products/bootstrap.md
@@ -1,6 +1,7 @@
 ---
 title: Bootstrap
 category: framework
+tags: css-runtime javascript-runtime
 iconSlug: bootstrap
 permalink: /bootstrap
 activeSupportColumn: true

--- a/products/cakephp.md
+++ b/products/cakephp.md
@@ -1,6 +1,7 @@
 ---
 title: CakePHP
 category: framework
+tags: php-runtime
 iconSlug: cakephp
 permalink: /cakephp
 alternate_urls:

--- a/products/centos-stream.md
+++ b/products/centos-stream.md
@@ -1,6 +1,7 @@
 ---
 title: CentOS Stream
 category: os
+tags: linux-distribution
 iconSlug: centos
 permalink: /centos-stream
 versionCommand: cat /etc/redhat-release

--- a/products/centos.md
+++ b/products/centos.md
@@ -1,6 +1,7 @@
 ---
 title: CentOS
 category: os
+tags: linux-distribution
 iconSlug: centos
 permalink: /centos
 versionCommand: cat /etc/redhat-release

--- a/products/citrix-apps-desktops.md
+++ b/products/citrix-apps-desktops.md
@@ -1,6 +1,7 @@
 ---
 title: Citrix Virtual Apps and Desktops
 category: app
+tags: citrix
 iconSlug: citrix
 permalink: /citrix-vad
 alternate_urls:

--- a/products/coldfusion.md
+++ b/products/coldfusion.md
@@ -1,6 +1,7 @@
 ---
 title: Adobe ColdFusion
 category: server-app
+tags: adobe
 iconSlug: adobe
 permalink: /coldfusion
 versionCommand: writeoutput(server.coldfusion.productversion);

--- a/products/composer.md
+++ b/products/composer.md
@@ -1,6 +1,7 @@
 ---
 title: Composer
 category: app
+tags: php-runtime
 changelogTemplate: https://getcomposer.org/changelog/__LATEST__
 iconSlug: composer
 permalink: /composer

--- a/products/confluence.md
+++ b/products/confluence.md
@@ -1,6 +1,7 @@
 ---
 title: Confluence
 category: server-app
+tags: atlassian java-runtime
 iconSlug: confluence
 permalink: /confluence
 alternate_urls:

--- a/products/consul.md
+++ b/products/consul.md
@@ -1,6 +1,7 @@
 ---
 title: Hashicorp Consul
 category: server-app
+tags: hashicorp
 iconSlug: consul
 permalink: /consul
 versionCommand: consul --version

--- a/products/cos.md
+++ b/products/cos.md
@@ -1,6 +1,7 @@
 ---
 title: Google Container-Optimized OS (COS)
 category: os
+tags: google
 changelogTemplate: "https://cloud.google.com/container-optimized-os/docs/release-notes/m{{'__RELEASE_CYCLE__'|split:'-'|last}}"
 iconSlug: googlecloud
 permalink: /cos

--- a/products/craft-cms.md
+++ b/products/craft-cms.md
@@ -1,6 +1,7 @@
 ---
 title: Craft CMS
 category: server-app
+tags: php-runtime
 iconSlug: craftcms
 permalink: /craft-cms
 alternate_urls:

--- a/products/debian.md
+++ b/products/debian.md
@@ -1,6 +1,7 @@
 ---
 title: Debian
 category: os
+tags: linux-distribution
 iconSlug: debian
 permalink: /debian
 versionCommand: cat /etc/os-release

--- a/products/dependencytrack.md
+++ b/products/dependencytrack.md
@@ -1,6 +1,7 @@
 ---
 title: Dependency-Track
 category: server-app
+tags: java-runtime
 permalink: /dependency-track
 alternate_urls:
 -   /dependencytrack

--- a/products/devuan.md
+++ b/products/devuan.md
@@ -3,6 +3,7 @@ permalink: /devuan
 title: Devuan
 versionCommand: cat /etc/os-release
 category: os
+tags: linux-distribution
 releasePolicyLink: https://www.devuan.org/os/releases
 activeSupportColumn: false
 releaseColumn: true

--- a/products/django.md
+++ b/products/django.md
@@ -1,6 +1,7 @@
 ---
 title: Django
 category: framework
+tags: python-runtime
 iconSlug: django
 permalink: /django
 versionCommand: python -c "import django; print(django.get_version())"

--- a/products/dotnet.md
+++ b/products/dotnet.md
@@ -1,6 +1,7 @@
 ---
 title: Microsoft .NET
 category: framework
+tags: microsoft
 iconSlug: dotnet
 permalink: /dotnet
 alternate_urls:

--- a/products/dotnetfx.md
+++ b/products/dotnetfx.md
@@ -1,6 +1,7 @@
 ---
 title: Microsoft .NET Framework
 category: framework
+tags: microsoft
 iconSlug: dotnet
 permalink: /dotnetfx
 alternative_urls:

--- a/products/drupal.md
+++ b/products/drupal.md
@@ -1,6 +1,7 @@
 ---
 title: Drupal
 category: server-app
+tags: php-runtime
 iconSlug: drupal
 permalink: /drupal
 versionCommand: drush status

--- a/products/drush.md
+++ b/products/drush.md
@@ -3,6 +3,7 @@ title: Drush
 permalink: /drush
 releasePolicyLink: https://www.drush.org/latest/install/#drupal-compatibility
 category: app
+tags: php-runtime
 changelogTemplate: https://github.com/drush-ops/drush/releases/tag/__LATEST__
 activeSupportColumn: false
 releaseDateColumn: true

--- a/products/eclipse-temurin.md
+++ b/products/eclipse-temurin.md
@@ -1,6 +1,7 @@
 ---
 title: Eclipse Temurin
 category: lang
+tags: eclipse java-distribution
 iconSlug: openjdk
 permalink: /eclipse-temurin
 alternate_urls:

--- a/products/eks.md
+++ b/products/eks.md
@@ -1,6 +1,7 @@
 ---
 title: Amazon EKS
 category: service
+tags: amazon managed-kubernetes
 iconSlug: amazoneks
 permalink: /amazon-eks
 versionCommand: eksctl get cluster --name=cluster-name

--- a/products/elasticsearch.md
+++ b/products/elasticsearch.md
@@ -1,6 +1,7 @@
 ---
 title: Elasticsearch
 category: db
+tags: elastic java-runtime
 iconSlug: elasticsearch
 permalink: /elasticsearch
 versionCommand: $ES_HOME/bin/elasticsearch -v

--- a/products/electron.md
+++ b/products/electron.md
@@ -1,6 +1,7 @@
 ---
 title: Electron
 category: framework
+tags: javascript-runtime
 iconSlug: electron
 permalink: /electron
 versionCommand: npm show electron version

--- a/products/emberjs.md
+++ b/products/emberjs.md
@@ -5,6 +5,7 @@ iconSlug: emberdotjs
 alternate_urls:
 -   /ember
 category: framework
+tags: javascript-runtime
 releasePolicyLink: https://emberjs.com/releases/
 changelogTemplate: https://github.com/emberjs/ember.js/releases/tag/v__LATEST__
 activeSupportColumn: true

--- a/products/eurolinux.md
+++ b/products/eurolinux.md
@@ -2,6 +2,7 @@
 permalink: /eurolinux
 title: EuroLinux
 category: os
+tags: linux-distribution
 versionCommand: lsb_release --release
 releasePolicyLink: https://euro-linux.com/eurolinux/technical-specifications/
 activeSupportColumn: true

--- a/products/fairphone.md
+++ b/products/fairphone.md
@@ -2,6 +2,7 @@
 permalink: /fairphone
 title: Fairphone
 category: device
+tags: mobile-phone
 releasePolicyLink: https://forum.fairphone.com/t/fairphone-product-release-cycle/52652
 discontinuedColumn: true
 activeSupportColumn: false

--- a/products/fedora.md
+++ b/products/fedora.md
@@ -1,6 +1,7 @@
 ---
 title: Fedora Linux
 category: os
+tags: linux-distribution
 iconSlug: fedora
 permalink: /fedora
 versionCommand: cat /etc/fedora-release

--- a/products/firefox.md
+++ b/products/firefox.md
@@ -1,6 +1,7 @@
 ---
 title: Firefox
 category: app
+tags: mozilla web-browser
 iconSlug: firefoxbrowser
 permalink: /firefox
 releasePolicyLink: https://www.mozilla.org/firefox/

--- a/products/fortios.md
+++ b/products/fortios.md
@@ -1,6 +1,7 @@
 ---
 title: FortiOS
 category: os
+tags: fortinet
 alternate_urls:
 -   /fortinet
 iconSlug: fortinet

--- a/products/freebsd.md
+++ b/products/freebsd.md
@@ -1,6 +1,7 @@
 ---
 title: FreeBSD
 category: os
+tags: bsd-distribution
 iconSlug: freebsd
 permalink: /freebsd
 versionCommand: freebsd-version

--- a/products/gitlab.md
+++ b/products/gitlab.md
@@ -1,6 +1,7 @@
 ---
 title: GitLab
 category: server-app
+tags: gitlab
 iconSlug: gitlab
 permalink: /gitlab
 versionCommand: gitlab-rake gitlab:env:info

--- a/products/gke.md
+++ b/products/gke.md
@@ -1,6 +1,7 @@
 ---
 title: Google Kubernetes Engine
 category: service
+tags: google managed-kubernetes
 iconSlug: kubernetes
 permalink: /google-kubernetes-engine
 alternate_urls:

--- a/products/go.md
+++ b/products/go.md
@@ -1,6 +1,7 @@
 ---
 title: Go
 category: lang
+tags: google
 iconSlug: go
 permalink: /go
 alternate_urls:

--- a/products/graalvm.md
+++ b/products/graalvm.md
@@ -1,6 +1,7 @@
 ---
 title: GraalVM
 category: lang
+tags: java-distribution oracle
 permalink: /graalvm
 releasePolicyLink: https://www.graalvm.org/release-notes/release-calendar/
 changelogTemplate: "https://www.graalvm.org/latest/release-notes/{{ '__RELEASE_CYCLE__' | replace:'.','_' }}/"

--- a/products/gradle.md
+++ b/products/gradle.md
@@ -1,6 +1,7 @@
 ---
 title: Gradle
 category: app
+tags: java-runtime
 iconSlug: gradle
 permalink: /gradle
 versionCommand: gradle --version

--- a/products/grails.md
+++ b/products/grails.md
@@ -1,6 +1,7 @@
 ---
 title: Grails Framework
 category: framework
+tags: java-runtime
 permalink: /grails
 alternate_urls:
 -   /grails-framework

--- a/products/haproxy.md
+++ b/products/haproxy.md
@@ -1,6 +1,7 @@
 ---
 title: HAProxy
 category: server-app
+tags: web-server
 permalink: /haproxy
 versionCommand: haproxy -v
 releasePolicyLink: https://www.haproxy.org/

--- a/products/hashicorp-vault.md
+++ b/products/hashicorp-vault.md
@@ -1,6 +1,7 @@
 ---
 title: Hashicorp Vault
 category: server-app
+tags: hashicorp
 iconSlug: vault
 permalink: /hashicorp-vault
 alternate_urls:

--- a/products/hbase.md
+++ b/products/hbase.md
@@ -1,6 +1,7 @@
 ---
 title: Apache HBase
 category: server-app
+tags: apache java-runtime
 permalink: /hbase
 alternate_urls:
 -   /apache_hbase

--- a/products/ibm-aix.md
+++ b/products/ibm-aix.md
@@ -1,6 +1,7 @@
 ---
 title: IBM AIX
 category: os
+tags: ibm
 iconSlug: ibm
 permalink: /ibm-aix
 alternate_urls:

--- a/products/ibm-aix.md
+++ b/products/ibm-aix.md
@@ -5,7 +5,7 @@ tags: ibm
 iconSlug: ibm
 permalink: /ibm-aix
 alternate_urls:
--   aix
+-   /aix
 versionCommand: oslevel -s
 releasePolicyLink: https://www.ibm.com/support/pages/standard-and-enhanced-ibm-support-lifecycle-policies
 releaseLabel: "{{'__RELEASE_CYCLE__'|split:'.'|pop|join:'.'}} TL{{'__RELEASE_CYCLE__'|split:'.'|last}}"

--- a/products/internetexplorer.md
+++ b/products/internetexplorer.md
@@ -1,6 +1,7 @@
 ---
 title: Internet Explorer
 category: app
+tags: microsoft web-browser
 iconSlug: internetexplorer
 permalink: /internet-explorer
 alternate_urls:

--- a/products/ionic.md
+++ b/products/ionic.md
@@ -1,6 +1,7 @@
 ---
 title: Ionic Framework
 category: framework
+tags: javascript-runtime
 iconSlug: ionic
 permalink: /ionic
 alternate_urls:

--- a/products/ios.md
+++ b/products/ios.md
@@ -1,6 +1,7 @@
 ---
 title: Apple iOS
 category: os
+tags: apple
 iconSlug: apple
 permalink: /ios
 releasePolicyLink: https://en.wikipedia.org/wiki/IOS_version_history#Overview

--- a/products/ipad.md
+++ b/products/ipad.md
@@ -1,6 +1,7 @@
 ---
 title: Apple iPad
 category: device
+tags: apple tablet
 iconSlug: apple
 permalink: /ipad
 releasePolicyLink: https://en.wikipedia.org/wiki/List_of_iOS,_iPadOS,_tvOS,_and_watchOS_devices#iPad_(lineup)

--- a/products/ipados.md
+++ b/products/ipados.md
@@ -1,6 +1,7 @@
 ---
 title: Apple iPadOS
 category: os
+tags: apple
 iconSlug: apple
 permalink: /ipados
 releasePolicyLink: https://en.wikipedia.org/wiki/IOS_version_history#Overview

--- a/products/iphone.md
+++ b/products/iphone.md
@@ -1,6 +1,7 @@
 ---
 title: Apple iPhone
 category: device
+tags: apple mobile-phone
 iconSlug: apple
 permalink: /iphone
 releasePolicyLink: https://wikipedia.org/wiki/List_of_iOS_and_iPadOS_devices#In_production_and_supported

--- a/products/java.md
+++ b/products/java.md
@@ -1,6 +1,7 @@
 ---
 title: Java/OpenJDK
 category: lang
+tags: java-distribution oracle
 iconSlug: openjdk
 permalink: /java
 alternate_urls:

--- a/products/jekyll.md
+++ b/products/jekyll.md
@@ -1,6 +1,7 @@
 ---
 title: Jekyll
 category: app
+tags: ruby-runtime
 iconSlug: jekyll
 permalink: /jekyll
 releasePolicyLink: https://jekyllrb.com/docs/security/

--- a/products/jenkins.md
+++ b/products/jenkins.md
@@ -1,6 +1,7 @@
 ---
 title: Jenkins
 category: server-app
+tags: java-runtime
 iconSlug: jenkins
 permalink: /jenkins
 releasePolicyLink: https://www.jenkins.io/download/lts/

--- a/products/jhipster.md
+++ b/products/jhipster.md
@@ -1,6 +1,7 @@
 ---
 title: JHipster
 category: app
+tags: java-runtime javascript-runtime
 permalink: /jhipster
 versionCommand: yo jhipster
 releasePolicyLink: https://www.jhipster.tech/releases/

--- a/products/jira.md
+++ b/products/jira.md
@@ -1,6 +1,7 @@
 ---
 title: Jira Software
 category: server-app
+tags: atlassian java-runtime
 iconSlug: jirasoftware
 permalink: /jira-software
 alternate_urls:

--- a/products/joomla.md
+++ b/products/joomla.md
@@ -1,6 +1,7 @@
 ---
 title: Joomla!
 category: server-app
+tags: php-runtime
 iconSlug: joomla
 permalink: /joomla
 releasePolicyLink: https://docs.joomla.org/Release_and_support_cycle

--- a/products/jquery.md
+++ b/products/jquery.md
@@ -1,6 +1,7 @@
 ---
 title: jQuery
 category: framework
+tags: javascript-runtime
 iconSlug: jquery
 permalink: /jquery
 changelogTemplate: "https://github.com/jquery/jquery/releases/tag/__LATEST__"

--- a/products/jreleaser.md
+++ b/products/jreleaser.md
@@ -1,6 +1,7 @@
 ---
 title: JReleaser
 category: app
+tags: java-runtime
 permalink: /jreleaser
 versionCommand: jreleaser --version
 releasePolicyLink: https://jreleaser.org/guide/latest/release-history.html

--- a/products/keycloak.md
+++ b/products/keycloak.md
@@ -1,6 +1,7 @@
 ---
 title: Keycloak
 category: server-app
+tags: java-runtime red-hat
 # https://github.com/simple-icons/simple-icons/issues/8125
 permalink: /keycloak
 releasePolicyLink: https://github.com/keycloak/keycloak/security/policy#supported-versions

--- a/products/kibana.md
+++ b/products/kibana.md
@@ -1,6 +1,7 @@
 ---
 title: Kibana
 category: server-app
+tags: elastic
 iconSlug: kibana
 permalink: /kibana
 releasePolicyLink: https://www.elastic.co/support_policy

--- a/products/kindle.md
+++ b/products/kindle.md
@@ -1,6 +1,7 @@
 ---
 title: Amazon Kindle
 category: device
+tags: amazon e-reader
 iconSlug: amazon
 permalink: /kindle
 alternate_urls:

--- a/products/kotlin.md
+++ b/products/kotlin.md
@@ -1,6 +1,7 @@
 ---
 title: Kotlin
 category: lang
+tags: jetbrains
 iconSlug: kotlin
 permalink: /kotlin
 alternate_urls:

--- a/products/laravel.md
+++ b/products/laravel.md
@@ -1,6 +1,7 @@
 ---
 title: Laravel
 category: framework
+tags: php-runtime
 iconSlug: laravel
 permalink: /laravel
 versionCommand: composer show laravel/framework|grep versions

--- a/products/linuxmint.md
+++ b/products/linuxmint.md
@@ -3,6 +3,7 @@ permalink: /linuxmint
 title: Linux Mint
 versionCommand: cat /etc/linuxmint/info
 category: os
+tags: linux-distribution
 releasePolicyLink: https://linuxmint.com/download_all.php
 activeSupportColumn: true
 releaseDateColumn: true

--- a/products/log4j.md
+++ b/products/log4j.md
@@ -1,6 +1,7 @@
 ---
 title: Apache Log4j
 category: framework
+tags: java-runtime
 iconSlug: apache
 permalink: /log4j
 alternate_urls:

--- a/products/logstash.md
+++ b/products/logstash.md
@@ -1,6 +1,7 @@
 ---
 title: Logstash
 category: server-app
+tags: elastic
 iconSlug: logstash
 permalink: /logstash
 releasePolicyLink: https://www.elastic.co/support_policy

--- a/products/looker.md
+++ b/products/looker.md
@@ -2,6 +2,7 @@
 title: Looker
 permalink: /looker
 category: server-app
+tags: google
 iconSlug: looker
 releasePolicyLink: https://cloud.google.com/looker/docs/release-overview
 changelogTemplate: |

--- a/products/macos.md
+++ b/products/macos.md
@@ -1,6 +1,7 @@
 ---
 title: Apple macOS
 category: os
+tags: apple
 iconSlug: macos
 permalink: /macos
 alternate_urls:

--- a/products/mageia.md
+++ b/products/mageia.md
@@ -1,6 +1,7 @@
 ---
 title: Mageia
 category: os
+tags: linux-distribution
 permalink: /mageia
 versionCommand: cat /usr/lib/os-release
 releasePolicyLink: https://www.mageia.org/support/

--- a/products/magento.md
+++ b/products/magento.md
@@ -1,6 +1,7 @@
 ---
 title: Magento
 category: server-app
+tags: php-runtime
 iconSlug: magento
 permalink: /magento
 alternate_urls:

--- a/products/mastodon.md
+++ b/products/mastodon.md
@@ -1,6 +1,7 @@
 ---
 title: Mastodon
 category: server-app
+tags: javascript-runtime ruby-runtime
 iconSlug: mastodon
 permalink: /mastodon
 releasePolicyLink: https://github.com/mastodon/mastodon/security/policy

--- a/products/mediawiki.md
+++ b/products/mediawiki.md
@@ -1,6 +1,7 @@
 ---
 title: MediaWiki
 category: server-app
+tags: php-runtime
 changelogTemplate: "https://www.mediawiki.org/wiki/Release_notes/__RELEASE_CYCLE__"
 releaseImage: https://upload.wikimedia.org/wikipedia/mediawiki/timeline/of9ibgdvah78ld94hnu3ob5qeiwy4em.png
 permalink: /mediawiki

--- a/products/micronaut.md
+++ b/products/micronaut.md
@@ -1,6 +1,7 @@
 ---
 title: Micronaut Framework
 category: framework
+tags: java-runtime
 permalink: /micronaut
 alternate_urls:
 -   /micronaut-framework

--- a/products/microsoft-build-of-openjdk.md
+++ b/products/microsoft-build-of-openjdk.md
@@ -1,6 +1,7 @@
 ---
 title: Microsoft Build of OpenJDK
 category: lang
+tags: java-distribution microsoft
 iconSlug: openjdk
 permalink: /microsoft-build-of-openjdk
 versionCommand: java -version

--- a/products/moodle.md
+++ b/products/moodle.md
@@ -1,6 +1,7 @@
 ---
 title: Moodle
 category: server-app
+tags: php-runtime
 permalink: /moodle
 releasePolicyLink: https://moodledev.io/general/releases
 changelogTemplate: "https://moodledev.io/general/releases/__RELEASE_CYCLE__/__LATEST__"

--- a/products/msexchange.md
+++ b/products/msexchange.md
@@ -3,6 +3,7 @@ title: Microsoft Exchange
 permalink: /msexchange
 iconSlug: microsoftexchange
 category: server-app
+tags: microsoft
 releasePolicyLink: https://learn.microsoft.com/lifecycle/products/?terms=Exchange%20Server
 activeSupportColumn: true
 versionCommand: Get-ExchangeServer | Format-List Name,Edition,AdminDisplayVersion

--- a/products/mssharepoint.md
+++ b/products/mssharepoint.md
@@ -1,6 +1,7 @@
 ---
 title: Microsoft SharePoint
 category: server-app
+tags: microsoft
 iconSlug: microsoftsharepoint
 permalink: /sharepoint
 alternate_urls:

--- a/products/mssqlserver.md
+++ b/products/mssqlserver.md
@@ -1,6 +1,7 @@
 ---
 title: Microsoft SQL Server
 category: db
+tags: microsoft
 iconSlug: microsoftsqlserver
 permalink: /mssqlserver
 alternate_urls:

--- a/products/muleruntime.md
+++ b/products/muleruntime.md
@@ -1,6 +1,7 @@
 ---
 title: Mule Runtime
 category: server-app
+tags: java-runtime
 iconSlug: mulesoft
 permalink: /mulesoft-runtime
 alternate_urls:

--- a/products/mxlinux.md
+++ b/products/mxlinux.md
@@ -1,6 +1,7 @@
 ---
 title: MX Linux
 category: os
+tags: linux-distribution
 iconSlug: mxlinux
 permalink: /mxlinux
 alternate_urls:

--- a/products/mysql.md
+++ b/products/mysql.md
@@ -1,6 +1,7 @@
 ---
 title: MySQL
 category: db
+tags: oracle
 iconSlug: mysql
 permalink: /mysql
 versionCommand: mysqld --version

--- a/products/neo4j.md
+++ b/products/neo4j.md
@@ -1,6 +1,7 @@
 ---
 title: Neo4j
 category: db
+tags: java-runtime
 iconSlug: neo4j
 permalink: /neo4j
 versionCommand: "call dbms.components() yield versions unwind versions as version\

--- a/products/netbsd.md
+++ b/products/netbsd.md
@@ -1,6 +1,7 @@
 ---
 title: NetBSD
 category: os
+tags: bsd-distribution
 iconSlug: netbsd
 permalink: /netbsd
 versionCommand: uname -r

--- a/products/nextcloud.md
+++ b/products/nextcloud.md
@@ -1,6 +1,7 @@
 ---
 title: Nextcloud
 category: server-app
+tags: php-runtime
 iconSlug: nextcloud
 permalink: /nextcloud
 releasePolicyLink: https://github.com/nextcloud/server/wiki/Maintenance-and-Release-Schedule

--- a/products/nexus.md
+++ b/products/nexus.md
@@ -1,6 +1,7 @@
 ---
 title: Nexus Repository OSS
 category: server-app
+tags: java-runtime
 # https://github.com/simple-icons/simple-icons/issues/7924
 permalink: /nexus
 alternate_urls:

--- a/products/nginx.md
+++ b/products/nginx.md
@@ -1,6 +1,7 @@
 ---
 title: nginx
 category: server-app
+tags: web-server
 iconSlug: nginx
 permalink: /nginx
 versionCommand: nginx -v

--- a/products/nixos.md
+++ b/products/nixos.md
@@ -1,6 +1,7 @@
 ---
 title: NixOS
 category: os
+tags: linux-distribution
 iconSlug: nixos
 permalink: /nixos
 alternate_urls:

--- a/products/nodejs.md
+++ b/products/nodejs.md
@@ -1,6 +1,7 @@
 ---
 title: Node.js
 category: framework
+tags: javascript-runtime
 iconSlug: nodedotjs
 permalink: /nodejs
 alternate_urls:

--- a/products/nokia.md
+++ b/products/nokia.md
@@ -5,6 +5,7 @@ alternate_urls:
 -   /hmd
 -   /nokiamobile
 category: device
+tags: mobile-phone
 iconSlug: nokia
 releasePolicyLink: https://www.nokia.com/phones/en_int/security-updates
 activeSupportColumn: false

--- a/products/nomad.md
+++ b/products/nomad.md
@@ -1,6 +1,7 @@
 ---
 title: Nomad
 category: server-app
+tags: hashicorp
 permalink: /nomad
 versionCommand: nomad --version
 releasePolicyLink: https://support.hashicorp.com/hc/articles/360021185113

--- a/products/numpy.md
+++ b/products/numpy.md
@@ -1,6 +1,7 @@
 ---
 title: NumPy
 category: framework
+tags: python-runtime
 iconSlug: numpy
 permalink: /numpy
 releasePolicyLink: https://numpy.org/neps/nep-0029-deprecation_policy.html

--- a/products/nutanix-aos.md
+++ b/products/nutanix-aos.md
@@ -1,6 +1,7 @@
 ---
 title: Nutanix AOS
 category: os
+tags: nutanix
 iconSlug: nutanix
 permalink: /nutanix-aos
 versionCommand: ncli cluster version

--- a/products/nutanix-files.md
+++ b/products/nutanix-files.md
@@ -1,6 +1,7 @@
 ---
 title: Nutanix Files
 category: server-app
+tags: nutanix
 iconSlug: nutanix
 permalink: /nutanix-files
 releasePolicyLink: "https://www.nutanix.com/support-services/product-support/support-policies-and-faqs"

--- a/products/nutanix-prism.md
+++ b/products/nutanix-prism.md
@@ -1,6 +1,7 @@
 ---
 title: Nutanix Prism Central
 category: server-app
+tags: nutanix
 iconSlug: nutanix
 permalink: /nutanix-prism
 alternate_urls:

--- a/products/nuxt.md
+++ b/products/nuxt.md
@@ -1,6 +1,7 @@
 ---
 title: Nuxt
 category: framework
+tags: javascript-runtime
 permalink: /nuxt
 versionCommand: npm list nuxt
 releasePolicyLink: https://nuxt.com/docs/community/roadmap

--- a/products/nvidiadriver.md
+++ b/products/nvidiadriver.md
@@ -3,6 +3,7 @@ releaseImage: https://docs.nvidia.com/datacenter/tesla/drivers/graphics/driver-b
 title: NVIDIA Driver
 permalink: /nvidia
 category: app
+tags: nvidia
 iconSlug: nvidia
 releasePolicyLink: https://www.nvidia.com/Download/index.aspx
 activeSupportColumn: true
@@ -11,152 +12,152 @@ releaseColumn: true
 versionCommand: nvidia-smi
 LTSLabel: "<abbr title='Long Term Support Branch'>LTSB</abbr>"
 releases:
--   releaseCycle: "R530-Windows (NFB)"
-    support: true
-    eol: 2023-06-24
-    latest: "531.79"
-    link: https://www.nvidia.com/Download/driverResults.aspx/204772/
-    releaseDate: 2023-03-23
+  -   releaseCycle: "R530-Windows (NFB)"
+      support: true
+      eol: 2023-06-24
+      latest: "531.79"
+      link: https://www.nvidia.com/Download/driverResults.aspx/204772/
+      releaseDate: 2023-03-23
 
--   releaseCycle: "R530-Linux (NFB)"
-    support: true
-    eol: 2023-06-24
-    latest: "530.41.03"
-    link: https://www.nvidia.com/Download/driverResults.aspx/200481/
-    releaseDate: 2023-03-23
+  -   releaseCycle: "R530-Linux (NFB)"
+      support: true
+      eol: 2023-06-24
+      latest: "530.41.03"
+      link: https://www.nvidia.com/Download/driverResults.aspx/200481/
+      releaseDate: 2023-03-23
 
--   releaseCycle: "R525-Windows (PB)"
-    support: true
-    eol: 2023-12-01
-    latest: "528.95"
-    link: https://www.nvidia.com/Download/driverResults.aspx/204574/
-    releaseDate: 2022-11-10
-    
--   releaseCycle: "R525-Linux (PB)"
-    support: true
-    eol: 2023-12-01
-    latest: "525.116.03"
-    link: https://www.nvidia.com/Download/driverResults.aspx/204639/
-    releaseDate: 2022-11-10
-    
--   releaseCycle: "R515-Windows (PB)"
-    support: true
-    eol: 2023-05-01
-    latest: "517.71"
-    link: https://www.nvidia.com/download/driverResults.aspx/195851/
-    releaseDate: 2022-05-11    
-    
--   releaseCycle: "R515-Linux (PB)"
-    support: true
-    eol: 2023-05-01
-    latest: "515.105.01"
-    link: https://www.nvidia.com/Download/driverResults.aspx/202059/
-    releaseDate: 2022-05-11
-    
--   releaseCycle: "R510-Windows (PB)"
-    support: true
-    eol: 2023-01-01
-    latest: "513.91"
-    link: https://www.nvidia.com/download/driverResults.aspx/194565/
-    releaseDate: 2022-01-14
-    
--   releaseCycle: "R510-Linux (PB)"
-    support: true
-    eol: 2023-01-01
-    latest: "510.108.03"
-    link: https://www.nvidia.com/download/driverResults.aspx/194569/
-    releaseDate: 2022-01-14
-    
--   releaseCycle: "R495-Windows (NFB)"
-    support: false
-    eol: 2022-01-14
-    latest: "497.29"
-    link: https://www.nvidia.com/Download/driverResults.aspx/184717/
-    releaseDate: 2021-10-12
-    
--   releaseCycle: "R495-Linux (NFB)"
-    support: false
-    eol: 2022-10-12
-    latest: "495.46"
-    link: https://www.nvidia.com/Download/driverResults.aspx/184248/
-    releaseDate: 2021-10-26
-    
--   releaseCycle: "R470-Windows"
-    lts: true
-    support: 2021-09-20
-    eol: 2024-07-01
-    latest: "474.04"
-    link: https://www.nvidia.com/Download/driverResults.aspx/196634/
-    releaseDate: 2021-06-22
-    
--   releaseCycle: "R470-Linux"
-    lts: true
-    support: 2021-10-26
-    eol: 2024-07-20
-    latest: "470.182.03"
-    link: https://www.nvidia.com/Download/driverResults.aspx/200634/
-    releaseDate: 2021-07-19
-    
--   releaseCycle: "R460-Windows (PB)"
-    support: 2021-06-23
-    eol: 2022-01-01
-    latest: "462.96"
-    link: https://docs.nvidia.com/datacenter/tesla/tesla-release-notes-460-91-03/
-    releaseDate: 2020-12-15
-    
--   releaseCycle: "R460-Linux (PB)"
-    support: 2021-07-19
-    eol: 2022-01-01
-    latest: "460.91.03"
-    link: https://docs.nvidia.com/datacenter/tesla/tesla-release-notes-460-91-03/
-    releaseDate: 2021-01-07
-    
--   releaseCycle: "R450-Windows"
-    lts: true
-    support: 2020-12-15
-    eol: 2023-07-01
-    latest: "453.94"
-    link: https://docs.nvidia.com/datacenter/tesla/tesla-release-notes-450-216-04/index.html
-    releaseDate: 2020-06-24
-    
--   releaseCycle: "R450-Linux"
-    lts: true
-    support: 2020-10-07
-    eol: 2023-07-01
-    latest: "450.216.04"
-    link: https://docs.nvidia.com/datacenter/tesla/tesla-release-notes-450-216-04/index.html
-    releaseDate: 2020-06-24
-    
--   releaseCycle: "R418-Windows"
-    lts: true
-    support: 2019-04-23
-    eol: 2022-03-01
-    latest: "427.45"
-    link: https://docs.nvidia.com/datacenter/tesla/tesla-release-notes-418-19702/
-    releaseDate: 2019-02-04
-    
--   releaseCycle: "R418-Linux"
-    lts: true
-    support: 2019-03-20
-    eol: 2022-03-01
-    latest: "418.197.02"
-    link: https://docs.nvidia.com/datacenter/tesla/tesla-release-notes-418-19702/
-    releaseDate: 2019-01-30
-    
--   releaseCycle: "R390-Windows"
-    lts: true
-    support: 2018-07-31
-    eol: 2021-10-26
-    latest: "392.68"
-    link: https://www.nvidia.com/download/driverResults.aspx/181267/
-    releaseDate: 2018-01-08
--   releaseCycle: "R390-Linux"
-    lts: true
-    support: 2018-03-10
-    eol: 2022-11-22
-    latest: "390.157"
-    link: https://www.nvidia.com/Download/driverResults.aspx/196214/
-    releaseDate: 2018-01-04
+  -   releaseCycle: "R525-Windows (PB)"
+      support: true
+      eol: 2023-12-01
+      latest: "528.95"
+      link: https://www.nvidia.com/Download/driverResults.aspx/204574/
+      releaseDate: 2022-11-10
+
+  -   releaseCycle: "R525-Linux (PB)"
+      support: true
+      eol: 2023-12-01
+      latest: "525.116.03"
+      link: https://www.nvidia.com/Download/driverResults.aspx/204639/
+      releaseDate: 2022-11-10
+
+  -   releaseCycle: "R515-Windows (PB)"
+      support: true
+      eol: 2023-05-01
+      latest: "517.71"
+      link: https://www.nvidia.com/download/driverResults.aspx/195851/
+      releaseDate: 2022-05-11
+
+  -   releaseCycle: "R515-Linux (PB)"
+      support: true
+      eol: 2023-05-01
+      latest: "515.105.01"
+      link: https://www.nvidia.com/Download/driverResults.aspx/202059/
+      releaseDate: 2022-05-11
+
+  -   releaseCycle: "R510-Windows (PB)"
+      support: true
+      eol: 2023-01-01
+      latest: "513.91"
+      link: https://www.nvidia.com/download/driverResults.aspx/194565/
+      releaseDate: 2022-01-14
+
+  -   releaseCycle: "R510-Linux (PB)"
+      support: true
+      eol: 2023-01-01
+      latest: "510.108.03"
+      link: https://www.nvidia.com/download/driverResults.aspx/194569/
+      releaseDate: 2022-01-14
+
+  -   releaseCycle: "R495-Windows (NFB)"
+      support: false
+      eol: 2022-01-14
+      latest: "497.29"
+      link: https://www.nvidia.com/Download/driverResults.aspx/184717/
+      releaseDate: 2021-10-12
+
+  -   releaseCycle: "R495-Linux (NFB)"
+      support: false
+      eol: 2022-10-12
+      latest: "495.46"
+      link: https://www.nvidia.com/Download/driverResults.aspx/184248/
+      releaseDate: 2021-10-26
+
+  -   releaseCycle: "R470-Windows"
+      lts: true
+      support: 2021-09-20
+      eol: 2024-07-01
+      latest: "474.04"
+      link: https://www.nvidia.com/Download/driverResults.aspx/196634/
+      releaseDate: 2021-06-22
+
+  -   releaseCycle: "R470-Linux"
+      lts: true
+      support: 2021-10-26
+      eol: 2024-07-20
+      latest: "470.182.03"
+      link: https://www.nvidia.com/Download/driverResults.aspx/200634/
+      releaseDate: 2021-07-19
+
+  -   releaseCycle: "R460-Windows (PB)"
+      support: 2021-06-23
+      eol: 2022-01-01
+      latest: "462.96"
+      link: https://docs.nvidia.com/datacenter/tesla/tesla-release-notes-460-91-03/
+      releaseDate: 2020-12-15
+
+  -   releaseCycle: "R460-Linux (PB)"
+      support: 2021-07-19
+      eol: 2022-01-01
+      latest: "460.91.03"
+      link: https://docs.nvidia.com/datacenter/tesla/tesla-release-notes-460-91-03/
+      releaseDate: 2021-01-07
+
+  -   releaseCycle: "R450-Windows"
+      lts: true
+      support: 2020-12-15
+      eol: 2023-07-01
+      latest: "453.94"
+      link: https://docs.nvidia.com/datacenter/tesla/tesla-release-notes-450-216-04/index.html
+      releaseDate: 2020-06-24
+
+  -   releaseCycle: "R450-Linux"
+      lts: true
+      support: 2020-10-07
+      eol: 2023-07-01
+      latest: "450.216.04"
+      link: https://docs.nvidia.com/datacenter/tesla/tesla-release-notes-450-216-04/index.html
+      releaseDate: 2020-06-24
+
+  -   releaseCycle: "R418-Windows"
+      lts: true
+      support: 2019-04-23
+      eol: 2022-03-01
+      latest: "427.45"
+      link: https://docs.nvidia.com/datacenter/tesla/tesla-release-notes-418-19702/
+      releaseDate: 2019-02-04
+
+  -   releaseCycle: "R418-Linux"
+      lts: true
+      support: 2019-03-20
+      eol: 2022-03-01
+      latest: "418.197.02"
+      link: https://docs.nvidia.com/datacenter/tesla/tesla-release-notes-418-19702/
+      releaseDate: 2019-01-30
+
+  -   releaseCycle: "R390-Windows"
+      lts: true
+      support: 2018-07-31
+      eol: 2021-10-26
+      latest: "392.68"
+      link: https://www.nvidia.com/download/driverResults.aspx/181267/
+      releaseDate: 2018-01-08
+  -   releaseCycle: "R390-Linux"
+      lts: true
+      support: 2018-03-10
+      eol: 2022-11-22
+      latest: "390.157"
+      link: https://www.nvidia.com/Download/driverResults.aspx/196214/
+      releaseDate: 2018-01-04
 
 ---
 

--- a/products/nvidiaproducts.md
+++ b/products/nvidiaproducts.md
@@ -5,6 +5,7 @@ alternate_urls:
 -   /nvidia-products
 -   /nvidia-gpus
 category: device
+tags: nvidia
 iconSlug: nvidia
 releasePolicyLink: https://www.nvidia.com/en-us/geforce/graphics-cards/
 activeSupportColumn: true

--- a/products/office.md
+++ b/products/office.md
@@ -1,6 +1,7 @@
 ---
 title: Microsoft Office
 category: app
+tags: microsoft
 iconSlug: microsoftoffice
 permalink: /office
 alternate_urls:

--- a/products/openbsd.md
+++ b/products/openbsd.md
@@ -1,6 +1,7 @@
 ---
 title: OpenBSD
 category: os
+tags: bsd-distribution
 iconSlug: openbsd
 permalink: /openbsd
 versionCommand: uname -r

--- a/products/opensearch.md
+++ b/products/opensearch.md
@@ -1,6 +1,7 @@
 ---
 title: OpenSearch
 category: db
+tags: amazon java-runtime
 iconSlug: opensearch
 permalink: /opensearch
 releasePolicyLink: https://www.opensearch.org/releases.html

--- a/products/opensuse.md
+++ b/products/opensuse.md
@@ -1,6 +1,7 @@
 ---
 title: openSUSE
 category: os
+tags: linux-distribution
 iconSlug: opensuse
 permalink: /opensuse
 alternate_urls:

--- a/products/openwrt.md
+++ b/products/openwrt.md
@@ -1,6 +1,7 @@
 ---
 title: OpenWrt
 category: os
+tags: linux-distribution
 iconSlug: openwrt
 permalink: /openwrt
 alternate_urls:

--- a/products/oracle-database.md
+++ b/products/oracle-database.md
@@ -1,6 +1,7 @@
 ---
 title: Oracle Database
 category: db
+tags: oracle
 iconSlug: oracle
 permalink: /oracle-database
 versionCommand: SELECT BANNER_FULL FROM V$VERSION;

--- a/products/oraclelinux.md
+++ b/products/oraclelinux.md
@@ -2,6 +2,7 @@
 permalink: /oraclelinux
 title: Oracle Linux
 category: os
+tags: linux-distribution oracle
 versionCommand: lsb_release --release
 releasePolicyLink: https://www.oracle.com/a/ocom/docs/elsp-lifetime-069338.pdf
 releaseDateColumn: true

--- a/products/pan-cortex-xdr.md
+++ b/products/pan-cortex-xdr.md
@@ -1,6 +1,7 @@
 ---
 title: Palo Alto Networks Cortex XDR agent
 category: app
+tags: palo-alto-networks
 permalink: /cortex-xdr
 alternate_urls:
 -   /pan-xdr

--- a/products/pan-gp.md
+++ b/products/pan-gp.md
@@ -1,6 +1,7 @@
 ---
 title: Palo Alto Networks GlobalProtect App
 category: app
+tags: palo-alto-networks
 permalink: /pangp
 releasePolicyLink: https://www.paloaltonetworks.com/services/support/end-of-life-announcements/end-of-life-summary
 

--- a/products/pan-os.md
+++ b/products/pan-os.md
@@ -1,6 +1,7 @@
 ---
 title: Palo Alto Networks PAN-OS
 category: os
+tags: palo-alto-networks
 permalink: /panos
 versionCommand: show system info | match sw-version
 releasePolicyLink: https://www.paloaltonetworks.com/services/support/end-of-life-announcements/end-of-life-summary

--- a/products/phpbb.md
+++ b/products/phpbb.md
@@ -1,6 +1,7 @@
 ---
 title: phpBB
 category: server-app
+tags: php-runtime
 permalink: /phpbb
 releaseColumn: true
 releaseDateColumn: true

--- a/products/phpmyadmin.md
+++ b/products/phpmyadmin.md
@@ -1,6 +1,7 @@
 ---
 title: phpMyAdmin
 category: server-app
+tags: php-runtime
 iconSlug: phpmyadmin
 permalink: /phpmyadmin
 releasePolicyLink: https://www.phpmyadmin.net/downloads/#support

--- a/products/pixel.md
+++ b/products/pixel.md
@@ -1,6 +1,7 @@
 ---
 title: Google Pixel
 category: device
+tags: google mobile-phone
 iconSlug: google
 permalink: /pixel
 versionCommand: "Settings -> About Phone -> Regulatory labels"

--- a/products/plesk.md
+++ b/products/plesk.md
@@ -1,6 +1,7 @@
 ---
 title: Plesk
 category: server-app
+tags: php-runtime
 iconSlug: plesk
 permalink: /plesk
 versionCommand: plesk version

--- a/products/pop_os.md
+++ b/products/pop_os.md
@@ -1,6 +1,7 @@
 ---
 title: Pop!_OS
 category: os
+tags: linux-distribution
 iconSlug: popos
 permalink: /pop_os
 alternate_urls:

--- a/products/powershell.md
+++ b/products/powershell.md
@@ -1,6 +1,7 @@
 ---
 title: Microsoft PowerShell
 category: lang
+tags: microsoft
 iconSlug: powershell
 permalink: /powershell
 alternate_urls:

--- a/products/quarkus.md
+++ b/products/quarkus.md
@@ -1,6 +1,7 @@
 ---
 title: Quarkus
 category: framework
+tags: java-runtime
 iconSlug: quarkus
 permalink: /quarkus-framework
 alternate_urls:

--- a/products/rabbitmq.md
+++ b/products/rabbitmq.md
@@ -1,6 +1,7 @@
 ---
 title: RabbitMQ
 category: server-app
+tags: erlang-runtime
 iconSlug: rabbitmq
 permalink: /rabbitmq
 versionCommand: rabbitmqctl --version

--- a/products/react.md
+++ b/products/react.md
@@ -3,6 +3,7 @@ title: React
 permalink: /react
 iconSlug: react
 category: library
+tags: meta javascript-runtime
 releasePolicyLink: https://react.dev/community/versioning-policy
 changelogTemplate: https://github.com/facebook/react/releases/tag/v__LATEST__
 activeSupportColumn: true

--- a/products/readynas.md
+++ b/products/readynas.md
@@ -1,6 +1,7 @@
 ---
 title: Netgear ReadyNAS
 category: device
+tags: linux-distribution
 permalink: /readynas
 changelogTemplate: "https://www.netgear.com/support/product/{{'__RELEASE_CYCLE__'|downcase}}"
 releaseColumn: false

--- a/products/red-hat-openshift.md
+++ b/products/red-hat-openshift.md
@@ -1,6 +1,7 @@
 ---
 title: Red Hat OpenShift
 category: server-app
+tags: red-hat
 iconSlug: redhatopenshift
 permalink: /red-hat-openshift
 alternate_urls:

--- a/products/redhat.md
+++ b/products/redhat.md
@@ -1,6 +1,7 @@
 ---
 title: Red Hat Enterprise Linux
 category: os
+tags: red-hat
 iconSlug: redhat
 permalink: /rhel
 alternate_urls:

--- a/products/redmine.md
+++ b/products/redmine.md
@@ -3,6 +3,7 @@ title: Redmine
 permalink: /redmine
 releasePolicyLink: https://www.redmine.org/projects/redmine/news
 category: server-app
+tags: ruby-runtime
 activeSupportColumn: false
 releaseDateColumn: true
 releaseColumn: true

--- a/products/rockylinux.md
+++ b/products/rockylinux.md
@@ -1,6 +1,7 @@
 ---
 title: Rocky Linux
 category: os
+tags: linux-distribution
 iconSlug: rockylinux
 permalink: /rocky-linux
 alternate_urls:

--- a/products/roundcube.md
+++ b/products/roundcube.md
@@ -2,6 +2,7 @@
 title: Roundcube Webmail
 permalink: /roundcube
 category: server-app
+tags: php-runtime
 activeSupportColumn: true
 changelogTemplate: https://github.com/roundcube/roundcubemail/releases/tag/__LATEST__
 auto:
@@ -63,7 +64,7 @@ iconSlug: roundcube
 
 ---
 
-> [Roundcube Webmail](https://roundcube.net/) is a browser-based multilingual IMAP client with an application-like user interface. 
+> [Roundcube Webmail](https://roundcube.net/) is a browser-based multilingual IMAP client with an application-like user interface.
 > It provides full functionality you expect from an email client, including MIME support, address book, folder manipulation, message searching and spell checking.
 
 As of the last release, the project supports last 2 release branches in a "LTS low maintenance mode", which only includes important security updates only. Regular improvement updates are only available on the latest stable release.

--- a/products/ruby-on-rails.md
+++ b/products/ruby-on-rails.md
@@ -11,6 +11,7 @@ releasePolicyLink: https://guides.rubyonrails.org/maintenance_policy.html
 changelogTemplate: https://github.com/rails/rails/releases/tag/v__LATEST__
 releaseDateColumn: true
 category: framework
+tags: ruby-runtime
 auto:
 -   git: https://github.com/rails/rails.git
     regex: v(?<major>[1-9]\d*)\.(?<minor>0|[1-9]\d*)\.(?<patch>0|[1-9]\d*)(\.(?<tiny>0|[1-9]\d*))?$

--- a/products/samsungmobile.md
+++ b/products/samsungmobile.md
@@ -1,6 +1,7 @@
 ---
 title: Samsung Mobile
 category: device
+tags: mobile-phone smartwatch tablet
 iconSlug: samsung
 permalink: /samsung-mobile
 alternate_urls:

--- a/products/satellite.md
+++ b/products/satellite.md
@@ -1,6 +1,7 @@
 ---
 title: Red Hat Satellite
 category: server-app
+tags: red-hat
 iconSlug: redhat
 permalink: /redhat-satellite
 alternate_urls:

--- a/products/scala.md
+++ b/products/scala.md
@@ -1,6 +1,7 @@
 ---
 title: Scala
 category: lang
+tags: java-runtime
 iconSlug: scala
 permalink: /scala
 alternate_urls:

--- a/products/silverstripe.md
+++ b/products/silverstripe.md
@@ -1,12 +1,13 @@
 ---
 title: Silverstripe CMS
 category: server-app
+tags: php-runtime
 permalink: /silverstripe
 alternate_urls:
 -   /silverstripe-cms
 -   /silverstripe-framework
 versionCommand: composer info silverstripe/cms
-releaseImage: 
+releaseImage:
   https://www.silverstripe.org/assets/Uploads/_resampled/ResizedImageWzYwMCwzOTdd/CMS-5-Support-Timeline-May-2023.png
 releasePolicyLink: https://www.silverstripe.org/software/roadmap/
 changelogTemplate: https://github.com/silverstripe/silverstripe-cms/releases/__LATEST__

--- a/products/slackware.md
+++ b/products/slackware.md
@@ -1,6 +1,7 @@
 ---
 title: Slackware Linux
 category: os
+tags: linux-distribution
 iconSlug: slackware
 permalink: /slackware
 alternate_urls:

--- a/products/sles.md
+++ b/products/sles.md
@@ -1,6 +1,7 @@
 ---
 title: SUSE Linux Enterprise Server
 category: os
+tags: linux-distribution
 iconSlug: suse
 permalink: /sles
 alternate_urls:

--- a/products/solr.md
+++ b/products/solr.md
@@ -1,6 +1,7 @@
 ---
 title: Apache Solr
 category: server-app
+tags: apache java-runtime
 iconSlug: apachesolr
 permalink: /solr
 alternate_urls:

--- a/products/sonarqube.md
+++ b/products/sonarqube.md
@@ -1,6 +1,7 @@
 ---
 title: SonarQube
 category: server-app
+tags: java-runtime
 iconSlug: sonarqube
 permalink: /sonar
 alternate_urls:

--- a/products/spring-boot.md
+++ b/products/spring-boot.md
@@ -1,6 +1,7 @@
 ---
 title: Spring Boot
 category: framework
+tags: java-runtime vmware
 iconSlug: springboot
 permalink: /spring-boot
 alternate_urls:

--- a/products/spring-framework.md
+++ b/products/spring-framework.md
@@ -1,6 +1,7 @@
 ---
 title: Spring Framework
 category: framework
+tags: java-runtime vmware
 iconSlug: spring
 permalink: /spring-framework
 alternate_urls:

--- a/products/surface.md
+++ b/products/surface.md
@@ -1,6 +1,7 @@
 ---
 title: Microsoft Surface
 category: device
+tags: microsoft
 iconSlug: windows
 permalink: /surface
 releasePolicyLink: https://learn.microsoft.com/surface/surface-driver-firmware-lifecycle-support

--- a/products/symfony.md
+++ b/products/symfony.md
@@ -1,6 +1,7 @@
 ---
 title: Symfony
 category: framework
+tags: php-runtime
 iconSlug: symfony
 permalink: /symfony
 versionCommand: composer show | grep "symfony/"

--- a/products/tails.md
+++ b/products/tails.md
@@ -1,6 +1,7 @@
 ---
 title: Tails
 category: os
+tags: linux-distribution
 iconSlug: tails
 permalink: /tails
 versionCommand: cat /etc/amnesia/version

--- a/products/terraform.md
+++ b/products/terraform.md
@@ -1,6 +1,7 @@
 ---
 title: Hashicorp Terraform
 category: app
+tags: hashicorp
 iconSlug: terraform
 permalink: /terraform
 versionCommand: terraform --version

--- a/products/tomcat.md
+++ b/products/tomcat.md
@@ -1,6 +1,7 @@
 ---
 title: Apache Tomcat
 category: server-app
+tags: apache web-server
 iconSlug: apachetomcat
 permalink: /tomcat
 versionCommand: ./bin/version.sh

--- a/products/twig.md
+++ b/products/twig.md
@@ -2,6 +2,7 @@
 title: Twig
 permalink: /twig
 category: framework
+tags: php-runtime
 activeSupportColumn: false
 releaseDateColumn: true
 releaseColumn: true

--- a/products/typo3.md
+++ b/products/typo3.md
@@ -1,6 +1,7 @@
 ---
 title: TYPO3
 category: server-app
+tags: php-runtime
 permalink: /typo3
 releasePolicyLink: https://get.typo3.org/
 changelogTemplate: https://get.typo3.org/release-notes/__LATEST__

--- a/products/ubuntu.md
+++ b/products/ubuntu.md
@@ -1,6 +1,7 @@
 ---
 title: Ubuntu
 category: os
+tags: linux-distribution
 iconSlug: ubuntu
 permalink: /ubuntu
 versionCommand: lsb_release --release

--- a/products/umbraco.md
+++ b/products/umbraco.md
@@ -1,6 +1,7 @@
 ---
 title: Umbraco CMS
 category: server-app
+tags: dotnet-runtime
 iconSlug: umbraco
 permalink: /umbraco
 alternative_urls:

--- a/products/varnish.md
+++ b/products/varnish.md
@@ -1,6 +1,7 @@
 ---
 title: Varnish
 category: server-app
+tags: web-server
 permalink: /varnish
 versionCommand: varnishd -V
 releasePolicyLink: https://varnish-cache.org/releases/

--- a/products/visualstudio.md
+++ b/products/visualstudio.md
@@ -1,6 +1,7 @@
 ---
 title: Microsoft Visual Studio
 category: app
+tags: microsoft
 iconSlug: visualstudio
 permalink: /visual-studio
 alternate_urls:

--- a/products/vmware-esxi.md
+++ b/products/vmware-esxi.md
@@ -1,6 +1,7 @@
 ---
 title: VMware ESXi
 category: os
+tags: vmware
 iconSlug: vmware
 permalink: /esxi
 alternate_urls:

--- a/products/vmware-horizon.md
+++ b/products/vmware-horizon.md
@@ -1,6 +1,7 @@
 ---
 title: VMware Horizon
 category: app
+tags: vmware
 iconSlug: vmware
 permalink: /horizon
 alternate_urls:

--- a/products/vmware-photon.md
+++ b/products/vmware-photon.md
@@ -1,6 +1,7 @@
 ---
 title: VMware Photon
 category: os
+tags: vmware
 iconSlug: vmware
 permalink: /photon
 alternate_urls:

--- a/products/vmware-srm.md
+++ b/products/vmware-srm.md
@@ -1,6 +1,7 @@
 ---
 title: VMware Site Recovery Manager
 category: server-app
+tags: vmware
 iconSlug: vmware
 permalink: /vmware-srm
 alternate_urls:

--- a/products/vmware-vcenter.md
+++ b/products/vmware-vcenter.md
@@ -1,6 +1,7 @@
 ---
 title: VMware vCenter Server
 category: app
+tags: vmware
 iconSlug: vmware
 permalink: /vcenter
 alternate_urls:

--- a/products/vue.md
+++ b/products/vue.md
@@ -1,6 +1,7 @@
 ---
 title: Vue
 category: framework
+tags: javascript-runtime
 iconSlug: vuedotjs
 permalink: /vue
 alternate_urls:

--- a/products/vuetify.md
+++ b/products/vuetify.md
@@ -1,9 +1,9 @@
 ---
 title: Vuetify
 category: framework
+tags: javascript-runtime
 iconSlug: vuetify
 permalink: /vuetify
-
 versionCommand: npm list vuetify
 releasePolicyLink: https://vuetifyjs.com/en/introduction/long-term-support/
 changelogTemplate: https://github.com/vuetifyjs/vuetify/releases/tag/v__LATEST__
@@ -15,6 +15,7 @@ auto:
 
 identifiers:
 -   purl: pkg:npm/vuetify
+
 releases:
 -   releaseCycle: "3"
     support: true

--- a/products/wagtail.md
+++ b/products/wagtail.md
@@ -1,6 +1,7 @@
 ---
 title: Wagtail
 category: framework
+tags: python-runtime
 iconSlug: wagtail
 permalink: /wagtail
 versionCommand: python -c "import wagtail; print(wagtail.__version__)"

--- a/products/watchos.md
+++ b/products/watchos.md
@@ -1,6 +1,7 @@
 ---
 title: Apple watchOS
 category: os
+tags: apple smartwatch
 iconSlug: apple
 permalink: /watchos
 releasePolicyLink: https://en.wikipedia.org/wiki/WatchOS#Version_history

--- a/products/windows.md
+++ b/products/windows.md
@@ -1,6 +1,7 @@
 ---
 title: Microsoft Windows
 category: os
+tags: microsoft windows
 iconSlug: windows
 permalink: /windows
 versionCommand: winver

--- a/products/windowsEmbedded.md
+++ b/products/windowsEmbedded.md
@@ -1,6 +1,7 @@
 ---
 title: Microsoft Windows Embedded
 category: os
+tags: microsoft windows
 iconSlug: windows
 permalink: /windows-embedded
 alternate_urls:

--- a/products/windowsServer.md
+++ b/products/windowsServer.md
@@ -1,6 +1,7 @@
 ---
 title: Microsoft Windows Server
 category: os
+tags: microsoft windows
 iconSlug: windows
 permalink: /windows-server
 alternate_urls:

--- a/products/wordpress.md
+++ b/products/wordpress.md
@@ -1,6 +1,7 @@
 ---
 title: WordPress
 category: server-app
+tags: php-runtime
 iconSlug: wordpress
 permalink: /wordpress
 versionCommand: wp core version

--- a/products/yocto.md
+++ b/products/yocto.md
@@ -1,6 +1,7 @@
 ---
 title: Yocto Project
 category: os
+tags: linux-distribution
 permalink: /yocto
 alternate_urls:
 -   /yocto-project

--- a/products/zabbix.md
+++ b/products/zabbix.md
@@ -1,6 +1,7 @@
 ---
 title: Zabbix
 category: server-app
+tags: php-runtime
 permalink: /zabbix
 versionCommand: zabbix_server -V
 releasePolicyLink: https://www.zabbix.com/life_cycle_and_release_policy

--- a/products/zookeeper.md
+++ b/products/zookeeper.md
@@ -1,6 +1,7 @@
 ---
 title: Apache ZooKeeper
 category: server-app
+tags: apache java-runtime
 permalink: /zookeeper
 alternate_urls:
 -   /apache_zookeeper


### PR DESCRIPTION
Define rules for tags in `CONTRIBUTING.md`, and add tags (aka labels) to products (relates to #2225).

This commit focus on a limited set of tags, meaning:

- tags to set a product family such as `linux-distribution`, `web-browser`, `mobile-phone` or `web-server`,
- tags to set a product vendor such as `adobe`, `amazon` or `apache`,
- tags to set a runtime dependency such as `java-runtime`, `javascript-runtime` or `php-runtime`.

How tags are displayed on the website will be handled later.