### PR TITLE
[unity] Update changelogTemplate and update/fix latest versions

### DIFF
--- a/products/unity.md
+++ b/products/unity.md
@@ -7,7 +7,7 @@ alternate_urls:
   -   /unity3d
 releaseImage: https://blog-api.unity.com/sites/default/files/2022-04/Unity-2021-LTS-Timeline.jpg
 releasePolicyLink: https://unity3d.com/unity/qa/lts-releases
-changelogTemplate: https://unity3d.com/unity/whats-new/{{"__LATEST__" | split:'f' | first}}#section-{{"__LATEST__" | remove:'.'}}-release-notes
+changelogTemplate: "https://unity.com/releases/editor/whats-new/{{'__LATEST__'|split:'f'|first}}#release-notes"
 releaseDateColumn: true
 releaseColumn: true
 

--- a/products/unity.md
+++ b/products/unity.md
@@ -52,7 +52,7 @@ releases:
 -   releaseCycle: "2020"
     lts: true
     releaseDate: 2020-06-20
-    eol: 2023-05-01
+    eol: 2023-05-05
     latest: "2020.3.47f1"
     latestReleaseDate: 2023-04-05
 

--- a/products/unity.md
+++ b/products/unity.md
@@ -15,8 +15,8 @@ releases:
 -   releaseCycle: "2022.2"
     releaseDate: 2022-12-07
     eol: false
-    latest: "2022.2.8f1"
-    latestReleaseDate: 2023-02-23
+    latest: "2022.2.9f1"
+    latestReleaseDate: 2023-03-03
 
 -   releaseCycle: "2022.1"
     releaseDate: 2022-05-09
@@ -28,33 +28,33 @@ releases:
     lts: true
     releaseDate: 2021-03-22
     eol: 2024-04-19
-    latest: "2021.3.19f1"
-    latestReleaseDate: 2023-02-17
+    latest: "2021.3.24f1"
+    latestReleaseDate: 2023-04-27
 
 -   releaseCycle: "2021.3"
     releaseDate: 2022-04-11
     eol: 2022-02-17
-    latest: "2022.3.19f1"
-    latestReleaseDate: 2022-02-17
+    latest: "2021.3.24f1"
+    latestReleaseDate: 2023-04-27
 
 -   releaseCycle: "2021.2"
     releaseDate: 2021-10-25
     eol: 2022-04-05
-    latest: "2022.2.19f1"
+    latest: "2021.2.19f1"
     latestReleaseDate: 2022-04-05
 
 -   releaseCycle: "2021.1"
     releaseDate: 2021-03-22
     eol: 2022-11-04
-    latest: "2022.1.28f1"
+    latest: "2021.1.28f1"
     latestReleaseDate: 2022-11-04
 
 -   releaseCycle: "2020"
     lts: true
     releaseDate: 2020-06-20
-    eol: 2023-02-14
-    latest: "2020.3.45f1"
-    latestReleaseDate: 2023-02-14
+    eol: 2023-05-01
+    latest: "2020.3.47f1"
+    latestReleaseDate: 2023-04-05
 
 -   releaseCycle: "2019"
     lts: true

--- a/products/unity.md
+++ b/products/unity.md
@@ -1,91 +1,95 @@
 ---
-permalink: /unity
 title: Unity
-alternate_urls:
--   /unity3d
 category: app
+iconSlug: unity
+permalink: /unity
+alternate_urls:
+  -   /unity3d
+releaseImage: https://blog-api.unity.com/sites/default/files/2022-04/Unity-2021-LTS-Timeline.jpg
 releasePolicyLink: https://unity3d.com/unity/qa/lts-releases
+changelogTemplate: https://unity3d.com/unity/whats-new/{{"__LATEST__" | split:'f' | first}}#section-{{"__LATEST__" | remove:'.'}}-release-notes
 releaseDateColumn: true
 releaseColumn: true
-iconSlug: unity
-changelogTemplate: |
-  https://unity3d.com/unity/whats-new/{{"__LATEST__" | split:'f' | first}}#section-{{"__LATEST__" | remove:'.'}}-release-notes
-releaseImage: https://blog-api.unity.com/sites/default/files/2022-04/Unity-2021-LTS-Timeline.jpg
+
 releases:
 -   releaseCycle: "2022.2"
+    releaseDate: 2022-12-07
     eol: false
     latest: "2022.2.8f1"
     latestReleaseDate: 2023-02-23
-    releaseDate: 2022-12-07
 
 -   releaseCycle: "2022.1"
