### PR TITLE
[panos]Updated PanOS to 10.2.4-h4

### DIFF
--- a/products/pan-os.md
+++ b/products/pan-os.md
@@ -22,9 +22,9 @@ releases:
 -   releaseCycle: "10.2"
     eol: 2025-08-27
     releaseDate: 2022-02-27
-    latest: "10.2.4-h3"
-    latestReleaseDate: 2023-07-05
-    link: https://docs.paloaltonetworks.com/pan-os/10-2/pan-os-release-notes/pan-os-10-2-4-known-and-addressed-issues/pan-os-10-2-4-h3-addressed-issues
+    latest: "10.2.4-h4"
+    latestReleaseDate: 2023-07-27
+    link: https://docs.paloaltonetworks.com/pan-os/10-2/pan-os-release-notes/pan-os-10-2-4-known-and-addressed-issues/pan-os-10-2-4-h4-addressed-issues
 
 -   releaseCycle: "10.1"
     eol: 2024-12-01


### PR DESCRIPTION
Updated PanOS to 10.2.4-h4
Released: 2023-07-27

https://docs.paloaltonetworks.com/pan-os/10-2/pan-os-release-notes/pan-os-10-2-4-known-and-addressed-issues/pan-os-10-2-4-h4-addressed-issues
