### PR TITLE
[pan-cortex-xdr] Update changelogTemplate and fix links

### DIFF
--- a/products/pan-cortex-xdr.md
+++ b/products/pan-cortex-xdr.md
@@ -8,8 +8,7 @@ alternate_urls:
 -   /xdr
 -   /pan-cortex-xdr
 releasePolicyLink: https://www.paloaltonetworks.com/services/support/end-of-life-announcements/end-of-life-summary
-changelogTemplate: https://docs.paloaltonetworks.com/cortex/cortex-xdr/{{"__RELEASE_CYCLE__"
-  | remove:'-' | replace:'.','-'}}/cortex-xdr-agent-release-notes/cortex-xdr-agent-release-information
+changelogTemplate: "https://docs.paloaltonetworks.com/cortex/cortex-xdr/{{'__RELEASE_CYCLE__'|remove:'-'|replace:'.','-'}}/cortex-xdr-agent-release-notes/cortex-xdr-agent-release-information"
 LTSLabel: CE
 activeSupportColumn: false
 releaseColumn: false
@@ -18,153 +17,163 @@ eolColumn: Support Status
 
 releases:
 -   releaseCycle: "8.0"
-    eol: 2023-12-19
     releaseDate: 2023-03-05
-    latestReleaseDate: 2023-03-05
-    latest: '8.0'
+    eol: 2023-12-19
     link: https://docs-cortex.paloaltonetworks.com/r/Cortex-XDR/8.0/Cortex-XDR-Agent-Release-Notes/Cortex-XDR-Agent-8.0-Release-Information
+    latest: '8.0'
+    latestReleaseDate: 2023-03-05
 
 -   releaseCycle: "7.9-ce"
     lts: true
-    eol: 2025-03-19
     releaseDate: 2023-03-19
-    latestReleaseDate: 2023-03-19
-    latest: '7.9-ce'
+    eol: 2025-03-19
     link: https://docs-cortex.paloaltonetworks.com/r/Cortex-XDR/7.9ce/Cortex-XDR-Agent-Release-Notes/Cortex-XDR-Agent-7.9-CE-Release-Information
+    latest: '7.9-ce'
+    latestReleaseDate: 2023-03-19
 
 -   releaseCycle: "7.9"
-    eol: 2023-09-11
     releaseDate: 2022-12-04
-    latestReleaseDate: 2023-03-19
-    latest: '7.9-ce'
+    eol: 2023-09-11
     link: https://docs-cortex.paloaltonetworks.com/r/Cortex-XDR/7.9/Cortex-XDR-Agent-Release-Notes/Cortex-XDR-Agent-7.9-Release-Information
+    latest: '7.9-ce'
+    latestReleaseDate: 2023-03-19
 
 -   releaseCycle: "7.8"
-    eol: 2023-04-24
     releaseDate: 2022-07-24
-    latestReleaseDate: 2022-07-24
+    eol: 2023-04-24
     latest: '7.8'
+    latestReleaseDate: 2022-07-24
 
 -   releaseCycle: "7.7"
-    eol: 2022-12-27
     releaseDate: 2022-03-27
-    latestReleaseDate: 2022-03-27
+    eol: 2022-12-27
     latest: '7.7'
+    latestReleaseDate: 2022-03-27
 
 -   releaseCycle: "7.6"
-    eol: 2022-09-05
     releaseDate: 2021-12-05
-    latestReleaseDate: 2021-12-05
+    eol: 2022-09-05
     latest: '7.6'
+    latestReleaseDate: 2021-12-05
 
 -   releaseCycle: "7.5-ce"
     lts: true
-    eol: 2024-03-06
     releaseDate: 2022-03-06
-    latestReleaseDate: 2022-03-06
+    eol: 2024-03-06
     latest: '7.5-ce'
+    latestReleaseDate: 2022-03-06
 
 -   releaseCycle: "7.5"
-    eol: 2022-08-22
     releaseDate: 2021-08-22
-    latestReleaseDate: 2022-03-06
+    eol: 2022-08-22
     latest: '7.5-ce'
