### PR TITLE
[gitlab] Update thresholds

### DIFF
--- a/products/gitlab.md
+++ b/products/gitlab.md
@@ -9,7 +9,9 @@ releasePolicyLink: https://docs.gitlab.com/ce/policy/maintenance.html
 changelogTemplate: https://gitlab.com/gitlab-org/gitlab/-/releases/v__RELEASE_CYCLE__.0-ee
 releaseDateColumn: true
 activeSupportColumn: true
+activeSupportWarnThreshold: 20
 eolColumn: Maintenance Support
+eolWarnThreshold: 60
 
 auto:
 # Reference: https://rubular.com/r/mFfxB8FgXXERX4


### PR DESCRIPTION
The activeSupport is for one month -> `activeSupportWarnThreshold: 20`
The eol is 3 months after release -> `eolWarnThreshold: 60`