### PR TITLE
[SLES] Add details about non-latest minor version releases for each major SLES version

### DIFF
--- a/products/sles.md
+++ b/products/sles.md
@@ -18,30 +18,111 @@ identifiers:
 -   cpe: cpe:/o:suse:sles
 -   cpe: cpe:2.3:o:suse:sles
 releases:
--   releaseCycle: "15"
-    support: 2028-07-31
-    eol: 2031-07-31
+-   releaseCycle: "15.4"
+    support: false
+    eol: false
     latest: "15.4"
+    releaseDate: 2022-06-21
+-   releaseCycle: "15.3"
+    support: 2022-12-31
+    eol: 2025-12-31
+    latest: "15.3"
+    releaseDate: 2021-06-22
+-   releaseCycle: "15.2"
+    support: 2021-12-31
+    eol: 2024-12-31
+    latest: "15.2"
+    releaseDate: 2020-07-21
+-   releaseCycle: "15.1"
+    support: 2021-01-31
+    eol: 2024-01-31
+    latest: "15.1"
+    releaseDate: 2019-06-24
+-   releaseCycle: "15"
+    support: 2019-12-31
+    eol: 2022-12-31
+    latest: "15"
     releaseDate: 2018-07-16
-    latestReleaseDate: 2022-06-21
--   releaseCycle: "12"
+-   releaseCycle: "12.5"
     support: 2024-10-31
     eol: 2027-10-31
     latest: "12.5"
+    releaseDate: 2019-12-09
+-   releaseCycle: "12.4"
+    support: 2020-06-30
+    eol: 2023-06-30
+    latest: "12.4"
+    releaseDate: 2018-12-12
+-   releaseCycle: "12.3"
+    support: 2019-06-30
+    eol: 2022-06-30
+    latest: "12.3"
+    releaseDate: 2017-09-07
+-   releaseCycle: "12.2"
+    support: 2018-03-31
+    eol: 2021-03-31
+    latest: "12.2"
+    releaseDate: 2016-11-08
+-   releaseCycle: "12.1"
+    support: 2017-05-31
+    eol: 2020-05-31
+    latest: "12.1"
+    releaseDate: 2015-12-15
+-   releaseCycle: "12"
+    support: 2016-06-30
+    eol: 2019-07-01
+    latest: "12"
     releaseDate: 2014-10-27
-    latestReleaseDate: 2019-12-09
--   releaseCycle: "11"
+-   releaseCycle: "11.4"
     support: 2019-03-31
     eol: 2022-03-31
     latest: "11.4"
+    releaseDate: 2015-07-15
+-   releaseCycle: "11.3"
+    support: 2016-01-31
+    eol: 2019-01-30
+    latest: "11.3"
+    releaseDate: 2013-07-01
+-   releaseCycle: "11.2"
+    support: 2014-01-31
+    eol: 2017-01-30
+    latest: "11.2"
+    releaseDate: 2012-02-29
+-   releaseCycle: "11.1"
+    support: 2012-08-31
+    eol: 2012-08-31
+    latest: "11.1"
+    releaseDate: 2010-06-02
+-   releaseCycle: "11"
+    support: 2010-12-31
+    eol: 2010-12-31
+    latest: "11"
     releaseDate: 2009-03-24
-    latestReleaseDate: 2015-07-15
--   releaseCycle: "10"
+-   releaseCycle: "10.4"
     support: 2013-07-31
     eol: 2016-07-31
     latest: "10.4"
+    releaseDate: 2011-04-12
+-   releaseCycle: "10.3"
+    support: 2011-10-11
+    eol: 2014-10-31
+    latest: "10.3"
+    releaseDate: 2009-10-12
+-   releaseCycle: "10.2"
+    support: 2010-04-11
+    eol: 2013-04-10
+    latest: "10.2"
+    releaseDate: 2008-05-19
+-   releaseCycle: "10.1"
+    support: 2008-11-30
+    eol: 2010-12-31
+    latest: "10.1"
+    releaseDate: 2007-06-18
+-   releaseCycle: "10"
+    support: 2007-12-31
+    eol: 2007-12-31
+    latest: "10"
     releaseDate: 2006-07-17
-    latestReleaseDate: 2011-04-12
 
 ---
 

