### PR TITLE
[neo4j] Drop unnecessary lts=false

### DIFF
--- a/products/neo4j.md
+++ b/products/neo4j.md
@@ -106,28 +106,24 @@ releases:
 -   releaseCycle: "4.3"
     eol: 2022-12-16
     latest: "4.3.23"
-    lts: false
     latestReleaseDate: 2022-12-21
     releaseDate: 2021-06-10
 
 -   releaseCycle: "4.2"
     eol: 2022-05-16
     latest: "4.2.19"
-    lts: false
     latestReleaseDate: 2022-08-11
     releaseDate: 2020-11-17
 
 -   releaseCycle: "4.1"
     eol: 2021-12-22
     latest: "4.1.12"
-    lts: false
     latestReleaseDate: 2022-08-11
     releaseDate: 2020-06-23
 
 -   releaseCycle: "4.0"
     eol: 2021-07-14
     latest: "4.0.12"
-    lts: false
     latestReleaseDate: 2021-07-06
     releaseDate: 2019-12-17
 


### PR DESCRIPTION
The default value for the lts property is already false.