### PR TITLE
[samsung-mobile] Switch H1 to to H2 in description

### DIFF
--- a/products/samsungmobile.md
+++ b/products/samsungmobile.md
@@ -2514,7 +2514,7 @@ releases:
 > Samsung Galaxy is a series of computing and mobile computing devices that are designed,
 > manufactured and marketed by Samsung Electronics.
 
-# Security brackets
+## Security brackets
 
 Samsung devices usually have four support brackets in which a device receives support. Which bracket
 your device falls under [can be found here](https://security.samsungmobile.com/workScope.smsb).


### PR DESCRIPTION
To resolve a report from Bing SEO:

> Remove redundant `<h1>` tags from the page source, so that only one `<h1>` tag exists.

> These pages have more than one `<h1>` tag. Multiple `<h1>` header tags might confuse search engine bots and website's users. It is recommended to use only one `<h1>` tag per page.