### PR TITLE
[mongodb] Adds 6.3 rapid release

### DIFF
--- a/products/mongodb.md
+++ b/products/mongodb.md
@@ -35,10 +35,17 @@ auto:
 # Dates are not in sync with https://www.mongodb.com/support-policy/lifecycles because we are using
 # git tag dates.
 releases:
+-   releaseCycle: "6.3"
+    releaseLabel: "6.3 (Rapid Release)"
+    releaseDate: 2023-04-11
+    eol: false
+    latest: '6.3.0'
+    latestReleaseDate: 2023-04-11
+
 -   releaseCycle: "6.2"
     releaseLabel: "6.2 (Rapid Release)"
     releaseDate: 2023-01-19
-    eol: false
+    eol: 2023-04-11
     latest: '6.2.1'
     latestReleaseDate: 2023-02-28
 


### PR DESCRIPTION
6.2 EOL is marked as April 2023, which I've taken
as 6.3 release date in this case (11th April).

See https://www.mongodb.com/support-policy/lifecycles