### PR TITLE
[slackware] Add EOL dates for 14.0, 14.1, 14.2.

### DIFF
--- a/products/slackware.md
+++ b/products/slackware.md
@@ -39,7 +39,7 @@ releases:
 
 -   releaseCycle: "14.1"
     releaseDate: 2013-11-07
-    eol: 2024-01-01
+    eol: 2024-01-01 # https://mirrors.slackware.com/slackware/slackware-14.1/ChangeLog.txt
     latest: '14.1'
     latestReleaseDate: 2013-11-07
 

--- a/products/slackware.md
+++ b/products/slackware.md
@@ -45,7 +45,7 @@ releases:
 
 -   releaseCycle: "14.0"
     releaseDate: 2012-09-28
-    eol: 2024-01-01
+    eol: 2024-01-01 # https://mirrors.slackware.com/slackware/slackware-14.0/ChangeLog.txt
     latest: '14.0'
     latestReleaseDate: 2012-09-28
 

--- a/products/slackware.md
+++ b/products/slackware.md
@@ -33,7 +33,7 @@ releases:
 
 -   releaseCycle: "14.2"
     releaseDate: 2016-07-01
-    eol: 2024-01-01
+    eol: 2024-01-01 # https://mirrors.slackware.com/slackware/slackware-14.2/ChangeLog.txt
     latest: '14.2'
     latestReleaseDate: 2016-07-01
 

--- a/products/slackware.md
+++ b/products/slackware.md
@@ -33,19 +33,19 @@ releases:
 
 -   releaseCycle: "14.2"
     releaseDate: 2016-07-01
-    eol: false
+    eol: 2024-01-01
     latest: '14.2'
     latestReleaseDate: 2016-07-01
 
 -   releaseCycle: "14.1"
     releaseDate: 2013-11-07
-    eol: false
+    eol: 2024-01-01
     latest: '14.1'
     latestReleaseDate: 2013-11-07
 
 -   releaseCycle: "14.0"
     releaseDate: 2012-09-28
-    eol: false
+    eol: 2024-01-01
     latest: '14.0'
     latestReleaseDate: 2012-09-28
 


### PR DESCRIPTION
As announced in the respective changelogs on 2023-10-09, these versions
will be EOL on 2024-01-01.