### PR TITLE
[iphone] Migrate the iOS Compatibility table to a custom column

### DIFF
--- a/products/iphone.md
+++ b/products/iphone.md
@@ -9,6 +9,11 @@ discontinuedColumn: true
 eolColumn: Supported
 releaseColumn: false
 releaseDateColumn: true
+customColumns:
+-   property: supportedIosVersions
+    position: after-release-column
+    label: Supported iOS
+    description: Supported iOS versions range
 
 # All links can be found on https://support.apple.com/en-us/HT201296.
 # All supported iOS versions can be found on https://en.wikipedia.org/wiki/List_of_iPhone_models#Release_dates.
@@ -51,7 +56,7 @@ releases:
     discontinued: false
     eol: false
     link: https://support.apple.com/kb/SP874
-    supportedIosVersions: 16, 17
+    supportedIosVersions: 16 - 17
 
 -   releaseCycle: "14"
     releaseLabel: "14"
@@ -59,7 +64,7 @@ releases:
     discontinued: false
     eol: false
     link: https://support.apple.com/kb/SP873
-    supportedIosVersions: 16, 17
+    supportedIosVersions: 16 - 17
 
 -   releaseCycle: "14-pro"
     releaseLabel: "14 Pro"
@@ -67,7 +72,7 @@ releases:
     discontinued: 2023-09-12
     eol: false
     link: https://support.apple.com/kb/SP875
-    supportedIosVersions: 16, 17
+    supportedIosVersions: 16 - 17
 
 -   releaseCycle: "14-pro-max"
     releaseLabel: "14 Pro Max"
@@ -75,7 +80,7 @@ releases:
     discontinued: 2023-09-12
     eol: false
     link: https://support.apple.com/kb/SP876
-    supportedIosVersions: 16, 17
+    supportedIosVersions: 16 - 17
 
 -   releaseCycle: "se-3"
     releaseLabel: "SE (3rd generation)"
@@ -83,7 +88,7 @@ releases:
     discontinued: false
     eol: false
     link: https://support.apple.com/kb/SP867
-    supportedIosVersions: 15, 16, 17
+    supportedIosVersions: 15 - 17
 
 -   releaseCycle: "13"
     releaseLabel: "13"
@@ -91,7 +96,7 @@ releases:
     discontinued: false
     eol: false
     link: https://support.apple.com/kb/SP851
-    supportedIosVersions: 15, 16, 17
+    supportedIosVersions: 15 - 17
 
 -   releaseCycle: "13-mini"
     releaseLabel: "13 Mini"
@@ -99,7 +104,7 @@ releases:
     discontinued: 2023-09-12
     eol: false
     link: https://support.apple.com/kb/SP847
-    supportedIosVersions: 15, 16, 17
+    supportedIosVersions: 15 - 17
 
 -   releaseCycle: "13-pro"
     releaseLabel: "13 Pro"
@@ -107,7 +112,7 @@ releases:
     discontinued: 2022-09-07
     eol: false
     link: https://support.apple.com/kb/SP852
-    supportedIosVersions: 15, 16, 17
+    supportedIosVersions: 15 - 17
 
 -   releaseCycle: "13-pro-max"
     releaseLabel: "13 Pro Max"
@@ -115,7 +120,7 @@ releases:
     discontinued: 2022-09-07
     eol: false
     link: https://support.apple.com/kb/SP848
-    supportedIosVersions: 15, 16, 17
+    supportedIosVersions: 15 - 17
 
 -   releaseCycle: "12-mini"
     releaseLabel: "12 Mini"
@@ -123,7 +128,7 @@ releases:
     discontinued: 2022-09-07
     eol: false
     link: https://support.apple.com/kb/SP829
-    supportedIosVersions: 14, 15, 16, 17
+    supportedIosVersions: 14 - 17
 
 -   releaseCycle: "12-pro-max"
     releaseLabel: "12 Pro Max"
@@ -131,7 +136,7 @@ releases:
     discontinued: 2021-09-14
     eol: false
     link: https://support.apple.com/kb/SP832
-    supportedIosVersions: 14, 15, 16, 17
+    supportedIosVersions: 14 - 17
 
 -   releaseCycle: "12"
     releaseLabel: "12"
@@ -139,7 +144,7 @@ releases:
     discontinued: 2023-09-12
     eol: false
     link: https://support.apple.com/kb/SP830
-    supportedIosVersions: 14, 15, 16, 17
+    supportedIosVersions: 14 - 17
 
 -   releaseCycle: "12-pro"
     releaseLabel: "12 Pro"
@@ -147,7 +152,7 @@ releases:
     discontinued: 2021-09-14
     eol: false
     link: https://support.apple.com/kb/SP831
