### PR TITLE
[angularjs] Fix changelogTemplate

### DIFF
--- a/products/angularjs.md
+++ b/products/angularjs.md
@@ -8,7 +8,7 @@ alternate_urls:
 -   /angular-js
 versionCommand: npm list angular
 releasePolicyLink: https://docs.angularjs.org/misc/version-support-status
-changelogTemplate: https://github.com/angular/angular.js/blob/v__RELEASE_CYCLE__.x/CHANGELOG.md
+changelogTemplate: https://github.com/angular/angular.js/blob/v__LATEST__/CHANGELOG.md
 eolColumn: Support
 releaseColumn: true
 releaseDateColumn: true


### PR DESCRIPTION
Using the branch name was not working for 1.1.x versions because the v1.1.x branch does not exist. Use tags instead.