### PR TITLE
[java] Add older releases

### DIFF
--- a/products/java.md
+++ b/products/java.md
@@ -32,118 +32,159 @@ releases:
     link: https://www.oracle.com/java/technologies/javase/20-relnote-issues.html
 
 -   releaseCycle: "19"
+    releaseDate: 2022-09-20
     support: 2023-03-21
     eol: 2023-03-21
     latest: "19.0.2"
-    releaseDate: 2022-09-20
     latestReleaseDate: 2023-01-17
 
 -   releaseCycle: "18"
+    releaseDate: 2022-03-22
     support: 2022-09-20
     eol: 2022-09-20
     latest: "18.0.2.1"
-    releaseDate: 2022-03-22
     latestReleaseDate: 2022-08-18
 
 -   releaseCycle: "17"
     lts: true
+    releaseDate: 2021-09-14
     support: 2026-09-30
     eol: 2029-09-30
     latest: "17.0.7"
-    releaseDate: 2021-09-14
     latestReleaseDate: 2023-04-18
 
 -   releaseCycle: "16"
+    releaseDate: 2021-03-16
     support: 2021-09-14
     eol: 2021-09-14
     latest: "16.0.2"
-    releaseDate: 2021-03-16
     latestReleaseDate: 2021-07-20
 
 -   releaseCycle: "15"
+    releaseDate: 2020-09-15
     support: 2021-03-16
     eol: 2021-03-16
     latest: "15.0.2"
-    releaseDate: 2020-09-15
     latestReleaseDate: 2021-01-19
 
 -   releaseCycle: "14"
+    releaseDate: 2020-03-17
     support: 2020-09-16
     eol: 2020-09-16
     latest: "14.0.2"
-    releaseDate: 2020-03-17
     latestReleaseDate: 2020-07-14
 
 -   releaseCycle: "13"
+    releaseDate: 2019-09-17
     support: 2020-03-17
     eol: 2020-03-17
     latest: "13.0.2"
-    releaseDate: 2019-09-17
     latestReleaseDate: 2020-01-14
 
 -   releaseCycle: "12"
+    releaseDate: 2019-03-19
     support: 2019-09-17
     eol: 2019-09-17
     latest: "12.0.2"
-    releaseDate: 2019-03-19
     latestReleaseDate: 2019-07-16
 
 -   releaseCycle: "11"
     lts: true
+    releaseDate: 2018-09-25
     support: 2023-09-30
     eol: 2026-09-30
     latest: "11.0.19"
-    releaseDate: 2018-09-25
     latestReleaseDate: 2023-04-18
 
 -   releaseCycle: "10"
+    releaseDate: 2018-03-20
     support: 2018-09-25
     eol: 2018-09-25
     latest: "10.0.2"
-    releaseDate: 2018-03-20
     latestReleaseDate: 2018-07-17
 
 -   releaseCycle: "9"
+    releaseDate: 2017-09-21
     support: 2018-03-20
     eol: 2018-03-20
     latest: "9.0.4"
-    releaseDate: 2017-09-21
     latestReleaseDate: 2018-01-16
 
 -   releaseCycle: "8"
     lts: true
+    releaseDate: 2014-03-18
     support: 2022-03-31
     eol: 2030-12-31
     latest: "8u371"
-    releaseDate: 2014-03-18
     latestReleaseDate: 2023-04-18
 
 -   releaseCycle: "7"
-    lts: true
+    releaseDate: 2011-07-11
     support: 2019-07-31
     eol: 2022-07-31
-    latest: "7u351"
-    releaseDate: 2011-07-11
     link: https://www.oracle.com/java/technologies/javase/7-support-relnotes.html#R170_361
+    latest: "7u351"
     latestReleaseDate: 2022-07-19
 
 -   releaseCycle: "6"
-    lts: true
+    releaseDate: 2006-12-12
     support: 2015-12-31
     eol: 2018-12-31
+    link: https://www.oracle.com/java/technologies/javase/6u211-relnotes.html
     latest: "6u211"
-    releaseDate: 2006-12-12
-    link: https://www.oracle.com/java/technologies/javase/6-relnotes.html#R160_211
     latestReleaseDate: 2018-10-16
 
 -   releaseCycle: "5"
-    lts: false
-    support: 2009-11-03
-    eol: 2009-11-03
-    latest: "5.0u85"
     releaseDate: 2004-09-30
+    # https://web.archive.org/web/20081217100039/http://java.sun.com/products/archive/eol.policy.html
+    support: 2009-10-30
+    eol: 2009-10-30
     link: https://www.oracle.com/java/technologies/javase/advancedv5-support-relnotes.html
+    latest: "5.0u85"
     latestReleaseDate: 2015-04-14
+
+-   releaseCycle: "1.4"
+    releaseDate: 2002-02-13
+    # https://web.archive.org/web/20081217100039/http://java.sun.com/products/archive/eol.policy.html
+    support: 2008-10-30
+    eol: 2008-10-30
+    link: https://www.oracle.com/java/technologies/javase/advanced-v142-support-relnotes.html
+    latest: "1.4.2_42"
+    latestReleaseDate: 2013-02-19
+
+-   releaseCycle: "1.3"
+    releaseDate: 2000-05-08
+    # https://web.archive.org/web/20080410071627/http://java.sun.com/products/archive/eol.policy.html
+    support: 2006-03-31
+    eol: 2006-03-31
+    link: https://www.oracle.com/java/technologies/javase/releasenote-v131.html
+    latest: "1.3.1_32"
+    latestReleaseDate: 2011-10-18
+
+-   releaseCycle: "1.2"
+    releaseDate: 1998-12-04
+    # https://web.archive.org/web/20080410071627/http://java.sun.com/products/archive/eol.policy.html
+    support: 2003-11-30
+    eol: 2003-11-30
+    link: https://web.archive.org/web/20080410071627/http://java.sun.com/products/archive/eol.policy.html
+    latest: "1.2.2_18"
+    latestReleaseDate: 2007-01-12
+
+-   releaseCycle: "1.1"
+    releaseDate: 1997-02-18
+    support: 2002-10-09
+    eol: 2002-10-09
+    link: null
+    latest: "1.1.8_010"
+    latestReleaseDate: 2002-10-09
+
+-   releaseCycle: "1.0"
+    releaseDate: 1996-01-23
+    support: 1996-05-07
+    eol: 1996-05-07
+    link: null
+    latest: "1.0.2"
+    latestReleaseDate: 1996-05-07
 
 ---
 


### PR DESCRIPTION
Also unmark java 7 and 6 as LTS: the LTS concept only appeared with Java 8.

EOL dates for 1.0 and 1.1 could not be found, so used the latest release date, which is consistent with https://en.wikipedia.org/wiki/Java_version_history.