-    supportedIosVersions: 14, 15, 16, 17
+    supportedIosVersions: 14 - 17
 
 -   releaseCycle: "se-2"
     releaseLabel: "SE (2nd generation)"
@@ -155,7 +160,7 @@ releases:
     discontinued: 2022-03-08
     eol: false
     link: https://support.apple.com/kb/SP820
-    supportedIosVersions: 13, 14, 15, 16, 17
+    supportedIosVersions: 13 - 17
 
 -   releaseCycle: "11"
     releaseLabel: "11"
@@ -163,7 +168,7 @@ releases:
     discontinued: 2022-09-07
     eol: false
     link: https://support.apple.com/kb/SP804
-    supportedIosVersions: 13, 14, 15, 16, 17
+    supportedIosVersions: 13 - 17
 
 -   releaseCycle: "11-pro"
     releaseLabel: "11 Pro"
@@ -171,7 +176,7 @@ releases:
     discontinued: 2020-10-13
     eol: false
     link: https://support.apple.com/kb/SP805
-    supportedIosVersions: 13, 14, 15, 16, 17
+    supportedIosVersions: 13 - 17
 
 -   releaseCycle: "11-pro-max"
     releaseLabel: "11 Pro Max"
@@ -179,7 +184,7 @@ releases:
     discontinued: 2020-10-13
     eol: false
     link: https://support.apple.com/kb/SP806
-    supportedIosVersions: 13, 14, 15, 16, 17
+    supportedIosVersions: 13 - 17
 
 -   releaseCycle: "xr"
     releaseLabel: "XR"
@@ -187,7 +192,7 @@ releases:
     discontinued: 2021-09-07
     eol: false
     link: https://support.apple.com/kb/SP781
-    supportedIosVersions: 12, 13, 14, 15, 16, 17
+    supportedIosVersions: 12 - 17
 
 -   releaseCycle: "xs"
     releaseLabel: "XS"
@@ -195,7 +200,7 @@ releases:
     discontinued: 2019-09-10
     eol: false
     link: https://support.apple.com/kb/SP779
-    supportedIosVersions: 12, 13, 14, 15, 16, 17
+    supportedIosVersions: 12 - 17
 
 -   releaseCycle: "xs-max"
     releaseLabel: "XS Max"
@@ -203,7 +208,7 @@ releases:
     discontinued: 2019-09-10
     eol: false
     link: https://support.apple.com/kb/SP780
-    supportedIosVersions: 12, 13, 14, 15, 16, 17
+    supportedIosVersions: 12 - 17
 
 -   releaseCycle: "8"
     releaseLabel: "8"
@@ -211,7 +216,7 @@ releases:
     discontinued: 2020-04-15
     eol: false
     link: https://support.apple.com/kb/SP767
-    supportedIosVersions: 11, 12, 13, 14, 15, 16
+    supportedIosVersions: 11 - 16
 
 -   releaseCycle: "8-plus"
     releaseLabel: "8 Plus"
@@ -219,7 +224,7 @@ releases:
     discontinued: 2020-04-15
     eol: false
     link: https://support.apple.com/kb/SP768
-    supportedIosVersions: 11, 12, 13, 14, 15, 16
+    supportedIosVersions: 11 - 16
 
 -   releaseCycle: "x"
     releaseLabel: "X"
@@ -227,7 +232,7 @@ releases:
     discontinued: 2018-09-12
     eol: false
     link: https://support.apple.com/kb/SP770
-    supportedIosVersions: 11, 12, 13, 14, 15, 16
+    supportedIosVersions: 11 - 16
 
 # iOS 15.7.2 was released on 13th Dec 2022
 # exclusively for 7/7+/SE1/6S/6S+
@@ -238,7 +243,7 @@ releases:
     discontinued: 2019-09-10
     eol: false
     link: https://support.apple.com/kb/SP743
-    supportedIosVersions: 10, 11, 12, 13, 14, 15
+    supportedIosVersions: 10 - 15
 
 # iOS 15.7.2 was released on 13th Dec 2022
 # exclusively for 7/7+/SE1/6S/6S+
@@ -249,7 +254,7 @@ releases:
     discontinued: 2019-09-10
     eol: false
     link: https://support.apple.com/kb/SP744
-    supportedIosVersions: 10, 11, 12, 13, 14, 15
+    supportedIosVersions: 10 - 15
 
 -   releaseCycle: "se-1"
     releaseLabel: "SE (1st generation)"
@@ -257,7 +262,7 @@ releases:
     discontinued: 2018-09-12
     eol: false
     link: https://support.apple.com/kb/SP738
