### PR TITLE
[opensearch] Drop few planned releases

### DIFF
--- a/products/opensearch.md
+++ b/products/opensearch.md
@@ -33,9 +33,6 @@ releases:
 
 Release  | Release Date
 -------- | ------------
- 2.8.0   | {{ "2023-06-06" | date_to_string }}
- 1.3.11  | {{ "2023-06-29" | date_to_string }}
- 2.9.0   | {{ "2023-07-18" | date_to_string }}
  1.3.12  | {{ "2023-08-10" | date_to_string }}
  2.10.0  | {{ "2023-08-29" | date_to_string }}
  1.3.13  | {{ "2023-09-21" | date_to_string }}


### PR DESCRIPTION
The release date for 2.9.0 was changed from July 18th to July 20, so we should have it on the main table in a few days.

Drop it from proposed releases as well.

Checked for any new proposed releases, and we're good.