### PR TITLE
[AngularJs] replace outdated xlts link 

### DIFF
--- a/products/angularjs.md
+++ b/products/angularjs.md
@@ -4,7 +4,7 @@ category: framework
 tags: google javascript-runtime
 permalink: /angularjs
 alternate_urls:
--   /angular-js
+  - /angular-js
 versionCommand: npm list angular
 releasePolicyLink: https://docs.angularjs.org/misc/version-support-status
 changelogTemplate: https://github.com/angular/angular.js/blob/v__LATEST__/CHANGELOG.md
@@ -16,14 +16,14 @@ eolColumn: Support
 extendedSupportColumn: Extended Long Term Support
 
 auto:
--   npm: angular
+  - npm: angular
 
 identifiers:
--   repology: angular.js
--   purl: pkg:npm/angular
+  - repology: angular.js
+  - purl: pkg:npm/angular
 
 releases:
--   releaseCycle: "1.8"
+  - releaseCycle: "1.8"
     lts: true
     releaseDate: 2020-06-04
     eol: 2021-12-31
@@ -31,62 +31,61 @@ releases:
     latest: "1.8.3"
     latestReleaseDate: 2022-04-07
 
--   releaseCycle: "1.7"
+  - releaseCycle: "1.7"
     releaseDate: 2018-05-11
     eol: 2021-12-31
     extendedSupport: false
     latest: "1.7.9"
     latestReleaseDate: 2019-11-19
 
--   releaseCycle: "1.6"
+  - releaseCycle: "1.6"
     releaseDate: 2016-12-08
     eol: 2021-12-31
     extendedSupport: false
     latest: "1.6.10"
     latestReleaseDate: 2018-04-17
 
--   releaseCycle: "1.5"
+  - releaseCycle: "1.5"
     releaseDate: 2016-02-05
     eol: 2021-12-31
     extendedSupport: true
     latest: "1.5.11"
     latestReleaseDate: 2017-01-12
 
--   releaseCycle: "1.4"
+  - releaseCycle: "1.4"
     releaseDate: 2015-05-27
     eol: 2021-12-31
     extendedSupport: false
     latest: "1.4.14"
     latestReleaseDate: 2016-10-11
 
--   releaseCycle: "1.3"
+  - releaseCycle: "1.3"
     releaseDate: 2014-10-13
     eol: 2021-12-31
     extendedSupport: false
     latest: "1.3.20"
     latestReleaseDate: 2015-09-29
 
--   releaseCycle: "1.2"
+  - releaseCycle: "1.2"
     releaseDate: 2013-11-23
     eol: 2021-12-31
     extendedSupport: false
     latest: "1.2.32"
     latestReleaseDate: 2016-10-11
 
--   releaseCycle: "1.1"
+  - releaseCycle: "1.1"
     releaseDate: 2013-11-23
     eol: 2021-12-31
     extendedSupport: false
     latest: "1.1.5"
     latestReleaseDate: 2013-11-23
 
--   releaseCycle: "1.0"
+  - releaseCycle: "1.0"
     releaseDate: 2013-11-23
     eol: 2021-12-31
     extendedSupport: false
     latest: "1.0.8"
     latestReleaseDate: 2013-11-23
-
 ---
 
 > AngularJS is a free and open-source JavaScript-based web framework for developing single-page

--- a/products/angularjs.md
+++ b/products/angularjs.md
@@ -4,7 +4,7 @@ category: framework
 tags: google javascript-runtime
 permalink: /angularjs
 alternate_urls:
-  - /angular-js
+-   /angular-js
 versionCommand: npm list angular
 releasePolicyLink: https://docs.angularjs.org/misc/version-support-status
 changelogTemplate: https://github.com/angular/angular.js/blob/v__LATEST__/CHANGELOG.md
@@ -16,14 +16,14 @@ eolColumn: Support
 extendedSupportColumn: Extended Long Term Support
 
 auto:
