### PR TITLE
[spring-framework] Fix changelogTemplate for versions 3.2 to 5.2

### DIFF
--- a/products/spring-framework.md
+++ b/products/spring-framework.md
@@ -6,7 +6,7 @@ permalink: /spring-framework
 alternate_urls:
 -   /spring
 releasePolicyLink: https://github.com/spring-projects/spring-framework/wiki/Spring-Framework-Versions
-changelogTemplate: "https://github.com/spring-projects/spring-framework/releases/tag/v__LATEST__"
+changelogTemplate: https://github.com/spring-projects/spring-framework/releases/tag/v__LATEST__
 releaseColumn: true
 releaseDateColumn: true
 activeSupportColumn: false
@@ -21,60 +21,65 @@ auto:
 releases:
 -   releaseCycle: "6.0"
     supportedJavaVersions: "17" # https://docs.spring.io/spring-framework/docs/current/reference/html/overview.html#overview
+    releaseDate: 2022-11-16
     eol: 2024-08-31
     extendedSupport: 2025-12-31
     latest: "6.0.8"
     latestReleaseDate: 2023-04-13
-    releaseDate: 2022-11-16
 
 -   releaseCycle: "5.3"
     supportedJavaVersions: "8, 11, 17" # https://github.com/spring-projects/spring-framework/wiki/Spring-Framework-Versions
+    releaseDate: 2020-10-27
     eol: 2024-12-31
     extendedSupport: 2026-12-31
     lts: true
     latest: "5.3.27"
     latestReleaseDate: 2023-04-13
-    releaseDate: 2020-10-27
 
 -   releaseCycle: "5.2"
     supportedJavaVersions: "8, 11" # https://docs.spring.io/spring-framework/docs/5.2.22.RELEASE/spring-framework-reference/overview.html#overview
+    releaseDate: 2019-09-30
     eol: 2021-12-31
     extendedSupport: 2023-12-31
+    link: https://github.com/spring-projects/spring-framework/releases/tag/v__LATEST__.RELEASE
     latest: "5.2.24"
     latestReleaseDate: 2023-04-13
-    releaseDate: 2019-09-30
 
 -   releaseCycle: "5.1"
     supportedJavaVersions: "8, 11" # https://docs.spring.io/spring-framework/docs/5.1.20.RELEASE/spring-framework-reference/overview.html#overview
+    releaseDate: 2018-09-21
     eol: 2020-12-31
     extendedSupport: 2022-12-31
+    link: https://github.com/spring-projects/spring-framework/releases/tag/v__LATEST__.RELEASE
     latest: "5.1.20"
     latestReleaseDate: 2020-12-09
-    releaseDate: 2018-09-21
 
 -   releaseCycle: "5.0"
     supportedJavaVersions: "8" # https://docs.spring.io/spring-framework/docs/5.0.20.RELEASE/spring-framework-reference/overview.html#overview
+    releaseDate: 2017-09-28
     eol: 2020-12-31
     extendedSupport: false
+    link: https://github.com/spring-projects/spring-framework/releases/tag/v__LATEST__.RELEASE
     latest: "5.0.20"
     latestReleaseDate: 2020-12-09
-    releaseDate: 2017-09-28
 
 -   releaseCycle: "4.3"
     supportedJavaVersions: "6, 7, 8" # https://docs.spring.io/spring-framework/docs/4.3.30.RELEASE/spring-framework-reference/html/new-in-4.0.html#_java_8_as_well_as_6_and_7
+    releaseDate: 2016-06-10
     eol: 2020-12-31
     extendedSupport: false
+    link: https://github.com/spring-projects/spring-framework/releases/tag/v__LATEST__.RELEASE
     latest: "4.3.30"
     latestReleaseDate: 2020-12-09
-    releaseDate: 2016-06-10
 
 -   releaseCycle: "3.2"
     supportedJavaVersions: "5, 6" # https://docs.spring.io/spring-framework/docs/3.2.18.RELEASE/spring-framework-reference/html/new-in-3.0.html#new-in-3.0
+    releaseDate: 2012-12-13
     eol: 2016-12-31
     extendedSupport: false
+    link: https://github.com/spring-projects/spring-framework/releases/tag/v__LATEST__.RELEASE
     latest: "3.2.18"
     latestReleaseDate: 2016-12-21
-    releaseDate: 2012-12-13
 
 ---
 


### PR DESCRIPTION
Bad links generated by the changelogTemplate are:

```
Product Validator: Invalid link 'https://github.com/spring-projects/spring-framework/releases/tag/v5.2.24' for spring-framework.md#5.2, got an error : '404 Not Found'.
Product Validator: Invalid link 'https://github.com/spring-projects/spring-framework/releases/tag/v5.1.20' for spring-framework.md#5.1, got an error : '404 Not Found'.
Product Validator: Invalid link 'https://github.com/spring-projects/spring-framework/releases/tag/v5.0.20' for spring-framework.md#5.0, got an error : '404 Not Found'.
Product Validator: Invalid link 'https://github.com/spring-projects/spring-framework/releases/tag/v4.3.30' for spring-framework.md#4.3, got an error : '404 Not Found'.
Product Validator: Invalid link 'https://github.com/spring-projects/spring-framework/releases/tag/v3.2.18' for spring-framework.md#3.2, got an error : '404 Not Found'.
```