### PR TITLE
[quarkus] Fix 0.28 link

### DIFF
--- a/products/quarkus.md
+++ b/products/quarkus.md
@@ -162,6 +162,7 @@ releases:
     latest: "0.28.1"
     latestReleaseDate: 2019-11-04
     releaseDate: 2018-12-12
+    link: https://github.com/quarkusio/quarkus/releases/tag/__LATEST__
 
 ---
 


### PR DESCRIPTION
Generated link, https://github.com/quarkusio/quarkus/releases/tag/0.28.1.Final, was wrong.