### PR TITLE
Gitlab 16.5 released

### DIFF
--- a/products/gitlab.md
+++ b/products/gitlab.md
@@ -23,6 +23,13 @@ auto:
 # Support of R = releaseDate(R+1)
 # This is quite predictable since releases are monthly (usually 22nd of every month).
 releases:
+-   releaseCycle: "16.5"
+    releaseDate: 2023-10-22
+    support: 
+    eol: 
+    latest: "16.5"
+    latestReleaseDate: 2023-10-22
+
 -   releaseCycle: "16.4"
     releaseDate: 2023-09-21
     support: 2023-10-22


### PR DESCRIPTION
# ❔ About

Today, Gitlab 16.5 has been released:

![image](https://github.com/endoflife-date/endoflife.date/assets/5235127/797bcc25-fa13-4133-a15b-e9485e645993)

https://about.gitlab.com/releases/2023/10/22/gitlab-16-5-released/

# ⚠️ Need for data

At this stage, I'm lacking : 

- `support`
- `eol`