### PR TITLE
[semeru] Fix latestreleaseDate for v8

### DIFF
--- a/products/ibm-semeru.md
+++ b/products/ibm-semeru.md
@@ -43,7 +43,7 @@ releases:
     releaseDate: 2021-09-16
     eol: 2026-11-30
     latest: '8u372-b07'
-    latestReleaseDate: 2023-11-30
+    latestReleaseDate: 2023-05-26
 
 ---
 


### PR DESCRIPTION
As per https://github.com/endoflife-date/release-data/blob/84beeb6b9839e7722324c441648580110d74ded2/releases/ibm-semeru.json#L9C1-L9C1