### PR TITLE
[mariadb] eol for 10.7 changed

### DIFF
--- a/products/mariadb.md
+++ b/products/mariadb.md
@@ -59,7 +59,7 @@ releases:
     releaseDate: 2022-05-20
     latestReleaseDate: 2023-05-10
 -   releaseCycle: "10.7"
-    eol: 2023-02-14
+    eol: 2023-02-09
     latest: "10.7.8"
     latestReleaseDate: 2023-02-06
     releaseDate: 2022-02-08


### PR DESCRIPTION
https://mariadb.org/about/#maintenance-policy says 9th Feb now.