--- a/products/sles.md
+++ b/products/sles.md
@@ -23,113 +23,113 @@ identifiers:
 releases:
 -   releaseCycle: "15.5"
     releaseDate: 2023-06-20
-    support: true
-    eol: false
+    eol: true
+    extendedSupport: false
 
 -   releaseCycle: "15.4"
     releaseDate: 2022-06-21
-    support: 2023-12-31
-    eol: 2026-12-31
+    eol: 2023-12-31
+    extendedSupport: 2026-12-31
 
 -   releaseCycle: "15.3"
     releaseDate: 2021-06-22
-    support: 2022-12-31
-    eol: 2025-12-31
+    eol: 2022-12-31
+    extendedSupport: 2025-12-31
 
 -   releaseCycle: "15.2"
     releaseDate: 2020-07-21
-    support: 2021-12-31
-    eol: 2024-12-31
+    eol: 2021-12-31
+    extendedSupport: 2024-12-31
 
 -   releaseCycle: "15.1"
     releaseDate: 2019-06-24
-    support: 2021-01-31
-    eol: 2024-01-31
+    eol: 2021-01-31
+    extendedSupport: 2024-01-31
 
 -   releaseCycle: "15"
     releaseDate: 2018-07-16
-    support: 2019-12-31
-    eol: 2022-12-31
+    eol: 2019-12-31
+    extendedSupport: 2022-12-31
 
 -   releaseCycle: "12.5"
     releaseDate: 2019-12-09
-    support: 2024-10-31
-    eol: 2027-10-31
+    eol: 2024-10-31
+    extendedSupport: 2027-10-31
 
 -   releaseCycle: "12.4"
     releaseDate: 2018-12-12
-    support: 2020-06-30
-    eol: 2023-06-30
+    eol: 2020-06-30
+    extendedSupport: 2023-06-30
 
 -   releaseCycle: "12.3"
     releaseDate: 2017-09-07
-    support: 2019-06-30
-    eol: 2022-06-30
+    eol: 2019-06-30
+    extendedSupport: 2022-06-30
 
 -   releaseCycle: "12.2"
     releaseDate: 2016-11-08
-    support: 2018-03-31
-    eol: 2021-03-31
+    eol: 2018-03-31
+    extendedSupport: 2021-03-31
 
 -   releaseCycle: "12.1"
     releaseDate: 2015-12-15
-    support: 2017-05-31
-    eol: 2020-05-31
+    eol: 2017-05-31
+    extendedSupport: 2020-05-31
 
 -   releaseCycle: "12"
     releaseDate: 2014-10-27
-    support: 2016-06-30
-    eol: 2019-07-01
+    eol: 2016-06-30
+    extendedSupport: 2019-07-01
 
 -   releaseCycle: "11.4"
     releaseDate: 2015-07-15
-    support: 2019-03-31
-    eol: 2022-03-31
+    eol: 2019-03-31
+    extendedSupport: 2022-03-31
 
 -   releaseCycle: "11.3"
     releaseDate: 2013-07-01
-    support: 2016-01-31
-    eol: 2019-01-30
+    eol: 2016-01-31
+    extendedSupport: 2019-01-30
 
 -   releaseCycle: "11.2"
     releaseDate: 2012-02-29
-    support: 2014-01-31
-    eol: 2017-01-30
+    eol: 2014-01-31
+    extendedSupport: 2017-01-30
 
 -   releaseCycle: "11.1"
     releaseDate: 2010-06-02
-    support: 2012-08-31
-    eol: 2015-08-30
+    eol: 2012-08-31
+    extendedSupport: 2015-08-30
 
 -   releaseCycle: "11"
     releaseDate: 2009-03-24
-    support: 2010-12-31
     eol: 2010-12-31
+    extendedSupport: 2010-12-31
 
 -   releaseCycle: "10.4"
     releaseDate: 2011-04-12
-    support: 2013-07-31
-    eol: 2016-07-30
+    eol: 2013-07-31
+    extendedSupport: 2016-07-30
 
 -   releaseCycle: "10.3"
     releaseDate: 2009-10-12
-    support: 2011-10-11
-    eol: 2014-10-31
+    eol: 2011-10-11
+    extendedSupport: 2014-10-31
 
 -   releaseCycle: "10.2"
     releaseDate: 2008-05-19
