### PR TITLE
[nutanix-aos][nutanix-files][nutanix-prism] Add missing auto configuration

### DIFF
--- a/products/nutanix-aos.md
+++ b/products/nutanix-aos.md
@@ -11,6 +11,10 @@ releaseColumn: true
 releaseDateColumn: true
 discontinuedColumn: false
 
+# See https://github.com/endoflife-date/release-data/blob/main/src/nutanix.py.
+auto:
+-   custom: true
+
 # Releases can be found at https://portal.nutanix.com/page/documents/eol/list?type=aos.
 releases:
 -   releaseCycle: "6.7"

--- a/products/nutanix-files.md
+++ b/products/nutanix-files.md
@@ -10,6 +10,10 @@ releaseColumn: true
 releaseDateColumn: true
 discontinuedColumn: false
 
+# See https://github.com/endoflife-date/release-data/blob/main/src/nutanix.py.
+auto:
+-   custom: true
+
 # Releases can be found on https://portal.nutanix.com/page/documents/eol/list?type=files.
 releases:
 -   releaseCycle: "4.4"

--- a/products/nutanix-prism.md
+++ b/products/nutanix-prism.md
@@ -14,6 +14,10 @@ activeSupportColumn: true
 releaseColumn: true
 releaseDateColumn: true
 
+# See https://github.com/endoflife-date/release-data/blob/main/src/nutanix.py.
+auto:
+-   custom: true
+
 # Releases can be found at https://portal.nutanix.com/page/documents/eol/list?type=pc.
 releases:
 -   releaseCycle: "pc.2023.3"


### PR DESCRIPTION
Note that this configuration is only declarative because the automation is based on a custom script.

Relates to https://github.com/endoflife-date/release-data/pull/165.