### PR TITLE
[apache-http-server] Bump version to 2.4.58

### DIFF
--- a/products/apache-http-server.md
+++ b/products/apache-http-server.md
@@ -26,8 +26,8 @@ releases:
 -   releaseCycle: "2.4"
     releaseDate: 2012-02-21
     eol: false
-    latest: "2.4.57"
-    latestReleaseDate: 2023-04-06
+    latest: "2.4.58"
+    latestReleaseDate: 2023-10-19
     link: https://downloads.apache.org/httpd/Announcement2.4.html
 
 -   releaseCycle: "2.2"


### PR DESCRIPTION
Adding this pull request in case https://github.com/endoflife-date/release-data/blob/main/releases/apache-http-server.json doesn't auto-update.  Feel free to reject if the auto-update succeeds.