-    supportedIosVersions: 9, 10, 11, 12, 13, 14, 15
+    supportedIosVersions: 9 - 15
 
 -   releaseCycle: "6s"
     releaseLabel: "6S"
@@ -265,7 +270,7 @@ releases:
     discontinued: 2018-09-12
     eol: false
     link: https://support.apple.com/kb/SP726
-    supportedIosVersions: 9, 10, 11, 12, 13, 14, 15
+    supportedIosVersions: 9 - 15
 
 -   releaseCycle: "6s-plus"
     releaseLabel: "6S Plus"
@@ -273,7 +278,7 @@ releases:
     discontinued: 2018-09-12
     eol: false
     link: https://support.apple.com/kb/SP727
-    supportedIosVersions: 9, 10, 11, 12, 13, 14, 15
+    supportedIosVersions: 9 - 15
 
 # iOS 12.5.7 was released on 23rd Jan 2023
 # so 6/6+/5S are marked as supported.
@@ -283,7 +288,7 @@ releases:
     discontinued: 2016-09-07
     eol: false
     link: https://support.apple.com/kb/SP705
-    supportedIosVersions: 8, 9, 10, 11, 12
+    supportedIosVersions: 8 - 12
 
   # iOS 12.5.7 was released on 23rd Jan 2023
   # so 6/6+/5S are marked as supported.
@@ -293,7 +298,7 @@ releases:
     discontinued: 2016-09-07
     eol: false
     link: https://support.apple.com/kb/SP706
-    supportedIosVersions: 8, 9, 10, 11, 12
+    supportedIosVersions: 8 - 12
 
 -   releaseCycle: "5c"
     releaseLabel: "5C"
@@ -309,7 +314,7 @@ releases:
     discontinued: 2016-03-21
     eol: false
     link: https://support.apple.com/kb/SP685
-    supportedIosVersions: 7, 8, 9, 10, 11, 12
+    supportedIosVersions: 7 - 12
 
 -   releaseCycle: "5"
     releaseLabel: "5"
@@ -317,7 +322,7 @@ releases:
     discontinued: 2013-09-10
     eol: 2019-07-22
     link: https://support.apple.com/kb/SP655
-    supportedIosVersions: 6, 7, 8, 9, 10
+    supportedIosVersions: 6 - 10
 
 -   releaseCycle: "4s"
     releaseLabel: "4S"
@@ -325,7 +330,7 @@ releases:
     discontinued: 2014-09-09
     eol: 2019-07-22
     link: https://support.apple.com/kb/SP643
-    supportedIosVersions: 5, 6, 7, 8, 9
+    supportedIosVersions: 5 - 9
 
 -   releaseCycle: "4"
     releaseLabel: "4"
@@ -333,7 +338,7 @@ releases:
     discontinued: 2013-09-10
     eol: 2014-09-17
     link: https://support.apple.com/kb/SP587
-    supportedIosVersions: 4, 5, 6, 7
+    supportedIosVersions: 4 - 7
 
 -   releaseCycle: "3gs"
     releaseLabel: "3GS"
@@ -341,7 +346,7 @@ releases:
     discontinued: 2012-09-12
     eol: 2014-02-21
     link: https://support.apple.com/kb/SP565
-    supportedIosVersions: 3, 4, 5, 6
+    supportedIosVersions: 3 - 6
 
 -   releaseCycle: "3g"
     releaseLabel: "3G"
@@ -349,7 +354,7 @@ releases:
     discontinued: 2010-08-09
     eol: 2011-03-03
     link: https://support.apple.com/kb/SP495
-    supportedIosVersions: 2, 3, 4
+    supportedIosVersions: 2 - 4
 
 -   releaseCycle: "1"
     releaseLabel: "1"
@@ -357,7 +362,7 @@ releases:
     discontinued: 2008-06-09
     eol: 2010-06-20
     link: https://web.archive.org/web/20070714051039/http://www.apple.com/iphone/specs.html
-    supportedIosVersions: 1, 2, 3
+    supportedIosVersions: 1 - 3
 
 ---
 
@@ -376,12 +381,3 @@ as a stop-gap to allow users time to update.
 Apple maintains a list of Supported iPhone models at <https://support.apple.com/guide/iphone/iphe3fa5df43>.
 
 Support information for iOS versions are available at [/ios](/ios).
-
-## iOS Compatibility
-
-{%- assign collapsedCycles = page.releases %}
-{% include table.html
-  labels="Release,iOS"
-  fields="releaseLabel,supportedIosVersions"
-  types="string,string"
-  rows=collapsedCycles %}


### PR DESCRIPTION
Also convert supportedIosVersions to a version range instead of a list of version in order to limit the field length.

Relates to #4002.