### PR TITLE
[neptune] Add some alternate URLs

### DIFF
--- a/products/amazon-neptune.md
+++ b/products/amazon-neptune.md
@@ -3,6 +3,9 @@ title: Amazon Neptune
 category: service
 tags: amazon
 iconSlug: amazonaws
+alternate_urls:
+-   /aws-neptune
+-   /neptune
 permalink: /amazon-neptune
 releasePolicyLink: https://docs.aws.amazon.com/neptune/latest/userguide/engine-releases.html
 versionCommand: >


### PR DESCRIPTION
While the product is officially called Amazon Neptune, Amazon has  a arcane way of deciding between the AWS/Amazon prefix.

This results in confusion, and it is helpful if we let users type either without any worries.