### PR TITLE
Kafka > Kafka 3.6.0 release announcement

### DIFF
--- a/products/apache-kafka.md
+++ b/products/apache-kafka.md
@@ -21,11 +21,11 @@ auto:
 # https://docs.confluent.io/platform/current/installation/versions-interoperability.html#cp-and-apache-ak-compatibility.
 releases:
 -   releaseCycle: "3.6"
-    releaseDate: 2023-10-03
+    releaseDate: 2023-10-10
     eol: false
     extendedSupport: true # not yet announced at # https://docs.confluent.io/platform/current/installation/versions-interoperability.html#cp-and-apache-ak-compatibility.
     latest: "3.6.0"
-    latestReleaseDate: 2023-10-03
+    latestReleaseDate: 2023-10-10
 
 -   releaseCycle: "3.5"
     releaseDate: 2023-06-13


### PR DESCRIPTION
This commit fixes the release date annoucement
https://kafka.apache.org/blog#apache_kafka_360_release_announcement

![image](https://github.com/endoflife-date/endoflife.date/assets/5235127/247d08d0-a9ce-4063-a774-5fa5894b506f)
