### PR TITLE
[contao] add icon slug for Contao

### DIFF
--- a/products/contao.md
+++ b/products/contao.md
@@ -1,6 +1,7 @@
 ---
 title: Contao
 category: server-app
+iconSlug: contao
 permalink: /contao
 releasePolicyLink: https://contao.org/release-plan.html
 changelogTemplate: "https://github.com/contao/contao/blob/__RELEASE_CYCLE__/CHANGELOG.md"


### PR DESCRIPTION
Simple Icons now contains the Contao icon. This commit makes use of that.