### PR TITLE
[fairphone] Fix links

### DIFF
--- a/products/fairphone.md
+++ b/products/fairphone.md
@@ -8,52 +8,57 @@ discontinuedColumn: true
 activeSupportColumn: false
 releaseColumn: false
 releaseDateColumn: true
-releaseLabel: "Fairphone __RELEASE_CYCLE__"
 
 releases:
 -   releaseCycle: "4"
+    highestAndroidVersion: "12"
+    releaseDate: 2021-09-30
     discontinued: false
     eol: 2026-09-30
-    releaseDate: 2021-09-30
     link: https://support.fairphone.com/hc/articles/4405858220945
 
 -   releaseCycle: "3+"
+    highestAndroidVersion: "13"
+    releaseDate: 2020-09-30
     discontinued: 2022-11-01
     eol: 2025-09-30
-    releaseDate: 2020-09-30
     link: https://support.fairphone.com/hc/articles/360048139032
 
 -   releaseCycle: "3"
+    highestAndroidVersion: "13"
+    releaseDate: 2019-09-30
     discontinued: 2021-09-01
     eol: 2024-09-30
-    releaseDate: 2019-09-30
     link: https://support.fairphone.com/hc/articles/360048139032
 
 -   releaseCycle: "2"
+    highestAndroidVersion: "10"
+    releaseDate: 2015-12-21
     # https://github.com/endoflife-date/endoflife.date/pull/2656#discussion_r1131930081
     discontinued: 2019-03-31
     # https://www.linkedin.com/posts/fairphone_fairphone2forever-unlaunching-changeisinyourhands-activity-7038910425882615808-DS7c
     eol: 2023-03-07
-    releaseDate: 2015-12-21
     link: https://support.fairphone.com/hc/articles/360019515018
 
 -   releaseCycle: "1"
+    highestAndroidVersion: "4.2"
+    releaseDate: 2013-12-01
     discontinued: 2017-07-13
     eol: 2017-07-13
-    releaseDate: 2013-12-01
     link: https://support.fairphone.com/hc/articles/6217522827281
+
 ---
 
-> Fairphone is a line of smartphones that are designed with the goal of having a lower environmental footprint and better social impact than is common in the industry.
+> Fairphone is a line of smartphones that are designed with the goal of having a lower environmental
+> footprint and better social impact than is common in the industry.
 
-Fairphone 4 is guaranteed an upgrade to Android 13. Updates to Android 14/15 [might happen on a best effort basis](https://support.fairphone.com/hc/articles/4405858006545-FP4-Fairphone-OS-Android-11-).
+Fairphone 4 is guaranteed an upgrade to Android 13. Updates to Android 14/15 [might happen on a best
+effort basis](https://support.fairphone.com/hc/en-us/articles/4405858006545-FP4-Fairphone-OS-Android-11-).
 
-## Support [Android Versions](https://endoflife.date/android)
+[Android](https://endoflife.date/android) versions support is:
 
-| Device       | Highest Android Version |
-| -------------| ----------------------- |
-| Fairphone 4  | 12                      |
-| Fairphone 3+ | 13                      |
-| Fairphone 3  | 13                      |
-| Fairphone 2  | 10                      |
-| Fairphone 1  | 4.2                     |
+{% include table.html
+labels="Device,Highest Android Version"
+fields="releaseCycle,highestAndroidVersion"
+types="string,string"
+rows=page.releases %}

--- a/products/fairphone.md
+++ b/products/fairphone.md
@@ -53,7 +53,7 @@ releases:
 > footprint and better social impact than is common in the industry.
 
 Fairphone 4 is guaranteed an upgrade to Android 13. Updates to Android 14/15 [might happen on a best
-effort basis](https://support.fairphone.com/hc/en-us/articles/4405858006545-FP4-Fairphone-OS-Android-11-).
+effort basis](https://support.fairphone.com/hc/en-us/articles/9979180437393).
 
 [Android](https://endoflife.date/android) versions support is:
 

--- a/products/fairphone.md
+++ b/products/fairphone.md
@@ -15,19 +15,19 @@ releases:
     discontinued: false
     eol: 2026-09-30
     releaseDate: 2021-09-30
-    link: https://shop.fairphone.com/buy-fairphone-4
+    link: https://support.fairphone.com/hc/articles/4405858220945
 
 -   releaseCycle: "3+"
     discontinued: 2022-11-01
     eol: 2025-09-30
     releaseDate: 2020-09-30
-    link: https://shop.fairphone.com/fairphone-3-plus
+    link: https://support.fairphone.com/hc/articles/360048139032
 
 -   releaseCycle: "3"
     discontinued: 2021-09-01
     eol: 2024-09-30
     releaseDate: 2019-09-30
-    link: https://shop.fairphone.com/fairphone-3
+    link: https://support.fairphone.com/hc/articles/360048139032
 
 -   releaseCycle: "2"
     # https://github.com/endoflife-date/endoflife.date/pull/2656#discussion_r1131930081
@@ -35,18 +35,18 @@ releases:
     # https://www.linkedin.com/posts/fairphone_fairphone2forever-unlaunching-changeisinyourhands-activity-7038910425882615808-DS7c
     eol: 2023-03-07
     releaseDate: 2015-12-21
-    link: https://support.fairphone.com/hc/articles/213290023-FP2-Fairphone-OS-downloads
+    link: https://support.fairphone.com/hc/articles/360019515018
 
 -   releaseCycle: "1"
     discontinued: 2017-07-13
     eol: 2017-07-13
     releaseDate: 2013-12-01
-    link: https://support.fairphone.com/hc/articles/6217522827281-Fairphone-1-Frequently-Asked-Questions-FAQ-
+    link: https://support.fairphone.com/hc/articles/6217522827281
 ---
 
 > Fairphone is a line of smartphones that are designed with the goal of having a lower environmental footprint and better social impact than is common in the industry.
 
-Fairphone 4 is guaranteed an upgrade to Android 13. Updates to Android 14/15 [might happen on a best effort basis](https://support.fairphone.com/hc/en-us/articles/4405858006545-FP4-Fairphone-OS-Android-11-).
+Fairphone 4 is guaranteed an upgrade to Android 13. Updates to Android 14/15 [might happen on a best effort basis](https://support.fairphone.com/hc/articles/4405858006545-FP4-Fairphone-OS-Android-11-).
 
 ## Support [Android Versions](https://endoflife.date/android)
 


### PR DESCRIPTION
Replace links to shop.fairphone.com with links to OS Release Notes on support.fairphone.com. shop.fairphone.com link for Fairphone 3 was broken, and support.fairphone.com links should be more resilient.

Also took the opportunity to normalize the page and use a `table.html` include for android versions (#2124).