### PR TITLE
[opensuse] update 15.1 and 15.2 EOL dates

### DIFF
--- a/products/opensuse.md
+++ b/products/opensuse.md
@@ -33,11 +33,11 @@ releases:
 
 -   releaseCycle: "15.3"
     releaseDate: 2021-06-02
-    eol: 2022-12-01
+    eol: 2022-12-31
 
 -   releaseCycle: "15.2"
     releaseDate: 2020-07-02
-    eol: 2021-12-01
+    eol: 2022-01-04
 
 -   releaseCycle: "15.1"
     releaseDate: 2019-05-22


### PR DESCRIPTION
The EOL dates for openSUSE 15.1 and 15.2 were incorrect by a few days.

15.2: https://lists.opensuse.org/archives/list/security-announce@lists.opensuse.org/thread/DKIXTCVYQEKZ2ANWGLWL5Q77ZMIOTQJ2/
15.1: https://lists.opensuse.org/archives/list/security-announce@lists.opensuse.org/thread/WTRFFZBITYZ7AJP45W3EUMP3ODMX4BV7/