### PR TITLE
[prometheus] Add 2.47, Update 2.46 eol, Add eolWarnThreshold

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -126,6 +126,8 @@ eolColumn: Security Support
 
 # Threshold at which the background color of the cycle's "eol" cell changes to indicate
 # that the EOL date is approaching (optional, default = 121 days).
+# If a fixed EOL calculation is taken the rule of thumb one third of the time can be applied.
+# e.g. eol = releaseDate + 6w -> 2w eolWarnThreshold: 14
 eolWarnThreshold: 121
 
 # Whether the "Active Support" column should be displayed (optional, default = false).
@@ -134,6 +136,8 @@ activeSupportColumn: Active Support
 
 # Threshold at which the background color of the cycle's "activeSupport" cell changes to indicate
 # that the end of active support date is approaching (optional, default = 121 days).
+# If a fixed support calculation is taken the rule of thumb one third of the time can be applied.
+# e.g. activeSupport = releaseDate + 3w -> 1w activeSupportWarnThreshold: 7
 activeSupportWarnThreshold: 121
 
 # Whether the "Latest" column should be displayed (optional, default = true).

--- a/products/prometheus.md
+++ b/products/prometheus.md
@@ -6,6 +6,7 @@ permalink: /prometheus
 releasePolicyLink: https://prometheus.io/docs/introduction/release-cycle/
 activeSupportColumn: false
 releaseDateColumn: true
+eolWarnThreshold: 14
 
 auto:
 -   git: https://github.com/prometheus/prometheus.git

--- a/products/prometheus.md
+++ b/products/prometheus.md
@@ -21,9 +21,15 @@ changelogTemplate: https://github.com/prometheus/prometheus/releases/tag/v__LATE
 # eol(x) = releaseDate(x) + 6w (non-LTS)
 # For LTS, as per https://prometheus.io/docs/introduction/release-cycle/#long-term-support
 releases:
+-   releaseCycle: "2.47"
+    releaseDate: 2023-09-06
+    eol: 2023-10-18
+    latestReleaseDate: 2023-09-06
+    latest: "2.47.0"
+
 -   releaseCycle: "2.46"
     releaseDate: 2023-07-25
-    eol: 2024-09-05
+    eol: 2023-09-05
     latestReleaseDate: 2023-07-25
     latest: "2.46.0"
 


### PR DESCRIPTION
https://github.com/prometheus/prometheus/releases/tag/v2.47.0
eol calc 2.47 
https://www.timeanddate.com/date/dateadded.html?d1=6&m1=9&y1=2023&aw=6

eol calc 2.46 https://www.timeanddate.com/date/dateadded.html?d1=25&m1=7&y1=2023&aw=6

Add eolWarnThreshold:
eol is 6 weeks after release, warn should be on last 1/3 -> 14 days