### PR TITLE
[oneplus] Add OnePlus devices

### DIFF
--- a/products/oneplus.md
+++ b/products/oneplus.md
@@ -13,11 +13,11 @@ activeSupportColumn: Active Major Updates
 discontinuedColumn: true
 eolColumn: Security Updates
 customColumns:
--   property: supportedAndroidVersions
+-   property: supportedOxygenOSVersions
     position: after-release-column
-    label: Supported Android
-    description: Supported Android versions range
-    link: https://endoflife.date/android
+    label: Supported OxygenOS
+    description: Supported OxygenOS versions range
+    link: https://wikipedia.org/wiki/OxygenOS
 
 # Use Support/Spec pages from https://www.oneplus.com/global/support/spec pages for older phones
 

--- a/products/oneplus.md
+++ b/products/oneplus.md
@@ -1,0 +1,124 @@
+---
+title: OnePlus
+category: device
+tags: mobile-phone oneplus
+iconSlug: oneplus
+permalink: /oneplus
+versionCommand: "Settings -> About device"
+releasePolicyLink: https://community.oneplus.com/thread/1462181
+releaseLabel: "OnePlus __RELEASE_CYCLE__"
+releaseColumn: false
+releaseDateColumn: true
+activeSupportColumn: Active Major Updates
+discontinuedColumn: true
+eolColumn: Security Updates
+customColumns:
+-   property: supportedAndroidVersions
+    position: after-release-column
+    label: Supported Android
+    description: Supported Android versions range
+    link: https://endoflife.date/android
+
+###### Supported Android versions ######
+# Because OnePlus is using community forum posts as official releases posts it is hard to parse the last Android/OxygenOS releases 
+# for all devices so I'm using the unofficial https://oxygenupdater.com/news/all/ that have been collecting all OnePlus OxygenOS announcements for several years and is an established and trusted way to get OP updates.
+# still not great but easier to search and parse than OnePlus Community and more up to date than GsmArena
+# There is also https://www.androidupdatetracker.com/policy/oneplus that is easier to parse, have good links to announcements but AFAIK is less established, and has one error in update policy regarding the Nord N series.
+
+###### List of Phones ######
+# for a list of released phones https://www.gsmarena.com/oneplus-phones-95.php
+# for links try to use first these specs pages https://www.oneplus.com/global/support/spec
+
+releases:
+-   releaseCycle: "12R"
+    releaseDate: 2024-01-23 # https://community.oneplus.com/thread/1514801169317232648
+    support: 2028-01-23 # approximation "4 major Android updates" https://community.oneplus.com/thread/1211291251581124608
+    eol: 2029-01-23
+    discontinued: false
+    link: https://www.oneplus.com/fr/oneplus-12r
+    supportedAndroidVersions: 14 # https://oxygenupdater.com/article/401/
+
+-   releaseCycle: "12"
+    releaseDate: 2024-01-23 # https://community.oneplus.com/thread/1514801169317232648
+    support: 2028-01-23 # approximation "4 major Android updates" https://community.oneplus.com/thread/1211291251581124608
+    eol: 2029-01-23
+    discontinued: false
+    link: https://www.oneplus.com/fr/oneplus-12
+    supportedAndroidVersions: 14 # https://oxygenupdater.com/article/396/
+
+-   releaseCycle: "11R"
+    releaseDate: 2023-02-07 #https://oxygenupdater.com/article/379/
+    support: 2027-02-07 # approximation "4 major Android updates" https://community.oneplus.com/thread/1211291251581124608
+    eol: 2028-02-07
+    discontinued: false
+    link: https://www.oneplus.in/11r
+    supportedAndroidVersions: 13 - 14 # https://oxygenupdater.com/article/431/ https://community.oneplus.com/thread/1480591576202739713
+
+-   releaseCycle: "11"
+    releaseDate: 2023-02-07 # https://oxygenupdater.com/article/379/
+    support: 2027-02-07 # approximation "4 major Android updates" https://community.oneplus.com/thread/1211291251581124608
+    eol: 2028-02-07
+    discontinued: false
+    link: https://service.oneplus.com/us/search/search-detail?id=2123192&articleIndex=2
+    supportedAndroidVersions: 13 - 14 # https://oxygenupdater.com/article/426/ https://community.oneplus.com/thread/1465453057260126214
+
+
+# following is a list of phones with their update policy...delete the entry once the device is implemented in the page
+
+# https://community.oneplus.com/thread/1462181 : 3 major android updates and 4 years of security updates
+#    OnePlus 10 Pro
+#    OnePlus 10R
+#    OnePlus 10T
+#    OnePlus Ace
+#    OnePlus Ace Racing Edition
+#    OnePlus 9RT
+#    OnePlus 9 Pro
+#    OnePlus 9R
+#    OnePlus 9
+#    OnePlus 8T
+#    OnePlus 8 Pro
+#    OnePlus 8
+
+# https://community.oneplus.com/thread/1356800969827942405 : 3 major android updates and 4 years of security updates
+#    OnePlus Nord 3
+
+# https://community.oneplus.com/thread/862347 : 2 major android updates and 3 years of security updates
+#    OnePlus 7 Pro
+#    OnePlus 7T Pro
+#    OnePlus 7T
+#    OnePlus 7
+#    OnePlus 6T
+#    OnePlus 6
+#    OnePlus 5T
+#    OnePlus 5
+#    OnePlus 3T
+#    OnePlus 3
+
+# https://community.oneplus.com/thread/1462181 : 2 major android updates and 3 years of security updates
+#    OnePlus Nord CE 3 Lite
+#    OnePlus Nord CE 3
+#    OnePlus Nord 2T
+#    OnePlus Nord CE 2 Lite
+#    OnePlus Nord CE 2
+#    OnePlus Nord 2
+#    OnePlus Nord CE
+#    OnePlus Nord
+
+# https://community.oneplus.com/thread/1462181 : 1 major android update and 3 years of security updates
+#    OnePlus Nord N30 SE
+#    OnePlus Nord N30
+#    OnePlus Nord N300
+#    OnePlus Nord N20 SE
+#    OnePlus Nord N20
+#    OnePlus Nord N200
+#    OnePlus Nord N100
+#    OnePlus Nord N10
+
+
+---
+
+> OnePlus is a Chinese manufacturer of Android phones and other consumer electronics.
+
+OnePlus phones run OxygenOS, which is based on Android. It receives updates every two months.
+
+OnePlus supports [four major Android updates](https://community.oneplus.com/thread/1211291251581124608) and five years of security updates on their flagship lineup (starting from OnePlus 11 onwards, including T & R series), [three major Android updates](https://community.oneplus.com/thread/1356800969827942405) and four years of security updates for the Nord series (starting from the Nord 3 onwards), [two major Android updates](https://community.oneplus.com/thread/1462181) and three years of security updates for the Nord CE series, and finally [one major Android updates](https://community.oneplus.com/thread/1462181) and three years of security updates for the Nord N series

--- a/products/oneplus.md
+++ b/products/oneplus.md
@@ -1,7 +1,7 @@
 ---
 title: OnePlus
 category: device
-tags: mobile-phone oneplus
+tags: mobile-phone
 iconSlug: oneplus
 permalink: /oneplus
 versionCommand: "Settings -> About device"
@@ -19,15 +19,7 @@ customColumns:
     description: Supported Android versions range
     link: https://endoflife.date/android
 
-###### Supported Android versions ######
-# Because OnePlus is using community forum posts as official releases posts it is hard to parse the last Android/OxygenOS releases 
-# for all devices so I'm using the unofficial https://oxygenupdater.com/news/all/ that have been collecting all OnePlus OxygenOS announcements for several years and is an established and trusted way to get OP updates.
-# still not great but easier to search and parse than OnePlus Community and more up to date than GsmArena
-# There is also https://www.androidupdatetracker.com/policy/oneplus that is easier to parse, have good links to announcements but AFAIK is less established, and has one error in update policy regarding the Nord N series.
-
-###### List of Phones ######
-# for a list of released phones https://www.gsmarena.com/oneplus-phones-95.php
-# for links try to use first these specs pages https://www.oneplus.com/global/support/spec
+# Use Support/Spec pages from https://www.oneplus.com/global/support/spec pages for older phones
 
 releases:
 -   releaseCycle: "12R"
@@ -62,63 +54,13 @@ releases:
     link: https://service.oneplus.com/us/search/search-detail?id=2123192&articleIndex=2
     supportedAndroidVersions: 13 - 14 # https://oxygenupdater.com/article/426/ https://community.oneplus.com/thread/1465453057260126214
 
-
-# following is a list of phones with their update policy...delete the entry once the device is implemented in the page
-
-# https://community.oneplus.com/thread/1462181 : 3 major android updates and 4 years of security updates
-#    OnePlus 10 Pro
-#    OnePlus 10R
-#    OnePlus 10T
-#    OnePlus Ace
-#    OnePlus Ace Racing Edition
-#    OnePlus 9RT
-#    OnePlus 9 Pro
-#    OnePlus 9R
-#    OnePlus 9
-#    OnePlus 8T
-#    OnePlus 8 Pro
-#    OnePlus 8
-
-# https://community.oneplus.com/thread/1356800969827942405 : 3 major android updates and 4 years of security updates
-#    OnePlus Nord 3
-
-# https://community.oneplus.com/thread/862347 : 2 major android updates and 3 years of security updates
-#    OnePlus 7 Pro
-#    OnePlus 7T Pro
-#    OnePlus 7T
-#    OnePlus 7
-#    OnePlus 6T
-#    OnePlus 6
-#    OnePlus 5T
-#    OnePlus 5
-#    OnePlus 3T
-#    OnePlus 3
-
-# https://community.oneplus.com/thread/1462181 : 2 major android updates and 3 years of security updates
-#    OnePlus Nord CE 3 Lite
-#    OnePlus Nord CE 3
-#    OnePlus Nord 2T
-#    OnePlus Nord CE 2 Lite
-#    OnePlus Nord CE 2
-#    OnePlus Nord 2
-#    OnePlus Nord CE
-#    OnePlus Nord
-
-# https://community.oneplus.com/thread/1462181 : 1 major android update and 3 years of security updates
-#    OnePlus Nord N30 SE
-#    OnePlus Nord N30
-#    OnePlus Nord N300
-#    OnePlus Nord N20 SE
-#    OnePlus Nord N20
-#    OnePlus Nord N200
-#    OnePlus Nord N100
-#    OnePlus Nord N10
-
-
 ---
 
-> OnePlus is a Chinese manufacturer of Android phones and other consumer electronics.
+> OnePlus is a manufacturer of Android phones and other consumer electronics.
 
 OnePlus phones run OxygenOS, which is based on Android. It receives updates every two months.
 
 OnePlus supports [four major Android updates](https://community.oneplus.com/thread/1211291251581124608) and five years of security updates on their flagship lineup (starting from OnePlus 11 onwards, including T & R series), [three major Android updates](https://community.oneplus.com/thread/1356800969827942405) and four years of security updates for the Nord series (starting from the Nord 3 onwards), [two major Android updates](https://community.oneplus.com/thread/1462181) and three years of security updates for the Nord CE series, and finally [one major Android updates](https://community.oneplus.com/thread/1462181) and three years of security updates for the Nord N series
+
+OxygenOS updates can be tracked at [Oxygen Updater](https://oxygenupdater.com/news/all/)
+and [Android Update Tracker](https://www.androidupdatetracker.com/policy/oneplus)

--- a/products/oneplus.md
+++ b/products/oneplus.md
@@ -28,7 +28,7 @@ releases:
     eol: 2029-01-23
     discontinued: false
     link: https://www.oneplus.com/fr/oneplus-12r
-    supportedAndroidVersions: 14 # https://oxygenupdater.com/article/401/
+    supportedOxygenOSVersions: 14 # https://oxygenupdater.com/article/401/
 
 -   releaseCycle: "12"
     releaseDate: 2024-01-23 # https://community.oneplus.com/thread/1514801169317232648
@@ -36,7 +36,7 @@ releases:
     eol: 2029-01-23
     discontinued: false
     link: https://www.oneplus.com/fr/oneplus-12
-    supportedAndroidVersions: 14 # https://oxygenupdater.com/article/396/
+    supportedOxygenOSVersions: 14 # https://oxygenupdater.com/article/396/
 
 -   releaseCycle: "11R"
     releaseDate: 2023-02-07 #https://oxygenupdater.com/article/379/
@@ -44,7 +44,7 @@ releases:
     eol: 2028-02-07
     discontinued: false
     link: https://www.oneplus.in/11r
-    supportedAndroidVersions: 13 - 14 # https://oxygenupdater.com/article/431/ https://community.oneplus.com/thread/1480591576202739713
+    supportedOxygenOSVersions: 13 - 14 # https://oxygenupdater.com/article/431/ https://community.oneplus.com/thread/1480591576202739713
 
 -   releaseCycle: "11"
     releaseDate: 2023-02-07 # https://oxygenupdater.com/article/379/
@@ -52,7 +52,7 @@ releases:
     eol: 2028-02-07
     discontinued: false
     link: https://service.oneplus.com/us/search/search-detail?id=2123192&articleIndex=2
-    supportedAndroidVersions: 13 - 14 # https://oxygenupdater.com/article/426/ https://community.oneplus.com/thread/1465453057260126214
+    supportedOxygenOSVersions: 13 - 14 # https://oxygenupdater.com/article/426/ https://community.oneplus.com/thread/1465453057260126214
 
 ---
 


### PR DESCRIPTION
Since the only "official" updates policy is a community post here https://community.oneplus.com/thread/1462181 (and here for the old one https://community.oneplus.com/thread/862347) should this be considered enough to start a PR for OnePlus devices ?
And since these are only promises should I display the exact calculated date or just yes ?
For instance for the active support they don't say X years of support but X major Android updates ? Should I translate these 4 major Android updates to 4 years ?