### PR TITLE
[dotnet] adding rpm PURLs

### DIFF
--- a/products/dotnet.md
+++ b/products/dotnet.md
@@ -44,9 +44,7 @@ identifiers:
 -   purl: pkg:rpm/rhel/dotnet-sdk-5.0
 -   purl: pkg:rpm/rhel/dotnet-sdk-3.1
 -   purl: pkg:rpm/rhel/dotnet-sdk-3.0
--   purl: pkg:rpm/rhel/dotnet-sdk-2.2
 -   purl: pkg:rpm/rhel/dotnet-sdk-2.1
--   purl: pkg:rpm/rhel/dotnet-sdk-2.0
 
 releases:
 -   releaseCycle: "7.0"

--- a/products/dotnet.md
+++ b/products/dotnet.md
@@ -47,14 +47,6 @@ identifiers:
 -   purl: pkg:rpm/rhel/dotnet-sdk-2.2
 -   purl: pkg:rpm/rhel/dotnet-sdk-2.1
 -   purl: pkg:rpm/rhel/dotnet-sdk-2.0
--   purl: pkg:rpm/rhel/dotnet-runtime-7.0
--   purl: pkg:rpm/rhel/dotnet-runtime-6.0
--   purl: pkg:rpm/rhel/dotnet-runtime-5.0
--   purl: pkg:rpm/rhel/dotnet-runtime-3.1
--   purl: pkg:rpm/rhel/dotnet-runtime-3.0
--   purl: pkg:rpm/rhel/dotnet-runtime-2.2
--   purl: pkg:rpm/rhel/dotnet-runtime-2.1
--   purl: pkg:rpm/rhel/dotnet-runtime-2.0
 
 releases:
 -   releaseCycle: "7.0"

--- a/products/dotnet.md
+++ b/products/dotnet.md
@@ -39,6 +39,22 @@ identifiers:
 -   purl: pkg:nuget/Microsoft.NETCore.App.Runtime.linux-bionic-x64
 -   purl: pkg:nuget/Microsoft.NETCore.App.Runtime.linux-bionic-arm64
 -   purl: pkg:nuget/Microsoft.NETCore.App.Runtime.linux-bionic-arm
+-   purl: pkg:rpm/rhel/dotnet-sdk-7.0
+-   purl: pkg:rpm/rhel/dotnet-sdk-6.0
+-   purl: pkg:rpm/rhel/dotnet-sdk-5.0
+-   purl: pkg:rpm/rhel/dotnet-sdk-3.1
+-   purl: pkg:rpm/rhel/dotnet-sdk-3.0
+-   purl: pkg:rpm/rhel/dotnet-sdk-2.2
+-   purl: pkg:rpm/rhel/dotnet-sdk-2.1
+-   purl: pkg:rpm/rhel/dotnet-sdk-2.0
+-   purl: pkg:rpm/rhel/dotnet-runtime-7.0
+-   purl: pkg:rpm/rhel/dotnet-runtime-6.0
+-   purl: pkg:rpm/rhel/dotnet-runtime-5.0
+-   purl: pkg:rpm/rhel/dotnet-runtime-3.1
+-   purl: pkg:rpm/rhel/dotnet-runtime-3.0
+-   purl: pkg:rpm/rhel/dotnet-runtime-2.2
+-   purl: pkg:rpm/rhel/dotnet-runtime-2.1
+-   purl: pkg:rpm/rhel/dotnet-runtime-2.0
 
 releases:
 -   releaseCycle: "7.0"


### PR DESCRIPTION
Reference: 
- https://learn.microsoft.com/en-us/dotnet/core/install/linux-rhel#install-the-sdk
- https://github.com/xeol-io/xeol/issues/102#issuecomment-1677352538

This is an unfortunate PURL structure for the rpm dotnet packages, since it means we have to add a new PURL every time there's a new release. Definitely will need to think about automation around this in the future. 