### PR TITLE
[postfix] Improve regex

### DIFF
--- a/products/postfix.md
+++ b/products/postfix.md
@@ -9,9 +9,8 @@ activeSupportColumn: false
 releaseDateColumn: true
 
 auto:
--   custom: true
 -   git: https://github.com/vdukhovni/postfix.git
-    regex: ^v(?<major>0|[1-9]\d*)\.(?<minor>0|[1-9]\d*)(\.(?<patch>0|[1-9]\d*))?$
+    regex: ^v(?<major>[3-9])\.(?<minor>[3-9])\.(?<patch>\d+)$
 
 releases:
 -   releaseCycle: "3.8"


### PR DESCRIPTION
Drop releases older than 3.3.0 since they have incorrect release dates.

Triggered a run here: https://github.com/endoflife-date/release-data/actions/runs/5212602912