### PR TITLE
[openSUSE] 15.5 release

### DIFF
--- a/products/opensuse.md
+++ b/products/opensuse.md
@@ -23,7 +23,7 @@ identifiers:
 
 releases:
 -   releaseCycle: "15.5"
-    releaseDate: 2023-06-08
+    releaseDate: 2023-06-07
     eol: 2024-12-31
 
 -   releaseCycle: "15.4"

--- a/products/opensuse.md
+++ b/products/opensuse.md
@@ -22,9 +22,13 @@ identifiers:
 -   cpe: cpe:2.3:o:opensuse:leap
 
 releases:
+-   releaseCycle: "15.5"
+    releaseDate: 2023-06-08
+    eol: 2024-12-31
+
 -   releaseCycle: "15.4"
     releaseDate: 2022-06-09
-    eol: 2023-12-01
+    eol: 2023-12-07
 
 -   releaseCycle: "15.3"
     releaseDate: 2021-06-02


### PR DESCRIPTION
https://news.opensuse.org/2023/06/07/leap-release-matures-sets-up-tech-transition/

15.4 EoL is 15.5 release + 6 months
15.5 EoL is taken from https://en.opensuse.org/Lifetime