### PR TITLE
[emberjs] Adds 5.4 release cycle

### DIFF
--- a/products/emberjs.md
+++ b/products/emberjs.md
@@ -27,10 +27,17 @@ auto:
 # - support(x) = release(x+1)
 # - eol(x) = release(x+1)
 releases:
--   releaseCycle: "5.3"
-    releaseDate: 2023-09-18
+-   releaseCycle: "5.4"
+    releaseDate: 2023-10-30
     support: true
     eol: false
+    latest: "5.4.0"
+    latestReleaseDate: 2023-10-30
+
+-   releaseCycle: "5.3"
+    releaseDate: 2023-09-18
+    support: 2023-11-04
+    eol: 2023-11-04
     latest: "5.3.0"
     latestReleaseDate: 2023-09-18
 

--- a/products/emberjs.md
+++ b/products/emberjs.md
@@ -36,8 +36,8 @@ releases:
 
 -   releaseCycle: "5.3"
     releaseDate: 2023-09-18
-    support: 2023-11-04
-    eol: 2023-11-04
+    support: 2023-11-03
+    eol: 2023-11-03
     latest: "5.3.0"
     latestReleaseDate: 2023-09-18
 

--- a/products/emberjs.md
+++ b/products/emberjs.md
@@ -28,11 +28,11 @@ auto:
 # - eol(x) = release(x+1)
 releases:
 -   releaseCycle: "5.4"
-    releaseDate: 2023-10-30
+    releaseDate: 2023-11-03
     support: true
     eol: false
     latest: "5.4.0"
-    latestReleaseDate: 2023-10-30
+    latestReleaseDate: 2023-11-03
 
 -   releaseCycle: "5.3"
     releaseDate: 2023-09-18


### PR DESCRIPTION
- 5.3 goes EOL once 5.4 is officially announced
- 5.4 is not really announced till a blog post is published

Tracking https://blog.emberjs.com/tag/releases/ to wait for the announcement, will keep this as draft till then. 