### PR TITLE
[angular] Update icons

### DIFF
--- a/products/angularjs.md
+++ b/products/angularjs.md
@@ -2,7 +2,7 @@
 title: AngularJS
 category: framework
 tags: google javascript-runtime
-iconSlug: angularjs
+iconSlug: angular
 permalink: /angularjs
 alternate_urls:
 -   /angular-js


### PR DESCRIPTION
The `angularjs` icon will be deprecated on 2023-11-26, see https://github.com/simple-icons/simple-icons/pull/9304. Using `angular` icon instead.

Relates to #3459.