### PR TITLE
[squid] Adds 6.1

### DIFF
--- a/products/squid.md
+++ b/products/squid.md
@@ -41,7 +41,7 @@ releases:
     link: http://www.squid-cache.org/Versions/v6/squid-__LATEST__-RELEASENOTES.html
     eol: false
     latest: '6.1'
-    latestReleaseDate: 
+    latestReleaseDate: 2023-07-06
 
 -   releaseCycle: "5"
     releaseDate: 2021-07-31

--- a/products/squid.md
+++ b/products/squid.md
@@ -35,11 +35,18 @@ auto:
     regex:
       ^SQUID_((?<major>(2|3))_(?<minor>\d)_((STABLE)?(?<patch>\d+))|(?<major>[4-9])_(?<minor>\d+))$
 
-releases:
+releases: 
+-   releaseCycle: "6"
+    releaseDate: 2023-07-06
+    link: http://www.squid-cache.org/Versions/v6/squid-__LATEST__-RELEASENOTES.html
+    eol: false
+    latest: '6.1'
+    latestReleaseDate: 
+
 -   releaseCycle: "5"
     releaseDate: 2021-07-31
     link: http://www.squid-cache.org/Versions/v5/squid-__LATEST__-RELEASENOTES.html
-    eol: false
+    eol: 2023-07-06
     latest: '5.9'
     latestReleaseDate: 2023-05-01
 


### PR DESCRIPTION
Announcement: http://lists.squid-cache.org/pipermail/squid-announce/2023-July/000150.html

Squid 4 is also marked as EOL now: http://lists.squid-cache.org/pipermail/squid-announce/2023-July/000151.html, but since it hasn't had any updates in a while, I'm letting the old date stay.

I've marked v5 as EOL, based on my understanding of:

> Support for Squid-5 bug fixes has now officially ceased. Bugs in 5.x will continue to be fixed, however the fixes will be added to the 6.x series. All users of Squid-5.x are encouraged to plan for upgrades.

I've taken it to understand that there will be no more 5.x releases, and anyone wanting 5.x bugfixes will need to manually patch it or find a distro that will do it for them.