### PR TITLE
[scala] Fix latest for 3.3

### DIFF
--- a/products/scala.md
+++ b/products/scala.md
@@ -26,7 +26,7 @@ releases:
     releaseDate: 2023-05-23
     support: true
     eol: false
-    latest: "3.3.2"
+    latest: "3.3.0"
     latestReleaseDate: 2023-05-23
 
 -   releaseCycle: "3.2"


### PR DESCRIPTION
3.3.1 and 3.3.2 versions does not exist.

The mistake was done when the cycle was added in 9d1afec8d72cfe53d2135a599b10720362905387.