### PR TITLE
[mageia] Fix `changelogtemplate` and add auto configuration

### DIFF
--- a/products/mageia.md
+++ b/products/mageia.md
@@ -4,15 +4,17 @@ category: os
 permalink: /mageia
 versionCommand: cat /usr/lib/os-release
 releasePolicyLink: https://www.mageia.org/support/
-changelogTemplate: https://wiki.mageia.org/en/Mageia___RELEASE_CYCLE___Release_Notes
+changelogTemplate: https://wiki.mageia.org/en/Archive:_Mageia___RELEASE_CYCLE___Release_Notes
 releaseDateColumn: true
 releaseColumn: false
 eolColumn: Supported
 
+# link must be retained only on the last release (and maybe for some time on the previous release).
 releases:
 -   releaseCycle: "8"
     releaseDate: 2021-02-26
     eol: false
+    link: https://wiki.mageia.org/en/Mageia___RELEASE_CYCLE___Release_Notes
 
 -   releaseCycle: "7"
     releaseDate: 2019-07-01

--- a/products/mageia.md
+++ b/products/mageia.md
@@ -13,30 +13,39 @@ releases:
 -   releaseCycle: "8"
     releaseDate: 2021-02-26
     eol: false
+
 -   releaseCycle: "7"
-    eol: 2021-06-30
     releaseDate: 2019-07-01
+    eol: 2021-06-30
+
 -   releaseCycle: "6"
-    eol: 2019-09-30
     releaseDate: 2017-07-16
+    eol: 2019-09-30
+
 -   releaseCycle: "5"
-    eol: 2017-12-31
     releaseDate: 2015-06-19
+    eol: 2017-12-31
+
 -   releaseCycle: "4"
-    eol: 2015-09-19
     releaseDate: 2014-02-01
+    eol: 2015-09-19
+
 -   releaseCycle: "3"
-    eol: 2014-11-26
     releaseDate: 2013-05-19
+    eol: 2014-11-26
+
 -   releaseCycle: "2"
-    eol: 2013-11-22
     releaseDate: 2012-05-22
+    eol: 2013-11-22
+
 -   releaseCycle: "1"
-    eol: 2012-12-01
     releaseDate: 2011-06-01
+    eol: 2012-12-01
 
 ---
 
-> [Mageia](https://www.mageia.org/) is a GNU/Linux-based, Free Software operating system. It is a community project, supported by a nonprofit organisation of elected contributors.
+> [Mageia](https://www.mageia.org/) is a GNU/Linux-based, Free Software operating system. It is a
+> community project, supported by a nonprofit organisation of elected contributors.
 
-Mageia releases are supported at least for 18 months. Or a minimum of 3 months after the next release, whichever is longer.
+Mageia releases are supported at least for 18 months. Or a minimum of 3 months after the next
+release, whichever is longer.

--- a/products/mageia.md
+++ b/products/mageia.md
@@ -9,6 +9,10 @@ releaseDateColumn: true
 releaseColumn: false
 eolColumn: Supported
 
+auto:
+-   distrowatch: mageia
+    regex: '^Distribution Release: Mageia (?P<major>\d+)$'
+
 # link must be retained only on the last release (and maybe for some time on the previous release).
 releases:
 -   releaseCycle: "8"


### PR DESCRIPTION
The new `changelogtemplate` works well for all the releases but the latest.

Auto configuration is based on https://distrowatch.com/index.php?distribution=mageia.