### PR TITLE
[mongodb] Fix links for release cycles 1.0 to 2.0

### DIFF
--- a/products/mongodb.md
+++ b/products/mongodb.md
@@ -153,36 +153,42 @@ releases:
 -   releaseCycle: "2.0"
     releaseDate: 2011-09-11
     eol: 2013-03-31
+    link: https://www.mongodb.com/docs/v2.2/release-notes/2.0/
     latest: '2.0.9'
     latestReleaseDate: 2013-04-02
 
 -   releaseCycle: "1.8"
     releaseDate: 2011-03-16
     eol: 2012-09-30
+    link: https://www.mongodb.com/docs/v2.2/release-notes/1.8/
     latest: '1.8.5'
     latestReleaseDate: 2012-02-01
 
 -   releaseCycle: "1.6"
     releaseDate: 2010-08-05
     eol: 2012-02-28
+    link: https://www.mongodb.com/docs/v2.2/release-notes/1.6/
     latest: '1.6.5'
     latestReleaseDate: 2010-12-08
 
 -   releaseCycle: "1.4"
     releaseDate: 2010-03-25
     eol: 2012-09-30
+    link: https://www.mongodb.com/docs/v2.2/release-notes/1.4/
     latest: '1.4.5'
     latestReleaseDate: 2010-08-31
 
 -   releaseCycle: "1.2"
     releaseDate: 2009-12-10
     eol: 2011-06-30
+    link: https://www.mongodb.com/docs/v2.2/release-notes/1.2/
     latest: '1.2.5'
     latestReleaseDate: 2010-04-07
 
 -   releaseCycle: "1.0"
     releaseDate: 2009-08-27
     eol: 2010-08-31
+    link: null
     latest: '1.0.1'
     latestReleaseDate: 2009-10-22
 


### PR DESCRIPTION
Bad links generated by the current changelogTemplate:

```
Product Validator: Invalid link 'https://www.mongodb.com/docs/v2.0/release-notes/2.0/' for mongodb.md#2.0, got an error : '404 Not Found'.
Product Validator: Invalid link 'https://www.mongodb.com/docs/v1.8/release-notes/1.8/' for mongodb.md#1.8, got an error : '404 Not Found'.
Product Validator: Invalid link 'https://www.mongodb.com/docs/v1.6/release-notes/1.6/' for mongodb.md#1.6, got an error : '404 Not Found'.
Product Validator: Invalid link 'https://www.mongodb.com/docs/v1.4/release-notes/1.4/' for mongodb.md#1.4, got an error : '404 Not Found'.
Product Validator: Invalid link 'https://www.mongodb.com/docs/v1.2/release-notes/1.2/' for mongodb.md#1.2, got an error : '404 Not Found'.
Product Validator: Invalid link 'https://www.mongodb.com/docs/v1.0/release-notes/1.0/' for mongodb.md#1.0, got an error : '404 Not Found'.
```