### PR TITLE
Allow overriding the data directory in latest.py

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ _data/gke.json
 *.code-workspace
 node_modules
 .DS_Store
+.venv


### PR DESCRIPTION
The directory can be specified in script parameters using the new `-d` or `--data-directory` option.
It is needed to easily run the script against a working branch of the [release-data](https://github.com/endoflife-date/release-data) directory.