### PR TITLE
bugfix: Fixes incorrect support end date for release 1.28

### DIFF
--- a/products/kubernetes.md
+++ b/products/kubernetes.md
@@ -23,7 +23,7 @@ auto:
 releases:
 -   releaseCycle: "1.28"
     releaseDate: 2023-08-15
-    support: 2023-08-28
+    support: 2024-08-28
     eol: 2024-10-28
     latest: "1.28.0"
     latestReleaseDate: 2023-08-15


### PR DESCRIPTION
Fixes incorrect support end date for release 1.28

![image](https://github.com/endoflife-date/endoflife.date/assets/45768550/c604e741-a64d-4e5b-b476-5cbf0dee9cf0)
