### PR TITLE
[laravel] Disable links for 5.5 and 5.8

### DIFF
--- a/products/laravel.md
+++ b/products/laravel.md
@@ -67,6 +67,8 @@ releases:
     support: 2019-08-26
     eol: 2020-02-26
     supportedPhpVersions: 7.1 - 7.3
+    # https://laravel.com/docs/5.8.x/releases return a 404
+    link: null
     latest: '5.8.38'
     latestReleaseDate: 2020-04-14
 
@@ -76,6 +78,8 @@ releases:
     support: 2019-08-30
     eol: 2020-08-30
     supportedPhpVersions: 7.0 - 7.1
+    # https://laravel.com/docs/5.5.x/releases return a 404
+    link: null
     latest: '5.5.50'
     latestReleaseDate: 2020-08-18
 

--- a/products/laravel.md
+++ b/products/laravel.md
@@ -67,8 +67,7 @@ releases:
     support: 2019-08-26
     eol: 2020-02-26
     supportedPhpVersions: 7.1 - 7.3
-    # https://laravel.com/docs/5.8.x/releases return a 404
-    link: null
+    link: https://laravel.com/docs/5.8/releases
     latest: '5.8.38'
     latestReleaseDate: 2020-04-14
 
@@ -78,8 +77,7 @@ releases:
     support: 2019-08-30
     eol: 2020-08-30
     supportedPhpVersions: 7.0 - 7.1
-    # https://laravel.com/docs/5.5.x/releases return a 404
-    link: null
+    link: https://laravel.com/docs/5.5/releases
     latest: '5.5.50'
     latestReleaseDate: 2020-08-18
 


### PR DESCRIPTION
https://laravel.com/docs/5.8.x/releases and https://laravel.com/docs/5.5.x/releases return a 404.