### PR TITLE
[spring-boot] Fix links for release cycles 1.5 to 2.3

### DIFF
--- a/products/spring-boot.md
+++ b/products/spring-boot.md
@@ -21,83 +21,88 @@ auto:
 releases:
 -   releaseCycle: "3.0"
     supportedJavaVersions: "17 - 19" # https://docs.spring.io/spring-boot/docs/3.0.2/reference/html/getting-started.html#getting-started.system-requirements
+    releaseDate: 2022-11-24
     eol: 2023-11-24
     extendedSupport: 2025-02-24
     latest: "3.0.6"
     latestReleaseDate: 2023-04-20
-    releaseDate: 2022-11-24
 
 -   releaseCycle: "2.7"
     supportedJavaVersions: "8 - 19" # https://docs.spring.io/spring-boot/docs/2.7.8/reference/html/getting-started.html#getting-started.system-requirements
+    releaseDate: 2022-05-19
     eol: 2023-11-18
     extendedSupport: 2025-02-18
     latest: "2.7.11"
     latestReleaseDate: 2023-04-20
-    releaseDate: 2022-05-19
 
 -   releaseCycle: "2.6"
     supportedJavaVersions: "8 - 19" # https://docs.spring.io/spring-boot/docs/2.6.14/reference/html/getting-started.html#getting-started.system-requirements
+    releaseDate: 2021-11-19
     eol: 2022-11-24
     extendedSupport: 2024-02-24
     latest: "2.6.14"
     latestReleaseDate: 2022-11-24
-    releaseDate: 2021-11-19
 
 -   releaseCycle: "2.5"
     supportedJavaVersions: "8 - 18" # https://docs.spring.io/spring-boot/docs/2.5.14/reference/html/getting-started.html#getting-started.system-requirements
+    releaseDate: 2021-05-20
     eol: 2022-05-19
     extendedSupport: 2023-08-24
     latest: "2.5.14"
     latestReleaseDate: 2022-05-19
-    releaseDate: 2021-05-20
 
 -   releaseCycle: "2.4"
     supportedJavaVersions: "8 - 16" # https://docs.spring.io/spring-boot/docs/2.4.13/reference/html/getting-started.html#getting-started-system-requirements
+    releaseDate: 2020-11-12
     eol: 2021-11-18
     extendedSupport: 2023-02-23
     latest: "2.4.13"
     latestReleaseDate: 2021-11-18
-    releaseDate: 2020-11-12
 
 -   releaseCycle: "2.3"
     supportedJavaVersions: "8 - 15" # https://docs.spring.io/spring-boot/docs/2.3.12.RELEASE/reference/html/getting-started.html#getting-started-system-requirements
+    releaseDate: 2020-05-15
     eol: 2021-05-20
     extendedSupport: 2022-08-20
+    link: https://github.com/spring-projects/spring-boot/releases/tag/v__LATEST__.RELEASE
     latest: "2.3.12"
     latestReleaseDate: 2021-06-10
-    releaseDate: 2020-05-15
 
 -   releaseCycle: "2.2"
     supportedJavaVersions: "8 - 15" # https://docs.spring.io/spring-boot/docs/2.2.13.RELEASE/reference/html/getting-started.html#getting-started-system-requirements
+    releaseDate: 2019-10-16
     eol: 2020-10-16
     extendedSupport: 2022-01-16
+    link: https://github.com/spring-projects/spring-boot/releases/tag/v__LATEST__.RELEASE
     latest: "2.2.13"
     latestReleaseDate: 2021-01-14
-    releaseDate: 2019-10-16
 
 -   releaseCycle: "2.1"
     supportedJavaVersions: "8 - 12" # https://docs.spring.io/spring-boot/docs/2.1.18.RELEASE/reference/html/getting-started-system-requirements.html
+    releaseDate: 2018-10-30
     eol: 2019-10-30
     extendedSupport: 2021-01-30
+    link: https://github.com/spring-projects/spring-boot/releases/tag/v__LATEST__.RELEASE
     latest: "2.1.18"
     latestReleaseDate: 2020-10-29
-    releaseDate: 2018-10-30
 
 -   releaseCycle: "2.0"
     supportedJavaVersions: "8 - 9" # https://docs.spring.io/spring-boot/docs/2.0.9.RELEASE/reference/html/getting-started-system-requirements.html
+    releaseDate: 2018-03-01
     eol: 2019-03-01
     extendedSupport: 2020-06-01
+    link: https://github.com/spring-projects/spring-boot/releases/tag/v__LATEST__.RELEASE
     latest: "2.0.9"
     latestReleaseDate: 2019-04-03
-    releaseDate: 2018-03-01
 
 -   releaseCycle: "1.5"
     supportedJavaVersions: "6 - 8" # https://docs.spring.io/spring-boot/docs/1.5.22.RELEASE/reference/html/getting-started-system-requirements.html
+    releaseDate: 2017-01-30
     eol: 2019-08-06
     extendedSupport: 2020-11-06
+    link: https://github.com/spring-projects/spring-boot/releases/tag/v__LATEST__.RELEASE
     latest: "1.5.22"
     latestReleaseDate: 2019-08-06
-    releaseDate: 2017-01-30
 
 ---
 


### PR DESCRIPTION
Wrong links generated by the changelogTemplate:

```
Product Validator: Invalid link 'https://github.com/spring-projects/spring-boot/releases/tag/v2.3.12' for spring-boot.md#2.3, got an error : '404 Not Found'.
Product Validator: Invalid link 'https://github.com/spring-projects/spring-boot/releases/tag/v2.2.13' for spring-boot.md#2.2, got an error : '404 Not Found'.
Product Validator: Invalid link 'https://github.com/spring-projects/spring-boot/releases/tag/v2.1.18' for spring-boot.md#2.1, got an error : '404 Not Found'.
Product Validator: Invalid link 'https://github.com/spring-projects/spring-boot/releases/tag/v2.0.9' for spring-boot.md#2.0, got an error : '404 Not Found'.
Product Validator: Invalid link 'https://github.com/spring-projects/spring-boot/releases/tag/v1.5.22' for spring-boot.md#1.5, got an error : '404 Not Found'.
```