### PR TITLE
[gstreamer] Disable links for version 1.0 to 1.4

### DIFF
--- a/products/gstreamer.md
+++ b/products/gstreamer.md
@@ -71,18 +71,24 @@ releases:
 -   releaseCycle: "1.4"
     releaseDate: 2014-07-19
     eol: true
+    # no known changelog for this versions
+    link: null
     latest: "1.4.5"
     latestReleaseDate: 2014-12-18
 
 -   releaseCycle: "1.2"
     releaseDate: 2013-09-24
     eol: true
+    # no known changelog for this versions
+    link: null
     latest: "1.2.4"
     latestReleaseDate: 2014-04-18
 
 -   releaseCycle: "1.0"
     releaseDate: 2012-09-24
     eol: true
+    # no known changelog for this versions
+    link: null
     latest: "1.0.10"
     latestReleaseDate: 2013-08-28
 


### PR DESCRIPTION
There are no known changelog for those versions.