### PR TITLE
[wordpress] Drop support column and clarify support policy

### DIFF
--- a/products/wordpress.md
+++ b/products/wordpress.md
@@ -7,10 +7,10 @@ permalink: /wordpress
 versionCommand: wp core version
 releasePolicyLink: https://codex.wordpress.org/Supported_Versions
 changelogTemplate: "https://wordpress.org/documentation/wordpress-version/version-{{'__LATEST__'|drop_zero_patch|replace:'.','-'}}/"
-activeSupportColumn: true
 releaseColumn: true
 releaseDateColumn: true
 discontinuedColumn: false
+eolColumn: Support
 
 # This regex drops '.0' from versions because x.y.0 releases are always referred as x.y.
 # The patch part is like that to handle properly tiny versions, such as 1.5.1.3, are handled properly.
@@ -29,12 +29,11 @@ identifiers:
 -   purl: pkg:docker/bitnami/wordpress-intel
 -   purl: pkg:docker/rapidfort/wordpress
 
-# support(x) = releaseDate(x+1)
+# eol(x) = releaseDate(x+1)
 releases:
 -   releaseCycle: "6.3"
     supportedPHPVersions: "7.0, 7.1, 7.2, 7.3, 7.4, 8.0, 8.1, 8.2"
     releaseDate: 2023-08-08
-    support: true
     eol: false
     latest: "6.3.2"
     latestReleaseDate: 2023-10-12
@@ -42,230 +41,205 @@ releases:
 -   releaseCycle: "6.2"
     supportedPHPVersions: "5.6, 7.0, 7.1, 7.2, 7.3, 7.4, 8.0, 8.1, 8.2"
     releaseDate: 2023-03-29
-    support: 2023-08-08
-    eol: false
+    eol: 2023-08-08
     latest: "6.2.3"
     latestReleaseDate: 2023-10-12
 
 -   releaseCycle: "6.1"
     supportedPHPVersions: "5.6, 7.0, 7.1, 7.2, 7.3, 7.4, 8.0, 8.1, 8.2"
     releaseDate: 2022-11-02
-    support: 2023-03-29
-    eol: false
+    eol: 2023-03-29
     latest: "6.1.4"
     latestReleaseDate: 2023-10-12
 
 -   releaseCycle: "6.0"
     supportedPHPVersions: "5.6, 7.0, 7.1, 7.2, 7.3, 7.4, 8.0, 8.1"
     releaseDate: 2022-05-24
-    support: 2022-11-01
-    eol: false
+    eol: 2022-11-01
     latest: "6.0.6"
     latestReleaseDate: 2023-10-12
 
 -   releaseCycle: "5.9"
     supportedPHPVersions: "5.6, 7.0, 7.1, 7.2, 7.3, 7.4, 8.0, 8.1"
     releaseDate: 2022-01-25
-    support: 2022-05-24
-    eol: false
+    eol: 2022-05-24
     latest: "5.9.8"
     latestReleaseDate: 2023-10-12
 
 -   releaseCycle: "5.8"
     supportedPHPVersions: "5.6, 7.0, 7.1, 7.2, 7.3, 7.4, 8.0"
     releaseDate: 2021-07-20
-    support: 2022-01-25
-    eol: false
+    eol: 2022-01-25
     latest: "5.8.8"
     latestReleaseDate: 2023-10-12
 
 -   releaseCycle: "5.7"
     supportedPHPVersions: "5.6, 7.0, 7.1, 7.2, 7.3, 7.4, 8.0"
     releaseDate: 2021-03-09
-    support: 2021-07-20
-    eol: false
+    eol: 2021-07-20
     latest: "5.7.10"
     latestReleaseDate: 2023-10-12
 
 -   releaseCycle: "5.6"
     supportedPHPVersions: "5.6, 7.0, 7.1, 7.2, 7.3, 7.4, 8.0"
     releaseDate: 2020-12-08
-    support: 2021-03-09
-    eol: false
+    eol: 2021-03-09
     latest: "5.6.12"
     latestReleaseDate: 2023-10-12
 
 -   releaseCycle: "5.5"
     supportedPHPVersions: "5.6, 7.0, 7.1, 7.2, 7.3, 7.4"
     releaseDate: 2020-08-11
-    support: 2020-12-08
-    eol: false
+    eol: 2020-12-08
     latest: "5.5.13"
     latestReleaseDate: 2023-10-12
 
 -   releaseCycle: "5.4"
     supportedPHPVersions: "5.6, 7.0, 7.1, 7.2, 7.3, 7.4"
     releaseDate: 2020-03-31
