### PR TITLE
[WIP] Initial work on release calendar.

### DIFF
--- a/_plugins/schedule.rb
+++ b/_plugins/schedule.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+# This plugin generates data for the schedule/calendar page
+require 'pp'
+module Jekyll
+  class ScheduleGenerator < Jekyll::Generator
+    # Show releases in the last 60 days
+    THRESHOLD = 30
+    safe true
+    # Set to high to be higher than the Product Data Enricher Plugin
+    priority :high
+    # Extract relevant schedule from a given product page
+    def schedule(page)
+
+    end
+
+    def recent_latest_release(cycle)
+      return false unless cycle.has_key?('latestReleaseDate')
+      (Date.today - cycle['latestReleaseDate']).to_i < THRESHOLD
+    end
+
+    def generate(site)
+      site.data['releases'] = []
+      site.pages.each do |page|
+        next unless page['layout'] == 'product'
+        page['releases'].each do |release_cycle|
+          if recent_latest_release(release_cycle)
+            site.data['releases'] << {'page'=>page, 'cycle'=>release_cycle}
+          end
+        end
+      end
+    end
+  end
+end

--- a/releases.md
+++ b/releases.md
@@ -22,7 +22,7 @@ This page lists recent releases across all known products.
 {% assign releases = site.data.releases | sort: 'cycle.latestReleaseDate' |reverse %}
 {% for r in releases %}
 <tr>
-  <td>{% if r.page.iconUrl %}<img class="product-logo" height=32 width=32 src="{{r.page.iconUrl}}">{%endif%}<a href="{{r.page.permalink}}" title="{{r.page.title}}">{{r.page.title}}</a> {{r.cycle.label}}</td>
+  <td>{% if r.page.iconUrl %}<img class="product-logo" style="float: right" height=32 width=32 src="{{r.page.iconUrl}}">{%endif%}<a href="{{r.page.permalink}}" title="{{r.page.title}}">{{r.page.title}}</a> {{r.cycle.label}}</td>
   <td>
     {% if r.cycle.link %}
     <a href="{{r.cycle.link}}">{{r.cycle.latest}}</a>

--- a/releases.md
+++ b/releases.md
@@ -1,0 +1,53 @@
+---
+layout: page
+title: Recent Releases
+permalink: /releases/
+---
+
+<h1>{{page.title}}</h1>
+
+This page lists recent releases across all known products.
+<!-- TODO: Add cycles without `latest` -->
+
+<table>
+  <thead>
+    <tr>
+      <th>Product</th>
+      <th>Release</th>
+      <th>Release Date</th>
+      <th>Support</th>
+    </tr>
+  </thead>
+  <tbody>
+{% assign releases = site.data.releases | sort: 'cycle.latestReleaseDate' |reverse %}
+{% for r in releases %}
+<tr>
+  <td>{% if r.page.iconUrl %}<img class="product-logo" height=32 width=32 src="{{r.page.iconUrl}}">{%endif%}<a href="{{r.page.permalink}}" title="{{r.page.title}}">{{r.page.title}}</a> {{r.cycle.label}}</td>
+  <td>
+    {% if r.cycle.link %}
+    <a href="{{r.cycle.link}}">{{r.cycle.latest}}</a>
+    {% else %}
+    {{ r.cycle.latest }}
+    {% endif %}
+  </td>
+  <td>{{r.cycle.latestReleaseDate | date_to_string}}</td>
+  <!-- Copied from product.html -->
+  <!--  TODO: Move to include perhaps-->
+  {% if r.page.eolColumn != false %}
+  {%- assign colorClass = 'bg-green-000' %}
+  {%- if r.cycle.days_toward_eol < r.page.eolWarnThreshold %}{% assign colorClass = 'bg-yellow-200' %}{% endif %}
+  {%- if r.cycle.days_toward_eol < 0 %}{% assign colorClass = 'bg-red-000' %}{% endif %}
+  <td class="{{ colorClass }}">
+    <small>{{r.page.eolColumnLabel}}</small>
+    {% if r.cycle.eol_from %}
+      {% if r.cycle.is_eol %}ended{% else %}ends{% endif %}
+      {{ r.cycle.eol_from | timeago }} <div>({{ r.cycle.eol_from | date_to_string }})</div>
+    {% else %}
+      {% if r.cycle.is_eol %}unavailable{% else %}available{% endif %}
+    {% endif %}
+  </td>
+  {% endif %}
+</tr>
+{% endfor %}
+
+</tbody></table>


### PR DESCRIPTION
Early Preview: https://deploy-preview-3285--endoflife-date.netlify.app/releases/

**What:** A Recent Releases page, to showcase recent releases made across products, with corresponding EOL dates.

**Why:** Our criteria results in "somewhat notable" products. And having a single page to showcase all of them together is a good idea.

## TODO:

- [ ] Create RSS Feed for recent releases. Maybe keep this for latter PR?
- [ ] Decide on information to showcase. I'm not 100% sure about showing EOL dates.
- [ ] Fix wording for several EOL dates, as it doesn't form a clear sentence in several cases.
- [ ] Also include pages without `latest` releases. For products, where we only have release cycle based EOLs (such as distros), that would also be important to include.

## Future Ideas

- [ ] Maybe switch to a real "calendar" based design, showing a large calendar for current and previous month, with the releases shown against all the given dates.
- [ ] Move this to an include, and support similar listings for all tag pages. So the `java-runtime` tag page can include "Recent Releases" across all similar products. Would be nice for folks working with specific stacks, to have a few pages that they can track for "product release bundles".