### PR TITLE
[openwrt] Add 23.05

### DIFF
--- a/products/openwrt.md
+++ b/products/openwrt.md
@@ -31,7 +31,7 @@ releases:
 -   releaseCycle: "22.03"
     releaseDate: 2022-09-03
     support: 2023-10-11
-    eol: 2023-04-30
+    eol: 2024-04-11
     latest: "22.03.5"
     latestReleaseDate: 2023-04-27
 

--- a/products/openwrt.md
+++ b/products/openwrt.md
@@ -21,12 +21,19 @@ auto:
 # EOL(R)=MAX(releaseDate(R+1)+6m, releaseDate(R)+1y)
 # Support(R) = releaseDate(R+1)
 releases:
--   releaseCycle: "22.03"
+-   releaseCycle: "23.05"
+    releaseDate: 2023-10-11
     support: true
     eol: false
+    latest: "23.05.0"
+    latestReleaseDate: 2023-10-11
+
+-   releaseCycle: "22.03"
     releaseDate: 2022-09-03
-    latestReleaseDate: 2023-04-27
+    support: 2023-10-11
+    eol: 2023-04-30
     latest: "22.03.5"
+    latestReleaseDate: 2023-04-27
 
 -   releaseCycle: "21.02"
     eol: 2023-04-30


### PR DESCRIPTION
See https://openwrt.org/releases/23.05/notes-23.05.0.

Used the tag date, not the actual release date which is 2023-10-14.