### PR TITLE
[plesk] Lower EOL warn threshold

### DIFF
--- a/products/plesk.md
+++ b/products/plesk.md
@@ -9,6 +9,7 @@ changelogTemplate: "https://docs.plesk.com/release-notes/obsidian/change-log/#pl
 eolColumn: Support
 releaseColumn: true
 releaseDateColumn: true
+eolWarnThreshold: 21
 
 auto:
 -   custom: true


### PR DESCRIPTION
A release is maintained for 12 weeks, so we warn in the last quartile of the support period.