### PR TITLE
[Nuxt] Update Nuxt 2 EOL date

### DIFF
--- a/products/nuxt.md
+++ b/products/nuxt.md
@@ -23,7 +23,7 @@ releases:
 -   releaseCycle: "2"
     releaseDate: 2018-09-21
     support: 2022-11-16
-    eol: 2023-12-31
+    eol: 2024-06-30
     latest: "2.17.1"
     latestReleaseDate: 2023-07-14
 
@@ -39,5 +39,5 @@ year, with an expectation of patch releases every week or so and minor releases 
 Minor and Patch releases should never contain breaking changes except for features marked as
 _experimental_.
 
-Nuxt 2 will reach End of Life (EOL) on December 31st, 2023 [at the same time as Vue 2 does](/vue).
+Nuxt 2 will reach End of Life (EOL) on June 30th, 2024.
 All supported versions should run on [all currently supported Node.js](/nodejs) releases.

--- a/products/nuxt.md
+++ b/products/nuxt.md
@@ -39,5 +39,4 @@ year, with an expectation of patch releases every week or so and minor releases 
 Minor and Patch releases should never contain breaking changes except for features marked as
 _experimental_.
 
-Nuxt 2 will reach End of Life (EOL) on June 30th, 2024.
 All supported versions should run on [all currently supported Node.js](/nodejs) releases.


### PR DESCRIPTION
Nuxt.js 2 EOL will be extended to June 30, 2024

> On December 31st, 2023, Vue 2 will reach End of Life (EOL), and Nuxt 2 will follow on June 30th, 2024.
After that date, Nuxt 2 will continue to be available on the NPM package manager, but will no longer receive updates, such as security and browser compatibility fixes. After that, if you wish to receive updates, please subscribe to HeroDevs' NES (Never-Ending Support) for Vue 2 & Nuxt 2 (Core + Essentials package) .

Relevant page: https://endoflife.date/nuxt
Official: https://v2.nuxt.com/lts/