### PR TITLE
Add Debian 12 "Bookworm"

### DIFF
--- a/products/debian.md
+++ b/products/debian.md
@@ -33,7 +33,7 @@ releases:
     releaseDate: 2021-08-14
     eol: 2024-07-01
     extendedSupport: 2026-06-30
-    link: https://www.debian.org/News/2022/20221217 https://www.debian.org/News/2023/20230429
+    link: https://www.debian.org/News/2023/20230429
     latest: "11.7"
     latestReleaseDate: 2023-04-29
 

--- a/products/debian.md
+++ b/products/debian.md
@@ -19,12 +19,21 @@ auto:
 -   custom: true
 
 releases:
+-   releaseCycle: "12"
+    codename: "Bookworm"
+    releaseDate: 2023-06-10
+    eol: 2026-06-10
+    extendedSupport: 2028-06-10
+    link: https://www.debian.org/News/2023/20230610
+    latest: "12.0"
+    latestReleaseDate: 2023-06-10
+
 -   releaseCycle: "11"
     codename: "Bullseye"
     releaseDate: 2021-08-14
     eol: 2024-07-01
     extendedSupport: 2026-06-30
-    link: https://www.debian.org/News/2022/20221217
+    link: https://www.debian.org/News/2022/20221217 https://www.debian.org/News/2023/20230429
     latest: "11.7"
     latestReleaseDate: 2023-04-29
 


### PR DESCRIPTION
Release announcement: https://www.debian.org/News/2023/20230610

According to the [release lifecycle](https://www.debian.org/releases/), support is 3y + 2y:
>Release life cycle
Debian announces its new stable release on a regular basis. Users can expect 3 years of full support for each release and 2 years of extra LTS support.

The statement in the release post is a bit misleading.