### PR TITLE
[cfengine] Update `changelogTemplate`

### DIFF
--- a/products/cfengine.md
+++ b/products/cfengine.md
@@ -4,7 +4,7 @@ category: app
 permalink: /cfengine
 versionCommand: cf-agent --version
 releasePolicyLink: https://cfengine.com
-changelogTemplate: https://github.com/cfengine/core/blob/__LATEST__/ChangeLog
+changelogTemplate: https://docs.cfengine.com/docs/__RELEASE_CYCLE__/guide-latest-release-whatsnew-changelog-core.html
 releaseDateColumn: true
 eolColumn: Supported
 
@@ -17,6 +17,7 @@ releases:
     releaseDate: 2022-12-21
     eol: 2025-12-21
     lts: true
+    link: https://docs.cfengine.com/docs/__RELEASE_CYCLE__/release-notes-whatsnew-changelog-core.html
     latest: "3.21.1"
     latestReleaseDate: 2023-04-24
 


### PR DESCRIPTION
Changelog are not always published for all minor versions, at least in due time. At this commit time, https://github.com/cfengine/core/blob/3.21.1/ChangeLog and https://github.com/cfengine/core/blob/3.18.4/ChangeLog are dead links despite those were released more than two weeks ago.

This commit update the `changelogTemplate` to use the changelog hosted on https://docs.cfengine.com, which is better because:

- links are more stable (they list all minor versions for a given cycle),
- each changelog contains links to enterprise and masterfile changelogs.