### PR TITLE
[Centos] Updated "releasePolicyLink"

### DIFF
--- a/products/centos.md
+++ b/products/centos.md
@@ -5,7 +5,7 @@ tags: linux-distribution
 iconSlug: centos
 permalink: /centos
 versionCommand: cat /etc/redhat-release
-releasePolicyLink: https://wiki.centos.org/About/Product
+releasePolicyLink: https://wiki.centos.org/About(2f)Product.html
 activeSupportColumn: true
 releaseDateColumn: true
 


### PR DESCRIPTION
- Fixed broken link from "https://wiki.centos.org/About/Product" to "https://wiki.centos.org/About(2f)Product.html"