### PR TITLE
[java] New LTS (21) Released

### DIFF
--- a/products/java.md
+++ b/products/java.md
@@ -24,6 +24,14 @@ auto:
 -   custom: true
 
 releases:
+-   releaseCycle: "21"
+    lts: true
+    releaseDate: 2023-09-19
+    support: 2026-09-30
+    eol: 2026-09-30
+    latest: "21.0.0"
+    latestReleaseDate: 2023-09-19
+
 -   releaseCycle: "20"
     releaseDate: 2023-03-21
     support: 2023-09-19

--- a/products/java.md
+++ b/products/java.md
@@ -31,6 +31,7 @@ releases:
     eol: 2026-09-30
     latest: "21.0.0"
     latestReleaseDate: 2023-09-19
+    link: https://www.oracle.com/java/technologies/javase/21-relnote-issues.html
 
 -   releaseCycle: "20"
     releaseDate: 2023-03-21


### PR DESCRIPTION
JDK 21 will receive updates under the NFTC, until September 2026, a year after the release of the next LTS
https://www.oracle.com/java/technologies/downloads/#java21