### PR TITLE
[mattermost] Add 9.2

### DIFF
--- a/products/mattermost.md
+++ b/products/mattermost.md
@@ -16,6 +16,12 @@ auto:
 
 # EOL date can be found on https://docs.mattermost.com/upgrade/release-lifecycle.html
 releases:
+-   releaseCycle: "9.2"
+    releaseDate: 2023-11-16
+    eol: 2024-02-15
+    latest: '9.2.0'
+    latestReleaseDate: 2023-11-16
+
 -   releaseCycle: "9.1"
     releaseDate: 2023-10-06
     eol: 2024-01-15

--- a/products/mattermost.md
+++ b/products/mattermost.md
@@ -19,7 +19,7 @@ releases:
 -   releaseCycle: "9.2"
     releaseDate: 2023-11-16
     eol: 2024-02-15
-    latest: '9.2.0'
+    latest: '9.2.2'
     latestReleaseDate: 2023-11-16
 
 -   releaseCycle: "9.1"


### PR DESCRIPTION
See https://docs.mattermost.com/upgrade/release-lifecycle.html.

Note that 9.2.2 is the initial release according to date in https://mattermost.com/download/, but dates will be overridden by tag dates, which are 2023-10-28 for 9.2.0 and 2023-11-08 for 9.2.2. There is not much we can do but at least correct dates will be in the git history.