### PR TITLE
[new-product] AWS Glue

### DIFF
--- a/products/amazon-glue.md
+++ b/products/amazon-glue.md
@@ -29,6 +29,23 @@ releases:
     pythonVersion: "3.7"
     sparkVersion: "2.4"
 
+-   releaseCycle: "1.0 (Python 3)"
+    releaseDate: 2019-07-25
+    eol: 2022-09-30
+    pythonVersion: "3.6"
+    sparkVersion: "2.4"
+
+-   releaseCycle: "1.0 (Python 2)"
+    releaseDate: 2019-07-25
+    eol: 2022-06-01
+    pythonVersion: "2.7"
+    sparkVersion: "2.4"
+
+-   releaseCycle: "0.9"
+    releaseDate: 2019-07-25
+    eol: 2022-06-01
+    pythonVersion: "2.7"
+    sparkVersion: "2.2"
 ---
 
 > [Amazon Glue](https://aws.amazon.com/glue/) is a serverless data integration service that makes

--- a/products/amazon-glue.md
+++ b/products/amazon-glue.md
@@ -56,6 +56,10 @@ The AWS Glue version determines the runtime versions of Apache Spark and Python.
 Glue generally include major version upgrades for Apache Spark and Python, so be sure to refer to
 Spark and Python migration guides when upgrading to a newer version of Glue.
 
+Jobs running on deprecated versions of AWS Glue are no longer eligible for technical support.
+Security patches or other updates will not be applied to deprecated versions. AWS Glue will also
+not honor SLAs when jobs are run on deprecated versions.
+
 ## [Compatibility matrix](https://docs.aws.amazon.com/glue/latest/dg/release-notes.html)
 
 {% include table.html

--- a/products/amazon-glue.md
+++ b/products/amazon-glue.md
@@ -4,48 +4,61 @@ category: service
 tags: amazon
 iconSlug: amazonaws
 permalink: /amazon-glue
-releasePolicyLink:
-  https://docs.aws.amazon.com/glue/latest/dg/glue-version-support-policy.html
+releasePolicyLink: https://docs.aws.amazon.com/glue/latest/dg/glue-version-support-policy.html
 releaseDateColumn: true
 releaseColumn: false
 
 # Versions taken from https://docs.aws.amazon.com/glue/latest/dg/release-notes.html
+# EOL dates from https://docs.aws.amazon.com/glue/latest/dg/glue-version-support-policy.html.
 releases:
 -   releaseCycle: "4.0"
+    releaseLabel: "4.0"
     releaseDate: 2022-11-28
     eol: false
     pythonVersion: "3.10"
     sparkVersion: "3.3"
+    link: https://aws.amazon.com/about-aws/whats-new/2022/11/introducing-aws-glue-4-0/
 
 -   releaseCycle: "3.0"
+    releaseLabel: "3.0"
     releaseDate: 2021-08-19
     eol: false
     pythonVersion: "3.7"
     sparkVersion: "3.1"
+    link: https://aws.amazon.com/blogs/big-data/introducing-aws-glue-3-0-with-optimized-apache-spark-3-1-runtime-for-faster-data-integration/
 
 -   releaseCycle: "2.0"
+    releaseLabel: "2.0"
     releaseDate: 2020-08-10
     eol: 2024-01-31
     pythonVersion: "3.7"
     sparkVersion: "2.4"
+    link: https://aws.amazon.com/blogs/aws/aws-glue-version-2-0-featuring-10x-faster-job-start-times-and-1-minute-minimum-billing-duration/
 
--   releaseCycle: "1.0 (Python 3)"
+-   releaseCycle: "1.0-python-3"
+    releaseLabel: "1.0 (Python 3)"
     releaseDate: 2019-07-25
     eol: 2022-09-30
     pythonVersion: "3.6"
     sparkVersion: "2.4"
+    link: https://docs.aws.amazon.com/glue/latest/dg/glue-version-support-policy.html
 
--   releaseCycle: "1.0 (Python 2)"
+-   releaseCycle: "1.0-python-2"
+    releaseLabel: "1.0 (Python 2)"
     releaseDate: 2019-07-25
     eol: 2022-06-01
     pythonVersion: "2.7"
     sparkVersion: "2.4"
+    link: https://docs.aws.amazon.com/glue/latest/dg/glue-version-support-policy.html
 
 -   releaseCycle: "0.9"
+    releaseLabel: "0.9"
     releaseDate: 2019-07-25
     eol: 2022-06-01
     pythonVersion: "2.7"
     sparkVersion: "2.2"
+    link: https://docs.aws.amazon.com/glue/latest/dg/glue-version-support-policy.html
+
 ---
 
 > [Amazon Glue](https://aws.amazon.com/glue/) is a serverless data integration service that makes
@@ -64,6 +77,6 @@ versions.
 
 {% include table.html
 labels="Glue version,Python version,Spark version"
-fields="releaseCycle,pythonVersion,sparkVersion"
+fields="releaseLabel,pythonVersion,sparkVersion"
 types="string,string,string"
 rows=page.releases %}

--- a/products/amazon-glue.md
+++ b/products/amazon-glue.md
@@ -17,20 +17,20 @@ releases:
 -   releaseCycle: "4.0"
     releaseDate: 2022-11-28
     eol: false
-    pythonVersion: 3.10
-    sparkVersion: 3.3
+    pythonVersion: "3.10"
+    sparkVersion: "3.3"
 
 -   releaseCycle: "3.0"
     releaseDate: 2021-08-19
     eol: false
-    pythonVersion: 3.7
-    sparkVersion: 3.1
+    pythonVersion: "3.7"
+    sparkVersion: "3.1"
 
 -   releaseCycle: "2.0"
     releaseDate: 2020-08-10
     eol: 2024-01-31
-    pythonVersion: 3.7
-    sparkVersion: 2.4
+    pythonVersion: "3.7"
+    sparkVersion: "2.4"
 
 ---
 

--- a/products/amazon-glue.md
+++ b/products/amazon-glue.md
@@ -9,9 +9,6 @@ releasePolicyLink:
 releaseDateColumn: true
 releaseColumn: false
 
-auto:
--   custom: true
-
 # Versions taken from https://docs.aws.amazon.com/glue/latest/dg/release-notes.html
 releases:
 -   releaseCycle: "4.0"

--- a/products/amazon-glue.md
+++ b/products/amazon-glue.md
@@ -7,6 +7,7 @@ permalink: /amazon-glue
 releasePolicyLink:
   https://docs.aws.amazon.com/glue/latest/dg/glue-version-support-policy.html
 releaseDateColumn: true
+releaseColumn: false
 
 auto:
 -   custom: true

--- a/products/amazon-glue.md
+++ b/products/amazon-glue.md
@@ -1,7 +1,7 @@
 ---
 title: Amazon Glue
 category: service
-tags: amazon glue
+tags: amazon
 iconSlug: amazonaws
 permalink: /amazon-glue
 releasePolicyLink:

--- a/products/amazon-glue.md
+++ b/products/amazon-glue.md
@@ -56,9 +56,9 @@ The AWS Glue version determines the runtime versions of Apache Spark and Python.
 Glue generally include major version upgrades for Apache Spark and Python, so be sure to refer to
 Spark and Python migration guides when upgrading to a newer version of Glue.
 
-Jobs running on deprecated versions of AWS Glue are no longer eligible for technical support.
-Security patches or other updates will not be applied to deprecated versions. AWS Glue will also
-not honor SLAs when jobs are run on deprecated versions.
+Jobs running on deprecated versions of AWS Glue are not eligible for technical support, security
+patches or any other updates. AWS Glue will also not honor SLAs when jobs are run on deprecated
+versions.
 
 ## [Compatibility matrix](https://docs.aws.amazon.com/glue/latest/dg/release-notes.html)
 

--- a/products/amazon-glue.md
+++ b/products/amazon-glue.md
@@ -1,0 +1,50 @@
+---
+title: Amazon Glue
+category: service
+tags: amazon glue
+iconSlug: amazonaws
+permalink: /amazon-glue
+releasePolicyLink:
+  https://docs.aws.amazon.com/glue/latest/dg/glue-version-support-policy.html
+releaseDateColumn: true
+
+auto:
+-   custom: true
+
+# Versions taken from https://docs.aws.amazon.com/glue/latest/dg/release-notes.html
+releases:
+-   releaseCycle: "4.0"
+    releaseDate: 2022-11-28
+    eol: false
+    pythonVersion: 3.10
+    sparkVersion: 3.3
+
+-   releaseCycle: "3.0"
+    releaseDate: 2021-08-19
+    eol: false
+    pythonVersion: 3.7
+    sparkVersion: 3.1
+
+-   releaseCycle: "2.0"
+    releaseDate: 2020-08-10
+    eol: 2024-01-31
+    pythonVersion: 3.7
+    sparkVersion: 2.4
+
+---
+
+> [Amazon Glue](https://aws.amazon.com/glue/) is a serverless data integration service that makes
+> it easier to discover, prepare, move, and integrate data from multiple sources for analytics,
+> machine learning (ML), and application development.
+
+The AWS Glue version determines the runtime versions of Apache Spark and Python. New versions of
+Glue generally include major version upgrades for Apache Spark and Python, so be sure to refer to
+Spark and Python migration guides when upgrading to a newer version of Glue.
+
+## [Compatibility matrix](https://docs.aws.amazon.com/glue/latest/dg/release-notes.html)
+
+{% include table.html
+labels="Glue version,Python version,Spark version"
+fields="releaseCycle,pythonVersion,sparkVersion"
+types="string,string,string"
+rows=page.releases %}


### PR DESCRIPTION
Adds [AWS Glue](https://aws.amazon.com/glue/)

Glue support policy - https://docs.aws.amazon.com/glue/latest/dg/glue-version-support-policy.html

Glue release history - https://docs.aws.amazon.com/glue/latest/dg/release-notes.html

Glue 4.0 release announcement - https://aws.amazon.com/about-aws/whats-new/2022/11/introducing-aws-glue-4-0/

Glue 3.0 release announcement - https://aws.amazon.com/blogs/big-data/introducing-aws-glue-3-0-with-optimized-apache-spark-3-1-runtime-for-faster-data-integration/

Glue 2.0 release announcement - https://aws.amazon.com/blogs/aws/aws-glue-version-2-0-featuring-10x-faster-job-start-times-and-1-minute-minimum-billing-duration/

Glue 1.0 release announcement - https://aws.amazon.com/about-aws/whats-new/2019/07/aws-glue-now-supports-ability-to-run-etl-jobs-apache-spark-243-with-python-3/ Note - this announcement states Glue jobs which previously had no version specified were set to 0.9. I am not 100% sure how Glue worked in the early dates (pre 1.0) so I set the release date of 0.9 to the same as 1.0. I assume they set all old Glue jobs to version 0.9 and released 1.0 with the spark upgrade and python 3 support together.

I decided to leave out versions prior to 2.0 because they did not previously align a major version with supported Python and Spark version, instead they added additional support while retaining version 1.0. The current model they appear to follow is to release a new major Glue version when adding support for a new major version of Spark or Python.
