### PR TITLE
[opensearch] 1.x is not yet EOL

### DIFF
--- a/products/opensearch.md
+++ b/products/opensearch.md
@@ -18,7 +18,7 @@ releases:
     latest: "2.9.0"
     latestReleaseDate: 2023-07-18
 -   releaseCycle: "1"
-    eol: 2023-12-31
+    eol: false
     releaseDate: 2021-07-02
     latest: "1.3.11"
     latestReleaseDate: 2023-06-22


### PR DESCRIPTION
The EOL date for 1.x was modified from end of 2023 to 3.x release recently (https://github.com/opensearch-project/project-website/pull/1801)

3.x is not yet released, so we mark it as false for now.

Closes #3371