+    latestReleaseDate: 2022-03-06
 
 -   releaseCycle: "7.4"
-    eol: 2022-05-24
     releaseDate: 2021-05-24
-    latestReleaseDate: 2021-05-24
+    eol: 2022-05-24
     latest: '7.4'
+    latestReleaseDate: 2021-05-24
 
 -   releaseCycle: "7.3"
-    eol: 2022-02-01
     releaseDate: 2021-02-01
-    latestReleaseDate: 2021-02-01
+    eol: 2022-02-01
     latest: '7.3'
+    latestReleaseDate: 2021-02-01
 
 -   releaseCycle: "7.2"
-    eol: 2022-03-07
     releaseDate: 2020-09-07
-    latestReleaseDate: 2020-09-07
+    eol: 2022-03-07
     latest: '7.2'
+    latestReleaseDate: 2020-09-07
 
 -   releaseCycle: "7.1"
-    eol: 2021-06-04
     releaseDate: 2020-04-22
-    latestReleaseDate: 2020-04-22
+    eol: 2021-06-04
     latest: '7.1'
+    latestReleaseDate: 2020-04-22
 
 -   releaseCycle: "7.0"
-    eol: 2021-06-04
     releaseDate: 2019-12-04
-    latestReleaseDate: 2019-12-04
+    eol: 2021-06-04
     latest: '7.0'
+    latestReleaseDate: 2019-12-04
 
 -   releaseCycle: "6.1"
-    eol: 2022-07-01
     releaseDate: 2019-07-02
-    latestReleaseDate: 2019-07-02
+    eol: 2022-07-01
     latest: '6.1'
+    latestReleaseDate: 2019-07-02
 
 -   releaseCycle: "6.0"
-    eol: 2020-02-26
     releaseDate: 2019-02-26
-    latestReleaseDate: 2019-02-26
+    eol: 2020-02-26
     latest: '6.0'
+    latestReleaseDate: 2019-02-26
 
 -   releaseCycle: "4.2"
-    eol: 2022-03-01
     releaseDate: 2018-06-25
-    latestReleaseDate: 2018-06-25
+    eol: 2022-03-01
     latest: '4.2'
+    latestReleaseDate: 2018-06-25
 
 -   releaseCycle: "5.0"
-    eol: 2024-06-01
     releaseDate: 2018-03-19
-    latestReleaseDate: 2018-03-19
+    eol: 2024-06-01
     latest: '5.0'
+    latestReleaseDate: 2018-03-19
 
 -   releaseCycle: "4.1"
-    eol: 2019-09-15
     releaseDate: 2017-09-15
-    latestReleaseDate: 2017-09-15
+    eol: 2019-09-15
     latest: '4.1'
+    latestReleaseDate: 2017-09-15
 
 -   releaseCycle: "4.0"
-    eol: 2018-04-05
     releaseDate: 2017-04-05
-    latestReleaseDate: 2017-04-05
+    eol: 2018-04-05
     latest: '4.0'
+    latestReleaseDate: 2017-04-05
 
 -   releaseCycle: "3.4"
-    eol: 2019-08-21
     releaseDate: 2016-08-21
-    latestReleaseDate: 2016-08-21
+    eol: 2019-08-21
     latest: '3.4'
+    latestReleaseDate: 2016-08-21
 
 -   releaseCycle: "3.3"
-    eol: 2017-02-28
     releaseDate: 2015-11-10
-    latestReleaseDate: 2015-11-10
+    eol: 2017-02-28
     latest: '3.3'
+    latestReleaseDate: 2015-11-10
 
 -   releaseCycle: "3.2"
-    eol: 2016-03-31
     releaseDate: 2015-03-31
-    latestReleaseDate: 2015-03-31
+    eol: 2016-03-31
     latest: '3.2'
+    latestReleaseDate: 2015-03-31
 
 -   releaseCycle: "3.1"
-    eol: 2015-09-03
     releaseDate: 2014-09-03
-    latestReleaseDate: 2014-09-03
+    eol: 2015-09-03
     latest: '3.1'
+    latestReleaseDate: 2014-09-03
 
 ---
 
