### PR TITLE
[activemq] Fix links

### DIFF
--- a/products/apache-activemq.md
+++ b/products/apache-activemq.md
@@ -60,18 +60,21 @@ releases:
     eol: 2016-12-16 # estimated based on latest release date
     latest: "5.13.5"
     latestReleaseDate: 2016-12-16
+    link: https://activemq.apache.org/activemq-5013004-release # no 5.13.5 changelog
 
 -   releaseCycle: "5.12"
     releaseDate: 2015-08-10
     eol: 2016-02-03 # estimated based on latest release date
     latest: "5.12.3"
     latestReleaseDate: 2016-02-03
+    link: https://activemq.apache.org/activemq-5012002-release # no 5.12.3 changelog
 
 -   releaseCycle: "5.11"
     releaseDate: 2015-01-30
     eol: 2016-02-03 # estimated based on latest release date
     latest: "5.11.4"
     latestReleaseDate: 2016-02-03
+    link: https://activemq.apache.org/activemq-5011003-release # no 5.11.4 changelog
 
 -   releaseCycle: "5.10"
     releaseDate: 2014-06-05

--- a/products/apache-activemq.md
+++ b/products/apache-activemq.md
@@ -7,7 +7,7 @@ permalink: /apache-activemq
 alternate_urls:
 -   /activemq
 releasePolicyLink: https://activemq.apache.org/support.html
-changelogTemplate: "https://activemq.apache.org/activemq-{{'__LATEST__'|replace:'.','0'}}-release"
+changelogTemplate: "https://activemq.apache.org/activemq-{{'__LATEST__'|replace_first:'.','0'|replace_first:'.','00'}}-release"
 # https://activemq.apache.org/activemq-command-line-tools-reference.html
 versionCommand: activemq --version
 releaseDateColumn: true
@@ -18,6 +18,11 @@ auto:
     regex: '^activemq-(?<major>\d+)\.(?<minor>\d+)(\.(?<patch>\d+))?$'
 
 # eol(x) = releaseCycle(x+2)
+# link(x) =
+# - y > 9 and z > 9 : "https://activemq.apache.org/activemq-{{'__LATEST__'|replace:'.','0'}}-release"
+# - y > 9 and z <= 9 : "https://activemq.apache.org/activemq-{{'__LATEST__'|replace_first:'.','0'|replace_first:'.','00'}}-release" (default, works for latest releases)
+# - y <= 9 and z > 9 : "https://activemq.apache.org/activemq-{{'__LATEST__'|replace_first:'.','00'|replace_first:'.','0'}}-release"
+# - y <= 9 and z <= 9 : "https://activemq.apache.org/activemq-{{'__LATEST__'|replace:'.','00'}}-release"
 releases:
 -   releaseCycle: "5.18"
     releaseDate: 2023-03-18
@@ -42,6 +47,7 @@ releases:
     eol: 2022-03-09 # estimated based on 5.17 release date
     latest: "5.15.15"
     latestReleaseDate: 2021-04-20
+    link: "https://activemq.apache.org/activemq-{{'__LATEST__'|replace:'.','0'}}-release"
 
 -   releaseCycle: "5.14"
     releaseDate: 2016-08-02
@@ -78,60 +84,70 @@ releases:
     eol: 2014-06-05 # estimated based on 5.10 release date
     latest: "5.9.1"
     latestReleaseDate: 2014-03-31
+    link: "https://activemq.apache.org/activemq-{{'__LATEST__'|replace:'.','00'}}-release"
 
 -   releaseCycle: "5.8"
     releaseDate: 2013-02-06
     eol: 2013-10-14 # estimated based on 5.9 release date
     latest: "5.8.0"
     latestReleaseDate: 2013-02-06
+    link: "https://activemq.apache.org/activemq-{{'__LATEST__'|replace:'.','00'}}-release"
 
 -   releaseCycle: "5.7"
     releaseDate: 2012-10-02
     eol: 2013-02-06 # estimated based on 5.8 release date
     latest: "5.7.0"
     latestReleaseDate: 2012-10-02
+    link: "https://activemq.apache.org/activemq-{{'__LATEST__'|replace:'.','00'}}-release"
 
 -   releaseCycle: "5.6"
     releaseDate: 2012-05-02
     eol: 2012-10-02 # estimated based on 5.7 release date
     latest: "5.6.0"
     latestReleaseDate: 2012-05-02
+    link: "https://activemq.apache.org/activemq-{{'__LATEST__'|replace:'.','00'}}-release"
 
 -   releaseCycle: "5.5"
     releaseDate: 2011-03-28
     eol: 2012-05-02 # estimated based on 5.6 release date
     latest: "5.5.1"
     latestReleaseDate: 2011-10-11
+    link: "https://activemq.apache.org/activemq-{{'__LATEST__'|replace:'.','00'}}-release"
 
 -   releaseCycle: "5.4"
     releaseDate: 2010-08-13
     eol: 2011-10-12 # estimated based on latest release date
     latest: "5.4.3"
     latestReleaseDate: 2011-10-12
+    link: "https://activemq.apache.org/activemq-{{'__LATEST__'|replace:'.','00'}}-release"
 
 -   releaseCycle: "5.3"
     releaseDate: 2009-10-23
     eol: 2010-08-13 # estimated based on 5.4 release date
     latest: "5.3.1"
     latestReleaseDate: 2010-03-18
+    link: "https://activemq.apache.org/activemq-{{'__LATEST__'|replace:'.','00'}}-release"
 
 -   releaseCycle: "5.2"
     releaseDate: 2009-06-30
     eol: 2009-10-23 # estimated based on 5.3 release date
     latest: "5.2.0"
     latestReleaseDate: 2009-06-30
+    link: "https://activemq.apache.org/activemq-{{'__LATEST__'|replace:'.','00'}}-release"
 
 -   releaseCycle: "5.1"
     releaseDate: 2008-05-01
     eol: 2009-06-30 # estimated based on 5.2 release date
     latest: "5.1.0"
     latestReleaseDate: 2008-05-01
+    link: "https://activemq.apache.org/activemq-{{'__LATEST__'|replace:'.','00'}}-release"
 
 -   releaseCycle: "5.0"
     releaseDate: 2007-12-07
     eol: 2008-05-01 # estimated based on 5.1 release date
     latest: "5.0.0"
     latestReleaseDate: 2007-12-07
+    link: "https://activemq.apache.org/activemq-{{'__LATEST__'|replace:'.','00'}}-release"
 
 ---
 


### PR DESCRIPTION
The changelogTemplate was only working if y > 9 and z > 9. So:

- it was changed for one which works best for latest releases,
- link was overwritten for other release cycles.