### PR TITLE
[New Product] Amazon-Neptune

### DIFF
--- a/products/amazon-neptune.md
+++ b/products/amazon-neptune.md
@@ -8,51 +8,51 @@ releases:
 -   releaseCycle: "1.2.1.0"
     releaseDate: 2023-03-08
     eol: 2025-10-30
-    latest: "1.2.1.0"
-    latestReleaseDate: 2023-03-08
+    latest: "1.2.1.0.R3"
+    latestReleaseDate: 2023-06-13
     upgradeVersion: "N/A"
 
 -   releaseCycle: "1.2.0.2"
     releaseDate: 2022-11-16
     eol: 2024-10-31
-    latest: "1.2.0.2"
-    latestReleaseDate: 2022-11-16
+    latest: "1.2.0.2.R4"
+    latestReleaseDate: 2023-05-08
     upgradeVersion: "1.2.1.0"
 
 -   releaseCycle: "1.2.0.1"
     releaseDate: 2022-10-26
     eol: 2024-10-31
-    latest: "1.2.0.1"
-    latestReleaseDate: 2022-10-26
+    latest: "1.2.0.1.R2"
+    latestReleaseDate: 2022-12-13
     upgradeVersion: "1.2.1.0"
 
 -   releaseCycle: "1.2.0.0"
     releaseDate: 2022-07-21
     eol: 2024-10-31
-    latest: "1.2.0.0"
-    latestReleaseDate: 2022-07-21
+    latest: "1.2.0.0.R2"
+    latestReleaseDate: 2022-10-14
     upgradeVersion: "1.2.1.0"
 
 -   releaseCycle: "1.1.1.0"
     releaseDate: 2022-04-19
     eol: 2024-10-31
-    latest: "1.1.1.0"
-    latestReleaseDate: 2022-04-19
+    latest: "1.1.1.0.R6"
+    latestReleaseDate: 2022-09-23
     upgradeVersion: "1.2.1.0"
 
 -   releaseCycle: "1.1.0.0"
     releaseDate: 2021-11-19
     eol: 2024-01-30
-    latest: "1.1.0.0"
-    latestReleaseDate: 2021-11-19
+    latest: "1.1.0.0.R2"
+    latestReleaseDate: 2022-05-16
     upgradeVersion: "1.1.1.0"
 
 # Use a single row for all 1.0.x releases
 -   releaseCycle: "1.0"
     releaseDate: 2019-07-02
     eol: 2023-01-30
-    latest: "1.0.5.1"
-    latestReleaseDate: 2021-10-01
+    latest: "1.0.5.1.R4"
+    latestReleaseDate: 2022-05-16
     upgradeVersion: "1.1.0.0"
 ---
 
@@ -70,6 +70,10 @@ In general, Neptune engine versions continue to be available as follows:
 
 - **Minor engine versions**: remain available for at least 6 months following their release.
 - **Major engine versions**: remain available for at least 12 months following their release.
