### PR TITLE
Add Go 1.21 support

### DIFF
--- a/products/go.md
+++ b/products/go.md
@@ -22,13 +22,18 @@ auto:
 -   git: https://github.com/golang/go.git
     regex: ^go(?<major>[1-9]\d*)\.(?<minor>0|[1-9]\d*)\.?(?<patch>0|[1-9]\d*)?$
 releases:
+-   releaseCycle: "1.21"
+    eol: false
+    latest: "1.21.0"
+    releaseDate: 2023-08-08
+    latestReleaseDate: 2023-08-08
 -   releaseCycle: "1.20"
     eol: false
     latest: "1.20.7"
     releaseDate: 2023-02-01
     latestReleaseDate: 2023-08-01
 -   releaseCycle: "1.19"
-    eol: false
+    eol: 2023-08-08
     latest: "1.19.12"
     releaseDate: 2022-08-02
     latestReleaseDate: 2023-08-01


### PR DESCRIPTION
And mark 1.19 as EOL with the same date that 1.21 was released.

Also updates the `release-data` to get the latest dates for Go versions.
