### PR TITLE
Change version command for AlmaLinux to default packages

### DIFF
--- a/products/almalinux.md
+++ b/products/almalinux.md
@@ -2,7 +2,7 @@
 title: AlmaLinux OS
 category: os
 permalink: /almalinux
-versionCommand: lsb_release --release
+versionCommand: cat /etc/redhat-release
 releasePolicyLink: https://blog.cloudlinux.com/announcing-open-sourced-community-driven-rhel-fork-by-cloudlinux
 changelogTemplate: https://wiki.almalinux.org/release-notes/__LATEST__.html
 activeSupportColumn: true


### PR DESCRIPTION
Surely the way to check the version, should not require a none-standard package.