### PR TITLE
[graalvm] Add GraalVM for JDK 17/20 and update description

### DIFF
--- a/products/graalvm.md
+++ b/products/graalvm.md
@@ -140,7 +140,7 @@ releases do).
 
 As part of this alignment, GraalVM adopted the JDK’s release numbering scheme based on the supported
 Java version. To avoid confusion with older releases, new releases are named _GraalVM for JDK
-<Java version>_, for example _GraalVM for JDK 20_.
+&lt;Java version&gt;_, for example _GraalVM for JDK 20_.
 
 A commercial offering with long term support is provided by Oracle as
 [Oracle GraalVM](https://docs.oracle.com/en/graalvm/index.html).

--- a/products/graalvm.md
+++ b/products/graalvm.md
@@ -135,7 +135,7 @@ releases:
 
 GraalVM Community release cadence used to be fixed, with one feature release every three months and
 an additional annual releases. But starting with JDK 20 in June 2023, GraalVM follows the JDK’s
-six-month release cadence and is only supporting the latest JDK version (just as Oracle OpenJDK
+six-month release cadence and only supports the latest JDK version (just as Oracle OpenJDK
 releases do).
 
 As part of this alignment, GraalVM adopted the JDK’s release numbering scheme based on the supported

--- a/products/graalvm.md
+++ b/products/graalvm.md
@@ -17,7 +17,22 @@ releaseDateColumn: true
 #    # https://rubular.com/r/mQMD3DVwhwZf6M
 #    regex: '^vm-(?<major>[0-9]+)\.(?<minor>[0-9]+)\.(?<patch>[0-9]+)(\.(?<tiny>[0-9]+))?$'
 
+# See https://www.graalvm.org/release-calendar/
 releases:
+-   releaseCycle: "jdk-20"
+    releaseLabel: "JDK 20"
+    releaseDate: 2023-06-13
+    eol: false
+    latest: "20.0.1"
+    latestReleaseDate: 2023-06-13
+
+-   releaseCycle: "jdk-17"
+    releaseLabel: "JDK 17"
+    releaseDate: 2023-06-13
+    eol: false
+    latest: "17.0.7"
+    latestReleaseDate: 2023-06-13
+
 -   releaseCycle: "22.3"
     releaseDate: 2022-10-25
     eol: 2023-10-25
@@ -118,12 +133,14 @@ releases:
 > Java. It supports additional programming languages and execution modes, like ahead-of-time
 > compilation of Java applications for fast startup and low memory footprint.
 
-GraalVM Community release cadence is fixed. There is one feature release every three months, always
-on the Tuesday closest to the 17th of the months of January, April, July, and October. Each feature
-release supersedes any previous one, except annual releases.
+GraalVM Community release cadence used to be fixed, with one feature release every three months and
+an additional annual releases. But starting with JDK 20 in June 2023, GraalVM follows the JDK’s
+six-month release cadence and is only supporting the latest JDK version (just as Oracle OpenJDK
+releases do).
 
-Each year, the fourth feature release (for example 22.3) receives bugfixes for the next 12 months.
-Such releases are called annual releases.
+As part of this alignment, GraalVM adopted the JDK’s release numbering scheme based on the supported
+Java version. To avoid confusion with older releases, new releases are named _GraalVM for JDK
+<Java version>_, for example _GraalVM for JDK 20_.
 
 A commercial offering with long term support is provided by Oracle as
-[GraalVM Enterprise](https://docs.oracle.com/en/graalvm/index.html).
+[Oracle GraalVM](https://docs.oracle.com/en/graalvm/index.html).


### PR DESCRIPTION
See https://www.graalvm.org/faq/ for information about the new naming and release cadence.

> Starting with JDK 20 in June 2023, GraalVM will follow the JDK’s six-month release cadence. In addition, starting with JDK 20, GraalVM releases will only support the latest JDK version (just as Oracle OpenJDK releases do). This will simplify the choice of versions and ensure that developers have access to the latest Java features with each GraalVM release. Check the [GraalVM release calendar](https://www.graalvm.org/release-calendar/).
> 
> As part of this alignment, GraalVM will adopt the JDK’s release numbering scheme based on the supported Java version. To avoid confusion with older releases, new releases will be named GraalVM for JDK <Java version>, for example GraalVM for JDK 20.

Despite the announcement that only the latest release is supported, both GraalVM for JDK 17 and JDK 20 were released. It is not clear whether LTS-based GraalVM versions will receive LTS support, so I did not say anything about it in the description and did not mark the JDK 17 version as LTS. But in any case the description will have to be updated in the future to clarify that point.