-    support: 2010-04-11
-    eol: 2013-04-10
+    eol: 2010-04-11
+    extendedSupport: 2013-04-10
 
 -   releaseCycle: "10.1"
     releaseDate: 2007-06-18
-    support: 2008-11-30
-    eol: 2010-12-31
+    eol: 2008-11-30
+    extendedSupport: 2010-12-31
 
 -   releaseCycle: "10"
     releaseDate: 2006-07-17
-    support: 2007-12-31
     eol: 2007-12-31
+    extendedSupport: 2007-12-31
 
 ---
 
@@ -137,7 +137,7 @@ releases:
 > distribution for both multimodal and traditional IT.
 
 SLES has a thirteen-year product lifecycle. The current support model consists of 10 years of
-general support, followed by 3 years of Long Term Service Pack Support (LTSS). Major versions are
+general support, followed by up to 3 years of paid Long Term Service Pack Support (LTSS). Major versions are
 released at an interval of 3–4 years, while minor versions (called "Service Packs") are released
 about every 12 months. SLES receives more intense testing than the upstream openSUSE community
 product.

--- a/products/sles.md
+++ b/products/sles.md
@@ -10,131 +10,158 @@ alternate_urls:
 -   /suselinuxenterpriseserver
 versionCommand: cat /etc/os-release
 releasePolicyLink: https://www.suse.com/lifecycle
-changelogTemplate: https://www.suse.com/releasenotes/x86_64/SUSE-SLES/{{"__LATEST__"
-  | replace:'.','-SP'}}/
+changelogTemplate: "https://www.suse.com/releasenotes/x86_64/SUSE-SLES/{{'__LATEST__'|replace:'.','-SP'}}/"
+LTSLabel: "<abbr title='Long Term Service Pack Support'>LTSS</abbr>"
 activeSupportColumn: true
 releaseColumn: true
 releaseDateColumn: true
-LTSLabel: "<abbr title='Long Term Service Pack Support'>LTSS</abbr>"
+
 identifiers:
 -   cpe: cpe:/o:suse:sles
 -   cpe: cpe:2.3:o:suse:sles
+
 releases:
 -   releaseCycle: "15.5"
+    releaseDate: 2023-06-20
     support: true
     eol: true
     latest: "15.5"
-    releaseDate: 2023-06-20
+
 -   releaseCycle: "15.4"
+    releaseDate: 2022-06-21
     support: 2023-12-31
     eol: 2026-12-31
     latest: "15.4"
-    releaseDate: 2022-06-21
+
 -   releaseCycle: "15.3"
+    releaseDate: 2021-06-22
     support: 2022-12-31
     eol: 2025-12-31
     latest: "15.3"
-    releaseDate: 2021-06-22
+
 -   releaseCycle: "15.2"
+    releaseDate: 2020-07-21
     support: 2021-12-31
     eol: 2024-12-31
     latest: "15.2"
-    releaseDate: 2020-07-21
+
 -   releaseCycle: "15.1"
+    releaseDate: 2019-06-24
     support: 2021-01-31
     eol: 2024-01-31
     latest: "15.1"
-    releaseDate: 2019-06-24
+
 -   releaseCycle: "15"
+    releaseDate: 2018-07-16
     support: 2019-12-31
     eol: 2022-12-31
     latest: "15"
-    releaseDate: 2018-07-16
+
 -   releaseCycle: "12.5"
+    releaseDate: 2019-12-09
     support: 2024-10-31
     eol: 2027-10-31
     latest: "12.5"
-    releaseDate: 2019-12-09
+
 -   releaseCycle: "12.4"
+    releaseDate: 2018-12-12
     support: 2020-06-30
     eol: 2023-06-30
     latest: "12.4"
-    releaseDate: 2018-12-12
+
 -   releaseCycle: "12.3"
+    releaseDate: 2017-09-07
     support: 2019-06-30
     eol: 2022-06-30
     latest: "12.3"
-    releaseDate: 2017-09-07
+
 -   releaseCycle: "12.2"
+    releaseDate: 2016-11-08
     support: 2018-03-31
     eol: 2021-03-31
     latest: "12.2"
-    releaseDate: 2016-11-08
+
 -   releaseCycle: "12.1"