-    support: 2020-08-11
-    eol: false
+    eol: 2020-08-11
     latest: "5.4.14"
     latestReleaseDate: 2023-10-12
 
 -   releaseCycle: "5.3"
     supportedPHPVersions: "5.6, 7.0, 7.1, 7.2, 7.3, 7.4"
     releaseDate: 2019-11-12
-    support: 2020-03-31
-    eol: false
+    eol: 2020-03-31
     latest: "5.3.16"
     latestReleaseDate: 2023-10-12
 
 -   releaseCycle: "5.2"
     supportedPHPVersions: "5.6, 7.0, 7.1, 7.2, 7.3"
     releaseDate: 2019-05-07
-    support: 2019-11-12
-    eol: false
+    eol: 2019-11-12
     latest: "5.2.19"
     latestReleaseDate: 2023-10-12
 
 -   releaseCycle: "5.1"
     supportedPHPVersions: "5.2, 5.3, 5.4, 5.5, 5.6, 7.0, 7.1, 7.2, 7.3"
     releaseDate: 2019-02-21
-    support: 2019-05-07
-    eol: false
+    eol: 2019-05-07
     latest: "5.1.17"
     latestReleaseDate: 2023-10-12
 
 -   releaseCycle: "5.0"
     supportedPHPVersions: "5.2, 5.3, 5.4, 5.5, 5.6, 7.0, 7.1, 7.2, 7.3"
     releaseDate: 2018-12-06
-    support: 2019-02-21
-    eol: false
+    eol: 2019-02-21
     latest: "5.0.20"
     latestReleaseDate: 2023-10-12
 
 -   releaseCycle: "4.9"
     supportedPHPVersions: "5.2, 5.3, 5.4, 5.5, 5.6, 7.0, 7.1, 7.2"
     releaseDate: 2017-11-16
-    support: 2018-12-06
-    eol: false
+    eol: 2018-12-06
     latest: "4.9.24"
     latestReleaseDate: 2023-10-12
 
 -   releaseCycle: "4.8"
     supportedPHPVersions: "5.2, 5.3, 5.4, 5.5, 5.6, 7.0, 7.1"
     releaseDate: 2017-06-08
-    support: 2017-11-16
-    eol: false
+    eol: 2017-11-16
     latest: "4.8.23"
     latestReleaseDate: 2023-10-12
 
 -   releaseCycle: "4.7"
     supportedPHPVersions: "5.2, 5.3, 5.4, 5.5, 5.6, 7.0, 7.1"
     releaseDate: 2016-12-06
-    support: 2017-06-08
-    eol: false
+    eol: 2017-06-08
     latest: "4.7.27"
     latestReleaseDate: 2023-10-12
 
 -   releaseCycle: "4.6"
     supportedPHPVersions: "5.2, 5.3, 5.4, 5.5, 5.6, 7.0"
     releaseDate: 2016-08-16
-    support: 2016-12-06
-    eol: false
+    eol: 2016-12-06
     latest: "4.6.27"
     latestReleaseDate: 2023-10-12
 
 -   releaseCycle: "4.5"
     supportedPHPVersions: "5.2, 5.3, 5.4, 5.5, 5.6, 7.0"
     releaseDate: 2016-04-12
-    support: 2016-08-16
-    eol: false
+    eol: 2016-08-16
     latest: "4.5.30"
     latestReleaseDate: 2023-10-12
 
 -   releaseCycle: "4.4"
     supportedPHPVersions: "5.2, 5.3, 5.4, 5.5, 5.6, 7.0"
     releaseDate: 2015-12-09
-    support: 2016-04-12
-    eol: false
+    eol: 2016-04-12
     latest: "4.4.31"
     latestReleaseDate: 2023-10-12
 
 -   releaseCycle: "4.3"
     supportedPHPVersions: "5.2, 5.3, 5.4, 5.5, 5.6"
     releaseDate: 2015-08-18
-    support: 2015-12-08
-    eol: false
+    eol: 2015-12-08
     latest: "4.3.32"
     latestReleaseDate: 2023-10-12
 
 -   releaseCycle: "4.2"
     supportedPHPVersions: "5.2, 5.3, 5.4, 5.5, 5.6"
     releaseDate: 2015-04-23
