### PR TITLE
Display `link` and `latestReleaseDate` for EOL releases

### DIFF
--- a/_layouts/product.html
+++ b/_layouts/product.html
@@ -53,9 +53,10 @@ layout: default
 {%- assign releaseClasses = 'release' %}
 {%- if r.can_be_hidden %}{% assign releaseClasses = 'release can-be-hidden' %}{% endif %}
   <tr class="{{ releaseClasses }}">
-    <td>
+    {%- if r.daysTowardEol < 0 %}{% assign cycleColumnClass = 'txt-linethrough' %}{% endif %}
+    <td class="{{ cycleColumnClass }}">
       {% comment %}Only put a link in the version column if the release column is not shown{% endcomment %}
-      {% if page.releaseColumn == false and r.link and r.daysTowardEol > 0  %}
+      {% if page.releaseColumn == false and r.link  %}
         <a href="{{ r.link }}" title="Release Notes / Changelog for {{ r.label | strip_html }}">{{ r.label }}</a>
       {% else %}
         {{ r.label }}
@@ -134,14 +135,12 @@ layout: default
     {%- assign releaseColumnClass = '' %}
     {%- if r.daysTowardEol < 0 %}{% assign releaseColumnClass = 'txt-linethrough' %}{% endif %}
     <td class="{{ releaseColumnClass }}">
-      {% if r.link and r.daysTowardEol > 0 %}
+      {% if r.link %}
         <a href="{{ r.link }}" title="Release Notes / Changelog">{{ r.latest }}</a>
       {% else %}
         {{ r.latest }}
       {% endif %}
-      {% if r.daysTowardEol > 0 and r.latestReleaseDate %}
-        <div>({{ r.latestReleaseDate | date_to_string }})</div>
-      {% endif %}
+      {% if r.latestReleaseDate %}<div>({{ r.latestReleaseDate | date_to_string }})</div>{% endif %}
     </td>
     {% endif %}
   </tr>


### PR DESCRIPTION
Those information may be useful to our users.

I also changed the style of the _Release_ column to use strike-through for EOL releases. Considering the `latestRelease` is optional, but already uses that convention, it makes more sense.