### PR TITLE
[sapmachine] Add 21

### DIFF
--- a/products/sapmachine.md
+++ b/products/sapmachine.md
@@ -15,6 +15,12 @@ auto:
 # LTS : EOL dates can be found on https://github.com/SAP/SapMachine/wiki/Security-Updates,-Maintenance-and-Support
 # non-LTS : EOL(x) = releaseDate(x+1) (exact date for future releases can be found on https://www.java.com/releases/)
 releases:
+-   releaseCycle: "21"
+    releaseDate: 2023-09-19
+    eol: false
+    latest: '21'
+    latestReleaseDate: 2023-09-19
+
 -   releaseCycle: "20"
     releaseDate: 2023-03-17
     eol: 2023-09-19

--- a/products/sapmachine.md
+++ b/products/sapmachine.md
@@ -16,6 +16,7 @@ auto:
 # non-LTS : EOL(x) = releaseDate(x+1) (exact date for future releases can be found on https://www.java.com/releases/)
 releases:
 -   releaseCycle: "21"
+    lts: true
     releaseDate: 2023-09-19
     eol: false
     latest: '21'


### PR DESCRIPTION
See https://github.com/SAP/SapMachine/releases/tag/sapmachine-21.

Note that the official release date for 21 is 2023-09-19, but the date will automatically be updated to 2023-09-18 because of the date of the GitHub release.