### PR TITLE
[mxlinux] Replace "cat /etc/os-release" by "cat /etc/lsb-release"

### DIFF
--- a/products/mxlinux.md
+++ b/products/mxlinux.md
@@ -8,7 +8,7 @@ alternate_urls:
 -   /mx_linux
 -   /mx-linux
 -   /mx
-versionCommand: cat /etc/os-release
+versionCommand: cat /etc/lsb-release
 releasePolicyLink: https://mxlinux.org/release-cycle/
 releaseLabel: "__RELEASE_CYCLE__ (__CODENAME__)"
 activeSupportColumn: true


### PR DESCRIPTION
In "MX Linux" it is the command "cat /etc/lsb-release" that  shows the MX Linux version. 

The command "cat /etc/os-release" shows the underlying Debian version instead.

Output of "cat /etc/lsb-release":

$ cat /etc/lsb-release 
PRETTY_NAME="MX 21.3 Wildflower"
DISTRIB_ID=MX
DISTRIB_RELEASE=21.3
DISTRIB_CODENAME="Wildflower"
DISTRIB_DESCRIPTION="MX 21.3 Wildflower"


Output of "cat /etc/os-release" in the same computer:

$ cat /etc/os-release 
PRETTY_NAME="Debian GNU/Linux 11 (bullseye)"
NAME="Debian GNU/Linux"
VERSION_ID="11"
VERSION="11 (bullseye)"
VERSION_CODENAME=bullseye
ID=debian
HOME_URL="https://www.debian.org/"
SUPPORT_URL="https://www.debian.org/support"
BUG_REPORT_URL="https://bugs.debian.org/"
