### PR TITLE
[electron] Adds v24

### DIFF
--- a/products/electron.md
+++ b/products/electron.md
@@ -21,6 +21,13 @@ auto:
 # v26 (releaseDate) = v23 (eol)
 # and so on...
 releases:
+-   releaseCycle: "24"
+    # 2023-04-05 + 6 months
+    eol: 2023-10-05
+    releaseDate: 2023-04-04
+    latestReleaseDate: 2023-04-04
+    latest: "24.0.0"
+
 -   releaseCycle: "23"
     # 2023-02-06 + 6 months
     eol: 2023-08-06
@@ -35,7 +42,7 @@ releases:
     latest: "22.3.5"
 
 -   releaseCycle: "21"
-    eol: 2023-04-05
+    eol: 2023-04-04
     releaseDate: 2022-09-26
     latestReleaseDate: 2023-03-16
     latest: "21.4.3"


### PR DESCRIPTION
A release for 21.4.4 [is imminent](https://releases.electronjs.org/release-build/otrk0cgEg), but it's not listed at https://releases.electronjs.org/, so we mark it as eol as well. 