### PR TITLE
Add pre-commit config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,3 +9,5 @@ repos:
         files: 'products/.*\.md$'
         types_or: []
         verbose: true
+        additional_dependencies:
+          - pyyaml

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,6 +4,8 @@ repos:
     rev: 0.26.3
     hooks:
       - id: check-jsonschema
-        name: Validate Products
-        args: ["--schemafile", "product-schema.json"]
-        files: ^products/.*\.md$
+        name: Validating products
+        entry: scripts/check-jsonschema-wrapper
+        files: 'products/.*\.md$'
+        types_or: []
+        verbose: true

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,9 @@
+---
+repos:
+  - repo: https://github.com/python-jsonschema/check-jsonschema
+    rev: 0.26.3
+    hooks:
+      - id: check-jsonschema
+        name: Validate Products
+        args: ["--schemafile", "product-schema.json"]
+        files: ^products/.*\.md$

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -348,6 +348,19 @@ You can visit <https://github.com/endoflife-date/endoflife.date/new/master/produ
 
 ## ✅ Validating your changes
 
+If you're using an IDE like `vscode` or `vim` (or any other IDE that support jsonschema validation),
+you can use [this jsonschema](./product-schema.json) to validate the new product.
+
+It's also possible to use [pre-commit](https://pre-commit.com/) [hooks](./.pre-commit-config.yaml) to validate the changed files.
+Install these hook with:
+
+```bash
+pre-commit install
+pre-commit install-hooks
+# You can manually run the hooks with
+# pre-commit run --all-files
+```
+
 Once you file your Pull Request, Netlify will provide a list of checks for your changes. If one of the checks is failed, you can click Details and see through the errors, or one of the Maintainers will be there to help you soon.
 
 If all of the checks pass, you can click the "Details" link on the "Deploy Preview" Status Check to see a preview of the website _with your changes_.

--- a/_config.yml
+++ b/_config.yml
@@ -1,3 +1,4 @@
+---
 # Jekyll configuration - https://jekyllrb.com/docs/configuration/
 
 # Site settings
@@ -117,3 +118,4 @@ exclude:
   - README.md
   - requirements.txt
   - runtime.txt
+  - scripts

--- a/scripts/check-jsonschema-wrapper
+++ b/scripts/check-jsonschema-wrapper
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+# This script is used by the pre-commit hook.
+# It's required because the product files contain invalid yaml data at the end.
+
+for file in "$@"; do
+  echo "Checking $file"
+  check-jsonschema --schemafile product-schema.json <(awk 'BEGIN { x=0 } $1=="---"{x+=1} x<2{print $0}' "$file" | yq -o=j '.' -)
+done

--- a/scripts/check-jsonschema-wrapper
+++ b/scripts/check-jsonschema-wrapper
@@ -5,5 +5,10 @@
 
 for file in "$@"; do
   echo "Checking $file"
-  check-jsonschema --schemafile product-schema.json <(awk 'BEGIN { x=0 } $1=="---"{x+=1} x<2{print $0}' "$file" | yq -o=j '.' -)
+  check-jsonschema \
+    --schemafile product-schema.json \
+    <(
+      awk 'BEGIN { x=0 } $1=="---"{x+=1} x<2{print $0}' "$file" \
+      | python -c "import sys, json, yaml; json.dump(yaml.safe_load(sys.stdin), sys.stdout, indent=4, default=str)" -
+    )
 done


### PR DESCRIPTION
These are the commits I had in the PR #3387

This would optionally add the possibility for users to enable the validation of product files. You only need to install the `pre-commit` tool and run the commands

```bash
pre-commit install
pre-commit install-hooks
```

Now everytime you change a file in the products directory and try to commit this change, the product will be validate with the jsonschema from #3387.