### PR TITLE
[yarn] Fix link for 1.x

### DIFF
--- a/products/yarn.md
+++ b/products/yarn.md
@@ -39,6 +39,7 @@ releases:
     eol: false
     latestReleaseDate: 2022-06-08
     latest: '1.22.19'
+    link: https://github.com/yarnpkg/yarn/releases/tag/v__LATEST__
 
 ---
 
@@ -49,5 +50,5 @@ Yarn's support and EOL policy is not clearly defined.
 
 Yarn Classic (v1) [entered maintenance mode in January 2020](https://dev.to/arcanis/introducing-yarn-2-4eh1#what-will-happen-to-the-legacy-codebase)
 and will eventually reach end-of-life. It is highly recommended to
-[Migrate](https://yarnpkg.com/getting-started/migration) to the latest version. Yarn
+[Migrate](https://yarnpkg.com/migration/overview) to the latest version. Yarn
 Classic only receives critical and security fixes.


### PR DESCRIPTION
1.x code is not hosted in the same GitHub repository, so the generated link (https://github.com/yarnpkg/berry/releases/tag/%40yarnpkg%2Fcli%2F1.22.19) is broken.

Also fix a link in the description.