### PR TITLE
[xenserver] XenServer.org redirects to xenserver.com

### DIFF
--- a/_plugins/product-data-validator.rb
+++ b/_plugins/product-data-validator.rb
@@ -74,7 +74,6 @@ module EndOfLifeHooks
     'https://www.microsoft.com/sql-server': SUPPRESSED_BECAUSE_TIMEOUT,
     'https://www.microsoft.com/windows': SUPPRESSED_BECAUSE_TIMEOUT,
     'https://www.mysql.com': SUPPRESSED_BECAUSE_403,
-    'https://xenserver.org/': SUPPRESSED_BECAUSE_CERT,
   }
   USER_AGENT = 'Mozilla/5.0 (Windows NT 6.1; Win64; x64; rv:47.0) Gecko/20100101 Firefox/47.0'
   URL_CHECK_OPEN_TIMEOUT = 3

--- a/products/xcp-ng.md
+++ b/products/xcp-ng.md
@@ -54,7 +54,7 @@ releases:
 ---
 
 > [XCP-ng](https://xcp-ng.org) is a free and open-source hypervisor based on
-> [Xen](https://xenproject.org/). It is a fork of [XenServer](https://xenserver.org/), which was
+> [Xen](https://xenproject.org/). It is a fork of [XenServer](https://xenserver.com/), which was
 > acquired by Citrix in 2013. It is a drop-in replacement for XenServer, and can be used to manage
 > and run virtual machines on any hardware that supports the Xen hypervisor. XCP-ng is developed by
 > a community of contributors and is available for free.


### PR DESCRIPTION
```
curl -kI https://xenserver.org
HTTP/2 301
date: Sun, 05 Nov 2023 12:43:46 GMT
content-length: 0
location: https://xenserver.com/
```