### PR TITLE
[auto] Add product maintainers / ownership

### DIFF
--- a/.github/workflows/auto-merge-release-updates.yml
+++ b/.github/workflows/auto-merge-release-updates.yml
@@ -57,6 +57,4 @@ jobs:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           message: |
             :warning: The following recent releases are not listed:
-            ```
             ${{ steps.latest.outputs.warning }}
-            ```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -227,7 +227,7 @@ auto:
 # Automation allows automatically updating the data of existing releases, but doesn't allow adding new releases.
 # However, Automation can notify GitHub users about new releases, so that they can be added manually.
 # Adding new products is great, maintaining products is even better - so you might want to add yourself here?
-# Notifications are sent by mentioning the maintainer in the auto updater pull request, no more than once a week.
+# Notifications are sent by mentioning the maintainer in the auto updater PR, no more than once every 3 days.
 # Add one or more GitHub usernames prefixed by "@" here (note: you MUST add quotes around the string).
 maintainers:
   - "@octocat"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -223,6 +223,15 @@ auto:
   # The value must always be `true`.
   - custom: true
 
+# Auto-update maintainers (optional).
+# Automation allows automatically updating the data of existing releases, but doesn't allow adding new releases.
+# However, Automation can notify GitHub users about new releases, so that they can be added manually.
+# Adding new products is great, maintaining products is even better - so you might want to add yourself here?
+# Notifications are sent by mentioning the maintainer in the auto updater pull request.
+# Add one or more GitHub usernames prefixed by "@" here (note: you MUST add quotes around the string).
+maintainers:
+  - "@octocat"
+
 # A list of identifiers that can be used to detect this product as being used,
 # especially by SBOM tooling
 identifiers:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -227,7 +227,7 @@ auto:
 # Automation allows automatically updating the data of existing releases, but doesn't allow adding new releases.
 # However, Automation can notify GitHub users about new releases, so that they can be added manually.
 # Adding new products is great, maintaining products is even better - so you might want to add yourself here?
-# Notifications are sent by mentioning the maintainer in the auto updater pull request.
+# Notifications are sent by mentioning the maintainer in the auto updater pull request, no more than once a week.
 # Add one or more GitHub usernames prefixed by "@" here (note: you MUST add quotes around the string).
 maintainers:
   - "@octocat"

--- a/_auto/latest.py
+++ b/_auto/latest.py
@@ -99,6 +99,12 @@ def github_output(str):
             f.write(str)
 
 
+def github_file_url(file):
+    if os.getenv("GITHUB_SERVER_URL") and os.getenv("GITHUB_REPOSITORY"):
+        return f'{os.getenv("GITHUB_SERVER_URL")}/{os.getenv("GITHUB_REPOSITORY")}/blob/master/{file}'
+    return None
+
+
 def yaml_to_str(obj):
     yaml = YAML()
     yaml.indent(sequence=4)
@@ -197,12 +203,15 @@ def update_product(name):
 
             # Print all unmatched versions released in the last 30 days
             if len(version_set) != 0:
+                gh = github_file_url(fn)
+                info = f'[`{name}`]({gh})' if gh else f'`{name}`'
+
                 for x in version_set:
                     date = datetime.date.fromisoformat(R1[x])
                     days_since_release = (datetime.date.today() - date).days
                     if days_since_release < 30:
                         print(f"[WARN] {name}:{x} ({R1[x]}) not included")
-                        github_output(f'- `{name}` version `{x}` ({R1[x]})\n')
+                        github_output(f'- {info} version `{x}` ({R1[x]})\n')
 
 
 if __name__ == "__main__":

--- a/_auto/latest.py
+++ b/_auto/latest.py
@@ -215,15 +215,18 @@ def update_product(name):
 
                 for x in version_set:
                     date = datetime.date.fromisoformat(R1[x])
-                    days_since_release = (datetime.date.today() - date).days
-                    if days_since_release < 30:
+                    age_days = (datetime.date.today() - date).days
+                    age_days_info = f'{age_days} day{"s"[:age_days^1]} ago' if age_days > 0 else "today"
+
+                    if age_days < 30:
                         print(f'[WARN] {name}:{x} ({R1[x]}) not included{f" (maintainers: {maintainers_info})" if maintainers else ""}')
 
