### PR TITLE
[micronaut] Add 4

### DIFF
--- a/products/micronaut.md
+++ b/products/micronaut.md
@@ -27,7 +27,7 @@ releases:
 -   releaseCycle: "3"
     releaseDate: 2021-08-18
     eol: false
-    support: true
+    support: 2023-07-11
     latest: "3.9.4"
     latestReleaseDate: 2023-06-23
 

--- a/products/micronaut.md
+++ b/products/micronaut.md
@@ -33,7 +33,7 @@ releases:
 
 -   releaseCycle: "2"
     releaseDate: 2020-06-26
-    eol: false
+    eol: 2023-03-01
     support: 2021-08-18
     latest: "2.5.13"
     latestReleaseDate: 2021-09-03

--- a/products/micronaut.md
+++ b/products/micronaut.md
@@ -17,6 +17,13 @@ auto:
 -   git: https://github.com/micronaut-projects/micronaut-core.git
 
 releases:
+-   releaseCycle: "4"
+    releaseDate: 2023-07-11
+    eol: false
+    support: true
+    latest: "4.0.0"
+    latestReleaseDate: 2023-07-11
+
 -   releaseCycle: "3"
     releaseDate: 2021-08-18
     eol: false
@@ -27,7 +34,7 @@ releases:
 -   releaseCycle: "2"
     releaseDate: 2020-06-26
     eol: false
-    support: false
+    support: 2023-03-01
     latest: "2.5.13"
     latestReleaseDate: 2021-09-03
 

--- a/products/micronaut.md
+++ b/products/micronaut.md
@@ -34,7 +34,7 @@ releases:
 -   releaseCycle: "2"
     releaseDate: 2020-06-26
     eol: false
-    support: 2023-03-01
+    support: 2021-08-18
     latest: "2.5.13"
     latestReleaseDate: 2021-09-03
 


### PR DESCRIPTION
https://micronaut.io/2023/07/14/micronaut-framework-4-0-0-released/
https://github.com/micronaut-projects/micronaut-core/releases/tag/v4.0.0

No changes on https://micronaut.io/support-schedule/ for 4, I left the eol/support for 3 as is.