### PR TITLE
Twig 2 End-Of-Life

### DIFF
--- a/products/twig.md
+++ b/products/twig.md
@@ -16,7 +16,7 @@ releases:
     releaseDate: 2019-11-15
     latestReleaseDate: 2023-08-28
 -   releaseCycle: "2"
-    eol: 2023-12-31
+    eol: 2023-12-31 # https://symfony.com/blog/twig-2-end-of-life
     latest: "2.15.5"
     releaseDate: 2017-01-05
     latestReleaseDate: 2023-05-03

--- a/products/twig.md
+++ b/products/twig.md
@@ -16,12 +16,12 @@ releases:
     releaseDate: 2019-11-15
     latestReleaseDate: 2023-08-28
 -   releaseCycle: "2"
-    eol: false
+    eol: 2023-12-31
     latest: "2.15.5"
     releaseDate: 2017-01-05
     latestReleaseDate: 2023-05-03
 -   releaseCycle: "1"
-    eol: false
+    eol: 2022-09-28
     latest: "1.44.7"
     releaseDate: 2011-03-27
     latestReleaseDate: 2022-09-28


### PR DESCRIPTION
The Twig 2 end of life was announced in a blog post: https://symfony.com/blog/twig-2-end-of-life