### PR TITLE
[Ansible] Ansible 7.x is still active until 7.7.0

### DIFF
--- a/products/ansible.md
+++ b/products/ansible.md
@@ -27,7 +27,7 @@ releases:
 
 -   releaseCycle: "7"
     releaseDate: 2022-11-22
-    eol: 2023-05-30
+    eol: false
     latest: "7.6.0"
     latestReleaseDate: 2023-05-23
 


### PR DESCRIPTION
relates to #3062

release cycle doc, https://docs.ansible.com/ansible/latest/reference_appendices/release_and_maintenance.html#ansible-community-package-release-cycle