### PR TITLE
[pan-gp]Update latest GlobalProtect version 5.2.13-c418

### DIFF
--- a/products/pan-gp.md
+++ b/products/pan-gp.md
@@ -49,7 +49,7 @@ releases:
     releaseDate: 2020-07-30
     latest: "5.2.13-c418"
     latestReleaseDate: 2023-07-11
-    link: https://docs.paloaltonetworks.com/globalprotect/5-2/globalprotect-app-release-notes
+    link: https://docs.paloaltonetworks.com/globalprotect/5-2/globalprotect-app-release-notes/globalprotect-known-and-addressed-issues/globalprotect-addressed-issues
 
 -   releaseCycle: "5.1"
     eol: 2023-06-30

--- a/products/pan-gp.md
+++ b/products/pan-gp.md
@@ -47,8 +47,8 @@ releases:
     eol: 2024-02-28
     support: 2023-08-31
     releaseDate: 2020-07-30
-    latest: "5.2.13"
-    latestReleaseDate: 2023-02-22
+    latest: "5.2.13-c418"
+    latestReleaseDate: 2023-07-11
     link: https://docs.paloaltonetworks.com/globalprotect/5-2/globalprotect-app-release-notes
 
 -   releaseCycle: "5.1"


### PR DESCRIPTION
Updated GlobalProtect 5.2.13-c418 hotfix released 2023/07/11.

https://docs.paloaltonetworks.com/globalprotect/5-2/globalprotect-app-release-notes/globalprotect-known-and-addressed-issues/globalprotect-addressed-issues

