### PR TITLE
Add support for custom columns

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -166,6 +166,44 @@ extendedSupportColumn: Extended Support
 # that the extended support date is approaching (optional, default = 121 days).
 extendedSupportWarnThreshold: 121
 
+# Custom columns configuration (optional).
+# Custom columns are columns that will be added to the releases table and populated based on a
+# custom release cycle property.
+# They can be used for documenting things such as related runtime versions, custom dates that
+# cannot be expressed using the default columns, etc.
+# Note that the use of a table include (see https://github.com/endoflife-date/endoflife.date/blob/master/products/ansible.md)
+# is usually preferred when there is more than two or three custom columns.
+customColumns:
+
+  # Name of the custom property in release cycles (mandatory).
+  # If the release cycle does not declare this property, the label 'N/A' will be displayed instead.
+  # Custom properties follows the camel-case syntax for naming.
+  - property: supportedIosVersions
+
+    # Position of the custom column in the table (mandatory).
+    # Allowed values are:
+    # - after-release-column: this is typically used for documenting related runtime versions
+    #   (such as the supported iOS version range for iphone models),
+    # - before-latest-column: this is typically used for documenting additional dates
+    #   (such as an obsolescence date for an iphone model - https://support.apple.com/en-us/HT201624),
+    # - after-latest-column: this is typically used for documenting a corresponding latest version
+    #   number (such as the OpenJDK version for https://endoflife.date/azul-zulu).
+    # If multiple columns have the same position, the order of the column in the customColumns list
+    # will be respected.
+    position: after-release-column
+
+    # Label of the custom column (mandatory).
+    # It will be displayed in the table header.
+    label: iOS
+
+    # A description of what contains the custom column (optional).
+    # It will be displayed as a tooltip of the column table header cell.
+    description: Supported iOS versions
+
+    # A link that gives more information about what contains the custom column (optional).
+    # It will be used to transform the table label to a link.
+    link: https://en.wikipedia.org/wiki/IPhone#Models
+
 # Auto-update release configuration (optional).
 # This is used for automatically updating `releaseDate`, `latest`, and `latestReleaseDate` for every release.
 # Multiple configurations are allowed.

--- a/_config.yml
+++ b/_config.yml
@@ -93,6 +93,7 @@ defaults:
       extendedSupportColumn: false
       extendedSupportColumnLabel: 'Extended Support'
       extendedSupportWarnThreshold: 121
+      customColumns: []
       LTSLabel: '<abbr title="Long Term Support">LTS</abbr>'
 
 

--- a/_includes/custom-column-td.html
+++ b/_includes/custom-column-td.html
@@ -1,0 +1,12 @@
+{%- comment %}
+Render a product custom column data cell (<td>).
+
+Parameters:
+- release (mandatory): a product release cycle definition.
+- column (mandatory): the custom column definition.
+- cssClasses (optional): a space-separated list of CSS classes to add to the cell.
+{% endcomment %}
+{%- assign release = include.release %}
+{%- assign propertyName = include.column.property %}
+{%- assign cssClasses = include.cssClasses | default:'' %}
+<td class="{{ cssClasses }}">{{ release[propertyName] | default: 'N/A' }}</td>

--- a/_includes/custom-column-th.html
+++ b/_includes/custom-column-th.html
@@ -1,0 +1,12 @@
+{%- comment %}
+Render a product custom column header cell (<th>).
+
+Parameters:
+- column (mandatory): the custom column definition.
+{% endcomment %}
+{%- assign label = include.column.label %}
+{%- assign description = include.column.description %}
+{%- assign link = include.column.link %}
+<th title="{{ description }}">
+  {% if link %}<a href="{{ link }}">{{ label }}</a>{% else %}{{ label }}{% endif %}
+</th>

--- a/_layouts/product.html
+++ b/_layouts/product.html
@@ -29,18 +29,24 @@ layout: default
 <img alt="Release Schedule Image Gantt Chart for {{page.title}}" src="{{page.releaseImage}}" />
 {% endif %}
 
-{% capture now %}{{ "now" | date: "%s" | plus:0 }}{% endcapture %}
+{%- capture now %}{{ "now" | date: "%s" | plus:0 }}{% endcapture %}
+{%- assign customColumnsAfterRelease = page.customColumns | where: 'position', 'after-release-column' %}
+{%- assign customColumnsBeforeLatest = page.customColumns | where: 'position', 'before-latest-column' %}
+{%- assign customColumnsAfterLatest = page.customColumns | where: 'position', 'after-latest-column' %}
 
 <table class="lifecycle">
   <thead>
     <tr>
       <th>Release</th>{% assign colCount = 1 %}
