### PR TITLE
[spring-boot] Add Java 20 to supported Java versions

### DIFF
--- a/products/spring-boot.md
+++ b/products/spring-boot.md
@@ -22,7 +22,7 @@ auto:
 # EOL dates can be found on https://spring.io/projects/spring-boot#support
 releases:
 -   releaseCycle: "3.1"
-    supportedJavaVersions: "17 - 20" # https://docs.spring.io/spring-boot/docs/3.1.0/reference/html/getting-started.html#getting-started.system-requirements
+    supportedJavaVersions: "17 - 20" # https://docs.spring.io/spring-boot/docs/3.1.1/reference/html/getting-started.html#getting-started.system-requirements
     releaseDate: 2023-05-18
     eol: 2024-05-18
     extendedSupport: 2025-08-18
@@ -30,7 +30,7 @@ releases:
     latestReleaseDate: 2023-06-22
 
 -   releaseCycle: "3.0"
-    supportedJavaVersions: "17 - 19" # https://docs.spring.io/spring-boot/docs/3.0.2/reference/html/getting-started.html#getting-started.system-requirements
+    supportedJavaVersions: "17 - 20" # https://docs.spring.io/spring-boot/docs/3.0.8/reference/html/getting-started.html#getting-started.system-requirements
     releaseDate: 2022-11-24
     eol: 2023-11-24
     extendedSupport: 2025-02-24
@@ -38,7 +38,7 @@ releases:
     latestReleaseDate: 2023-06-22
 
 -   releaseCycle: "2.7"
-    supportedJavaVersions: "8 - 19" # https://docs.spring.io/spring-boot/docs/2.7.8/reference/html/getting-started.html#getting-started.system-requirements
+    supportedJavaVersions: "8 - 20" # https://docs.spring.io/spring-boot/docs/2.7.13/reference/html/getting-started.html#getting-started.system-requirements
     releaseDate: 2022-05-19
     eol: 2023-11-18
     extendedSupport: 2025-02-18


### PR DESCRIPTION
Spring Boot 2.7, 3.0, & 3.1 release cycles all support Java 20 as stated in the doc links I additionally updated. The recent release note also show Java 20 is supported:

- [v2.7.13](https://github.com/spring-projects/spring-boot/releases/tag/v2.7.13)
- [v3.0.8](https://github.com/spring-projects/spring-boot/releases/tag/v3.0.8)
- [v3.1.1](https://github.com/spring-projects/spring-boot/releases/tag/v3.1.1)