### PR TITLE
[grafana] Add 9.5 and update 9.4 support / 9.3 eol dates

### DIFF
--- a/products/grafana.md
+++ b/products/grafana.md
@@ -18,59 +18,66 @@ auto:
 # - support(x) = releaseDate(x+1)
 # - eol(x) = releaseDate(x+2)
 releases:
--   releaseCycle: "9.4"
+-   releaseCycle: "9.5"
+    releaseDate: 2023-04-06
     support: true
     eol: false
+    latest: "9.5.1"
+    latestReleaseDate: 2023-04-24
+
+-   releaseCycle: "9.4"
     releaseDate: 2023-02-27
+    support: 2023-04-06
+    eol: false
     latest: "9.4.9"
     latestReleaseDate: 2023-04-24
 
 -   releaseCycle: "9.3"
-    support: 2023-02-27
-    eol: false
     releaseDate: 2022-11-29
+    support: 2023-02-27
+    eol: 2023-04-06
     latest: "9.3.13"
     latestReleaseDate: 2023-04-24
 
 -   releaseCycle: "9.2"
+    releaseDate: 2022-10-11
     support: 2022-11-29
     eol: 2023-02-27
-    releaseDate: 2022-10-11
     latest: "9.2.17"
     latestReleaseDate: 2023-04-24
 
 -   releaseCycle: "9.1"
+    releaseDate: 2022-08-16
     support: 2022-10-11
     eol: 2022-11-29
-    releaseDate: 2022-08-16
     latest: "9.1.8"
     latestReleaseDate: 2022-10-11
 
 -   releaseCycle: "9.0"
+    releaseDate: 2022-06-13
     support: 2022-08-16
     eol: 2022-10-11
-    releaseDate: 2022-06-13
     latest: "9.0.9"
     latestReleaseDate: 2022-09-20
 
 -   releaseCycle: "8"
+    releaseDate: 2021-06-08
     support: 2022-06-13
     eol: false
-    releaseDate: 2021-06-08
     latest: "8.5.24"
     latestReleaseDate: 2023-04-26
 
 -   releaseCycle: "7"
+    releaseDate: 2020-05-15
     support: 2021-06-08
     eol: 2022-06-14
-    releaseDate: 2020-05-15
     latest: "7.5.17"
     latestReleaseDate: 2022-09-26
 
 -   releaseCycle: "6"
+    releaseDate: 2019-02-25
     support: 2020-05-15
     eol: 2021-06-08
-    releaseDate: 2019-02-25
     latest: "6.7.6"
     latestReleaseDate: 2021-03-18
 


### PR DESCRIPTION
See https://github.com/grafana/grafana/releases/tag/v9.5.0.