### PR TITLE
:older_adult:  Ubuntu > Add historical releases (< 12.04)

### DIFF
--- a/products/ubuntu.md
+++ b/products/ubuntu.md
@@ -220,6 +220,7 @@ releases:
     codename: "Oneiric Ocelot"
     lts: false
     releaseDate: 2011-10-13
+    support: 2013-05-09
     eol: 2013-05-09
     extendedSupport: 
     latest: "11.10"
@@ -228,6 +229,7 @@ releases:
 -   releaseCycle: "11.04"
     codename: "Natty Narwhal"
     lts: false
+    support: 2012-10-28
     releaseDate: 2011-04-28
     eol: 2012-10-28
     extendedSupport: 
@@ -237,6 +239,7 @@ releases:
 -   releaseCycle: "10.10"
     codename: "Maverick Meerkat"
     lts: false
+    support: 2012-04-10
     releaseDate: 2011-10-10
     eol: 2012-04-10
     extendedSupport: 
@@ -245,6 +248,7 @@ releases:
 
 -   releaseCycle: "10.04"
     codename: "Lucid Lynx"
+    support: 2013-05-09
     lts: true
     releaseDate: 2010-04-29
     eol: 2013-05-09
@@ -253,6 +257,7 @@ releases:
 
 -   releaseCycle: "9.10"
     codename: "Karmic Koala"
+    support: 2011-04-30
     lts: false
     releaseDate: 2009-10-29
     eol: 2011-04-30 
@@ -261,6 +266,7 @@ releases:
 
 -   releaseCycle: "9.04"
     codename: "Jaunty Jackalope"
+    support: 2010-10-23
     lts: false
     releaseDate: 2009-04-23
     eol: 2010-10-23
@@ -269,6 +275,7 @@ releases:
   
 -   releaseCycle: "8.04"
     codename: "Hardy Heron"
+    support: 2013-05-09
     lts: true
     releaseDate: 2008-04-24
     eol: 2013-05-09
@@ -277,6 +284,7 @@ releases:
 
 -   releaseCycle: "7.10"
     codename: "Gutsy Gibbon"
+    support: 2009-04-18
     lts: false
     releaseDate: 2007-10-18
     eol: 2009-04-18
@@ -285,6 +293,7 @@ releases:
 
 -   releaseCycle: "7.04"
     codename: "Feisty Fawn"
+    support: 2008-10-19
     lts: false
     releaseDate: 2007-04-19
     eol: 2008-10-19
@@ -293,6 +302,7 @@ releases:
 
 -   releaseCycle: "6.10"
     codename: "Edgy Eft"
+    support: 2006-10-26
     lts: false
     releaseDate: 2006-10-26
     eol: 2008-04-26
@@ -301,6 +311,7 @@ releases:
 
 -   releaseCycle: "6.06"
     codename: "Dapper Drake"
+    support: 2011-06-01
     lts: true
     releaseDate: 2006-06-01
     eol: 2011-06-01
@@ -309,6 +320,7 @@ releases:
 
 -   releaseCycle: "5.10"
     codename: "Breezy Badger"
+    support: 2007-04-13
     lts: false
     releaseDate: 2005-10-12
     eol: 2007-04-13
@@ -317,6 +329,7 @@ releases:
 
 -   releaseCycle: "5.04"
     codename: "Hoary Hedgehog"
+    support: 2006-10-31
     lts: false
     releaseDate: 2005-04-08
     eol: 2006-10-31
@@ -325,6 +338,7 @@ releases:
 
 -   releaseCycle: "4.10"
     codename: "Warty Warthog"
+    support: 2004-10-26
     lts: false
     releaseDate: 2004-10-26
     eol: 2006-04-30

--- a/products/ubuntu.md
+++ b/products/ubuntu.md
@@ -216,6 +216,120 @@ releases:
     latest: "12.04.5"
     latestReleaseDate: 2014-08-08
 
