### PR TITLE
[vuetify] Drop unnecessary lts=false

### DIFF
--- a/products/vuetify.md
+++ b/products/vuetify.md
@@ -21,7 +21,6 @@ releases:
     support: true
     eol: false
     latest: "3.3.20"
-    lts: false
     latestReleaseDate: 2023-10-03
     releaseDate: 2022-10-31
 
@@ -29,7 +28,6 @@ releases:
     support: 2021-11-15
     eol: false
     latest: "2.7.1"
-    lts: false
     latestReleaseDate: 2023-08-09
     releaseDate: 2019-07-23
 


### PR DESCRIPTION
The default value for the lts property is already false.