-  - npm: angular
+-   npm: angular
 
 identifiers:
-  - repology: angular.js
-  - purl: pkg:npm/angular
+-   repology: angular.js
+-   purl: pkg:npm/angular
 
 releases:
-  - releaseCycle: "1.8"
+-   releaseCycle: "1.8"
     lts: true
     releaseDate: 2020-06-04
     eol: 2021-12-31
@@ -31,61 +31,62 @@ releases:
     latest: "1.8.3"
     latestReleaseDate: 2022-04-07
 
-  - releaseCycle: "1.7"
+-   releaseCycle: "1.7"
     releaseDate: 2018-05-11
     eol: 2021-12-31
     extendedSupport: false
     latest: "1.7.9"
     latestReleaseDate: 2019-11-19
 
-  - releaseCycle: "1.6"
+-   releaseCycle: "1.6"
     releaseDate: 2016-12-08
     eol: 2021-12-31
     extendedSupport: false
     latest: "1.6.10"
     latestReleaseDate: 2018-04-17
 
-  - releaseCycle: "1.5"
+-   releaseCycle: "1.5"
     releaseDate: 2016-02-05
     eol: 2021-12-31
     extendedSupport: true
     latest: "1.5.11"
     latestReleaseDate: 2017-01-12
 
-  - releaseCycle: "1.4"
+-   releaseCycle: "1.4"
     releaseDate: 2015-05-27
     eol: 2021-12-31
     extendedSupport: false
     latest: "1.4.14"
     latestReleaseDate: 2016-10-11
 
-  - releaseCycle: "1.3"
+-   releaseCycle: "1.3"
     releaseDate: 2014-10-13
     eol: 2021-12-31
     extendedSupport: false
     latest: "1.3.20"
     latestReleaseDate: 2015-09-29
 
-  - releaseCycle: "1.2"
+-   releaseCycle: "1.2"
     releaseDate: 2013-11-23
     eol: 2021-12-31
     extendedSupport: false
     latest: "1.2.32"
     latestReleaseDate: 2016-10-11
 
-  - releaseCycle: "1.1"
+-   releaseCycle: "1.1"
     releaseDate: 2013-11-23
     eol: 2021-12-31
     extendedSupport: false
     latest: "1.1.5"
     latestReleaseDate: 2013-11-23
 
-  - releaseCycle: "1.0"
+-   releaseCycle: "1.0"
     releaseDate: 2013-11-23
     eol: 2021-12-31
     extendedSupport: false
     latest: "1.0.8"
     latestReleaseDate: 2013-11-23
+
 ---
 
 > AngularJS is a free and open-source JavaScript-based web framework for developing single-page

--- a/products/angularjs.md
+++ b/products/angularjs.md
@@ -4,7 +4,7 @@ category: framework
 tags: google javascript-runtime
 permalink: /angularjs
 alternate_urls:
--   /angular-js
+  - /angular-js
 versionCommand: npm list angular
 releasePolicyLink: https://docs.angularjs.org/misc/version-support-status
 changelogTemplate: https://github.com/angular/angular.js/blob/v__LATEST__/CHANGELOG.md
@@ -16,14 +16,14 @@ eolColumn: Support
 extendedSupportColumn: Extended Long Term Support
 
 auto:
--   npm: angular
+  - npm: angular
 
 identifiers:
--   repology: angular.js
--   purl: pkg:npm/angular
+  - repology: angular.js
+  - purl: pkg:npm/angular
 
 releases:
--   releaseCycle: "1.8"
+  - releaseCycle: "1.8"
     lts: true
     releaseDate: 2020-06-04
     eol: 2021-12-31
@@ -31,62 +31,61 @@ releases:
     latest: "1.8.3"
     latestReleaseDate: 2022-04-07
 
--   releaseCycle: "1.7"
+  - releaseCycle: "1.7"
     releaseDate: 2018-05-11
     eol: 2021-12-31
     extendedSupport: false
     latest: "1.7.9"
     latestReleaseDate: 2019-11-19
 
