### PR TITLE
[ansible] Fix 2.9 link

### DIFF
--- a/products/ansible.md
+++ b/products/ansible.md
@@ -60,6 +60,7 @@ releases:
     eol: 2022-05-23
     latest: "2.9.27"
     latestReleaseDate: 2021-10-11
+    link: https://github.com/ansible/ansible/blob/stable-2.9/changelogs/CHANGELOG-v2.9.rst
 
 ---
 


### PR DESCRIPTION
Generated link, https://github.com/ansible-community/ansible-build-data/blob/main/2.9/CHANGELOG-v2.9.rst, was wrong.