### PR TITLE
[nexus] Adjust version template

### DIFF
--- a/products/nexus.md
+++ b/products/nexus.md
@@ -14,6 +14,7 @@ auto:
 -   git: https://github.com/sonatype/nexus-public.git
     # See https://rubular.com/r/607xFn4zIA4fDw for reference
     regex: '^release-(?<major>\d+)\.(?<minor>\d+)\.(?<patch>\d+)-(?<tiny>\d+)$'
+    template: '{{major}}.{{minor}}.{{patch}}-{{tiny}}'
 
 releases:
 -   releaseCycle: "3"


### PR DESCRIPTION
Adjust version template to render the correct version number. See https://github.com/sonatype/nexus-oss/releases.