-    support: 2015-08-18
-    eol: false
+    eol: 2015-08-18
     latest: "4.2.36"
     latestReleaseDate: 2023-10-12
 
 -   releaseCycle: "4.1"
     supportedPHPVersions: "5.2, 5.3, 5.4, 5.5, 5.6"
     releaseDate: 2014-12-18
-    support: 2015-04-23
-    eol: false
+    eol: 2015-04-23
     latest: "4.1.39"
     latestReleaseDate: 2023-10-12
 
 -   releaseCycle: "4.0"
     supportedPHPVersions: "5.2, 5.3, 5.4, 5.5"
     releaseDate: 2014-09-04
-    support: 2014-12-18
-    eol: 2022-12-01
+    eol: 2014-12-18
     latest: "4.0.38"
     latestReleaseDate: 2022-11-30
 
 -   releaseCycle: "3.9"
     supportedPHPVersions: "5.2, 5.3, 5.4, 5.5"
     releaseDate: 2014-04-16
-    support: 2014-09-04
-    eol: 2022-12-01
+    eol: 2014-09-04
     latest: "3.9.40"
     latestReleaseDate: 2022-11-30
 
 -   releaseCycle: "3.8"
     supportedPHPVersions: "5.2, 5.3, 5.4, 5.5"
     releaseDate: 2013-12-12
-    support: 2014-04-16
-    eol: 2022-12-01
+    eol: 2014-04-16
     latest: "3.8.41"
     latestReleaseDate: 2022-11-30
 
 -   releaseCycle: "3.7"
     supportedPHPVersions: "5.2, 5.3, 5.4, 5.5"
     releaseDate: 2013-10-24
-    support: 2013-12-12
-    eol: 2022-12-01
+    eol: 2013-12-12
     latest: "3.7.41"
     latestReleaseDate: 2022-11-30
 
 -   releaseCycle: "3.6"
     releaseDate: 2013-08-01
-    support: 2013-10-24
     eol: 2013-10-24
     latest: "3.6.1"
     latestReleaseDate: 2013-09-11
 
 ---
 
-> [WordPress](https://wordpress.org/) is a free and open-source content management system written in PHP.
+> [WordPress](https://wordpress.org/) is a free and open-source content management system (CMS)
+> written in PHP and paired with a MySQL or MariaDB database. Features include a plugin architecture
+> and a template system, referred to within WordPress as "Themes".
 
-Only the latest major release is supported. Security patches are backported when possible, but this
-is not guaranteed. [Version 3.7 to 4.0 won't get security updates after Dec 1, 2022](https://wordpress.org/news/2022/09/dropping-security-updates-for-wordpress-versions-3-7-through-4-0/).
+The only officially supported and actively maintained version of WordPress is the last one.
+There are no fixed period of support nor Long Term Support (LTS) version.
+
+Security updates are backported to older releases when possible, but the Wordpress team offers no
+guarantee and no timeframe. Moreover, versions below 4.1 [are guaranteed to not get security
+updates](https://wordpress.org/news/2022/09/dropping-security-updates-for-wordpress-versions-3-7-through-4-0/).
 
 ## [PHP Support](https://make.wordpress.org/core/handbook/references/php-compatibility-and-wordpress-versions/)
-
-:warning: Note that PHP 8 compatibility is
-[considered as beta](https://make.wordpress.org/core/2020/11/23/wordpress-and-php-8-0/),
-and thoroughly testing a site is recommended before upgrading it to PHP 8.
 
 {%- assign collapsedCycles = page.releases  | where_exp:"r","r.releaseCycle != '3.6'" | collapse_cycles:"supportedPHPVersions"," - " %}
 {% include table.html

--- a/products/wordpress.md
+++ b/products/wordpress.md
@@ -232,8 +232,7 @@ releases:
 > written in PHP and paired with a MySQL or MariaDB database. Features include a plugin architecture
 > and a template system, referred to within WordPress as "Themes".
 
-The only officially supported and actively maintained version of WordPress is the last one.
-There are no fixed period of support nor Long Term Support (LTS) version.
+The only officially supported and actively maintained version of WordPress is the latest one.
 
 Security updates are backported to older releases when possible, but the Wordpress team offers no
 guarantee and no timeframe. Moreover, versions below 4.1 [are guaranteed to not get security


### PR DESCRIPTION
Because of the [lack of guarantee on security updates](https://codex.wordpress.org/Supported_Versions), only the latest version should be marked as supported.