### PR TITLE
Fix Docker Hub auto method name in documentation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -196,7 +196,7 @@ auto:
   # The value must be the "owner/repo" combination for a docker hub public image.
   # Use "library" as the owner name for an official docker/community image.
   # For example, for PostgreSQL:
-  - dockerhub: library/postgres
+  - docker_hub: library/postgres
 
   # Configuration for auto-update based on the npm registry.
   # The value must be the package identifier on https://www.npmjs.com .


### PR DESCRIPTION
Since https://github.com/endoflife-date/release-data/pull/137 the Ruby `dockerhub` auto method has been replaced by the Python based one named `docker_hub`.