### PR TITLE
Fix `latest.py`

### DIFF
--- a/_auto/latest.py
+++ b/_auto/latest.py
@@ -68,6 +68,11 @@ def releases_matches(r, prefix):
         # this is notably used in java
         # prefix = 7, r = 7u72
         r.startswith(prefix + "u")
+        or
+        # It matches the release cycle with an extra '+' as a build number
+        # this is notably used in java
+        # prefix = 17, r = 17.0.7+7
+        r.startswith(prefix + "+")
     )
 
 

--- a/products/bellsoft-liberica.md
+++ b/products/bellsoft-liberica.md
@@ -46,21 +46,21 @@ auto:
 # Extended support dates can be found on https://bell-sw.com/roadmap/.
 releases:
 -   releaseCycle: "20"
-    releaseDate: 2023-04-19
+    releaseDate: 2023-03-22
     eol: 2023-09-19
     extendedSupport: false
     latest: "20.0.1+10"
     latestReleaseDate: 2023-04-19
 
 -   releaseCycle: "19"
-    releaseDate: 2022-10-21
+    releaseDate: 2022-09-21
     eol: 2023-03-21
     extendedSupport: false
     latest: "19.0.2+9"
     latestReleaseDate: 2023-01-18
 
 -   releaseCycle: "18"
-    releaseDate: 2022-04-21
+    releaseDate: 2022-03-23
     eol: 2022-09-20
     extendedSupport: false
     latest: "18.0.2.1+1"
@@ -68,28 +68,28 @@ releases:
 
 -   releaseCycle: "17"
     lts: true
-    releaseDate: 2021-10-22
+    releaseDate: 2021-09-17
     eol: 2027-10-31
     extendedSupport: 2030-03-31
     latest: "17.0.7+7"
     latestReleaseDate: 2023-04-19
 
 -   releaseCycle: "16"
-    releaseDate: 2021-04-21
+    releaseDate: 2021-03-19
     eol: 2021-09-14
     extendedSupport: false
     latest: "16.0.2+7"
     latestReleaseDate: 2021-07-23
 
 -   releaseCycle: "15"
-    releaseDate: 2020-10-22
+    releaseDate: 2020-09-17
     eol: 2021-03-16
     extendedSupport: false
     latest: "15.0.2+10"
     latestReleaseDate: 2021-01-22
 
 -   releaseCycle: "14"
-    releaseDate: 2020-04-15
+    releaseDate: 2020-03-19
     eol: 2020-09-16
     extendedSupport: false
     latest: "14.0.2+13"

--- a/products/eclipse-temurin.md
+++ b/products/eclipse-temurin.md
@@ -34,27 +34,27 @@ auto:
 # EOL dates can be found on https://adoptium.net/support/.
 releases:
 -   releaseCycle: "20"
-    releaseDate: 2023-04-20
+    releaseDate: 2023-03-23
     # expected 21 release date (see https://www.java.com/releases/)
     eol: 2023-09-19
     latest: "20.0.1+9"
     latestReleaseDate: 2023-04-20
 
 -   releaseCycle: "19"
-    releaseDate: 2022-10-26
+    releaseDate: 2022-09-26
     eol: 2023-03-31
     latest: "19.0.2+7"
     latestReleaseDate: 2023-01-20
 
 -   releaseCycle: "18"
-    releaseDate: 2022-04-22
+    releaseDate: 2022-03-24
     eol: 2022-09-30
     latest: "18.0.2.1+1"
     latestReleaseDate: 2022-08-26
 
 -   releaseCycle: "17"
     lts: true
-    releaseDate: 2021-10-27
+    releaseDate: 2021-09-22
     eol: 2027-10-31
     latest: "17.0.7+7"
     latestReleaseDate: 2023-04-19


### PR DESCRIPTION
`latest.py` did not work well with java versions containing a build numbers, such as `17.0.7+7` for the 17 cycle.