### PR TITLE
[log4j] Update link for 2

### DIFF
--- a/products/log4j.md
+++ b/products/log4j.md
@@ -28,20 +28,21 @@ releases:
     eol: 2021-12-14
     latest: "2.12.4"
     latestReleaseDate: 2021-12-28
+    link: https://github.com/apache/logging-log4j2/blob/rel/__LATEST__/RELEASE-NOTES.md
 
 -   releaseCycle: "2.3"
     releaseDate: 2015-05-10
     eol: 2015-09-20
-    link: https://github.com/apache/logging-log4j2/blob/rel/__LATEST__/RELEASE-NOTES.txt
     latest: "2.3.2"
     latestReleaseDate: 2021-12-29
+    link: https://github.com/apache/logging-log4j2/blob/rel/__LATEST__/RELEASE-NOTES.txt
 
 -   releaseCycle: "1"
     releaseDate: 2001-01-08
     eol: 2015-10-15
-    link: https://logging.apache.org/log4j/1.2/changes-report.html#a1.2.17
     latest: "1.2.17"
     latestReleaseDate: 2012-05-06
+    link: https://logging.apache.org/log4j/1.2/changes-report.html#a1.2.17
 
 ---
 

--- a/products/log4j.md
+++ b/products/log4j.md
@@ -8,7 +8,7 @@ alternate_urls:
 -   /apache_log4j
 -   /apache-log4j
 releasePolicyLink: https://logging.apache.org/log4j/2.x/security.html
-changelogTemplate: https://github.com/apache/logging-log4j2/blob/rel/__LATEST__/RELEASE-NOTES.md
+changelogTemplate: https://logging.apache.org/log4j/2.0/release-notes.html#release-notes-{{'__LATEST__'|replace:'.','-'}}
 activeSupportColumn: false
 releaseDateColumn: true
 eolColumn: Supported
@@ -22,7 +22,6 @@ releases:
     eol: false
     latest: "2.21.0"
     latestReleaseDate: 2023-10-12
-    link: https://github.com/apache/logging-log4j2/releases/tag/rel%2F__LATEST__
 
 -   releaseCycle: "2.12"
     releaseDate: 2019-06-26

--- a/products/log4j.md
+++ b/products/log4j.md
@@ -22,6 +22,7 @@ releases:
     eol: false
     latest: "2.21.0"
     latestReleaseDate: 2023-10-12
+    link: https://github.com/apache/logging-log4j2/releases/tag/rel%2F__LATEST__
 
 -   releaseCycle: "2.12"
     releaseDate: 2019-06-26


### PR DESCRIPTION
The log4j team may have started to publish release notes in GitHub releases. https://github.com/apache/logging-log4j2/blob/rel/2.21.0/RELEASE-NOTES.md is not available anymore.

This makes use of the official release note page at https://logging.apache.org/log4j/2.0/release-notes.html.