### PR TITLE
[nexus] Update external links

### DIFF
--- a/products/nexus.md
+++ b/products/nexus.md
@@ -35,11 +35,11 @@ releases:
 
 ---
 
-> [Nexus Repository OSS](https://www.sonatype.com/products/repository-oss-download) is an open
+> [Nexus Repository OSS](https://help.sonatype.com/repomanager3/product-information/download) is an open
 > source repository manager developed by Sonatype that supports many artifact formats, including
 > Docker, Java, and npm.
 
 Only the latest version of each major release is supported.
 
 Sonatype provides [commercial support](https://sonatype.com/usage/software-support-policy) with
-additional features with [Nexus Repository Pro](https://www.sonatype.com/products/repository-oss-vs-pro-features).
+additional features with [Nexus Repository Pro](https://www.sonatype.com/products/sonatype-nexus-oss-vs-pro-features).


### PR DESCRIPTION
The part `repository-oss` in several nexus links was rename to `sonatype-nexus-oss`

Old
```
https://www.sonatype.com/products/repository-oss-download
https://www.sonatype.com/products/repository-oss-vs-pro-features
```

New
```
https://www.sonatype.com/products/sonatype-nexus-oss-download
https://www.sonatype.com/products/sonatype-nexus-oss-vs-pro-features
```
Unsure if https://help.sonatype.com/repomanager3/product-information/download (the link in pull request) might be a better download page. Should there be a link to a general information page instead? Any suggestions? I miss some general information on the official page https://www.sonatype.com/products/sonatype-nexus-repository 