+    releaseDate: 2022-05-09
     eol: 2022-12-06
     latest: "2022.1.24f1"
     latestReleaseDate: 2022-12-06
-    releaseDate: 2022-05-09
 
 -   releaseCycle: "2021"
-    eol: 2024-04-19
     lts: true
+    releaseDate: 2021-03-22
+    eol: 2024-04-19
     latest: "2021.3.19f1"
     latestReleaseDate: 2023-02-17
-    releaseDate: 2021-03-22
 
 -   releaseCycle: "2021.3"
+    releaseDate: 2022-04-11
     eol: 2022-02-17
     latest: "2022.3.19f1"
     latestReleaseDate: 2022-02-17
-    releaseDate: 2022-04-11
 
 -   releaseCycle: "2021.2"
+    releaseDate: 2021-10-25
     eol: 2022-04-05
     latest: "2022.2.19f1"
     latestReleaseDate: 2022-04-05
-    releaseDate: 2021-10-25
 
 -   releaseCycle: "2021.1"
+    releaseDate: 2021-03-22
     eol: 2022-11-04
     latest: "2022.1.28f1"
     latestReleaseDate: 2022-11-04
-    releaseDate: 2021-03-22
 
 -   releaseCycle: "2020"
-    eol: 2023-02-14
     lts: true
+    releaseDate: 2020-06-20
+    eol: 2023-02-14
     latest: "2020.3.45f1"
     latestReleaseDate: 2023-02-14
-    releaseDate: 2020-06-20
 
 -   releaseCycle: "2019"
-    eol: 2022-06-16
     lts: true
+    releaseDate: 2019-04-08
+    eol: 2022-06-16
     latest: "2019.4.40f1"
     latestReleaseDate: 2022-06-16
-    releaseDate: 2019-04-08
 
 -   releaseCycle: "2018"
-    eol: 2021-06-17
     lts: true
+    releaseDate: 2018-04-26
+    eol: 2021-06-17
     latest: "2018.4.36f1"
     latestReleaseDate: 2021-06-17
-    releaseDate: 2018-04-26
 
 -   releaseCycle: "2017"
-    eol: 2020-05-18
     lts: true
+    releaseDate: 2017-06-26
+    eol: 2020-05-18
     latest: "2017.4.40f1"
     latestReleaseDate: 2020-05-18
-    releaseDate: 2017-06-26
 
 ---
 
-> [Unity](https://unity.com/) is a cross-platform game engine developed by Unity Technologies, first announced and released in June 2005. The engine can be used to create three-dimensional (3D) and two-dimensional (2D) games, as well as interactive simulations and other experiences.
+> [Unity](https://unity.com/) is a cross-platform game engine developed by Unity Technologies,
+> first announced and released in June 2005. The engine can be used to create three-dimensional (3D)
+> and two-dimensional (2D) games, as well as interactive simulations and other experiences.
 
 Unity has two releases: Tech stream and LTS.
 
-*Tech stream* releases are released twice a year (each one receiving weekly updates), and are supported only until the next tech stream release is out.
+*Tech stream* releases are released twice a year (each one receiving weekly updates), and are
+supported only until the next tech stream release is out.
 
-*Unity LTS releases* are released once a year and are based off the previous tech stream branch. LTS releases offer two years of bi-weekly updates, then an additional year of monthly updates.
+*Unity LTS releases* are released once a year and are based off the previous tech stream branch.
+LTS releases offer two years of bi-weekly updates, then an additional year of monthly updates.
 
 Officially supported platforms as of Unity 2020 LTS are:
 
@@ -93,4 +97,5 @@ Officially supported platforms as of Unity 2020 LTS are:
 - Desktop: Windows (Universal Windows Platform), Mac, Linux
 - Web: WebGL
 - Consoles: PlayStation (PS4, PS5), Xbox (Xbox One, Xbox Series X/S), Nintendo Switch, Stadia
-- Virtual/Extended reality: Oculus, PlayStation VR, Google's ARCore, Apple's ARKit, Windows Mixed Reality (HoloLens), Magic Leap, and via Unity XR SDK Steam VR, Google Cardboard.
+- Virtual/Extended reality: Oculus, PlayStation VR, Google's ARCore, Apple's ARKit, Windows Mixed
+  Reality (HoloLens), Magic Leap, and via Unity XR SDK Steam VR, Google Cardboard.


### PR DESCRIPTION
https://unity3d.com/unity/whats-new/ URLs are now redirected to https://unity.com/releases/editor/whats-new/.

Some latest version were also wrong or outdated.

Also normalized the page (#2124).