### PR TITLE
Disable the check-links workflow on forks

### DIFF
--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -8,6 +8,8 @@ on:
 jobs:
   check_urls:
     runs-on: ubuntu-latest
+    # Do not run this job on forks, as it's not cool to query servers for nothing.
+    if: ${{ github.repository == 'endoflife-date/endoflife.date' }}
     steps:
       - name: Checkout site
         uses: actions/checkout@v4


### PR DESCRIPTION
This workflow generates a lot of queries, and it's not cool to query servers for nothing. We could also be denied or rate-limited if website owner detect too much traffic from us.