### PR TITLE
[grafana] Manually update to 9.4.7

### DIFF
--- a/products/grafana.md
+++ b/products/grafana.md
@@ -22,8 +22,8 @@ releases:
     support: true
     eol: false
     releaseDate: 2023-02-27
-    latest: "9.4.3"
-    latestReleaseDate: 2023-03-02
+    latest: "9.4.7"
+    latestReleaseDate: 2023-03-16
 
 -   releaseCycle: "9.3"
     support: 2023-02-27


### PR DESCRIPTION
Automation refused to upgrade it because
9.4.0 was tagged after 9.4.7, and the automation
considers that as a newer release.

So it finds a newer release which has a lower
version number, and decides to not change anything since lowering a version number always a bad idea.

This is a manual patch to fix the same, which shouldn't happen again as 9.4.8 or beyond will have a higher date.