### PR TITLE
[rabbitmq] Fix dates for 3.11, Adds 3.12

### DIFF
--- a/products/rabbitmq.md
+++ b/products/rabbitmq.md
@@ -7,8 +7,7 @@ versionCommand: rabbitmqctl --version
 releasePolicyLink: https://www.rabbitmq.com/versions.html
 changelogTemplate: https://github.com/rabbitmq/rabbitmq-server/releases/tag/v__LATEST__
 releaseDateColumn: true
-activeSupportColumn: Community Support
-eolColumn: false
+eolColumn: Community Support
 extendedSupportColumn: Extended Commercial Support
 
 auto:
@@ -16,44 +15,51 @@ auto:
     regex: ^(rabbitmq_v(?<major>[1-9]\d*)_(?<minor>0|[1-9]\d*)_(?<patch>0|[1-9]\d*)|v(?<major>[1-9]\d*)\.(?<minor>0|[1-9]\d*)\.(?<patch>0|[1-9]\d*))$
 
 releases:
+-   releaseCycle: "3.12"
+    releaseDate: 2023-06-01
+    eol: false
+    extendedSupport: true
+    latest: "3.12.0"
+    latestReleaseDate: 2023-06-01
+
 -   releaseCycle: "3.11"
     releaseDate: 2022-09-26
-    support: 2023-12-31
+    eol: 2023-12-31
     extendedSupport: 2024-07-31
-    latest: "3.11.17"
-    latestReleaseDate: 2023-05-29
+    latest: "3.11.18"
+    latestReleaseDate: 2023-06-05
 
 -   releaseCycle: "3.10"
     releaseDate: 2022-05-03
-    support: 2023-07-31
+    eol: 2023-07-31
     extendedSupport: 2023-12-31
     latest: "3.10.23"
     latestReleaseDate: 2023-05-24
 
 -   releaseCycle: "3.9"
     releaseDate: 2021-07-23
-    support: 2023-01-31
+    eol: 2023-01-31
     extendedSupport: 2023-07-31
     latest: "3.9.29"
     latestReleaseDate: 2023-03-09
 
 -   releaseCycle: "3.8"
     releaseDate: 2019-10-01
-    support: 2022-07-31
+    eol: 2022-07-31
     extendedSupport: 2022-07-31
     latest: "3.8.35"
     latestReleaseDate: 2022-07-09
 
 -   releaseCycle: "3.7"
     releaseDate: 2017-11-28
-    support: 2020-09-30
+    eol: 2020-09-30
     extendedSupport: 2020-09-30
     latest: "3.7.28"
     latestReleaseDate: 2020-08-17
 
 -   releaseCycle: "3.6"
     releaseDate: 2015-12-22
-    support: 2018-05-31
+    eol: 2018-05-31
     extendedSupport: 2018-05-31
     latest: "3.6.16"
     latestReleaseDate: 2018-06-13
@@ -61,7 +67,7 @@ releases:
 
 -   releaseCycle: "3.5"
     releaseDate: 2015-03-11
-    support: 2016-10-31
+    eol: 2016-10-31
     extendedSupport: 2016-10-31
     latest: "3.5.8"
     latestReleaseDate: 2016-11-03
@@ -69,7 +75,7 @@ releases:
 
 -   releaseCycle: "3.4"
     releaseDate: 2014-10-21
-    support: 2015-10-31
+    eol: 2015-10-31
     extendedSupport: 2015-10-31
     latest: "3.4.4"
     latestReleaseDate: 2015-02-11
@@ -77,7 +83,7 @@ releases:
 
 -   releaseCycle: "3.3"
     releaseDate: 2014-04-02
-    support: 2015-03-31
+    eol: 2015-03-31
     extendedSupport: 2015-03-31
     latest: "3.3.5"
     latestReleaseDate: 2014-08-11
@@ -85,7 +91,7 @@ releases:
 
 -   releaseCycle: "3.2"
     releaseDate: 2013-10-23
-    support: 2014-10-31
+    eol: 2014-10-31
     extendedSupport: 2014-10-31
     latest: "3.2.4"
     latestReleaseDate: 2014-03-04
@@ -93,7 +99,7 @@ releases:
 
 -   releaseCycle: "3.1"
     releaseDate: 2013-05-01
-    support: 2014-04-30
+    eol: 2014-04-30
     extendedSupport: 2014-04-30
     latest: "3.1.5"
     latestReleaseDate: 2013-08-15
@@ -101,7 +107,7 @@ releases:
 
 -   releaseCycle: "3.0"
     releaseDate: 2012-11-19
-    support: 2013-11-30
+    eol: 2013-11-30
     extendedSupport: 2013-11-30
     latest: "3.0.4"
     latestReleaseDate: 2013-03-06

--- a/products/rabbitmq.md
+++ b/products/rabbitmq.md
@@ -20,7 +20,6 @@ releases:
     releaseDate: 2022-09-26
     support: 2023-12-31
     extendedSupport: 2024-07-31
-    support: true
     latest: "3.11.17"
     latestReleaseDate: 2023-05-29
 

--- a/products/rabbitmq.md
+++ b/products/rabbitmq.md
@@ -8,7 +8,8 @@ releasePolicyLink: https://www.rabbitmq.com/versions.html
 changelogTemplate: https://github.com/rabbitmq/rabbitmq-server/releases/tag/v__LATEST__
 releaseDateColumn: true
 activeSupportColumn: Community Support
