### PR TITLE
reset cycleColumnClass

### DIFF
--- a/_layouts/product.html
+++ b/_layouts/product.html
@@ -53,6 +53,7 @@ layout: default
 {%- assign releaseClasses = 'release' %}
 {%- if r.can_be_hidden %}{% assign releaseClasses = 'release can-be-hidden' %}{% endif %}
   <tr class="{{ releaseClasses }}">
+    {%- assign cycleColumnClass = '' %}
     {%- if r.daysTowardEol < 0 %}{% assign cycleColumnClass = 'txt-linethrough' %}{% endif %}
     <td class="{{ cycleColumnClass }}">
       {% comment %}Only put a link in the version column if the release column is not shown{% endcomment %}


### PR DESCRIPTION
This is so an end of life release can occur without it having a permanent effect on all other cycles.

This was obvious in the MariaDB entry that has 10.7 as EOL, but 10.6 still active as a LTS.

This change follows the same pattern as releaseColumnClass and its txt-linethrough.