### PR TITLE
ROS 2: add Iron Irwini release

### DIFF
--- a/products/ros2.md
+++ b/products/ros2.md
@@ -12,6 +12,11 @@ releaseDateColumn: true
 eolColumn: End Of Life
 
 releases:
+-   releaseCycle: 'iron'
+    codename: 'Iron Irwini'
+    releaseDate: 2023-05-23
+    eol: 2024-11-01
+
 -   releaseCycle: 'humble'
     codename: 'Humble Hawksbill'
     releaseDate: 2022-05-23


### PR DESCRIPTION
This adds the latest ROS 2 release called `Iron Irwini`

See here: https://docs.ros.org/en/iron/Releases.html