### PR TITLE
[cfengine] Set up automation

### DIFF
--- a/products/cfengine.md
+++ b/products/cfengine.md
@@ -12,6 +12,9 @@ identifiers:
 -   repology: cfengine
 -   purl: pkg:homebrew/cfengine
 
+auto:
+-   git: https://github.com/cfengine/core.git
+
 releases:
 -   releaseCycle: "3.21"
     releaseDate: 2022-12-21


### PR DESCRIPTION
Diff after the auto update : 

```diff
 releases:
 -   releaseCycle: "3.21"
     releaseDate: 2022-12-21
@@ -41,19 +44,19 @@ releases:
     latestReleaseDate: 2023-06-09
 
 -   releaseCycle: "3.17"
-    releaseDate: 2020-11-18
+    releaseDate: 2020-11-19
     eol: true
     latest: "3.17.0"
-    latestReleaseDate: 2020-11-18
+    latestReleaseDate: 2020-11-19
 
 -   releaseCycle: "3.16"
-    releaseDate: 2020-06-25
+    releaseDate: 2020-06-23
     eol: true
     latest: "3.16.0"
-    latestReleaseDate: 2020-06-25
+    latestReleaseDate: 2020-06-23
 
 -   releaseCycle: "3.15"
-    releaseDate: 2019-12-18
+    releaseDate: 2019-12-19
```

It may not be entirely accurate (did not check), but it's close enough.