### PR TITLE
Add a validation rule to make sure releases are properly ordered

### DIFF
--- a/products/hbase.md
+++ b/products/hbase.md
@@ -48,6 +48,7 @@ releases:
     latestReleaseDate: 2021-10-19
 
 -   releaseCycle: "1.7"
+    outOfOrder: true # wrong tag date for https://github.com/apache/hbase/releases/tag/rel%2F1.7.0
     releaseDate: 2021-06-12
     eol: 2022-08-09
     link: https://github.com/apache/hbase/blob/rel/__LATEST__/CHANGES.txt

--- a/products/ibm-aix.md
+++ b/products/ibm-aix.md
@@ -85,6 +85,7 @@ releases:
     latestReleaseDate: 2015-12-31
 
 -   releaseCycle: "7.1.5"
+    outOfOrder: true # wrong date on https://www.ibm.com/support/pages/aix-support-lifecycle-information
     releaseDate: 2017-10-31
     eol: 2023-04-30
     latest: "7.1.5"

--- a/products/ibm-i.md
+++ b/products/ibm-i.md
@@ -149,6 +149,7 @@ releases:
     latestReleaseDate: 1995-12-22
 
 -   releaseCycle: "3.2"
+    outOfOrder: true # wrong date on https://www.ibm.com/support/pages/release-life-cycle
     releaseDate: 1996-06-21
     eol: 2000-05-31
     latest: "3.2"

--- a/products/jenkins.md
+++ b/products/jenkins.md
@@ -30,6 +30,7 @@ auto:
 # See https://github.com/endoflife-date/endoflife.date/pull/2695#issuecomment-1472929098
 releases:
 -   releaseCycle: "2"
+    outOfOrder: true # to keep it at the top
     releaseLabel: "Regular"
     releaseDate: 2016-04-20
     eol: false

--- a/products/log4j.md
+++ b/products/log4j.md
@@ -23,6 +23,7 @@ auto:
 
 releases:
 -   releaseCycle: "2"
+    outOfOrder: true # to keep it at the top
     releaseDate: 2014-07-12
     eol: false
     latest: "2.23.1"

--- a/products/nutanix-aos.md
+++ b/products/nutanix-aos.md
@@ -95,6 +95,7 @@ releases:
     latestReleaseDate: 2020-05-18
 
 -   releaseCycle: "5.15"
+    outOfOrder: true # wrong data on https://portal.nutanix.com/api/v1/eol/find?type=NOS
     releaseDate: 2020-03-31
     eoas: 2021-08-31
     eol: 2022-05-31

--- a/products/nutanix-files.md
+++ b/products/nutanix-files.md
@@ -78,7 +78,7 @@ releases:
     latestReleaseDate: 2020-07-08
 
 -   releaseCycle: "3.5"
-    releaseDate: 2019-12-15 # https://next.nutanix.com/community-blog-154/nutanix-files-3-5-31952
+    releaseDate: 2019-03-21 # https://next.nutanix.com/community-blog-154/nutanix-files-3-5-31952
     eoas: 2020-01-31
     eol: 2020-10-31
     latest: "3.5.6"

--- a/products/office.md
+++ b/products/office.md
@@ -13,6 +13,7 @@ eoasColumn: true
 # Release date can be found on subpages of https://en.wikipedia.org/wiki/Microsoft_Office.
 releases:
 -   releaseCycle: "365"
+    outOfOrder: true # to keep it at the top
     releaseDate: 2015-09-22
     eoas: false
     eol: false


### PR DESCRIPTION
According to the contributing guide (https://github.com/endoflife-date/endoflife.date/blob/master/CONTRIBUTING.md) releases must be ordered from the newest (on top of the list) to the lowest. This updates product-data-validator to enforce that rule.

Close #3960.