### PR TITLE
[yarn] mark 1.x as eol

### DIFF
--- a/products/yarn.md
+++ b/products/yarn.md
@@ -36,8 +36,8 @@ releases:
 
 -   releaseCycle: "1"
     releaseDate: 2017-09-05
-    eol: false
-    latestReleaseDate: 2022-06-08
+    eol: 2022-05-10
+    latestReleaseDate: 2022-05-10
     latest: '1.22.19'
     link: https://github.com/yarnpkg/yarn/releases/tag/v__LATEST__
 

--- a/products/yarn.md
+++ b/products/yarn.md
@@ -48,7 +48,7 @@ releases:
 
 Yarn's support and EOL policy is not clearly defined.
 
-Yarn Classic (v1) [entered maintenance mode in January 2020](https://dev.to/arcanis/introducing-yarn-2-4eh1#what-will-happen-to-the-legacy-codebase)
-and will eventually reach end-of-life. It is highly recommended to
+Yarn Classic (v1) [entered maintenance mode in January 2020](https://dev.to/arcanis/introducing-yarn-2-4eh1#what-will-happen-to-the-legacy-codebase) and subsequently [entered frozen mode in September 2022](https://github.com/yarnpkg/yarn/commit/158d96dce95313d9a00218302631cd263877d164)
+and is considered to have reached end-of-life. It is highly recommended to
 [Migrate](https://yarnpkg.com/migration/overview) to the latest version. Yarn
 Classic only receives critical and security fixes.

--- a/products/yarn.md
+++ b/products/yarn.md
@@ -36,8 +36,8 @@ releases:
 
 -   releaseCycle: "1"
     releaseDate: 2017-09-05
-    eol: 2022-05-10
-    latestReleaseDate: 2022-05-10
+    eol: 2022-09-05
+    latestReleaseDate: 2022-06-08
     latest: '1.22.19'
     link: https://github.com/yarnpkg/yarn/releases/tag/v__LATEST__
 


### PR DESCRIPTION
Corrects the last release date according to the release here https://github.com/yarnpkg/yarn/releases

The project about section here https://github.com/yarnpkg/yarn states the repo is frozen and all the changes need to be submitted to a different repo targeting higher versions.