### PR TITLE
[linuxmint] Drop unnecessary lts=false

### DIFF
--- a/products/linuxmint.md
+++ b/products/linuxmint.md
@@ -123,7 +123,6 @@ releases:
     releaseDate: 2017-11-27
 -   releaseCycle: "18.1"
     codename: Serena
-    lts: false
     support: false
     eol: 2021-04-01
     latest: "18.1"


### PR DESCRIPTION
The default value for the lts property is already false.