### PR TITLE
Fix link macOS Ventura

### DIFF
--- a/products/macos.md
+++ b/products/macos.md
@@ -24,7 +24,7 @@ releases:
 -   releaseCycle: "13"
     codename: "Ventura"
     eol: false
-    link: https://support.apple.com/HT213931
+    link: https://support.apple.com/en-us/HT213268
     releaseDate: 2022-10-24
     latestReleaseDate: 2023-09-21
     latest: '13.6'

--- a/products/macos.md
+++ b/products/macos.md
@@ -24,7 +24,7 @@ releases:
 -   releaseCycle: "13"
     codename: "Ventura"
     eol: false
-    link: https://support.apple.com/HT213906
+    link: https://support.apple.com/HT213931
     releaseDate: 2022-10-24
     latestReleaseDate: 2023-09-21
     latest: '13.6'

--- a/products/macos.md
+++ b/products/macos.md
@@ -24,7 +24,7 @@ releases:
 -   releaseCycle: "13"
     codename: "Ventura"
     eol: false
-    link: https://support.apple.com/en-us/HT213268
+    link: https://support.apple.com/HT213268
     releaseDate: 2022-10-24
     latestReleaseDate: 2023-09-21
     latest: '13.6'


### PR DESCRIPTION
Current link is redirecting to 13.5.2