### PR TITLE
[Consul] Add legacy releases (beyond 1.8)

### DIFF
--- a/products/consul.md
+++ b/products/consul.md
@@ -58,13 +58,13 @@ releases:
     releaseDate: 2021-06-22
 
 -   releaseCycle: "1.9"
-    eol: true
+    eol: 2022-04-19
     latest: "1.9.17"
     latestReleaseDate: 2022-04-14
     releaseDate: 2020-11-24
 
 -   releaseCycle: "1.8"
-    eol: true
+    eol: 2021-12-14
     latest: "1.8.19"
     latestReleaseDate: 2021-12-15
     releaseDate: 2020-06-18

--- a/products/consul.md
+++ b/products/consul.md
@@ -69,6 +69,17 @@ releases:
     latestReleaseDate: 2021-12-15
     releaseDate: 2020-06-18
 
+-   releaseCycle: "1.7"
+    eol: true
+    latest: "1.7.14"
+    latestReleaseDate: 2021-04-05
+    releaseDate: 2020-06-10
+  
+-   releaseCycle: "1.6"
+    eol: true
+    latest: "1.6.10"
+    latestReleaseDate: 2020-11-19
+    releaseDate: 2020-06-10
 ---
 
 > [Hashicorp Consul](https://www.consul.io/) automates networking for simple and secure application

--- a/products/consul.md
+++ b/products/consul.md
@@ -76,7 +76,7 @@ releases:
     releaseDate: 2020-06-10
   
 -   releaseCycle: "1.6"
-    eol: true
+    eol: 2020-11-24
     latest: "1.6.10"
     latestReleaseDate: 2020-11-19
     releaseDate: 2020-06-10

--- a/products/consul.md
+++ b/products/consul.md
@@ -72,7 +72,7 @@ releases:
 -   releaseCycle: "1.7"
     eol: true
     latest: "1.7.14"
-    latestReleaseDate: 2021-04-05
+    latestReleaseDate: 2021-04-15
     releaseDate: 2020-06-10
   
 -   releaseCycle: "1.6"

--- a/products/consul.md
+++ b/products/consul.md
@@ -70,7 +70,7 @@ releases:
     releaseDate: 2020-06-18
 
 -   releaseCycle: "1.7"
-    eol: true
+    eol: 2021-06-22
     latest: "1.7.14"
     latestReleaseDate: 2021-04-15
     releaseDate: 2020-06-10


### PR DESCRIPTION
# ❔ About

Current [Hashicorp Consul](https://endoflife.date/consul) are not going beyond [`1.8`](https://github.com/hashicorp/consul/blob/v1.8.19/CHANGELOG.md) : 

![image](https://github.com/endoflife-date/endoflife.date/assets/5235127/83d83b54-6d77-4b8d-bdef-87e531dd8e25)

👉 The aim of this PR is to fix this.