### PR TITLE
[quarkus] Add 3.0

### DIFF
--- a/products/quarkus.md
+++ b/products/quarkus.md
@@ -23,6 +23,13 @@ auto:
 # - eol(x) = releaseDate(x+1)
 # - tag and Maven release of new minor versions are usually created a week before the "official" announcement
 releases:
+-   releaseCycle: "3.0"
+    releaseDate: 2023-04-12
+    eol: false
+    extendedSupport: false
+    latest: "3.0.0"
+    latestReleaseDate: 2023-04-12
+
 -   releaseCycle: "2.16"
     eol: false
     extendedSupport: false


### PR DESCRIPTION
Did not mark 2.16 as eol because it might be an exception and documentations, such as https://quarkus.io/security/, were not up-to-date yet.