### PR TITLE
[visualstudio] Fix typo on 17.6 `lts` field

### DIFF
--- a/products/visualstudio.md
+++ b/products/visualstudio.md
@@ -18,7 +18,7 @@ eolColumn: Active Support
 releases:
 -   releaseCycle: "17.6"
     codename: "2022"
-    lts: lts
+    lts: true
     eol: 2025-01-09
     releaseDate: 2023-05-16
     latest: "17.6.5"


### PR DESCRIPTION
While working on API v1 tests:

- #2080

, I felt on this:

![image](https://github.com/endoflife-date/endoflife.date/assets/5235127/cb67e186-9c66-484a-8ebd-2be8882de7c2)


According to https://learn.microsoft.com/en-us/visualstudio/releases/2022/release-notes

![image](https://github.com/endoflife-date/endoflife.date/assets/5235127/7a427e23-9109-4e18-b2c4-1b6438a677db)