+    releaseDate: 2015-12-15
     support: 2017-05-31
     eol: 2020-05-31
     latest: "12.1"
-    releaseDate: 2015-12-15
+
 -   releaseCycle: "12"
+    releaseDate: 2014-10-27
     support: 2016-06-30
     eol: 2019-07-01
     latest: "12"
-    releaseDate: 2014-10-27
+
 -   releaseCycle: "11.4"
+    releaseDate: 2015-07-15
     support: 2019-03-31
     eol: 2022-03-31
     latest: "11.4"
-    releaseDate: 2015-07-15
+
 -   releaseCycle: "11.3"
+    releaseDate: 2013-07-01
     support: 2016-01-31
     eol: 2019-01-30
     latest: "11.3"
-    releaseDate: 2013-07-01
+
 -   releaseCycle: "11.2"
+    releaseDate: 2012-02-29
     support: 2014-01-31
     eol: 2017-01-30
     latest: "11.2"
-    releaseDate: 2012-02-29
+
 -   releaseCycle: "11.1"
+    releaseDate: 2010-06-02
     support: 2012-08-31
     eol: 2012-08-31
     latest: "11.1"
-    releaseDate: 2010-06-02
+
 -   releaseCycle: "11"
+    releaseDate: 2009-03-24
     support: 2010-12-31
     eol: 2010-12-31
     latest: "11"
-    releaseDate: 2009-03-24
+
 -   releaseCycle: "10.4"
+    releaseDate: 2011-04-12
     support: 2013-07-31
     eol: 2016-07-31
     latest: "10.4"
-    releaseDate: 2011-04-12
+
 -   releaseCycle: "10.3"
+    releaseDate: 2009-10-12
     support: 2011-10-11
     eol: 2014-10-31
     latest: "10.3"
-    releaseDate: 2009-10-12
+
 -   releaseCycle: "10.2"
+    releaseDate: 2008-05-19
     support: 2010-04-11
     eol: 2013-04-10
     latest: "10.2"
-    releaseDate: 2008-05-19
+
 -   releaseCycle: "10.1"
+    releaseDate: 2007-06-18
     support: 2008-11-30
     eol: 2010-12-31
     latest: "10.1"
-    releaseDate: 2007-06-18
+
 -   releaseCycle: "10"
+    releaseDate: 2006-07-17
     support: 2007-12-31
     eol: 2007-12-31
     latest: "10"
-    releaseDate: 2006-07-17
 
 ---
 
