### PR TITLE
[pan-pg] update GlobalProtect 6.0.8

### DIFF
--- a/products/pan-gp.md
+++ b/products/pan-gp.md
@@ -31,8 +31,8 @@ releases:
     eol: 2024-02-22
     support: 2024-02-22
     releaseDate: 2022-02-22
-    latest: "6.0.7"
-    latestReleaseDate: 2023-06-21
+    latest: "6.0.8"
+    latestReleaseDate: 2023-10-18
     link: https://docs.paloaltonetworks.com/globalprotect/6-0/globalprotect-app-release-notes
 
 -   releaseCycle: "5.3"


### PR DESCRIPTION
Updated Globalprotect from 6.0.7 to 6.0.8.
Released 2023-10-18.
https://docs.paloaltonetworks.com/globalprotect/6-0/globalprotect-app-release-notes/globalprotect-addressed-issues