--   releaseCycle: "1.6"
+  - releaseCycle: "1.6"
     releaseDate: 2016-12-08
     eol: 2021-12-31
     extendedSupport: false
     latest: "1.6.10"
     latestReleaseDate: 2018-04-17
 
--   releaseCycle: "1.5"
+  - releaseCycle: "1.5"
     releaseDate: 2016-02-05
     eol: 2021-12-31
     extendedSupport: true
     latest: "1.5.11"
     latestReleaseDate: 2017-01-12
 
--   releaseCycle: "1.4"
+  - releaseCycle: "1.4"
     releaseDate: 2015-05-27
     eol: 2021-12-31
     extendedSupport: false
     latest: "1.4.14"
     latestReleaseDate: 2016-10-11
 
--   releaseCycle: "1.3"
+  - releaseCycle: "1.3"
     releaseDate: 2014-10-13
     eol: 2021-12-31
     extendedSupport: false
     latest: "1.3.20"
     latestReleaseDate: 2015-09-29
 
--   releaseCycle: "1.2"
+  - releaseCycle: "1.2"
     releaseDate: 2013-11-23
     eol: 2021-12-31
     extendedSupport: false
     latest: "1.2.32"
     latestReleaseDate: 2016-10-11
 
--   releaseCycle: "1.1"
+  - releaseCycle: "1.1"
     releaseDate: 2013-11-23
     eol: 2021-12-31
     extendedSupport: false
     latest: "1.1.5"
     latestReleaseDate: 2013-11-23
 
--   releaseCycle: "1.0"
+  - releaseCycle: "1.0"
     releaseDate: 2013-11-23
     eol: 2021-12-31
     extendedSupport: false
     latest: "1.0.8"
     latestReleaseDate: 2013-11-23
-
 ---
 
 > AngularJS is a free and open-source JavaScript-based web framework for developing single-page
@@ -99,9 +98,9 @@ AngularJS was [deprecated](https://docs.angularjs.org/misc/version-support-statu
 December 31, 2021 after a [LTS period](https://blog.angular.io/stable-angularjs-and-long-term-support-7e077635ee9c)
 on the final version 1.8.3 which was released April 7, 2022.
 
-Beginning January 1, 2022, [extended long term support for AngularJS](https://xlts.dev/angularjs)
+Beginning January 1, 2022, [extended long term support for AngularJS](https://www.herodevs.com/support/nes-angularjs)
 became available for 1.5.x and 1.8.x versions through a fork of the project maintained by the
-independent team at [XLTS.dev](http://xlts.dev/).
+independent team at [HeroDevs](https://www.herodevs.com/) (formely XLTS.dev).
 
-AngularJS version 1.8 has continued commercial support through the XLTS 1.9 forked version, where
-XLTS 1.9 is a compatible replacement for AngularJS version 1.8.
+AngularJS version 1.8 has continued commercial support through the HeroDevs Never-Ending Support initiative.
+AngularJS NES 1.9 is a compatible replacement for AngularJS version 1.8.


### PR DESCRIPTION
### Here the announcement blogs about the merging of XLTS and HeroDevs: 

HeroDevs Merger Announcement: [https://blog.herodevs.com/herodevs-and-xlts-dev-officially-unite-5eaa383eb285](https://www.google.com/url?q=https://blog.herodevs.com/herodevs-and-xlts-dev-officially-unite-5eaa383eb285&sa=D&source=docs&ust=1696877399097129&usg=AOvVaw2GSnmD0C19vbrWzQKVRxir)

XLTS.dev Merger Announcement: [https://xlts.dev/blog/2023-09-28-xlts-and-herodevs-unite](https://www.google.com/url?q=https://xlts.dev/blog/2023-09-28-xlts-and-herodevs-unite&sa=D&source=docs&ust=1696877399097248&usg=AOvVaw0DuDFI-S9MozYwVtJY2aT9)