-> [Suse Linux Enterprise Server](https://www.suse.com/products/server/) is a modular linux distribution for both multimodal and traditional IT.
+> [Suse Linux Enterprise Server](https://www.suse.com/products/server/) is a modular linux
+> distribution for both multimodal and traditional IT.
 
-SLES has a thirteen-year product lifecycle. The current support model consists of 10 years of general support, followed by 3 years of Long Term Service Pack Support (LTSS). Major versions are released at an interval of 3–4 years, while minor versions (called "Service Packs") are released about every 12 months. SLES receives more intense testing than the upstream openSUSE community product.
+SLES has a thirteen-year product lifecycle. The current support model consists of 10 years of
+general support, followed by 3 years of Long Term Service Pack Support (LTSS). Major versions are
+released at an interval of 3–4 years, while minor versions (called "Service Packs") are released
+about every 12 months. SLES receives more intense testing than the upstream openSUSE community
+product.
 
 SLES 13 and SLES 14 version numbers were skipped. Advisories are published at <https://www.suse.com/support/update/>.

--- a/products/sles.md
+++ b/products/sles.md
@@ -10,10 +10,10 @@ alternate_urls:
 -   /suselinuxenterpriseserver
 versionCommand: cat /etc/os-release
 releasePolicyLink: https://www.suse.com/lifecycle
-changelogTemplate: "https://www.suse.com/releasenotes/x86_64/SUSE-SLES/{{'__LATEST__'|replace:'.','-SP'}}/"
+changelogTemplate: "https://www.suse.com/releasenotes/x86_64/SUSE-SLES/{{'__RELEASE_CYCLE__'|replace:'.','-SP'}}/"
 LTSLabel: "<abbr title='Long Term Service Pack Support'>LTSS</abbr>"
 activeSupportColumn: true
-releaseColumn: true
+releaseColumn: false
 releaseDateColumn: true
 
 identifiers:
@@ -25,133 +25,111 @@ releases:
     releaseDate: 2023-06-20
     support: true
     eol: false
-    latest: "15.5"
 
 -   releaseCycle: "15.4"
     releaseDate: 2022-06-21
     support: 2023-12-31
     eol: 2026-12-31
-    latest: "15.4"
 
 -   releaseCycle: "15.3"
     releaseDate: 2021-06-22
     support: 2022-12-31
     eol: 2025-12-31
-    latest: "15.3"
 
 -   releaseCycle: "15.2"
     releaseDate: 2020-07-21
     support: 2021-12-31
     eol: 2024-12-31
-    latest: "15.2"
 
 -   releaseCycle: "15.1"
     releaseDate: 2019-06-24
     support: 2021-01-31
     eol: 2024-01-31
-    latest: "15.1"
 
 -   releaseCycle: "15"
     releaseDate: 2018-07-16
     support: 2019-12-31
     eol: 2022-12-31
-    latest: "15"
 
 -   releaseCycle: "12.5"
     releaseDate: 2019-12-09
     support: 2024-10-31
     eol: 2027-10-31
-    latest: "12.5"
 
 -   releaseCycle: "12.4"
     releaseDate: 2018-12-12
     support: 2020-06-30
     eol: 2023-06-30
-    latest: "12.4"
 
 -   releaseCycle: "12.3"
     releaseDate: 2017-09-07
     support: 2019-06-30
     eol: 2022-06-30
-    latest: "12.3"
 
 -   releaseCycle: "12.2"
     releaseDate: 2016-11-08
     support: 2018-03-31
     eol: 2021-03-31
-    latest: "12.2"
 
 -   releaseCycle: "12.1"
     releaseDate: 2015-12-15
     support: 2017-05-31
     eol: 2020-05-31
-    latest: "12.1"
 
 -   releaseCycle: "12"
     releaseDate: 2014-10-27
     support: 2016-06-30
     eol: 2019-07-01
-    latest: "12"
 
 -   releaseCycle: "11.4"
     releaseDate: 2015-07-15
     support: 2019-03-31
     eol: 2022-03-31
-    latest: "11.4"
 
 -   releaseCycle: "11.3"
     releaseDate: 2013-07-01
     support: 2016-01-31
     eol: 2019-01-30
-    latest: "11.3"
 
 -   releaseCycle: "11.2"
     releaseDate: 2012-02-29
     support: 2014-01-31
     eol: 2017-01-30
-    latest: "11.2"
 
 -   releaseCycle: "11.1"
     releaseDate: 2010-06-02
     support: 2012-08-31
     eol: 2015-08-30
-    latest: "11.1"
 
 -   releaseCycle: "11"
     releaseDate: 2009-03-24
     support: 2010-12-31
     eol: 2010-12-31
-    latest: "11"
 
 -   releaseCycle: "10.4"
     releaseDate: 2011-04-12
     support: 2013-07-31
     eol: 2016-07-30
-    latest: "10.4"
 
 -   releaseCycle: "10.3"
     releaseDate: 2009-10-12
     support: 2011-10-11
     eol: 2014-10-31
-    latest: "10.3"
 
 -   releaseCycle: "10.2"
     releaseDate: 2008-05-19
     support: 2010-04-11
     eol: 2013-04-10
-    latest: "10.2"
 
 -   releaseCycle: "10.1"
     releaseDate: 2007-06-18
     support: 2008-11-30
     eol: 2010-12-31
-    latest: "10.1"
 
 -   releaseCycle: "10"
     releaseDate: 2006-07-17
     support: 2007-12-31
     eol: 2007-12-31
-    latest: "10"
 
 ---
 

--- a/products/sles.md
+++ b/products/sles.md
@@ -12,9 +12,9 @@ versionCommand: cat /etc/os-release
 releasePolicyLink: https://www.suse.com/lifecycle
 changelogTemplate: "https://www.suse.com/releasenotes/x86_64/SUSE-SLES/{{'__RELEASE_CYCLE__'|replace:'.','-SP'}}/"
 LTSLabel: "<abbr title='Long Term Service Pack Support'>LTSS</abbr>"
-activeSupportColumn: true
 releaseColumn: false
 releaseDateColumn: true
+extendedSupportColumn: true
 
 identifiers:
 -   cpe: cpe:/o:suse:sles

--- a/products/sles.md
+++ b/products/sles.md
@@ -18,9 +18,14 @@ identifiers:
 -   cpe: cpe:/o:suse:sles
 -   cpe: cpe:2.3:o:suse:sles
 releases:
+-   releaseCycle: "15.5"
+    support: true
+    eol: true
+    latest: "15.5"
+    releaseDate: 2023-06-20
 -   releaseCycle: "15.4"
-    support: false
-    eol: false
+    support: 2023-12-31
+    eol: 2026-12-31
     latest: "15.4"
     releaseDate: 2022-06-21
 -   releaseCycle: "15.3"

--- a/products/sles.md
+++ b/products/sles.md
@@ -11,10 +11,10 @@ alternate_urls:
 versionCommand: cat /etc/os-release
 releasePolicyLink: https://www.suse.com/lifecycle
 changelogTemplate: "https://www.suse.com/releasenotes/x86_64/SUSE-SLES/{{'__RELEASE_CYCLE__'|replace:'.','-SP'}}/"
-LTSLabel: "<abbr title='Long Term Service Pack Support'>LTSS</abbr>"
 releaseColumn: false
 releaseDateColumn: true
-extendedSupportColumn: true
+eolColumn: General Support
+extendedSupportColumn: Long Term Service Pack Support
 
 identifiers:
 -   cpe: cpe:/o:suse:sles
@@ -137,7 +137,7 @@ releases:
 > [Suse Linux Enterprise Server](https://www.suse.com/products/server/) is a modular linux
 > distribution for both multimodal and traditional IT.
 
-SLES has a thirteen-year product lifecycle. The current support model consists of 10 years of
+SLES has a thirteen-year product lifecycle for major versions. The current support model consists of 10 years of
 general support, followed by up to 3 years of paid Long Term Service Pack Support (LTSS). Major versions are
 released at an interval of 3–4 years, while minor versions (called "Service Packs") are released
 about every 12 months. SLES receives more intense testing than the upstream openSUSE community

--- a/products/sles.md
+++ b/products/sles.md
@@ -24,7 +24,7 @@ releases:
 -   releaseCycle: "15.5"
     releaseDate: 2023-06-20
     support: true
-    eol: true
+    eol: false
     latest: "15.5"
 
 -   releaseCycle: "15.4"
@@ -114,7 +114,7 @@ releases:
 -   releaseCycle: "11.1"
     releaseDate: 2010-06-02
     support: 2012-08-31
-    eol: 2012-08-31
+    eol: 2015-08-30
     latest: "11.1"
 
 -   releaseCycle: "11"
@@ -126,7 +126,7 @@ releases:
 -   releaseCycle: "10.4"
     releaseDate: 2011-04-12
     support: 2013-07-31
-    eol: 2016-07-31
+    eol: 2016-07-30
     latest: "10.4"
 
 -   releaseCycle: "10.3"

--- a/products/sles.md
+++ b/products/sles.md
@@ -130,6 +130,7 @@ releases:
     releaseDate: 2006-07-17
     eol: 2007-12-31
     extendedSupport: 2007-12-31
+    link: null
 
 ---
 


### PR DESCRIPTION
I've added minor SLES releases as separate releases so that complete information about SLES releases is available. It's a continuation of efforts from my PR to release-data repository: https://github.com/endoflife-date/release-data/pull/103.

A few remarks:
- I'm not sure how to handle the topic of patches - the [Live Patch Updates](https://www.suse.com/support/update/) could be used to indicate latest patch version (`latest` and `latestReleaseDate` properties) but I could find them only for SLES 12+.
- For SLES 10 and 11 (without service pack) [the LTSS Ends date are missing (marked as "N/A")](https://www.suse.com/lifecycle#suse-linux-enterprise-server-10). I've put `eol` equal to `support` for them but perhaps it should be written in another way.
- The release notes for SLES 10 (without service pack) are at least currently unavailable - [you can check it yourselves](https://www.suse.com/releasenotes/x86_64/SUSE-SLES/10/index.html). It's the only version for which the template link doesn't work. If it isn't a temporary error, perhaps the link for SLES 10 should be made null?