### PR TITLE
Added Palo Alto Networks Icon/Logo

### DIFF
--- a/products/pan-cortex-xdr.md
+++ b/products/pan-cortex-xdr.md
@@ -11,6 +11,7 @@ alternate_urls:
 releasePolicyLink: https://www.paloaltonetworks.com/services/support/end-of-life-announcements/end-of-life-summary
 changelogTemplate: https://docs-cortex.paloaltonetworks.com/r/Cortex-XDR/__RELEASE_CYCLE__/Cortex-XDR-Agent-Release-Notes/Cortex-XDR-Agent-__RELEASE_CYCLE__-Release-Information
 LTSLabel: CE
+iconSlug: paloaltonetworks
 activeSupportColumn: false
 releaseColumn: false
 releaseDateColumn: true

--- a/products/pan-gp.md
+++ b/products/pan-gp.md
@@ -4,7 +4,7 @@ category: app
 tags: palo-alto-networks
 permalink: /pangp
 releasePolicyLink: https://www.paloaltonetworks.com/services/support/end-of-life-announcements/end-of-life-summary
-
+iconSlug: paloaltonetworks
 activeSupportColumn: true
 releaseColumn: true
 releaseDateColumn: true

--- a/products/pan-os.md
+++ b/products/pan-os.md
@@ -5,7 +5,7 @@ tags: palo-alto-networks
 permalink: /panos
 versionCommand: show system info | match sw-version
 releasePolicyLink: https://www.paloaltonetworks.com/services/support/end-of-life-announcements/end-of-life-summary
-
+iconSlug: paloaltonetworks
 activeSupportColumn: false
 releaseColumn: true
 releaseDateColumn: true


### PR DESCRIPTION
Based on https://simpleicons.org/?q=palo%20alto%20networks which now includes the paloaltonetworks icon/logo.

Added to all tracked Palo Alto Networks products:
panos
cortex-xdr
pangp