### PR TITLE
[ionic] Add 7.0

### DIFF
--- a/products/ionic.md
+++ b/products/ionic.md
@@ -22,7 +22,7 @@ releases:
     releaseDate: 2023-03-29
     support: true
     eol: false
-    extendedSupport: false
+    extendedSupport: true
     latest: "7.0.0"
     latestReleaseDate: 2023-03-29
 
@@ -30,7 +30,7 @@ releases:
     releaseDate: 2021-12-08
     support: 2023-03-29
     eol: 2024-03-29
-    extendedSupport: false
+    extendedSupport: 2024-03-29
     latest: "6.7.2"
     latestReleaseDate: 2023-04-05
 

--- a/products/ionic.md
+++ b/products/ionic.md
@@ -29,7 +29,7 @@ releases:
 -   releaseCycle: "6"
     releaseDate: 2021-12-08
     support: 2023-03-29
-    eol: 2024-03-29
+    eol: 2024-09-29
     extendedSupport: 2024-03-29
     latest: "6.7.2"
     latestReleaseDate: 2023-04-05

--- a/products/ionic.md
+++ b/products/ionic.md
@@ -11,14 +11,23 @@ activeSupportColumn: true
 eolColumn: Maintenance
 releaseColumn: true
 releaseDateColumn: true
+extendedSupportColumn: true
 
 auto:
 -   git: https://github.com/ionic-team/ionic-framework.git
 
+# support(R) = releaseDate(R+1)
 releases:
 -   releaseCycle: "6"
     releaseDate: 2021-12-08
-    support: true
+    support: 2023-03-29
+    eol: false
+    latest: "6.7.1"
+    latestReleaseDate: 2023-03-29
+
+-   releaseCycle: "6"
+    releaseDate: 2021-12-08
+    support: 2023-03-29
     eol: false
     latest: "6.7.2"
     latestReleaseDate: 2023-04-05
@@ -27,6 +36,7 @@ releases:
     releaseDate: 2020-02-11
     support: 2021-12-08
     eol: 2022-06-08
+    extendedSupport: 2022-12-08
     latest: "5.9.4"
     latestReleaseDate: 2022-04-27
 
@@ -34,6 +44,7 @@ releases:
     releaseDate: 2019-01-23
     support: 2020-02-11
     eol: 2020-08-11
+    extendedSupport: 2022-09-30
     latest: "4.11.13"
     latestReleaseDate: 2020-10-01
 
@@ -41,6 +52,7 @@ releases:
     releaseDate: 2017-04-05
     support: 2019-01-23
     eol: 2019-10-30
+    extendedSupport: 2020-08-11
     latest: "3.9.3"
     latestReleaseDate: 2019-01-14
 
@@ -48,6 +60,7 @@ releases:
     releaseDate: 2017-01-24
     support: 2017-04-05
     eol: 2017-04-05
+    extendedSupport: 2017-04-05
     latest: "2.3.0"
     latestReleaseDate: 2017-03-17
 
@@ -55,6 +68,7 @@ releases:
     releaseDate: 2015-05-12
     support: 2017-01-25
     eol: 2017-01-25
+    extendedSupport: 2017-01-25
     latest: "1.3.2"
     latestReleaseDate: 2016-10-24
 
@@ -67,13 +81,15 @@ Only the latest version sees active development. The previous release gets criti
 fixes for a limited time, documented on [this page](https://ionicframework.com/docs/reference/support#framework-maintenance-and-support-status)
 (usually six months).
 
-## Compatibility Recommendations
+Extended Support is available along with the [Ionic Enterprise](https://ionic.io/enterprise) offering.
+
+
+## [Compatibility Recommendations](https://ionicframework.com/docs/reference/support#compatibility-recommendations)
 
 | Ionic Framework | Angular    | React  | Vue     |
 |-----------------|------------|--------|---------|
+| 7               | v14  - v15 | v17+   | v3.0.6+ |
 | 6               | v12  - v15 | v17+   | v3.0.6+ |
 | 5               | v8.2 - v12 | v16.8+ | v3.0+   |
 | 4               | v8.2 - v11 | v16.8+ | N/A     |
 | 3               | v5.2.11    | N/A    | N/A     |
-
-More details are documented [in the Ionic Framework documentation](https://ionicframework.com/docs/reference/support#compatibility-recommendations).

--- a/products/ionic.md
+++ b/products/ionic.md
@@ -22,6 +22,7 @@ releases:
     releaseDate: 2021-12-08
     support: 2023-03-29
     eol: false
+    extendedSupport: false
     latest: "6.7.1"
     latestReleaseDate: 2023-03-29
 
@@ -29,6 +30,7 @@ releases:
     releaseDate: 2021-12-08
     support: 2023-03-29
     eol: false
+    extendedSupport: false
     latest: "6.7.2"
     latestReleaseDate: 2023-04-05
 

--- a/products/ionic.md
+++ b/products/ionic.md
@@ -29,7 +29,7 @@ releases:
 -   releaseCycle: "6"
     releaseDate: 2021-12-08
     support: 2023-03-29
-    eol: 2024-09-29
+    eol: 2023-09-29
     extendedSupport: 2024-03-29
     latest: "6.7.2"
     latestReleaseDate: 2023-04-05

--- a/products/ionic.md
+++ b/products/ionic.md
@@ -23,8 +23,8 @@ releases:
     support: true
     eol: false
     extendedSupport: true
-    latest: "7.0.0"
-    latestReleaseDate: 2023-03-29
+    latest: "7.0.1"
+    latestReleaseDate: 2023-04-05
 
 -   releaseCycle: "6"
     releaseDate: 2021-12-08

--- a/products/ionic.md
+++ b/products/ionic.md
@@ -18,18 +18,18 @@ auto:
 
 # support(R) = releaseDate(R+1)
 releases:
--   releaseCycle: "6"
-    releaseDate: 2021-12-08
-    support: 2023-03-29
+-   releaseCycle: "7"
+    releaseDate: 2023-03-29
+    support: true
     eol: false
     extendedSupport: false
-    latest: "6.7.1"
+    latest: "7.0.0"
     latestReleaseDate: 2023-03-29
 
 -   releaseCycle: "6"
     releaseDate: 2021-12-08
     support: 2023-03-29
-    eol: false
+    eol: 2024-03-29
     extendedSupport: false
     latest: "6.7.2"
     latestReleaseDate: 2023-04-05


### PR DESCRIPTION
Added extended Support dates as well, which are unavailable for 6 and 7.

Keeping in draft for now, in case https://github.com/ionic-team/ionic-docs/issues/2867 is resolved quickly and we get some better dates for v6 and v7.