### PR TITLE
[dotnet] Adding more purl identifiers

### DIFF
--- a/products/dotnet.md
+++ b/products/dotnet.md
@@ -24,6 +24,21 @@ auto:
 
 identifiers:
 -   purl: pkg:nuget/Microsoft.NETCore.App
+-   purl: pkg:nuget/Microsoft.NETCore.App.Runtime.win-x64
+-   purl: pkg:nuget/Microsoft.NETCore.App.Runtime.win-x86
+-   purl: pkg:nuget/Microsoft.NETCore.App.Runtime.win-arm
+-   purl: pkg:nuget/Microsoft.NETCore.App.Runtime.win-arm64
+-   purl: pkg:nuget/Microsoft.NETCore.App.Runtime.osx-x64
+-   purl: pkg:nuget/Microsoft.NETCore.App.Runtime.osx-arm64
+-   purl: pkg:nuget/Microsoft.NETCore.App.Runtime.linux-x64
+-   purl: pkg:nuget/Microsoft.NETCore.App.Runtime.linux-arm64
+-   purl: pkg:nuget/Microsoft.NETCore.App.Runtime.linux-arm
+-   purl: pkg:nuget/Microsoft.NETCore.App.Runtime.linux-musl-x64
+-   purl: pkg:nuget/Microsoft.NETCore.App.Runtime.linux-musl-arm64
+-   purl: pkg:nuget/Microsoft.NETCore.App.Runtime.linux-musl-arm
+-   purl: pkg:nuget/Microsoft.NETCore.App.Runtime.linux-bionic-x64
+-   purl: pkg:nuget/Microsoft.NETCore.App.Runtime.linux-bionic-arm64
+-   purl: pkg:nuget/Microsoft.NETCore.App.Runtime.linux-bionic-arm
 
 releases:
 -   releaseCycle: "7.0"


### PR DESCRIPTION
Adding some more PURLs for dotnet. [Nuget link](https://www.nuget.org/packages?q=Microsoft.NETCore.App.Runtime.&frameworks=&tfms=&packagetype=&prerel=true&sortby=relevance)

An example from a CycloneDX BOM
```
      "bom-ref": "pkg:nuget/Microsoft.NETCore.App.Runtime.linux-musl-x64@7.0.9?package-id=7f1ce8b7dc0f0411",
      "type": "library",
      "name": "Microsoft.NETCore.App.Runtime.linux-musl-x64",
      "version": "7.0.9",
      "cpe": "cpe:2.3:a:Microsoft.NETCore.App.Runtime.linux-musl-x64:Microsoft.NETCore.App.Runtime.linux-musl-x64:7.0.9:*:*:*:*:*:*:*",
      "purl": "pkg:nuget/Microsoft.NETCore.App.Runtime.linux-musl-x64@7.0.9",
```