### PR TITLE
[apache-kafka] Update extendedSupport for 3.5

### DIFF
--- a/products/apache-kafka.md
+++ b/products/apache-kafka.md
@@ -23,7 +23,7 @@ releases:
 -   releaseCycle: "3.5"
     releaseDate: 2023-06-13
     eol: false
-    extendedSupport: 2025-08-29
+    extendedSupport: 2025-08-25
     latest: "3.5.1"
     latestReleaseDate: 2023-07-20
 


### PR DESCRIPTION
They updated the date for 3.5 on 
https://docs.confluent.io/platform/current/installation/versions-interoperability.html