### PR TITLE
[quarkus] Fix regex

### DIFF
--- a/products/quarkus.md
+++ b/products/quarkus.md
@@ -18,8 +18,8 @@ releaseColumn: true
 # The Quarkus team forgot to declare a GitHub release for 2.11.0.
 auto:
 -   github_releases: quarkusio/quarkus
-    # See https://rubular.com/r/NyoXd9iCLFcl25 for reference
-    regex: '^(?P<version>[1-9][\d\.]+)(\.Final)?$'
+    # See https://regex101.com/r/4mf9xU/1 for reference
+    regex: '^(?:Release )?(?P<version>[1-9][\d\.]+)(\.Final)?$'
 
 # Note:
 # - eol(x) = releaseDate(x+1) for non-LTS


### PR DESCRIPTION
The title of the latest release (`Release 2.16.8.Final`)  is different from what our regex expected.

Also see #3239