### PR TITLE
[airflow] Update latest version to 2.5.3

### DIFF
--- a/products/apache-airflow.md
+++ b/products/apache-airflow.md
@@ -21,7 +21,7 @@ releases:
 -   releaseCycle: "2"
     eol: false
     latest: "2.5.2"
-    latestReleaseDate: 2023-03-14
+    latestReleaseDate: 2023-04-01
     releaseDate: 2020-12-17
 -   releaseCycle: "1.10"
     eol: 2021-07-17


### PR DESCRIPTION
Hello,

Small update to the lastest release date for airlfow.

2.5.3 package was pushed to PyPI during the night around midnight, but  official release date and announcement is 2023-04-01.

https://airflow.apache.org/docs/apache-airflow/stable/release_notes.html#airflow-2-5-3-2023-04-01