### PR TITLE
[eks] Precise EOL date for 1.24

### DIFF
--- a/products/eks.md
+++ b/products/eks.md
@@ -43,7 +43,7 @@ releases:
     latest: '1.25-eks-5'
 
 -   releaseCycle: "1.24"
-    eol: 2024-01-01
+    eol: 2024-01-31
     releaseDate: 2022-11-15
     latestReleaseDate: 2023-06-30
     latest: '1.24-eks-8'


### PR DESCRIPTION
Upstream put a more accurate date.