### PR TITLE
Add category library

### DIFF
--- a/_auto/validate.py
+++ b/_auto/validate.py
@@ -12,6 +12,7 @@ VALID_CATEGORIES = [
     "device",
     "framework",
     "lang",
+    "library",
     "os",
     "server-app",
     "service",


### PR DESCRIPTION
#3026 introduced the new category library. In #3029 there was a new validation error:

https://github.com/endoflife-date/endoflife.date/actions/runs/5068988237/jobs/9101984105?pr=3029#step:4:113
`AssertionError: category 'library' is not valid in products/react.md, it must be in ['app', 'db', 'device', 'framework', 'lang', 'os', 'server-app', 'service', 'standard']`

This PR fixes the validation if we @endoflife-date/everyone agree to add the new category library.