### PR TITLE
Update os/EuroLinux

### DIFF
--- a/products/eurolinux.md
+++ b/products/eurolinux.md
@@ -25,8 +25,8 @@ releases:
     releaseDate: 2021-07-12
     support: 2029-03-01
     eol: 2029-06-30
-    latest: "8.7"
-    latestReleaseDate: 2022-11-15
+    latest: "8.8"
+    latestReleaseDate: 2023-05-17
 
 -   releaseCycle: "7"
     releaseDate: 2020-11-25


### PR DESCRIPTION
Based on https://en.euro-linux.com/blog/eurolinux-8-8-released/ there is a never minor version for 8.x that was release on `May 17, 2023`.