### PR TITLE
[yocto] Fix EOL for 3.3

### DIFF
--- a/products/yocto.md
+++ b/products/yocto.md
@@ -52,7 +52,7 @@ releases:
 -   releaseCycle: "3.3"
     codename: 'Hardknott'
     latest: "3.3.6"
-    eol: 2021-11-01
+    eol: 2022-04-20
     releaseDate: 2021-04-19
 
     latestReleaseDate: 2022-04-27


### PR DESCRIPTION
3.3 was supported till Apr 20, 2022.

See https://lists.yoctoproject.org/g/yocto/topic/98893130#60147