### PR TITLE
Ubuntu > Add 23.10 (Mantic Minotaur)

### DIFF
--- a/products/ubuntu.md
+++ b/products/ubuntu.md
@@ -28,8 +28,8 @@ identifiers:
 -   cpe: cpe:2.3:o:canonical:ubuntu_linux
 -   cpe: cpe:/o:canonical:ubuntu_linux
 
+# Support and EOL dates available on https://wiki.ubuntu.com/Releases.
 releases:
-
 -   releaseCycle: "23.10"
     codename: "Mantic Minotaur"
     releaseDate: 2023-10-13

--- a/products/ubuntu.md
+++ b/products/ubuntu.md
@@ -38,7 +38,6 @@ releases:
     extendedSupport: false
     latest: "23.10"
     latestReleaseDate: 2023-10-13
-    lts: false
 
 -   releaseCycle: "23.04"
     codename: "Lunar Lobster"

--- a/products/ubuntu.md
+++ b/products/ubuntu.md
@@ -30,6 +30,15 @@ identifiers:
 
 releases:
 
+-   releaseCycle: "23.10"
+    codename: "Mantic Minotaur"
+    releaseDate: 2023-10-13
+    support: 2024-01-20
+    eol: 2024-07-01
+    extendedSupport: false
+    latest: "23.10"
+    latestReleaseDate: 2023-10-13
+
 -   releaseCycle: "23.04"
     codename: "Lunar Lobster"
     releaseDate: 2023-04-20

--- a/products/ubuntu.md
+++ b/products/ubuntu.md
@@ -33,7 +33,7 @@ releases:
 -   releaseCycle: "23.10"
     codename: "Mantic Minotaur"
     releaseDate: 2023-10-13
-    support: 2024-01-20
+    support: 2024-07-01
     eol: 2024-07-01
     extendedSupport: false
     latest: "23.10"

--- a/products/ubuntu.md
+++ b/products/ubuntu.md
@@ -38,6 +38,7 @@ releases:
     extendedSupport: false
     latest: "23.10"
     latestReleaseDate: 2023-10-13
+    lts: false
 
 -   releaseCycle: "23.04"
     codename: "Lunar Lobster"


### PR DESCRIPTION
# :newspaper_roll: 

![image](https://github.com/endoflife-date/endoflife.date/assets/5235127/f9629c7f-2bd4-4964-af1c-e1ac612959c6)

- https://discourse.ubuntu.com/t/mantic-minotaur-release-notes/35534
- https://twitter.com/ubuntu/status/1712509138876399934
- https://twitter.com/omgubuntu/status/1712494158227571142

# :information_source: 

[Ubuntu 23.10 is Available to Download, This is What’s New](https://www.omgubuntu.co.uk/2023/10/ubuntu-23-10-new-features-download-link)

> This update is a short-term release supported by 9 months of ongoing support, bug fixes, and critical app updates. 


> remember that Ubuntu 24.04 is out in April 2024 as a long-term support release with 5 years of support.