### PR TITLE
[.NET] Add purl identifier

### DIFF
--- a/products/dotnet.md
+++ b/products/dotnet.md
@@ -22,6 +22,9 @@ auto:
 -   git: https://github.com/dotnet/core.git
     regex: '^v(?<major>\d+)\.(?<minor>\d+)\.?(?<patch>\d{0,2})?$'
 
+identifiers:
+-   purl: pkg:nuget/Microsoft.NETCore.App
+
 releases:
 -   releaseCycle: "7.0"
     lts: false


### PR DESCRIPTION
An example from syft

```
$ syft mcr.microsoft.com/dotnet/sdk:5.0 -o json | grep "\"name\": \"Microsoft.NETCore.App\"" -A 10 -B 10

 ✔ Loaded image
 ✔ Parsed image
 ✔ Cataloged packages      [1674 packages]
   "metadata": {
    "name": "Microsoft.NET.StringTools",
    "version": "1.0.0",
    "path": "microsoft.net.stringtools/1.0.0",
    "sha512": "sha512-ZYVcoDM0LnSyT5nWoRGfShYdOecCw2sOXWwP6j1Z0u48Xq3+BVvZ+EiPCX9/8Gz439giW+O1H1kWF9Eb/w6rVg==",
    "hashPath": "microsoft.net.stringtools.1.0.0.nupkg.sha512"
   }
  },
  {
   "id": "ef7950afcbd80cc6",
   "name": "Microsoft.NETCore.App",
   "version": "5.0.17-servicing.22213.14",
   "type": "dotnet",
   "foundBy": "dotnet-deps-cataloger",
   "locations": [
    {
     "path": "/usr/share/dotnet/shared/Microsoft.NETCore.App/5.0.17/Microsoft.NETCore.App.deps.json",
     "layerID": "sha256:25c40e3d53abf3986e098e8eddfbc45d622cd39bb1c93fd17c90576b10f7aee3"
    }
   ],
   "licenses": [],
   "language": "dotnet",
   "cpes": [
    "cpe:2.3:a:Microsoft.NETCore.App:Microsoft.NETCore.App:5.0.17-servicing.22213.14:*:*:*:*:*:*:*"
   ],
   "purl": "pkg:nuget/Microsoft.NETCore.App@5.0.17-servicing.22213.14",
   "metadataType": "DotnetDepsMetadata",
   "metadata": {
    "name": "Microsoft.NETCore.App",
    "version": "5.0.17-servicing.22213.14",
    "path": "microsoft.netcore.app/5.0.17-servicing.22213.14",
    "sha512": "sha512-zw83CtBDRVJcWTJ/OGOtBeJBX0sGAW3ULKvVyTHRYCTohgbKCChEqD53xXJ9T3VDM0rORa7G2ih2b8GZ0AWvOw==",
    "hashPath": "microsoft.netcore.app.5.0.17-servicing.22213.14.nupkg.sha512"
   }
  },
  {
   "id": "4d78428a52f5cd24",
   "name": "Microsoft.NETCore.App.Internal",
   "version": "5.0.17-servicing.22213.14",
```