### PR TITLE
[neo4j] Add 5.8, update 5.7 eol

### DIFF
--- a/products/neo4j.md
+++ b/products/neo4j.md
@@ -16,9 +16,15 @@ auto:
 
 # eol(x) = releaseDate(x+1)
 releases:
+-   releaseCycle: "5.8"
+    releaseDate: 2023-05-16
+    eol: false
+    latest: "5.8.0"
+    latestReleaseDate: 2023-05-16
+
 -   releaseCycle: "5.7"
     releaseDate: 2023-04-20
-    eol: false
+    eol: 2023-05-16
     latest: "5.7.0"
     latestReleaseDate: 2023-04-20
 


### PR DESCRIPTION
https://neo4j.com/release-notes/database/neo4j-5/

Not yet listed on https://neo4j.com/developer/kb/neo4j-supported-versions/ but https://neo4j.com/download-center/ lists as current.