-                        bold = "**" if days_since_release > 22 else ""
-                        if days_since_release % 7 == 0:
-                            github_output(f'- {bold}{info} version `{x}` ({R1[x]}){f", notifying {maintainers_info}" if maintainers else ""}{bold}\n')
+                        bold = "**" if age_days > 22 else ""
+                        if age_days % 7 == 0:
+                            github_output(f'- {bold}{info} version `{x}` ({R1[x]}, {age_days_info})'
+                                          f'{f", notifying {maintainers_info}" if maintainers else ""}{bold}\n')
                         else:
-                            github_output(f'- {bold}{info} version `{x}` ({R1[x]}){bold}\n')
+                            github_output(f'- {bold}{info} version `{x}` ({R1[x]}, {age_days_info}){bold}\n')
 
 
 if __name__ == "__main__":

--- a/_auto/latest.py
+++ b/_auto/latest.py
@@ -226,11 +226,10 @@ def update_product(name):
                             github_output(f'- {bold}{info} version `{x}` ({R1[x]}, {age_days_info})'
                                           f'{f", notifying maintainers {maintainers_info}" if maintainers else ""}{bold}\n')
                         else:
-                            maintainers = [f'@&#8288;{i[1:]}' for i in maintainers]
-                            maintainers_info = " ".join(maintainers)
+                            maintainers_silent = [f'@&#8288;{i[1:]}' for i in maintainers]
+                            maintainers_silent_info = f', maintained by {" ".join(maintainers_silent)}' if maintainers_silent else ""
 
-                            github_output(f'- {bold}{info} version `{x}` ({R1[x]}, {age_days_info})'
-                                          f'{f", maintained by {maintainers_info}" if maintainers else ""}{bold}\n')
+                            github_output(f'- {bold}{info} version `{x}` ({R1[x]}, {age_days_info}){maintainers_silent_info}{bold}\n')
 
 
 if __name__ == "__main__":

--- a/_auto/latest.py
+++ b/_auto/latest.py
@@ -224,9 +224,13 @@ def update_product(name):
                         bold = "**" if age_days > 22 else ""
                         if age_days % 7 == 0:
                             github_output(f'- {bold}{info} version `{x}` ({R1[x]}, {age_days_info})'
-                                          f'{f", notifying {maintainers_info}" if maintainers else ""}{bold}\n')
+                                          f'{f", notifying maintainers {maintainers_info}" if maintainers else ""}{bold}\n')
                         else:
-                            github_output(f'- {bold}{info} version `{x}` ({R1[x]}, {age_days_info}){bold}\n')
+                            maintainers = [f'@&#8288;{i[1:]}' for i in maintainers]
+                            maintainers_info = " ".join(maintainers)
+
+                            github_output(f'- {bold}{info} version `{x}` ({R1[x]}, {age_days_info})'
+                                          f'{f", maintained by {maintainers_info}" if maintainers else ""}{bold}\n')
 
 
 if __name__ == "__main__":

--- a/_auto/latest.py
+++ b/_auto/latest.py
@@ -202,7 +202,7 @@ def update_product(name):
                     days_since_release = (datetime.date.today() - date).days
                     if days_since_release < 30:
                         print(f"[WARN] {name}:{x} ({R1[x]}) not included")
-                        github_output(f"{name}:{x} ({R1[x]})\n")
+                        github_output(f'- `{name}` version `{x}` ({R1[x]})\n')
 
 
 if __name__ == "__main__":

--- a/_auto/latest.py
+++ b/_auto/latest.py
@@ -219,10 +219,11 @@ def update_product(name):
                     if days_since_release < 30:
                         print(f'[WARN] {name}:{x} ({R1[x]}) not included{f" (maintainers: {maintainers_info})" if maintainers else ""}')
 
+                        bold = "**" if days_since_release > 22 else ""
                         if days_since_release % 7 == 0:
-                            github_output(f'- {info} version `{x}` ({R1[x]}){f", notifying {maintainers_info}" if maintainers else ""}\n')
+                            github_output(f'- {bold}{info} version `{x}` ({R1[x]}){f", notifying {maintainers_info}" if maintainers else ""}{bold}\n')
                         else:
