### PR TITLE
[nginx] Add 1.19

### DIFF
--- a/products/nginx.md
+++ b/products/nginx.md
@@ -68,7 +68,7 @@ releases:
 
 -   releaseCycle: "1.19"
     releaseDate: 2020-05-26
-    eol: 2021-07-01
+    eol: 2021-05-25
     latest: "1.19.10"
     latestReleaseDate: 2021-04-13
 

--- a/products/nginx.md
+++ b/products/nginx.md
@@ -66,6 +66,12 @@ releases:
     latest: "1.20.2"
     latestReleaseDate: 2021-11-16
 
+-   releaseCycle: "1.19"
+    releaseDate: 2020-05-26
+    eol: 2021-07-01
+    latest: "1.19.10"
+    latestReleaseDate: 2021-04-13
+
 -   releaseCycle: "1.18"
     releaseDate: 2020-04-21
     eol: 2021-04-20


### PR DESCRIPTION
# :grey_question: About

NGINX `1.19` seems to be missing on eol,  cf

-  #3215

The aim of this PR is to (try to) fix that.

# :bookmark_tabs: Resources

- NGINX Blog : [Introducing NGINX `1.18` and `1.19`](https://www.nginx.com/blog/nginx-1-18-1-19-released/)
- https://docs.nginx.com/nginx/releases/#nginxplusrelease-19-r19
- https://github.com/paketo-buildpacks/nginx/issues/258
- :whale:  [`nginx:1.19.10`](https://hub.docker.com/layers/library/nginx/1.19.10/images/sha256-37a736fc41095dae5d3003fbf4d7dc2374d51e9ecc3e58bdd37eeaf9f3b9e759?context=explore)
- [2021-04-13   nginx-1.19.10 mainline version has been released.](https://nginx.org/2021.html) 

![image](https://github.com/endoflife-date/endoflife.date/assets/5235127/831ea480-0661-4886-8a38-cddfda49b8fd)
