### PR TITLE
Replaces AWS icons with RDS icons

### DIFF
--- a/products/amazon-rds-mysql.md
+++ b/products/amazon-rds-mysql.md
@@ -2,7 +2,7 @@
 title: Amazon RDS for MySQL
 category: service
 tags: amazon managed-mysql
-iconSlug: amazonaws
+iconSlug: amazonrds
 permalink: /amazon-rds-mysql
 releasePolicyLink: 
   https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/MySQL.Concepts.VersionMgmt.html

--- a/products/amazon-rds-mysql.md
+++ b/products/amazon-rds-mysql.md
@@ -4,7 +4,7 @@ category: service
 tags: amazon managed-mysql
 iconSlug: amazonrds
 permalink: /amazon-rds-mysql
-releasePolicyLink: 
+releasePolicyLink:
   https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/MySQL.Concepts.VersionMgmt.html
 releaseDateColumn: true
 

--- a/products/amazon-rds-postgresql.md
+++ b/products/amazon-rds-postgresql.md
@@ -2,7 +2,7 @@
 title: Amazon RDS for PostgreSQL
 category: service
 tags: amazon managed-postgresql
-iconSlug: amazonaws
+iconSlug: amazonrds
 permalink: /amazon-rds-postgresql
 releasePolicyLink: 
   https://docs.aws.amazon.com/AmazonRDS/latest/PostgreSQLReleaseNotes/postgresql-release-calendar.html

--- a/products/amazon-rds-postgresql.md
+++ b/products/amazon-rds-postgresql.md
@@ -4,7 +4,7 @@ category: service
 tags: amazon managed-postgresql
 iconSlug: amazonrds
 permalink: /amazon-rds-postgresql
-releasePolicyLink: 
+releasePolicyLink:
   https://docs.aws.amazon.com/AmazonRDS/latest/PostgreSQLReleaseNotes/postgresql-release-calendar.html
 releaseDateColumn: true
 


### PR DESCRIPTION
Replaces AWS icon with RDS icon for the two RDS pages

**Before:**
![Screenshot 2023-09-20 at 7 54 06 PM](https://github.com/endoflife-date/endoflife.date/assets/16943514/84529b3c-ff06-4542-adb8-828dfeacf891)
![Screenshot 2023-09-20 at 7 54 55 PM](https://github.com/endoflife-date/endoflife.date/assets/16943514/23e047e8-632b-4509-976c-de3c58af61a5)

**After:**
![Screenshot 2023-09-20 at 7 54 12 PM](https://github.com/endoflife-date/endoflife.date/assets/16943514/b413fb34-a41e-44ba-9301-7d21941d6945)
![Screenshot 2023-09-20 at 7 55 03 PM](https://github.com/endoflife-date/endoflife.date/assets/16943514/45b471e7-cc19-42e1-b291-9d617015735e)



plus additional redundant whitespace removal