### PR TITLE
[eks] Add 1.27, update eol and releases

### DIFF
--- a/products/eks.md
+++ b/products/eks.md
@@ -43,7 +43,7 @@ releases:
 
 -   releaseCycle: "1.24"
     eol: 2024-01-01
-    latest: "1.24-eks-6"
+    latest: "1.24-eks-18"
     latestReleaseDate: 2023-05-24
     releaseDate: 2022-11-15
 

--- a/products/eks.md
+++ b/products/eks.md
@@ -23,35 +23,41 @@ auto:
 
 # EOL dates can be found on https://docs.aws.amazon.com/eks/latest/userguide/kubernetes-versions.html#kubernetes-release-calendar
 releases:
+-   releaseCycle: "1.27"
+    releaseDate: 2023-05-24
+    eol: 2024-07-01
+    latest: "1.27-eks-4"
+    latestReleaseDate: 2023-05-24
+
 -   releaseCycle: "1.26"
     releaseDate: 2023-04-11
-    eol: false
-    latest: "1.26-eks-2"
-    latestReleaseDate: 2023-05-05
+    eol: 2024-06-01
+    latest: "1.26-eks-10"
+    latestReleaseDate: 2023-05-24
 
 -   releaseCycle: "1.25"
     releaseDate: 2023-02-21
     eol: 2024-05-01
-    latest: "1.25-eks-3"
-    latestReleaseDate: 2023-05-05
+    latest: "1.25-eks-14"
+    latestReleaseDate: 2023-05-24
 
 -   releaseCycle: "1.24"
     eol: 2024-01-01
     latest: "1.24-eks-6"
-    latestReleaseDate: 2023-05-05
+    latestReleaseDate: 2023-05-24
     releaseDate: 2022-11-15
 
 -   releaseCycle: "1.23"
-    eol: 2023-10-01
-    latest: "1.23-eks-8"
+    eol: 2023-10-11
+    latest: "1.23-eks-23"
     releaseDate: 2022-08-11
-    latestReleaseDate: 2023-05-05
+    latestReleaseDate: 2023-05-24
 
 -   releaseCycle: "1.22"
     eol: 2023-06-04
-    latest: "1.22-eks-12"
+    latest: "1.22-eks-28"
     releaseDate: 2022-04-04
-    latestReleaseDate: 2023-05-05
+    latestReleaseDate: 2023-05-24
 
 -   releaseCycle: "1.21"
     eol: 2023-02-15


### PR DESCRIPTION
Update versions, releases dates and EOL according to [AWS page](https://docs.aws.amazon.com/eks/latest/userguide/kubernetes-versions.html#kubernetes-release-calendar) and [EKS Distros](https://github.com/aws/eks-distro/tags)