### PR TITLE
[godot] Remove link for 1.0

### DIFF
--- a/products/godot.md
+++ b/products/godot.md
@@ -89,6 +89,7 @@ releases:
     releaseDate: 2014-12-15
     support: false
     eol: true
+    link: https://godotengine.org/article/godot-engine-reaches-1-0/
     latest: "1.0"
     latestReleaseDate: 2014-12-15
 


### PR DESCRIPTION
https://godotengine.org/article/maintenance-release-godot-1-0 returns a 404.