-> [Palo Alto Networks](https://www.paloaltonetworks.com/) [Cortex XDR agent](https://docs.paloaltonetworks.com/cortex/cortex-xdr) protects endpoints by preventing known and unknown malware from running on those endpoints and by halting any attempts to leverage software exploits and vulnerabilities. The agent can be installed on a variety of operating systems including Windows, macOS, Android, and Linux.
-Software updates are provided as part of a valid support agreement.
+> [Palo Alto Networks](https://www.paloaltonetworks.com/) [Cortex XDR agent](https://docs.paloaltonetworks.com/cortex/cortex-xdr)
+> protects endpoints by preventing known and unknown malware from running on those endpoints and by
+> halting any attempts to leverage software exploits and vulnerabilities. The agent can be installed
+> on a variety of operating systems including Windows, macOS, Android, and Linux. Software updates
+> are provided as part of a valid support agreement.
 
 ## Critical Environment (CE)
-The critical environment (CE) line, released every 12-18 months is supported for 24 months. This CE line is based on an existing agent line, already available, and becomes a critical environment line only after its stability has been verified. The line receives content updates and minor version releases relating to high and critical-severity bug fixes alongside security fixes within the existing capabilities for its entire support cycle.
-The CE line is recommended for customers running in regulated environments, looking for less frequent upgrades and stability-focused versions.
+
+The critical environment (CE) line, released every 12-18 months is supported for 24 months. This CE
+line is based on an existing agent line, already available, and becomes a critical environment line
+only after its stability has been verified. The line receives content updates and minor version
+releases relating to high and critical-severity bug fixes alongside security fixes within the
+existing capabilities for its entire support cycle.
+
+The CE line is recommended for customers running in regulated environments, looking for less
+frequent upgrades and stability-focused versions.

--- a/products/pan-cortex-xdr.md
+++ b/products/pan-cortex-xdr.md
@@ -8,18 +8,18 @@ alternate_urls:
 -   /xdr
 -   /pan-cortex-xdr
 releasePolicyLink: https://www.paloaltonetworks.com/services/support/end-of-life-announcements/end-of-life-summary
-changelogTemplate: "https://docs.paloaltonetworks.com/cortex/cortex-xdr/{{'__RELEASE_CYCLE__'|remove:'-'|replace:'.','-'}}/cortex-xdr-agent-release-notes/cortex-xdr-agent-release-information"
+changelogTemplate: https://docs-cortex.paloaltonetworks.com/r/Cortex-XDR/__RELEASE_CYCLE__/Cortex-XDR-Agent-Release-Notes/Cortex-XDR-Agent-__RELEASE_CYCLE__-Release-Information
 LTSLabel: CE
 activeSupportColumn: false
 releaseColumn: false
 releaseDateColumn: true
 eolColumn: Support Status
 
+# EOL dates can be found on https://docs-cortex.paloaltonetworks.com/r/Cortex-XDR/Cortex-XDR-Agent-Releases/Cortex-XDR-Agent-Releases
 releases:
 -   releaseCycle: "8.0"
     releaseDate: 2023-03-05
     eol: 2023-12-19
-    link: https://docs-cortex.paloaltonetworks.com/r/Cortex-XDR/8.0/Cortex-XDR-Agent-Release-Notes/Cortex-XDR-Agent-8.0-Release-Information
     latest: '8.0'
     latestReleaseDate: 2023-03-05
 
@@ -34,7 +34,6 @@ releases:
 -   releaseCycle: "7.9"
     releaseDate: 2022-12-04
     eol: 2023-09-11
-    link: https://docs-cortex.paloaltonetworks.com/r/Cortex-XDR/7.9/Cortex-XDR-Agent-Release-Notes/Cortex-XDR-Agent-7.9-Release-Information
     latest: '7.9-ce'
     latestReleaseDate: 2023-03-19
 
@@ -53,6 +52,7 @@ releases:
 -   releaseCycle: "7.6"
     releaseDate: 2021-12-05
     eol: 2022-09-05
+    link: null
     latest: '7.6'
     latestReleaseDate: 2021-12-05
 
@@ -60,102 +60,119 @@ releases:
     lts: true
     releaseDate: 2022-03-06
     eol: 2024-03-06
+    link: https://docs-cortex.paloaltonetworks.com/r/Cortex-XDR/7.5ce/Cortex-XDR-Agent-Release-Notes/Cortex-XDR-Agent-7.5-CE-Release-Information
     latest: '7.5-ce'
     latestReleaseDate: 2022-03-06
 
 -   releaseCycle: "7.5"
     releaseDate: 2021-08-22
     eol: 2022-08-22
+    link: null
     latest: '7.5-ce'
     latestReleaseDate: 2022-03-06
 
 -   releaseCycle: "7.4"
     releaseDate: 2021-05-24
     eol: 2022-05-24
+    link: null
     latest: '7.4'
     latestReleaseDate: 2021-05-24
 
 -   releaseCycle: "7.3"
     releaseDate: 2021-02-01
     eol: 2022-02-01
+    link: null
     latest: '7.3'
     latestReleaseDate: 2021-02-01
 
 -   releaseCycle: "7.2"
     releaseDate: 2020-09-07
     eol: 2022-03-07
+    link: null
     latest: '7.2'
     latestReleaseDate: 2020-09-07
 
 -   releaseCycle: "7.1"
     releaseDate: 2020-04-22
     eol: 2021-06-04
+    link: null
     latest: '7.1'
     latestReleaseDate: 2020-04-22
 
 -   releaseCycle: "7.0"
     releaseDate: 2019-12-04
     eol: 2021-06-04
+    link: null
     latest: '7.0'
     latestReleaseDate: 2019-12-04
 
 -   releaseCycle: "6.1"
     releaseDate: 2019-07-02
     eol: 2022-07-01
+    link: null
     latest: '6.1'
     latestReleaseDate: 2019-07-02
 
 -   releaseCycle: "6.0"
     releaseDate: 2019-02-26
     eol: 2020-02-26
+    link: null
     latest: '6.0'
     latestReleaseDate: 2019-02-26
 
 -   releaseCycle: "4.2"
     releaseDate: 2018-06-25
     eol: 2022-03-01
+    link: null
     latest: '4.2'
     latestReleaseDate: 2018-06-25
 
 -   releaseCycle: "5.0"
     releaseDate: 2018-03-19
     eol: 2024-06-01
+    link: https://docs-cortex.paloaltonetworks.com/r/Cortex-XDR/5.0/Traps-Agent-Release-Notes/Traps-Agent-Release-Information
     latest: '5.0'
     latestReleaseDate: 2018-03-19
 
 -   releaseCycle: "4.1"
     releaseDate: 2017-09-15
     eol: 2019-09-15
+    link: null
     latest: '4.1'
     latestReleaseDate: 2017-09-15
 
 -   releaseCycle: "4.0"
     releaseDate: 2017-04-05
     eol: 2018-04-05
+    link: null
     latest: '4.0'
     latestReleaseDate: 2017-04-05
 
 -   releaseCycle: "3.4"
     releaseDate: 2016-08-21
     eol: 2019-08-21
+    link: null
     latest: '3.4'
     latestReleaseDate: 2016-08-21
 
 -   releaseCycle: "3.3"
     releaseDate: 2015-11-10
     eol: 2017-02-28
+    link: null
     latest: '3.3'
     latestReleaseDate: 2015-11-10
 
 -   releaseCycle: "3.2"
     releaseDate: 2015-03-31
     eol: 2016-03-31
+    link: null
     latest: '3.2'
     latestReleaseDate: 2015-03-31
 
 -   releaseCycle: "3.1"
     releaseDate: 2014-09-03
     eol: 2015-09-03
+    link: null
     latest: '3.1'
     latestReleaseDate: 2014-09-03
 


### PR DESCRIPTION
Links following the https://docs.paloaltonetworks.com/cortex/cortex-xdr/X-Y/cortex-xdr-agent-release-notes/cortex-xdr-agent-release-information pattern are now always redirected to https://docs-cortex.paloaltonetworks.com. Most of the links for EOL releases do not work, so they have been set to null.