+-   releaseCycle: "11.10"
+    codename: "Oneiric Ocelot"
+    lts: false
+    releaseDate: 2011-10-13
+    eol: 2013-05-09
+    extendedSupport: 
+    latest: "11.10"
+    latestReleaseDate: 2011-10-13
+
+-   releaseCycle: "11.04"
+    codename: "Natty Narwhal"
+    lts: false
+    releaseDate: 2011-04-28
+    eol: 2012-10-28
+    extendedSupport: 
+    latest: "11.04"
+    latestReleaseDate: 2011-04-28
+
+-   releaseCycle: "10.10"
+    codename: "Maverick Meerkat"
+    lts: false
+    releaseDate: 2011-10-10
+    eol: 2012-04-10
+    extendedSupport: 
+    latest: "10.10"
+    latestReleaseDate: 2011-10-10
+
+-   releaseCycle: "10.04"
+    codename: "Lucid Lynx"
+    lts: true
+    releaseDate: 2010-04-29
+    eol: 2013-05-09
+    latest: "10.04.4"
+    latestReleaseDate: 2012-02-16
+
+-   releaseCycle: "9.10"
+    codename: "Karmic Koala"
+    lts: false
+    releaseDate: 2009-10-29
+    eol: 2011-04-30 
+    latest: "9.10"
+    latestReleaseDate: 2009-10-29
+
+-   releaseCycle: "9.04"
+    codename: "Jaunty Jackalope"
+    lts: false
+    releaseDate: 2009-04-23
+    eol: 2010-10-23
+    latest: "9.04"
+    latestReleaseDate: 2009-04-23
+  
+-   releaseCycle: "8.04"
+    codename: "Hardy Heron"
+    lts: true
+    releaseDate: 2008-04-24
+    eol: 2013-05-09
+    latest: "8.04.4"
+    latestReleaseDate: 2010-01-28
+
+-   releaseCycle: "7.10"
+    codename: "Gutsy Gibbon"
+    lts: false
+    releaseDate: 2007-10-18
+    eol: 2009-04-18
+    latest: "7.10"
+    latestReleaseDate: 2007-10-18
+
+-   releaseCycle: "7.04"
+    codename: "Feisty Fawn"
+    lts: false
+    releaseDate: 2007-04-19
+    eol: 2008-10-19
+    latest: "7.04"
+    latestReleaseDate: 2007-04-19
+
+-   releaseCycle: "6.10"
+    codename: "Edgy Eft"
+    lts: false
+    releaseDate: 2006-10-26
+    eol: 2008-04-26
+    latest: "6.10"
+    latestReleaseDate: 2006-10-26
+
+-   releaseCycle: "6.06"
+    codename: "Dapper Drake"
+    lts: true
+    releaseDate: 2006-06-01
+    eol: 2011-06-01
+    latest: "6.06.2"
+    latestReleaseDate: 2008-01-21
+
+-   releaseCycle: "5.10"
+    codename: "Breezy Badger"
+    lts: false
+    releaseDate: 2005-10-12
+    eol: 2007-04-13
+    latest: "5.10"
+    latestReleaseDate: 2005-10-12
+
+-   releaseCycle: "5.04"
+    codename: "Hoary Hedgehog"
+    lts: false
+    releaseDate: 2005-04-08
+    eol: 2006-10-31
+    latest: "5.04"
+    latestReleaseDate: 2005-04-08
+
+-   releaseCycle: "4.10"
+    codename: "Warty Warthog"
+    lts: false
+    releaseDate: 2004-10-26
+    eol: 2006-04-30
+    latest: "4.10"
+    latestReleaseDate: 2004-10-26
 ---
 
 >[Ubuntu](https://ubuntu.com) is a free and open-source Linux distribution based on Debian. Ubuntu

--- a/products/ubuntu.md
+++ b/products/ubuntu.md
@@ -222,7 +222,7 @@ releases:
     releaseDate: 2011-10-13
     support: 2013-05-09
     eol: 2013-05-09
-    extendedSupport: 
+    extendedSupport: false
     latest: "11.10"
     latestReleaseDate: 2011-10-13
 
@@ -232,7 +232,7 @@ releases:
     support: 2012-10-28
     releaseDate: 2011-04-28
     eol: 2012-10-28
-    extendedSupport: 
+    extendedSupport: false
     latest: "11.04"
     latestReleaseDate: 2011-04-28
 
@@ -242,7 +242,7 @@ releases:
     support: 2012-04-10
     releaseDate: 2011-10-10
     eol: 2012-04-10
-    extendedSupport: 
+    extendedSupport: false
     latest: "10.10"
     latestReleaseDate: 2011-10-10
 
@@ -252,6 +252,7 @@ releases:
     lts: true
     releaseDate: 2010-04-29
     eol: 2013-05-09
+    extendedSupport: false
     latest: "10.04.4"
     latestReleaseDate: 2012-02-16
 
@@ -260,7 +261,8 @@ releases:
     support: 2011-04-30
     lts: false
     releaseDate: 2009-10-29
-    eol: 2011-04-30 
+    eol: 2011-04-30
+    extendedSupport: false
     latest: "9.10"
     latestReleaseDate: 2009-10-29
 
@@ -270,6 +272,7 @@ releases:
     lts: false
     releaseDate: 2009-04-23
     eol: 2010-10-23
+    extendedSupport: false
     latest: "9.04"
     latestReleaseDate: 2009-04-23
   
@@ -279,6 +282,7 @@ releases:
     lts: true
     releaseDate: 2008-04-24
     eol: 2013-05-09
+    extendedSupport: 2011-05-12
     latest: "8.04.4"
     latestReleaseDate: 2010-01-28
 
@@ -288,6 +292,7 @@ releases:
     lts: false
     releaseDate: 2007-10-18
     eol: 2009-04-18
+    extendedSupport: false
     latest: "7.10"
     latestReleaseDate: 2007-10-18
 
@@ -297,6 +302,7 @@ releases:
     lts: false
     releaseDate: 2007-04-19
     eol: 2008-10-19
+    extendedSupport: false
     latest: "7.04"
     latestReleaseDate: 2007-04-19
 
@@ -306,6 +312,7 @@ releases:
     lts: false
     releaseDate: 2006-10-26
     eol: 2008-04-26
+    extendedSupport: false
     latest: "6.10"
     latestReleaseDate: 2006-10-26
 
@@ -315,6 +322,7 @@ releases:
     lts: true
     releaseDate: 2006-06-01
     eol: 2011-06-01
+    extendedSupport: 2009-07-14
     latest: "6.06.2"
     latestReleaseDate: 2008-01-21
 
@@ -324,6 +332,7 @@ releases:
     lts: false
     releaseDate: 2005-10-12
     eol: 2007-04-13
+    extendedSupport: false
     latest: "5.10"
     latestReleaseDate: 2005-10-12
 
@@ -333,6 +342,7 @@ releases:
     lts: false
     releaseDate: 2005-04-08
     eol: 2006-10-31
+    extendedSupport: false
     latest: "5.04"
     latestReleaseDate: 2005-04-08
 
@@ -342,6 +352,7 @@ releases:
     lts: false
     releaseDate: 2004-10-26
     eol: 2006-04-30
+    extendedSupport: false
     latest: "4.10"
     latestReleaseDate: 2004-10-26
 ---


### PR DESCRIPTION
# :grey_question:  About

Today I saw this [tweet](https://twitter.com/omgubuntu/status/1720920461456867474) about _Hardy Heron_ release:

![image](https://github.com/endoflife-date/endoflife.date/assets/5235127/2902a636-8626-416c-9b33-b39ca3378f36)

... and I wanted to drop a screenshot of it from [`endoflife.date/ubuntu`](https://endoflife.date/ubuntu)... but it was lacking these old ones : 

![image](https://github.com/endoflife-date/endoflife.date/assets/5235127/c10a8578-f4c5-42dc-9465-c8a722337d0d)

![image](https://github.com/endoflife-date/endoflife.date/assets/5235127/c9fbf125-6ff6-45c9-8a2a-ba92ec943590)

:point_right: The purpose of this PR is to make these historic releases available :hugs: 

# :information_source: Source of information

I've used https://wiki.ubuntu.com/Releases as input.
Notice what we should telle wether we're talking about _server_ of _desktop_ edition :thought_balloon:  