### PR TITLE
[drush] Adds v12

### DIFF
--- a/products/drush.md
+++ b/products/drush.md
@@ -18,45 +18,52 @@ identifiers:
 iconSlug: drupal
 releases:
 -   releaseCycle: "12"
+    releaseDate: 2023-06-03
     eol: false
     latest: "12.0.0"
-    latestReleaseDate: 
-    releaseDate: 2023-06-03
+    latestReleaseDate: 2023-06-03
+
 -   releaseCycle: "11"
+    releaseDate: 2022-01-11
     eol: 2023-11-01
     latest: "11.6.0"
     latestReleaseDate: 2023-06-06
-    releaseDate: 2022-01-11
+    
 -   releaseCycle: "10"
+    releaseDate: 2019-10-31
     eol: 2022-01-01
     latest: "10.6.2"
     latestReleaseDate: 2021-12-15
-    releaseDate: 2019-10-31
+    
 -   releaseCycle: "9"
+    releaseDate: 2018-01-24
     eol: 2020-05-01
     latest: "9.7.3"
     latestReleaseDate: 2021-03-22
-    releaseDate: 2018-01-24
+    
 -   releaseCycle: "8"
+    releaseDate: 2015-11-19
     eol: 2025-01-01
     latest: "8.4.12"
     latestReleaseDate: 2023-03-15
-    releaseDate: 2015-11-19
+    
 -   releaseCycle: "7"
+    releaseDate: 2015-05-20
     eol: 2017-07-01
     latest: "7.4.2"
     latestReleaseDate: 2022-03-25
-    releaseDate: 2015-05-20
+    
 -   releaseCycle: "6"
+    releaseDate: 2013-08-16
     eol: 2015-12-01
     latest: "6.7.0"
     latestReleaseDate: 2015-12-02
-    releaseDate: 2013-08-16
+    
 -   releaseCycle: "5"
+    releaseDate: 2012-03-23
     eol: 2015-05-01
     latest: "5.11.0"
     latestReleaseDate: 2014-05-22
-    releaseDate: 2012-03-23
 
 ---
 

--- a/products/drush.md
+++ b/products/drush.md
@@ -17,8 +17,13 @@ identifiers:
 -   purl: pkg:github/drush-ops/drush
 iconSlug: drupal
 releases:
--   releaseCycle: "11"
+-   releaseCycle: "12"
     eol: false
+    latest: "12.0.0"
+    latestReleaseDate: 
+    releaseDate: 
+-   releaseCycle: "11"
+    eol: 2023-11-01
     latest: "11.6.0"
     latestReleaseDate: 2023-06-06
     releaseDate: 2022-01-11
@@ -33,7 +38,7 @@ releases:
     latestReleaseDate: 2021-03-22
     releaseDate: 2018-01-24
 -   releaseCycle: "8"
-    eol: false
+    eol: 2025-01-01
     latest: "8.4.12"
     latestReleaseDate: 2023-03-15
     releaseDate: 2015-11-19
@@ -61,5 +66,6 @@ releases:
 
 | Drush version | Supported PHP versions | Supported Drupal versions |
 |---------------|------------------------|---------------------------|
+| 12            | 8.1+                   | 10+                       |
 | 11            | 7.4+                   | 9+                        |
 | 8             | 5.4.5+                 | 7                         |

--- a/products/drush.md
+++ b/products/drush.md
@@ -20,8 +20,8 @@ releases:
 -   releaseCycle: "12"
     releaseDate: 2023-06-03
     eol: false
-    latest: "12.0.0"
-    latestReleaseDate: 2023-06-03
+    latest: "12.0.1"
+    latestReleaseDate: 2023-06-07
 
 -   releaseCycle: "11"
     releaseDate: 2022-01-11

--- a/products/drush.md
+++ b/products/drush.md
@@ -21,7 +21,7 @@ releases:
     eol: false
     latest: "12.0.0"
     latestReleaseDate: 
-    releaseDate: 
+    releaseDate: 2023-06-03
 -   releaseCycle: "11"
     eol: 2023-11-01
     latest: "11.6.0"


### PR DESCRIPTION
Also updates the EOL date for Drush 8, which matches the new Drupal 7 EOL (See #3081)