+
+New engine versions are announced on the [Changes and Updates](https://docs.aws.amazon.com/neptune/latest/userguide/doc-history.html)
+page, as well as [published via an RSS feed](https://docs.aws.amazon.com/neptune/latest/userguide/rssupdates.rss).
+It takes several days for a new release to become available in every region.
 
 At least 3 months before an engine version reaches its End-of-life, AWS sends an
 automated email notification and posts the same message to the AWS Health Dashboard. This

--- a/products/amazon-neptune.md
+++ b/products/amazon-neptune.md
@@ -3,6 +3,7 @@ title: Amazon-Neptune
 category: service
 tags: amazon
 permalink: https://docs.aws.amazon.com/neptune/latest/userguide/engine-releases.html
+versionCommand: aws neptune describe-db-clusters --db-cluster-identifier your-neptune-db-identifier --filters Name=engine,Values=neptune
 releases:
 -   releaseCycle: "1.2.1.0"
     releaseDate: 2023-03-08

--- a/products/amazon-neptune.md
+++ b/products/amazon-neptune.md
@@ -3,7 +3,10 @@ title: Amazon-Neptune
 category: service
 tags: amazon
 permalink: https://docs.aws.amazon.com/neptune/latest/userguide/engine-releases.html
-versionCommand: aws neptune describe-db-clusters --db-cluster-identifier your-neptune-db-identifier --filters Name=engine,Values=neptune
+versionCommand: >
+    aws neptune describe-db-clusters
+    --db-cluster-identifier your-neptune-db-identifier
+    --filters Name=engine,Values=neptune
 releases:
 -   releaseCycle: "1.2.1.0"
     releaseDate: 2023-03-08

--- a/products/amazon-neptune.md
+++ b/products/amazon-neptune.md
@@ -7,66 +7,67 @@ versionCommand: >
     aws neptune describe-db-clusters
     --db-cluster-identifier your-neptune-db-identifier
     --filters Name=engine,Values=neptune
+
 releases:
 -   releaseCycle: "1.2.1.0"
     releaseDate: 2023-03-08
     eol: 2025-10-30
+    upgradeVersion: "N/A"
     latest: "1.2.1.0.R3"
     latestReleaseDate: 2023-06-13
-    upgradeVersion: "N/A"
 
 -   releaseCycle: "1.2.0.2"
     releaseDate: 2022-11-16
     eol: 2024-10-31
+    upgradeVersion: "1.2.1.0"
     latest: "1.2.0.2.R4"
     latestReleaseDate: 2023-05-08
-    upgradeVersion: "1.2.1.0"
 
 -   releaseCycle: "1.2.0.1"
     releaseDate: 2022-10-26
     eol: 2024-10-31
+    upgradeVersion: "1.2.1.0"
     latest: "1.2.0.1.R2"
     latestReleaseDate: 2022-12-13
-    upgradeVersion: "1.2.1.0"
 
 -   releaseCycle: "1.2.0.0"
     releaseDate: 2022-07-21
     eol: 2024-10-31
+    upgradeVersion: "1.2.1.0"
     latest: "1.2.0.0.R2"
     latestReleaseDate: 2022-10-14
-    upgradeVersion: "1.2.1.0"
 
 -   releaseCycle: "1.1.1.0"
     releaseDate: 2022-04-19
     eol: 2024-10-31
+    upgradeVersion: "1.2.1.0"
     latest: "1.1.1.0.R6"
     latestReleaseDate: 2022-09-23
-    upgradeVersion: "1.2.1.0"
 
 -   releaseCycle: "1.1.0.0"
     releaseDate: 2021-11-19
     eol: 2024-01-30
+    upgradeVersion: "1.1.1.0"
     latest: "1.1.0.0.R2"
     latestReleaseDate: 2022-05-16
-    upgradeVersion: "1.1.1.0"
 
 # Use a single row for all 1.0.x releases
 -   releaseCycle: "1.0"
     releaseDate: 2019-07-02
     eol: 2023-01-30
+    upgradeVersion: "1.1.0.0"
     latest: "1.0.5.1.R4"
     latestReleaseDate: 2022-05-16
-    upgradeVersion: "1.1.0.0"
+
 ---
 
-> [Amazon Neptune](https://docs.aws.amazon.com/neptune/index.html) is a fast, reliable,
->  fully managed graph database service that makes it easy to build and run applications
->  that work with highly connected datasets. It supports multiple property-graph
->  query languages - Apache TinkerPop Gremlin, openCypher, and SPARQL. 
->  Neptune powers graph use cases such as recommendation engines,
->  fraud detection, knowledge graphs, drug discovery, and network security.
+> [Amazon Neptune](https://docs.aws.amazon.com/neptune/index.html) is a fast, reliable, fully
+> managed graph database service that makes it easy to build and run applications that work with
+> highly connected datasets. It supports multiple property-graph query languages: Apache TinkerPop,
+> Gremlin, openCypher, and SPARQL. Neptune powers graph use cases such as recommendation engines,
+> fraud detection, knowledge graphs, drug discovery, and network security.
 
-Neptune engine versions almost always reach their end-of-life at the end of a calendar quarter. 
+Neptune engine versions almost always reach their end-of-life at the end of a calendar quarter.
 Exceptions occur only when important security or availability issues arise.
 
 In general, Neptune engine versions continue to be available as follows:
@@ -78,14 +79,14 @@ New engine versions are announced on the [Changes and Updates](https://docs.aws.
 page, as well as [published via an RSS feed](https://docs.aws.amazon.com/neptune/latest/userguide/rssupdates.rss).
 It takes several days for a new release to become available in every region.
 
-At least 3 months before an engine version reaches its End-of-life, AWS sends an
-automated email notification and posts the same message to the AWS Health Dashboard. This
-will include details about the update (upgraded version,  impact on clusters, recommended actions).
+At least 3 months before an engine version reaches its End-of-life, AWS sends an automated email
+notification and posts the same message to the AWS Health Dashboard. This will include details about
+the update (upgraded version, impact on clusters, recommended actions).
 
-When an engine version reaches its end of life, customers can no longer
-create new clusters or instances using that version, nor will autoscaling be
-able to create instances using that version. An engine version that reaches 
-its end of life will automatically be upgraded during a maintenance window.
+When an engine version reaches its end of life, customers can no longer create new clusters or
+instances using that version, nor will autoscaling be able to create instances using that version.
+An engine version that reaches its end of life will automatically be upgraded during a maintenance
+window.
 
 Legacy Engines are not considered Generally Available, and AWS guarantees no support for the same.
 Databases running on a Legacy Engine are subject to Service Level Agreement (SLA) Exceptions.

--- a/products/amazon-neptune.md
+++ b/products/amazon-neptune.md
@@ -4,29 +4,55 @@ category: service
 tags: amazon
 permalink: https://docs.aws.amazon.com/neptune/latest/userguide/engine-releases.html
 releases:
--   releaseCycle: "1.2"
-    releaseDate: 2022-07-21
+-   releaseCycle: "1.2.1.0"
+    releaseDate: 2023-03-08
     eol: 2025-10-30
     latest: "1.2.1.0"
     latestReleaseDate: 2023-03-08
-    
--   releaseCycle: "1.1"
-    releaseDate: 2021-11-19
+    upgradeVersion: "N/A"
+
+-   releaseCycle: "1.2.0.2"
+    releaseDate: 2022-11-16
+    eol: 2024-10-31
+    latest: "1.2.0.2"
+    latestReleaseDate: 2022-11-16
+    upgradeVersion: "1.2.1.0"
+
+-   releaseCycle: "1.2.0.1"
+    releaseDate: 2022-10-26
+    eol: 2024-10-31
+    latest: "1.2.0.1"
+    latestReleaseDate: 2022-10-26
+    upgradeVersion: "1.2.1.0"
+
+-   releaseCycle: "1.2.0.0"
+    releaseDate: 2022-07-21
+    eol: 2024-10-31
+    latest: "1.2.0.0"
+    latestReleaseDate: 2022-07-21
+    upgradeVersion: "1.2.1.0"
+
+-   releaseCycle: "1.1.1.0"
+    releaseDate: 2022-04-19
     eol: 2024-10-31
     latest: "1.1.1.0"
     latestReleaseDate: 2022-04-19
+    upgradeVersion: "1.2.1.0"
 
+-   releaseCycle: "1.1.0.0"
+    releaseDate: 2021-11-19
+    eol: 2024-01-30
+    latest: "1.1.0.0"
+    latestReleaseDate: 2021-11-19
+    upgradeVersion: "1.1.1.0"
+
+# Use a single row for all 1.0.x releases
 -   releaseCycle: "1.0"
     releaseDate: 2019-07-02
     eol: 2023-01-30
     latest: "1.0.5.1"
     latestReleaseDate: 2021-10-01
-    
--   releaseCycle: "1.0"
-    releaseDate: 2021-07-27
-    eol: 2023-01-30
-    latest: "1.0.5.1"
-    latestReleaseDate: 2021-10-01  
+    upgradeVersion: "1.1.0.0"
 ---
 
 > [Amazon Neptune](https://docs.aws.amazon.com/neptune/index.html) is a fast, reliable,
@@ -37,27 +63,27 @@ releases:
 >  fraud detection, knowledge graphs, drug discovery, and network security.
 
 Neptune engine versions almost always reach their end-of-life at the end of a calendar quarter. 
-Exceptions occur only when important security or availability issues arise. When an engine
-version reaches its end of life, you will be required to upgrade your Neptune database
-to a newer version.
+Exceptions occur only when important security or availability issues arise.
 
 In general, Neptune engine versions continue to be available as follows:
 
 - **Minor engine versions**: remain available for at least 6 months following their release.
 - **Major engine versions**: remain available for at least 12 months following their release.
 
-At least 3 months before an engine version reaches its End-of-life, AWS will send an
-automated email notification to the email address associated with your AWS account
-and post the same message to your AWS Health Dashboard. This will give you time to
-plan and prepare to upgrade.
+At least 3 months before an engine version reaches its End-of-life, AWS sends an
+automated email notification and posts the same message to the AWS Health Dashboard. This
+will include details about the update (upgraded version,  impact on clusters, recommended actions).
 
-When an engine version reaches its end of life, you will no longer be able to
+When an engine version reaches its end of life, customers can no longer
 create new clusters or instances using that version, nor will autoscaling be
-able to create instances using that version.
+able to create instances using that version. An engine version that reaches 
+its end of life will automatically be upgraded during a maintenance window.
 
-An engine version that actually reaches its end of life will automatically
-be upgraded during a maintenance window. The message sent to you 3 months
-before the engine version's end of life will contain details about what this
-automatic update would involve, including the version to which you would be
-automatically upgraded, the impact on your DB clusters, and actions that we
-recommend.
+Legacy Engines are not considered Generally Available, and AWS guarantees no support for the same.
+Databases running on a Legacy Engine are subject to Service Level Agreement (SLA) Exceptions.
+
+{% include table.html
+labels="Engine Version,Upgrade To"
+fields="releaseCycle,upgradeVersion"
+types="string,string"
+rows=page.releases %}

--- a/products/amazon-neptune.md
+++ b/products/amazon-neptune.md
@@ -1,8 +1,9 @@
 ---
-title: Amazon-Neptune
+title: Amazon Neptune
 category: service
 tags: amazon
-permalink: https://docs.aws.amazon.com/neptune/latest/userguide/engine-releases.html
+permalink: /amazon-neptune
+releasePolicyLink: https://docs.aws.amazon.com/neptune/latest/userguide/engine-releases.html
 versionCommand: >
     aws neptune describe-db-clusters
     --db-cluster-identifier your-neptune-db-identifier

--- a/products/amazon-neptune.md
+++ b/products/amazon-neptune.md
@@ -1,5 +1,4 @@
 ---
-
 title: Amazon-Neptune
 category: db
 tags: amazon
@@ -29,23 +28,38 @@ releases:
     releaseDate: 2021-07-27
     eol: 2023-01-30
     latest: "1.0.5.1"
-    latestReleaseDate: 2021-10-01
-    
-    
+    latestReleaseDate: 2021-10-01  
 ---
 
-Amazon Neptune is a fast, reliable, fully managed graph database service that makes it easy to build and run applications that work with highly connected datasets. The core of Neptune is a purpose-built, high-performance graph database engine. This engine is optimized for storing billions of relationships and querying the graph with milliseconds latency. Neptune supports the popular property-graph query languages Apache TinkerPop Gremlin and Neo4j's openCypher, and the W3C's RDF query language, SPARQL. This enables you to build queries that efficiently navigate highly connected datasets. Neptune powers graph use cases such as recommendation engines, fraud detection, knowledge graphs, drug discovery, and network security. "https://docs.aws.amazon.com/neptune/index.html"
+> [Amazon Neptune](https://docs.aws.amazon.com/neptune/index.html) is a fast, reliable,
+>  fully managed graph database service that makes it easy to build and run applications
+>  that work with highly connected datasets. It supports multiple property-graph
+>  query languages - Apache TinkerPop Gremlin, openCypher, and SPARQL. 
+>  Neptune powers graph use cases such as recommendation engines,
+>  fraud detection, knowledge graphs, drug discovery, and network security.
 
-
-Neptune engine versions almost always reach their end of life at the end of a calendar quarter. Exceptions occur only when important security or availability issues arise.
-When an engine version reaches its end of life, you will be required to upgrade your Neptune database to a newer version.
+Neptune engine versions almost always reach their end-of-life at the end of a calendar quarter. 
+Exceptions occur only when important security or availability issues arise. When an engine
+version reaches its end of life, you will be required to upgrade your Neptune database
+to a newer version.
 
 In general, Neptune engine versions continue to be available as follows:
-Minor engine versions: Minor engine versions remain available for at least 6 months following their release.
-Major engine versions: Major engine versions remain available for at least 12 months following their release.
 
-At least 3 months before an engine version reaches its end of life, AWS will send an automated email notification to the email address associated with your AWS account and post the same message to your AWS Health Dashboard. This will give you time to plan and prepare to upgrade.
+- **Minor engine versions**: remain available for at least 6 months following their release.
+- **Major engine versions**: remain available for at least 12 months following their release.
 
-When an engine version reaches its end of life, you will no longer be able to create new clusters or instances using that version, nor will autoscaling be able to create instances using that version.
+At least 3 months before an engine version reaches its End-of-life, AWS will send an
+automated email notification to the email address associated with your AWS account
+and post the same message to your AWS Health Dashboard. This will give you time to
+plan and prepare to upgrade.
 
-An engine version that actually reaches its end of life will automatically be upgraded during a maintenance window. The message sent to you 3 months before the engine version's end of life will contain details about what this automatic update would involve, including the version to which you would be automatically upgraded, the impact on your DB clusters, and actions that we recommend.
+When an engine version reaches its end of life, you will no longer be able to
+create new clusters or instances using that version, nor will autoscaling be
+able to create instances using that version.
+
+An engine version that actually reaches its end of life will automatically
+be upgraded during a maintenance window. The message sent to you 3 months
+before the engine version's end of life will contain details about what this
+automatic update would involve, including the version to which you would be
+automatically upgraded, the impact on your DB clusters, and actions that we
+recommend.

--- a/products/amazon-neptune.md
+++ b/products/amazon-neptune.md
@@ -1,10 +1,8 @@
 ---
 title: Amazon-Neptune
-category: db
+category: service
 tags: amazon
 permalink: https://docs.aws.amazon.com/neptune/latest/userguide/engine-releases.html
-auto:
--   custom: true
 releases:
 -   releaseCycle: "1.2"
     releaseDate: 2022-07-21

--- a/products/amazon-neptune.md
+++ b/products/amazon-neptune.md
@@ -1,4 +1,6 @@
-Title: Amazon-Neptune
+---
+
+title: Amazon-Neptune
 category: db
 tags: amazon
 permalink: https://docs.aws.amazon.com/neptune/latest/userguide/engine-releases.html

--- a/products/amazon-neptune.md
+++ b/products/amazon-neptune.md
@@ -1,0 +1,49 @@
+Title: Amazon-Neptune
+category: db
+tags: amazon
+permalink: https://docs.aws.amazon.com/neptune/latest/userguide/engine-releases.html
+auto:
+-   custom: true
+releases:
+-   releaseCycle: "1.2"
+    releaseDate: 2022-07-21
+    eol: 2025-10-30
+    latest: "1.2.1.0"
+    latestReleaseDate: 2023-03-08
+    
+-   releaseCycle: "1.1"
+    releaseDate: 2021-11-19
+    eol: 2024-10-31
+    latest: "1.1.1.0"
+    latestReleaseDate: 2022-04-19
+
+-   releaseCycle: "1.0"
+    releaseDate: 2019-07-02
+    eol: 2023-01-30
+    latest: "1.0.5.1"
+    latestReleaseDate: 2021-10-01
+    
+-   releaseCycle: "1.0"
+    releaseDate: 2021-07-27
+    eol: 2023-01-30
+    latest: "1.0.5.1"
+    latestReleaseDate: 2021-10-01
+    
+    
+---
+
+Amazon Neptune is a fast, reliable, fully managed graph database service that makes it easy to build and run applications that work with highly connected datasets. The core of Neptune is a purpose-built, high-performance graph database engine. This engine is optimized for storing billions of relationships and querying the graph with milliseconds latency. Neptune supports the popular property-graph query languages Apache TinkerPop Gremlin and Neo4j's openCypher, and the W3C's RDF query language, SPARQL. This enables you to build queries that efficiently navigate highly connected datasets. Neptune powers graph use cases such as recommendation engines, fraud detection, knowledge graphs, drug discovery, and network security. "https://docs.aws.amazon.com/neptune/index.html"
+
+
+Neptune engine versions almost always reach their end of life at the end of a calendar quarter. Exceptions occur only when important security or availability issues arise.
+When an engine version reaches its end of life, you will be required to upgrade your Neptune database to a newer version.
+
+In general, Neptune engine versions continue to be available as follows:
+Minor engine versions: Minor engine versions remain available for at least 6 months following their release.
+Major engine versions: Major engine versions remain available for at least 12 months following their release.
+
+At least 3 months before an engine version reaches its end of life, AWS will send an automated email notification to the email address associated with your AWS account and post the same message to your AWS Health Dashboard. This will give you time to plan and prepare to upgrade.
+
+When an engine version reaches its end of life, you will no longer be able to create new clusters or instances using that version, nor will autoscaling be able to create instances using that version.
+
+An engine version that actually reaches its end of life will automatically be upgraded during a maintenance window. The message sent to you 3 months before the engine version's end of life will contain details about what this automatic update would involve, including the version to which you would be automatically upgraded, the impact on your DB clusters, and actions that we recommend.


### PR DESCRIPTION
There is no AWS API to get End of life dates for RDS databases.

Better have this on an open-source platform than an individual web-scraper.