+      {% for column in customColumnsAfterRelease %}{% include custom-column-th.html column=column %}{% assign colCount = colCount | plus:1 %}{% endfor %}
       {% if page.releaseDateColumn %}<th>{{ page.releaseDateColumnLabel }}</th>{% assign colCount = colCount | plus:1 %}{% endif %}
       {% if page.discontinuedColumn %}<th>{{ page.discontinuedColumnLabel }}</th>{% assign colCount = colCount | plus:1 %}{% endif %}
       {% if page.activeSupportColumn %}<th>{{ page.activeSupportColumnLabel }}</th>{% assign colCount = colCount | plus:1 %}{% endif %}
       {% if page.eolColumn %}<th>{{ page.eolColumnLabel }}</th>{% assign colCount = colCount | plus:1 %}{% endif %}
       {% if page.extendedSupportColumn %}<th>{{ page.extendedSupportColumnLabel }}</th>{% assign colCount = colCount | plus:1 %}{% endif %}
+      {% for column in customColumnsBeforeLatest %}{% include custom-column-th.html column=column %}{% assign colCount = colCount | plus:1 %}{% endfor %}
       {% if page.releaseColumn %}<th>{{ page.releaseColumnLabel }}</th>{% assign colCount = colCount | plus:1 %}{% endif %}
+      {% for column in customColumnsAfterLatest %}{% include custom-column-th.html column=column %}{% assign colCount = colCount | plus:1 %}{% endfor %}
     </tr>
   </thead>
 
@@ -49,7 +55,7 @@ layout: default
 {%- if r.can_be_hidden %}{% assign releaseClasses = 'release can-be-hidden' %}{% endif %}
   <tr class="{{ releaseClasses }}">
     {%- assign cycleColumnClass = '' %}
-    {%- if r.daysTowardEol < 0 %}{% assign cycleColumnClass = 'txt-linethrough' %}{% endif %}
+    {%- if r.days_toward_eol < 0 %}{% assign cycleColumnClass = 'txt-linethrough' %}{% endif %}
     <td class="{{ cycleColumnClass }}">
       {% comment %}Only put a link in the version column if the release column is not shown{% endcomment %}
       {% if page.releaseColumn == false and r.link  %}
@@ -58,6 +64,10 @@ layout: default
         {{ r.label }}
       {% endif %}
     </td>
+
+    {%- for column in customColumnsAfterRelease %}
+    {% include custom-column-td.html release=r column=column cssClasses=cycleColumnClass %}
+    {%- endfor %}
 
     {% if page.releaseDateColumn %}
     <td>{{ r.releaseDate | timeago }} <div>({{ r.releaseDate | date_to_string }})</div></td>
@@ -119,6 +129,10 @@ layout: default
     </td>
     {% endif %}
 
+    {%- for column in customColumnsBeforeLatest %}
+    {% include custom-column-td.html release=r column=column %}
+    {%- endfor %}
+
     {% if page.releaseColumn != false %}
     {%- assign releaseColumnClass = '' %}
     {%- if r.days_toward_eol < 0 %}{% assign releaseColumnClass = 'txt-linethrough' %}{% endif %}
@@ -131,6 +145,10 @@ layout: default
       {% if r.latestReleaseDate %}<div>({{ r.latestReleaseDate | date_to_string }})</div>{% endif %}
     </td>
     {% endif %}
+
+    {%- for column in customColumnsAfterLatest %}
+    {% include custom-column-td.html release=r column=column cssClasses=releaseColumnClass %}
+    {%- endfor %}
   </tr>
 {% endfor %}
 {% assign can_be_hidden_releases_count = page.releases | where: 'can_be_hidden', true | size %}

--- a/product-schema.json
+++ b/product-schema.json
@@ -265,6 +265,14 @@
         ]
       }
     },
+    "customColumns": {
+      "title": "Custom columns",
+      "description": "Array of custom columns for this product.",
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/customColumn"
+      }
+    },
     "releases": {
       "title": "Releases",
       "description": "Array of releases for this product.",
@@ -305,6 +313,49 @@
       "title": "Regex",
       "description": "Regex which will be used to filter the releases.",
       "type": "string"
+    },
+    "customColumn": {
+      "type": "object",
+      "properties": {
+        "property": {
+          "title": "Property",
+          "description": "Name of the custom property in release cycles.",
+          "examples": [
+            "supportedIosVersions",
+            "correspondingAndroidVersion"
+          ],
+          "type": "string"
+        },
+        "position": {
+          "title": "Position",
+          "description": "Position of the custom column in the table.",
+          "enum": [
+            "after-release-column",
+            "before-latest-column",
+            "after-latest-column"
+          ]
+        },
+        "label": {
+          "title": "Label",
+          "description": "Label of the custom column.",
+          "type": "string"
+        },
+        "description": {
+          "title": "Description",
+          "description": "A description of what contains the custom column.",
+          "type": "string"
+        },
+        "link": {
+          "title": "Link",
+          "description": "A link that gives more information about what contains the custom column.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "property",
+        "position",
+        "label"
+      ]
     },
     "release": {
       "type": "object",


### PR DESCRIPTION
They can be used for documenting things such as related runtime versions, custom dates that cannot
be expressed using the default columns, etc. See the documentation in the contribution guide for
more information on how to use them.

This is only an initial support and:

- The allowed positions have been limited to positions that have a chance to be used. More positions
  may be added in the future if needed.
- Those properties may also be exposed in the new API responses (after #2080).

Closes #3642.