### PR TITLE
[camel] Adds 3.21

### DIFF
--- a/products/apache-camel.md
+++ b/products/apache-camel.md
@@ -20,6 +20,14 @@ auto:
 #   Camel may never release patches for non-LTS, but they can still be considered active.
 #   See https://github.com/endoflife-date/endoflife.date/pull/2328#discussion_r1086927567.
 releases:
+-   releaseCycle: "3.21"
+    releaseDate: 2023-06-23
+    eol: 2024-06-23
+    lts: true
+    supportedJavaVersions: 11, 17
+    latest: "3.21.0"
+    latestReleaseDate: 2023-06-23
+
 -   releaseCycle: "3.20"
     releaseDate: 2022-12-16
     eol: 2023-12-31


### PR DESCRIPTION
Marked as LTS, with 1 yr support as per https://camel.apache.org/releases/release-3.21.0/