-                            github_output(f'- {info} version `{x}` ({R1[x]})\n')
+                            github_output(f'- {bold}{info} version `{x}` ({R1[x]}){bold}\n')
 
 
 if __name__ == "__main__":

--- a/_auto/latest.py
+++ b/_auto/latest.py
@@ -119,9 +119,9 @@ def update_product(name):
         f.seek(0)
         _, content = frontmatter.parse(f.read())
 
-        fn = "_data/release-data/releases/%s.json" % (name)
-        if exists(fn):
-            with open(fn) as releases_file:
+        rfn = "_data/release-data/releases/%s.json" % (name)
+        if exists(rfn):
+            with open(rfn) as releases_file:
                 # Entire releases data as a dict
                 R1 = json.loads(releases_file.read())
                 # Just the list of versions

--- a/_auto/latest.py
+++ b/_auto/latest.py
@@ -202,7 +202,8 @@ def update_product(name):
                 f.write(final_contents)
 
             # Print all unmatched versions released in the last 30 days
-            # Ping product maintainers only once a week (on 1st, 7th, 14th, 21st, and 28th day)
+            # Highlight versions older than 21 days (i.e. starting with the 22nd day)
+            # Ping product maintainers only once every 3 days (on 1st, 4th, 7th, 10th, 13th, 16th, 19th, 22nd, 25th, and 28th day)
             if len(version_set) != 0:
                 gh = github_file_url(fn)
                 info = f'[`{name}`]({gh})' if gh else f'`{name}`'
@@ -221,8 +222,8 @@ def update_product(name):
                     if age_days < 30:
                         print(f'[WARN] {name}:{x} ({R1[x]}) not included{f" (maintainers: {maintainers_info})" if maintainers else ""}')
 
-                        bold = "**" if age_days > 22 else ""
-                        if age_days % 7 == 0:
+                        bold = "**" if age_days >= 21 else ""
+                        if age_days % 3 == 0:
                             github_output(f'- {bold}{info} version `{x}` ({R1[x]}, {age_days_info})'
                                           f'{f", notifying maintainers {maintainers_info}" if maintainers else ""}{bold}\n')
                         else:

--- a/_auto/latest.py
+++ b/_auto/latest.py
@@ -201,7 +201,8 @@ def update_product(name):
                 f.truncate()
                 f.write(final_contents)
 
-            # Print all unmatched versions released in the last 30 days, and ping maintainers
+            # Print all unmatched versions released in the last 30 days
+            # Ping product maintainers only once a week (on 1st, 7th, 14th, 21st, and 28th day)
             if len(version_set) != 0:
                 gh = github_file_url(fn)
                 info = f'[`{name}`]({gh})' if gh else f'`{name}`'
@@ -217,7 +218,11 @@ def update_product(name):
                     days_since_release = (datetime.date.today() - date).days
                     if days_since_release < 30:
                         print(f'[WARN] {name}:{x} ({R1[x]}) not included{f" (maintainers: {maintainers_info})" if maintainers else ""}')
-                        github_output(f'- {info} version `{x}` ({R1[x]}){f", notifying {maintainers_info}" if maintainers else ""}\n')
+
+                        if days_since_release % 7 == 0:
+                            github_output(f'- {info} version `{x}` ({R1[x]}){f", notifying {maintainers_info}" if maintainers else ""}\n')
+                        else:
+                            github_output(f'- {info} version `{x}` ({R1[x]})\n')
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Automation only allows automatically updating the data of existing releases, but doesn't allow adding new releases right now. However, Automation can indeed notice that a new / unknown release was found, which causes Dependabot to dump these versions in its pull request, see e.g. https://github.com/endoflife-date/endoflife.date/pull/3308#issuecomment-1647869022. This imposes not to be underestimated burden on `endoflife.date`'s major contributors (big :heart: :heart: to you people!) to manually add these releases after Dependabot first mentions a new / unknown release.

The problem is: Other people can't really help here. If one would want to help, even with just a single product, one would have to check every pull request manually whether the product showed up and take appropriate action.

