### PR TITLE
[new product] WeeChat

### DIFF
--- a/products/weechat.md
+++ b/products/weechat.md
@@ -1,0 +1,76 @@
+---
+title: WeeChat
+category: app
+permalink: /weechat
+releaseDateColumn: true
+eolColumn: Active Support
+releaseColumn: true
+changelogTemplate: "https://weechat.org/files/doc/weechat/ReleaseNotes-__LATEST__.html"
+
+versionCommand: weechat --version
+
+auto:
+-   git: https://github.com/weechat/weechat.git
+
+releases:
+-   releaseCycle: "4.0"
+    releaseDate: 2023-06-24
+    eol: false
+    latest: "4.0.1"
+    latestReleaseDate: 2023-06-30
+-   releaseCycle: "3.8"
+    releaseDate: 2023-01-08
+    eol: 2023-06-24
+    latest: "3.8"
+    latestReleaseDate: 2023-01-08
+-   releaseCycle: "3.7"
+    releaseDate: 2022-10-09
+    eol: 2023-01-08
+    latest: "3.7.1"
+    latestReleaseDate: 2022-10-21
+-   releaseCycle: "3.6"
+    releaseDate: 2022-07-10
+    eol: 2022-10-09
+    latest: "3.6"
+    latestReleaseDate: 2022-07-10
+-   releaseCycle: "3.5"
+    releaseDate: 2022-03-27
+    eol: 2022-07-10
+    latest: "3.5"
+    latestReleaseDate: 2022-03-27
+-   releaseCycle: "3.4"
+    releaseDate: 2021-12-18
+    eol: 2022-03-27
+    latest: "3.4.1"
+    latestReleaseDate: 2022-03-20
+-   releaseCycle: "3.3"
+    releaseDate: 2021-09-19
+    eol: 2021-12-18
+    latest: "3.3"
+    latestReleaseDate: 2021-09-19
+-   releaseCycle: "3.2"
+    releaseDate: 2021-06-13
+    eol: 2021-09-19
+    latest: "3.2.1"
+    latestReleaseDate: 2021-09-04
+-   releaseCycle: "3.1"
+    releaseDate: 2021-03-07
+    eol: 2021-06-13
+    latest: "3.1"
+    latestReleaseDate: 2021-03-07
+-   releaseCycle: "3.0"
+    releaseDate: 2020-11-11
+    eol: 2021-03-07
+    latest: "3.0.1"
+    latestReleaseDate: 2021-01-31
+-   releaseCycle: "2.9"
+    releaseDate: 2020-07-18
+    eol: 2020-11-11
+    latest: "2.9"
+    latestReleaseDate: 2020-07-18
+
+---
+
+> [WeeChat](https://weechat.org) (Wee Enhanced Environment for Chat) is a free and open-source Internet Relay Chat client that is designed to be light and fast. It is released under the terms of the GNU GPL-3.0-or-later and has been developed since 2003. 
+
+WeeChat supports its respective latest version only.

--- a/products/weechat.md
+++ b/products/weechat.md
@@ -5,7 +5,7 @@ permalink: /weechat
 releaseDateColumn: true
 eolColumn: Active Support
 releaseColumn: true
-changelogTemplate: "https://weechat.org/files/doc/weechat/ReleaseNotes-__LATEST__.html"
+changelogTemplate: "https://weechat.org/files/doc/weechat/ChangeLog-__LATEST__.html"
 
 versionCommand: weechat --version
 

--- a/products/weechat.md
+++ b/products/weechat.md
@@ -82,4 +82,4 @@ releases:
 
 > [WeeChat](https://weechat.org) (Wee Enhanced Environment for Chat) is a free and open-source Internet Relay Chat client that is designed to be light and fast. It is released under the terms of the GNU GPL-3.0-or-later and has been developed since 2003. 
 
-WeeChat only supports the latest release.
+WeeChat [only supports the latest release](https://github.com/endoflife-date/endoflife.date/pull/3267#issuecomment-1632930520).

--- a/products/weechat.md
+++ b/products/weechat.md
@@ -2,12 +2,11 @@
 title: WeeChat
 category: app
 permalink: /weechat
+versionCommand: weechat --version
+changelogTemplate: https://weechat.org/files/doc/weechat/ChangeLog-__LATEST__.html
 releaseDateColumn: true
 eolColumn: Active Support
 releaseColumn: true
-changelogTemplate: "https://weechat.org/files/doc/weechat/ChangeLog-__LATEST__.html"
-
-versionCommand: weechat --version
 
 auto:
 -   git: https://github.com/weechat/weechat.git
@@ -18,51 +17,61 @@ releases:
     eol: false
     latest: "4.0.1"
     latestReleaseDate: 2023-06-30
+
 -   releaseCycle: "3.8"
     releaseDate: 2023-01-08
     eol: 2023-06-24
     latest: "3.8"
     latestReleaseDate: 2023-01-08
+
 -   releaseCycle: "3.7"
     releaseDate: 2022-10-09
     eol: 2023-01-08
     latest: "3.7.1"
     latestReleaseDate: 2022-10-21
+
 -   releaseCycle: "3.6"
     releaseDate: 2022-07-10
     eol: 2022-10-09
     latest: "3.6"
     latestReleaseDate: 2022-07-10
+
 -   releaseCycle: "3.5"
     releaseDate: 2022-03-27
     eol: 2022-07-10
     latest: "3.5"
     latestReleaseDate: 2022-03-27
+
 -   releaseCycle: "3.4"
     releaseDate: 2021-12-18
     eol: 2022-03-27
     latest: "3.4.1"
     latestReleaseDate: 2022-03-20
+
 -   releaseCycle: "3.3"
     releaseDate: 2021-09-19
     eol: 2021-12-18
     latest: "3.3"
     latestReleaseDate: 2021-09-19
+
 -   releaseCycle: "3.2"
     releaseDate: 2021-06-13
     eol: 2021-09-19
     latest: "3.2.1"
     latestReleaseDate: 2021-09-04
+
 -   releaseCycle: "3.1"
     releaseDate: 2021-03-07
     eol: 2021-06-13
     latest: "3.1"
     latestReleaseDate: 2021-03-07
+
 -   releaseCycle: "3.0"
     releaseDate: 2020-11-11
     eol: 2021-03-07
     latest: "3.0.1"
     latestReleaseDate: 2021-01-31
+
 -   releaseCycle: "2.9"
     releaseDate: 2020-07-18
     eol: 2020-11-11
@@ -73,4 +82,4 @@ releases:
 
 > [WeeChat](https://weechat.org) (Wee Enhanced Environment for Chat) is a free and open-source Internet Relay Chat client that is designed to be light and fast. It is released under the terms of the GNU GPL-3.0-or-later and has been developed since 2003. 
 
-WeeChat supports its respective latest version only.
+WeeChat only supports the latest release.


### PR DESCRIPTION
The release dates were taken from the GitHub releases page.

There's no release policy, WeeChat only supports the respective latest version. However, @flashcode (mentioning to give him a heads up about this) isn't creating releases too often, so this shouldn't be an issue.

Not sure whether it's better to reference the changelog (e.g. https://weechat.org/files/doc/weechat/ChangeLog-4.0.0.html) or the release notes (e.g. https://weechat.org/files/doc/weechat/ReleaseNotes-4.0.0.html). The release notes are more important for updates, but don't list all changes.

Preview: https://deploy-preview-3267--endoflife-date.netlify.app/weechat