-eolColumn: Extended Support
+eolColumn: false
+extendedSupportColumn: Extended Commercial Support
 
 auto:
 -   git: https://github.com/rabbitmq/rabbitmq-server.git
@@ -17,7 +18,8 @@ auto:
 releases:
 -   releaseCycle: "3.11"
     releaseDate: 2022-09-26
-    eol: false
+    support: 2023-12-31
+    extendedSupport: 2024-07-31
     support: true
     latest: "3.11.17"
     latestReleaseDate: 2023-05-29
@@ -25,35 +27,35 @@ releases:
 -   releaseCycle: "3.10"
     releaseDate: 2022-05-03
     support: 2023-07-31
-    eol: 2023-12-30
+    extendedSupport: 2023-12-31
     latest: "3.10.23"
     latestReleaseDate: 2023-05-24
 
 -   releaseCycle: "3.9"
     releaseDate: 2021-07-23
     support: 2023-01-31
-    eol: 2023-07-31
+    extendedSupport: 2023-07-31
     latest: "3.9.29"
     latestReleaseDate: 2023-03-09
 
 -   releaseCycle: "3.8"
     releaseDate: 2019-10-01
     support: 2022-07-31
-    eol: 2022-07-31
+    extendedSupport: 2022-07-31
     latest: "3.8.35"
     latestReleaseDate: 2022-07-09
 
 -   releaseCycle: "3.7"
     releaseDate: 2017-11-28
     support: 2020-09-30
-    eol: 2020-09-30
+    extendedSupport: 2020-09-30
     latest: "3.7.28"
     latestReleaseDate: 2020-08-17
 
 -   releaseCycle: "3.6"
     releaseDate: 2015-12-22
     support: 2018-05-31
-    eol: 2018-05-31
+    extendedSupport: 2018-05-31
     latest: "3.6.16"
     latestReleaseDate: 2018-06-13
     link: "https://github.com/rabbitmq/rabbitmq-server/releases/tag/rabbitmq_v{{'__LATEST__'|replace:'.','_'}}"
@@ -61,7 +63,7 @@ releases:
 -   releaseCycle: "3.5"
     releaseDate: 2015-03-11
     support: 2016-10-31
-    eol: 2016-10-31
+    extendedSupport: 2016-10-31
     latest: "3.5.8"
     latestReleaseDate: 2016-11-03
     link: "https://github.com/rabbitmq/rabbitmq-server/releases/tag/rabbitmq_v{{'__LATEST__'|replace:'.','_'}}"
@@ -69,7 +71,7 @@ releases:
 -   releaseCycle: "3.4"
     releaseDate: 2014-10-21
     support: 2015-10-31
-    eol: 2015-10-31
+    extendedSupport: 2015-10-31
     latest: "3.4.4"
     latestReleaseDate: 2015-02-11
     link: "https://github.com/rabbitmq/rabbitmq-server/releases/tag/rabbitmq_v{{'__LATEST__'|replace:'.','_'}}"
@@ -77,7 +79,7 @@ releases:
 -   releaseCycle: "3.3"
     releaseDate: 2014-04-02
     support: 2015-03-31
-    eol: 2015-03-31
+    extendedSupport: 2015-03-31
     latest: "3.3.5"
     latestReleaseDate: 2014-08-11
     link: "https://github.com/rabbitmq/rabbitmq-server/releases/tag/rabbitmq_v{{'__LATEST__'|replace:'.','_'}}"
@@ -85,7 +87,7 @@ releases:
 -   releaseCycle: "3.2"
     releaseDate: 2013-10-23
     support: 2014-10-31
-    eol: 2014-10-31
+    extendedSupport: 2014-10-31
     latest: "3.2.4"
     latestReleaseDate: 2014-03-04
     link: "https://github.com/rabbitmq/rabbitmq-server/releases/tag/rabbitmq_v{{'__LATEST__'|replace:'.','_'}}"
@@ -93,7 +95,7 @@ releases:
 -   releaseCycle: "3.1"
     releaseDate: 2013-05-01
     support: 2014-04-30
-    eol: 2014-04-30
+    extendedSupport: 2014-04-30
     latest: "3.1.5"
     latestReleaseDate: 2013-08-15
     link: "https://github.com/rabbitmq/rabbitmq-server/releases/tag/rabbitmq_v{{'__LATEST__'|replace:'.','_'}}"
@@ -101,7 +103,7 @@ releases:
 -   releaseCycle: "3.0"
     releaseDate: 2012-11-19
     support: 2013-11-30
-    eol: 2013-11-30
+    extendedSupport: 2013-11-30
     latest: "3.0.4"
     latestReleaseDate: 2013-03-06
     link: "https://github.com/rabbitmq/rabbitmq-server/releases/tag/rabbitmq_v{{'__LATEST__'|replace:'.','_'}}"
@@ -114,5 +116,5 @@ releases:
 - **Community Support**: includes regular patch releases. Was earlier called "General Support", but
   renamed to avoid confusion with [VMware terminology](https://tanzu.vmware.com/support/lifecycle_policy)
   related to support lifecycle policy.
-- **[Extended Support](https://tanzu.vmware.com/rabbitmq)**: is available from VMWare. It includes
+- **[Extended Commercial Support](https://tanzu.vmware.com/rabbitmq)**: is available from VMWare. It includes
   security patches, and fixes for high-severity issues reported by users with a commercial license.


### PR DESCRIPTION
Switches from eol to extendedSupport instead.
This makes it clear that the offering is not "default", and only community support is guaranteed (via `support`).

Dates updated as per https://www.rabbitmq.com/versions.html