This PR allows people to add themselves (and possibly others, but before merging a PR with other people one should always ask for permission first) as maintainer / owner of a product. As soon as Automation finds a new / unknown release, Dependabot will notify (by mentioning them in said pull request comment, i.e. "notifying @PhrozenByte") the listed GitHub users (yes, possibly plural) about the matter.

To do so we also change Dependabot's pull request comment from a simple code block to a formatted list with some extra information. This includes not only mentioning the maintainers, but also adds a link to the product file, the relative age of new / unknown releases, and highlights versions older than 3 weeks. The idea of highlighting old versions is to let `endoflife.date`'s major contributors know that something is wrong and the maintainer is inactive, or most notifications happened to be skipped (see below).

Since we don't want to spam maintainers with daily notifications, we notify them on the 1st, 7th, 14th, 21st, and 28th day after a version's release only (otherwise the maintainers are printed as `@&#8288;PhrozenByte`, resulting in the literal string "@&#8288;PhrozenByte"). This is a bit problematic because Dependabot only runs when new versions are found (resp. [`endoflife-date/release-data`](https://github.com/endoflife-date/release-data) was updated), so notifications might be skipped (especially later notifications; unless releases aren't added with an earlier (i.e. usually wrong) release date, the first notification should always work). However, not having such limitation would possibly cause daily notifications, which is no option either... The more products we have, the more likely it is that Dependabot runs daily. So: Let's add more products :laughing: Okay, seriously, since maintainers are still mentioned (but not notified), `endoflife.date`'s major contributors could still manually ping maintainers when they learn that a notification was skipped.

This is how a Dependabot comment now looks like (with some test data, not actual release data):

> - [`grails`](https://github.com/endoflife-date/endoflife.date/blob/master/products/grails.md) version `6.0.0` (2023-07-25, today), notifying maintainers @octocat @PhrozenByte
> - [`nomad`](https://github.com/endoflife-date/endoflife.date/blob/master/products/nomad.md) version `1.6.0` (2023-07-18, 7 days ago)
> - [`nomad`](https://github.com/endoflife-date/endoflife.date/blob/master/products/nomad.md) version `1.6.1` (2023-07-21, 4 days ago)
> - **[`plesk`](https://github.com/endoflife-date/endoflife.date/blob/master/products/plesk.md) version `18.0.54` (2023-07-01, 24 days ago), maintained by @&#8288;PhrozenByte**
> - [`gitlab`](https://github.com/endoflife-date/endoflife.date/blob/master/products/gitlab.md) version `16.2.0` (2023-07-21, 4 days ago)
> - **[`artifactory`](https://github.com/endoflife-date/endoflife.date/blob/master/products/artifactory.md) version `7.63.5` (2023-06-27, 28 days ago), notifying maintainers @octocat**
> - [`artifactory`](https://github.com/endoflife-date/endoflife.date/blob/master/products/artifactory.md) version `7.63.7` (2023-07-24, 1 day ago), maintained by @&#8288;octocat


The output of `_auto/latest.py` looks like the following:

> ```
> [WARN] grails:6.0.0 (2023-07-25) not included (maintainers: @octocat @PhrozenByte)
> [WARN] nomad:1.6.0 (2023-07-18) not included
> [WARN] nomad:1.6.1 (2023-07-21) not included
> [WARN] plesk:18.0.54 (2023-07-01) not included (maintainers: @PhrozenByte)
> [WARN] gitlab:16.2.0 (2023-07-21) not included
> [WARN] artifactory:7.63.5 (2023-06-27) not included (maintainers: @octocat)
> [WARN] artifactory:7.63.7 (2023-07-24) not included (maintainers: @octocat)
> ```

I did run `_auto/latest.py` locally a few times, everything seems to work. However, for the pull request comment to actually show we must run Dependabot's GitHub workflow, so this part wasn't tested.

The reason for this addition is a discussion about LimeSurvey (see https://github.com/endoflife-date/endoflife.date/pull/3266#discussion_r1271950985): I was asked to take responsibility for adding new releases, with this merged I'd able to actually do it.

The product maintainer / ownership concept could allow more automation in the future, like automatically creating a pull request without auto-merge for new releases and requesting a review from the listed maintainers.