### PR TITLE
Fix EOLs on apache-cassandra.md

### DIFF
--- a/products/apache-cassandra.md
+++ b/products/apache-cassandra.md
@@ -14,46 +14,48 @@ auto:
 
 releases:
 -   releaseCycle: "4.1"
-    eol: 2025-05-01
+    eol: 2025-07-15
     support: true
     releaseDate: 2022-12-13
     latest: "4.1.2"
     latestReleaseDate: 2023-05-29
 -   releaseCycle: "4.0"
-    eol: 2024-05-01
+    eol: 2024-07-15
     support: true
     releaseDate: 2021-07-26
     latest: "4.0.10"
     latestReleaseDate: 2023-05-29
 -   releaseCycle: "3.11"
-    eol: 2023-05-01
+    eol: 2023-12-01
     support: true
     releaseDate: 2017-06-23
     latest: "3.11.15"
     discontinued: true
     latestReleaseDate: 2023-05-05
 -   releaseCycle: "3.0"
-    eol: 2023-05-01
+    eol: 2023-12-15
     support: true
     releaseDate: 2015-11-09
     latest: "3.0.29"
     discontinued: true
-    latestReleaseDate: 2023-05-15
+    latestReleaseDate: 2023-05-01
 
 ---
 
 > [Apache Cassandra](https://cassandra.apache.org) is a free and open-source, distributed, wide-column store, NoSQL database management system designed to handle large amounts of data across many commodity servers, providing high availability with no single point of failure.
 
-Three GA releases (MAJOR and/or MINOR) are supported at any given time. The release of a new MINOR or MAJOR will cause the oldest supported GA release to go End-of-Life. The 3.0 release will be supported for one more cycle, on an exceptional basis.
+Three major GA releases (MAJOR and/or MINOR versions) are supported at any given time. The release of a new MINOR or MAJOR version will cause the oldest supported GA release to go End-of-Life. The 3.0 release will be supported for one more cycle, on an exceptional basis.
 
 ## [Versioning](https://cassandra.apache.org/_/blog/Behind-the-scenes-of-an-Apache-Cassandra-Release.html)
 
 Cassandra follows [SemVer](https://semver.org/). These are the rough heuristics followed for what can be included in a given release.
 
 * Patch releases on a GA branch should only include bug fixes.
-* Minor release should prioritize introducing new, non-API changing, and non-default behavior breaking features and changes (Bug Fix, Improvements, New Features).
-* Disruptive changes (API changes, protocol changes, etc.) are deferred to Major releases.
+* Minor versions are always upgradable without downtime from any minor version from the previous major version. For example an upgrade from a 3.x version to a 5.x version is not supported. Only upgrades stepping through each major version (3.x -> 4.x -> 5.x) is supported. 
+* Disruptive changes that prevent always-up upgrades from the previous major versions are deferred to the next non-adjacent Major version.
+
+As an always-on technology, Cassandra does not break user-facing API compatabilities without a deprecated grace period demarcated by major versions.
 
 ## Release Cadence
 
-The project currently targets yearly Minor or Major releases (depending on whether they’re API breaking or not). Patch releases are cut based on either volume of fixes or severity of bugfixes that get committed to the project.
+The project currently targets yearly major releases (can be a new major or minor version, depending on upgrade compatability). Patch releases are cut based on either volume of fixes or severity of bugfixes that get committed to the project.

--- a/products/apache-cassandra.md
+++ b/products/apache-cassandra.md
@@ -51,8 +51,8 @@ Three major GA releases (MAJOR and/or MINOR versions) are supported at any given
 Cassandra follows [SemVer](https://semver.org/). These are the rough heuristics followed for what can be included in a given release.
 
 * Patch releases on a GA branch should only include bug fixes.
-* Minor versions are always upgradable without downtime from any minor version from the previous major version. For example an upgrade from a 3.x version to a 5.x version is not supported. Only upgrades stepping through each major version (3.x -> 4.x -> 5.x) are supported. 
-* Disruptive changes that prevent always-up upgrades from the previous major versions are deferred to the next non-adjacent Major version.
+* Minor versions are always upgradable without downtime from any minor version from the previous major version. For example an upgrade from a 3.x version to a 5.x version is not supported. Only upgrades stepping through each major version (3.x -> 4.x -> 5.x) are supported.
+* Disruptive changes that prevent always-up upgrades from the previous major versions are deferred to the next-to-next major version.
 
 As an always-on technology, Cassandra does not break user-facing API compatabilities without a deprecated grace period demarcated by major versions.
 

--- a/products/apache-cassandra.md
+++ b/products/apache-cassandra.md
@@ -51,7 +51,7 @@ Three major GA releases (MAJOR and/or MINOR versions) are supported at any given
 Cassandra follows [SemVer](https://semver.org/). These are the rough heuristics followed for what can be included in a given release.
 
 * Patch releases on a GA branch should only include bug fixes.
-* Minor versions are always upgradable without downtime from any minor version from the previous major version. For example an upgrade from a 3.x version to a 5.x version is not supported. Only upgrades stepping through each major version (3.x -> 4.x -> 5.x) is supported. 
+* Minor versions are always upgradable without downtime from any minor version from the previous major version. For example an upgrade from a 3.x version to a 5.x version is not supported. Only upgrades stepping through each major version (3.x -> 4.x -> 5.x) are supported. 
 * Disruptive changes that prevent always-up upgrades from the previous major versions are deferred to the next non-adjacent Major version.
 
 As an always-on technology, Cassandra does not break user-facing API compatabilities without a deprecated grace period demarcated by major versions.


### PR DESCRIPTION
Fix EOL dates, according to https://cassandra.apache.org/_/download.html

Fix semantics around major/minor terminology for releases versus (semver) versions.

Fix Versioning section, major versions are about operational compatibility between adjacent majors, not user-facing API changes.