### PR TITLE
[grails] Fix EOL dates and link

### DIFF
--- a/products/grails.md
+++ b/products/grails.md
@@ -5,7 +5,7 @@ tags: java-runtime
 permalink: /grails
 alternate_urls:
 -   /grails-framework
-releasePolicyLink: https://grails.org/support-schedule.html
+releasePolicyLink: https://grails.org/support.html
 changelogTemplate: "https://github.com/grails/grails-core/releases/tag/v__LATEST__"
 activeSupportColumn: Active Development
 eolColumn: Active Maintenance
@@ -15,16 +15,16 @@ auto:
 -   git: https://github.com/grails/grails-core.git
 
 releases:
--   releaseCycle: "6" # support information not yet available on https://grails.org/support-schedule.html
+-   releaseCycle: "6"
     releaseDate: 2023-07-24
     support: true
     eol: false
-    latest: "6.1.0"
-    latestReleaseDate: 2023-11-03
+    latest: "6.0.0"
+    latestReleaseDate: 2023-07-24
 
 -   releaseCycle: "5"
     releaseDate: 2021-10-12
-    support: true
+    support: 2023-07-24
     eol: false
     latest: "5.3.3"
     latestReleaseDate: 2023-07-11
@@ -70,5 +70,5 @@ releases:
   around the resolution of critical security advisories. New features, performance improvements,
   and minor bug fixes are unlikely.
 
-The Grails Foundation offers [commercial support](https://grails.org/support.html). This typically
+The Grails Foundation offers [commercial support](https://grails.org/support.html#standard). This typically
 lasts a few years after active maintenance ends.


### PR DESCRIPTION
- Active Development on v5 ended with v6 release
- 6.1.0 was accidentally tagged, its no longer published upstream.
- Change link from /support-schedule.html to /support.html. The former is the old link, and pending deletion upstream.