### PR TITLE
[New product] Add IBM i operating system (AS400)

### DIFF
--- a/products/ibm-i.md
+++ b/products/ibm-i.md
@@ -17,6 +17,7 @@ versionCommand: DSPJOB OUTPUT(*PRINT)
 releasePolicyLink: https://www.ibm.com/support/pages/release-life-cycle # https://www.ibm.com/support/pages/ibm-i-release-support
 releaseDateColumn: true
 eolColumn: End of Service Pack Support (<abbr title="End of Service Pack Support">EoSPS</abbr>)
+extendedSupportColumn: Extended Life Cycle Support
 
 
 releases:
@@ -41,6 +42,7 @@ releases:
     latest: "7.3"
     latestReleaseDate: 2016-04-15
     link: https://www.ibm.com/support/pages/customer-notices-and-information-ibm-i-73
+    extendedSupport: 2026-09-30
 
 -   releaseCycle: "7.2"
     releaseDate: 2014-05-02
@@ -48,6 +50,7 @@ releases:
     latest: "7.2"
     latestReleaseDate: 2014-05-02
     link: https://www.ibm.com/support/pages/customer-notices-and-information-ibm-i-72
+    extendedSupport: 2026-04-30
 
 -   releaseCycle: "7.1"
     releaseDate: 2010-04-23
@@ -62,12 +65,14 @@ releases:
     latest: "6.1"
     latestReleaseDate: 2008-04-23
     link: https://www.ibm.com/support/pages/customer-notices-and-information-ibm-i-61
+    extendedSupport: 2019-09-30
 
 -   releaseCycle: "5.4"
     releaseDate: 2006-02-14
     eol: 2013-09-30
     latest: "5.4"
     latestReleaseDate: 2006-02-14
+    extendedSupport: 2017-09-30
     
 
 -   releaseCycle: "5.3"
@@ -75,6 +80,7 @@ releases:
     eol: 2009-04-30
     latest: "5.3"
     latestReleaseDate: 2004-06-11
+    extendedSupport: 2013-04-30
     
 -   releaseCycle: "5.2"
     releaseDate: 2002-08-30
@@ -93,12 +99,14 @@ releases:
     eol: 2002-07-31
     latest: "4.5"
     latestReleaseDate: 2000-07-28
+    extendedSupport: 2002-12-31
 
 -   releaseCycle: "4.4"
     releaseDate: 1999-05-21
     eol: 2001-05-30
     latest: "4.4"
     latestReleaseDate: 1999-05-21
+    extendedSupport: 2001-11-30
 
 -   releaseCycle: "4.3"
     releaseDate: 1998-09-11
@@ -111,6 +119,7 @@ releases:
     eol: 2000-05-31
     latest: "4.2"
     latestReleaseDate: 1998-02-27
+    extendedSupport: 2001-01-31
 
 -   releaseCycle: "4.1"
     releaseDate: 1997-08-29

--- a/products/ibm-i.md
+++ b/products/ibm-i.md
@@ -1,0 +1,167 @@
+---
+title: IBM iSeries
+category: os
+tags: ibm
+iconSlug: ibm
+permalink: /ibm-i
+alternate_urls:
+-   /iseries
+-   /i-series
+-   /ibm-iseries
+-   /ibmi
+-   /as400
+-   /os400
+-   /os-400
+
+versionCommand: DSPJOB OUTPUT(*PRINT)
+releasePolicyLink: https://www.ibm.com/support/pages/release-life-cycle # https://www.ibm.com/support/pages/ibm-i-release-support
+releaseDateColumn: true
+eolColumn: End of Service Pack Support (<abbr title="End of Service Pack Support">EoSPS</abbr>)
+
+
+releases:
+
+-   releaseCycle: "7.5"
+    releaseDate: 2022-05-10
+    eol: false
+    latest: "7.5"
+    latestReleaseDate: 2022-05-10
+    link: https://www.ibm.com/support/pages/customer-notices-and-information-ibm-i-75
+
+-   releaseCycle: "7.4"
+    releaseDate: 2019-06-21
+    eol: false
+    latest: "7.4"
+    latestReleaseDate: 2019-06-21
+    link: https://www.ibm.com/support/pages/customer-notices-and-information-ibm-i-74
+
+-   releaseCycle: "7.3"
+    releaseDate: 2016-04-15
+    eol: 2023-09-30
+    latest: "7.3"
+    latestReleaseDate: 2016-04-15
+    link: https://www.ibm.com/support/pages/customer-notices-and-information-ibm-i-73
+
+-   releaseCycle: "7.2"
+    releaseDate: 2014-05-02
+    eol: 2021-04-30
+    latest: "7.2"
+    latestReleaseDate: 2014-05-02
+    link: https://www.ibm.com/support/pages/customer-notices-and-information-ibm-i-72
+
+-   releaseCycle: "7.1"
+    releaseDate: 2010-04-23
+    eol: 2018-04-30
+    latest: "7.1"
+    latestReleaseDate: 2010-04-23
+    link: https://www.ibm.com/support/pages/customer-notices-and-information-ibm-i-71
+
+-   releaseCycle: "6.1"
+    releaseDate: 2008-04-23
+    eol: 2015-09-30
+    latest: "6.1"
+    latestReleaseDate: 2008-04-23
+    link: https://www.ibm.com/support/pages/customer-notices-and-information-ibm-i-61
+
+-   releaseCycle: "5.4"
+    releaseDate: 2006-02-14
+    eol: 2013-09-30
+    latest: "5.4"
+    latestReleaseDate: 2006-02-14
+    
+
+-   releaseCycle: "5.3"
+    releaseDate: 2004-06-11
+    eol: 2009-04-30
+    latest: "5.3"
+    latestReleaseDate: 2004-06-11
+    
+-   releaseCycle: "5.2"
+    releaseDate: 2002-08-30
+    eol: 2007-04-30
+    latest: "5.2"
+    latestReleaseDate: 2002-08-30
+    
+-   releaseCycle: "5.1"
+    releaseDate: 2001-05-25
+    eol: 2005-09-30
+    latest: "5.1"
+    latestReleaseDate: 2001-05-25
+
+-   releaseCycle: "4.5"
+    releaseDate: 200-07-28
+    eol: 2002-07-31
+    latest: "4.5"
+    latestReleaseDate: 200-07-28
+
+-   releaseCycle: "4.4"
+    releaseDate: 1999-05-21
+    eol: 2001-05-30
+    latest: "4.4"
+    latestReleaseDate: 1999-05-21
+
+-   releaseCycle: "4.3"
+    releaseDate: 1998-09-11
+    eol: 2001-01-31
+    latest: "4.3"
+    latestReleaseDate: 1998-09-11
+
+-   releaseCycle: "4.2"
+    releaseDate: 1998-02-27
+    eol: 2000-05-31
+    latest: "4.2"
+    latestReleaseDate: 1998-02-27
+
+-   releaseCycle: "4.1"
+    releaseDate: 1997-08-29
+    eol: 2000-05-31
+    latest: "4.1"
+    latestReleaseDate: 1997-08-29
+
+-   releaseCycle: "3.7"
+    releaseDate: 1996-11-08
+    eol: 199-06-30
+    latest: "3.7"
+    latestReleaseDate: 1996-11-08
+
+-   releaseCycle: "3.6"
+    releaseDate: 1995-12-22
+    eol: 1998-10-31
+    latest: "3.6"
+    latestReleaseDate: 1995-12-22
+
+-   releaseCycle: "3.2"
+    releaseDate: 1996-06-21
+    eol: 2000-05-31
+    latest: "3.2"
+    latestReleaseDate: 1996-06-21
+
+-   releaseCycle: "3.1"
+    releaseDate: 1994-11-25
+    eol: 1998-10-31
+    latest: "3.1"
+    latestReleaseDate: 1994-11-25
+
+-   releaseCycle: "3.0"
+    releaseDate: 1994-06-03
+    eol: 1997-05-31
+    latest: "3.0.5"
+    latestReleaseDate: 1994-06-03
+
+---
+
+> [IBM i](https://www.ibm.com/products/ibm-i) is a fully integrated operating system, meaning the database, middleware, security, runtime and hypervisor are integrated into the stack and licensed as one solution.
+
+_Note 1_: End of program support date will be announced with at least 12 months notice prior to the effective termination date.
+
+_Note 2_: For 6.1, includes both Machine Code Level V6R1M0 and V6R1M1.
+
+_Note 3_: IBM i 7.1 extended Service Extension started on May 1, 2021. The duration of IBM i 7.1 extended Service Extension is dependent on the Power hardware generation. The extended Service Extension coverage is usage and known defect support, and there some exceptions of products and functions which are not supported. For notes regarding extended Service Extension duration and support coverage, see Service Extension for IBM i 7.3, 7.2 and 7.1.
+
+_Note 4_: IBM i 7.2 Service Extension Offering started on May 1, 2021. For details regarding support coverage for the various products in the IBM i portfolio, see Service Extension for IBM i 7.3, 7.2 and 7.1.
+
+_Note 5_: IBM i 7.3 Service Extension Offering starts on October 1, 2023. For details regarding support coverage for the various products in the IBM i portfolio, see Service Extension for IBM i 7.3, 7.2 and 7.1.
+
+Find more information about Technology Levels (TL) and Service Packs (SP) and their support dates
+on [IBM i Release Support](https://www.ibm.com/support/pages/ibm-i-release-support)
+page.

--- a/products/ibm-i.md
+++ b/products/ibm-i.md
@@ -177,15 +177,15 @@ releases:
 
 > [IBM i](https://www.ibm.com/products/ibm-i) is a fully integrated operating system, meaning the database, middleware, security, runtime and hypervisor are integrated into the stack and licensed as one solution.
 
-_Note 1_: End of program support date will be announced with at least 12 months notice prior to the effective termination date.
+End of program support date will be announced with at least 12 months notice prior to the effective termination date.
 
-_Note 2_: For 6.1, includes both Machine Code Level V6R1M0 and V6R1M1.
+IBM i 7.3 Service Extension Offering starts on October 1, 2023. For details regarding support coverage for the various products in the IBM i portfolio, see Service Extension for IBM i 7.3, 7.2 and 7.1.
 
-_Note 3_: IBM i 7.1 extended Service Extension started on May 1, 2021. The duration of IBM i 7.1 extended Service Extension is dependent on the Power hardware generation. The extended Service Extension coverage is usage and known defect support, and there some exceptions of products and functions which are not supported. For notes regarding extended Service Extension duration and support coverage, see Service Extension for IBM i 7.3, 7.2 and 7.1.
+IBM i 7.2 Service Extension Offering started on May 1, 2021. For details regarding support coverage for the various products in the IBM i portfolio, see Service Extension for IBM i 7.3, 7.2 and 7.1.
 
-_Note 4_: IBM i 7.2 Service Extension Offering started on May 1, 2021. For details regarding support coverage for the various products in the IBM i portfolio, see Service Extension for IBM i 7.3, 7.2 and 7.1.
+IBM i 7.1 extended Service Extension started on May 1, 2021. The duration of IBM i 7.1 extended Service Extension is dependent on the Power hardware generation. The extended Service Extension coverage is usage and known defect support, and there some exceptions of products and functions which are not supported. For notes regarding extended Service Extension duration and support coverage, see Service Extension for IBM i 7.3, 7.2 and 7.1.
 
-_Note 5_: IBM i 7.3 Service Extension Offering starts on October 1, 2023. For details regarding support coverage for the various products in the IBM i portfolio, see Service Extension for IBM i 7.3, 7.2 and 7.1.
+For 6.1, includes both Machine Code Level V6R1M0 and V6R1M1.
 
 Find more information about Technology Levels (TL) and Service Packs (SP) and their support dates
 on [IBM i Release Support](https://www.ibm.com/support/pages/ibm-i-release-support)

--- a/products/ibm-i.md
+++ b/products/ibm-i.md
@@ -101,7 +101,7 @@ releases:
 
 -   releaseCycle: "4.4"
     releaseDate: 1999-05-21
-    eol: 2001-05-30
+    eol: 2001-05-31
     latest: "4.4"
     latestReleaseDate: 1999-05-21
     extendedSupport: 2001-11-30

--- a/products/ibm-i.md
+++ b/products/ibm-i.md
@@ -73,6 +73,7 @@ releases:
     latest: "5.4"
     latestReleaseDate: 2006-02-14
     extendedSupport: 2017-09-30
+    
 -   releaseCycle: "5.3"
     releaseDate: 2004-06-11
     eol: 2009-04-30

--- a/products/ibm-i.md
+++ b/products/ibm-i.md
@@ -28,6 +28,7 @@ releases:
     latest: "7.5"
     latestReleaseDate: 2022-05-10
     link: https://www.ibm.com/support/pages/customer-notices-and-information-ibm-i-75
+    extendedSupportColumn: false
 
 -   releaseCycle: "7.4"
     releaseDate: 2019-06-21
@@ -35,6 +36,7 @@ releases:
     latest: "7.4"
     latestReleaseDate: 2019-06-21
     link: https://www.ibm.com/support/pages/customer-notices-and-information-ibm-i-74
+    extendedSupportColumn: false
 
 -   releaseCycle: "7.3"
     releaseDate: 2016-04-15
@@ -58,6 +60,7 @@ releases:
     latest: "7.1"
     latestReleaseDate: 2010-04-23
     link: https://www.ibm.com/support/pages/customer-notices-and-information-ibm-i-71
+    extendedSupportColumn: false
 
 -   releaseCycle: "6.1"
     releaseDate: 2008-04-23
@@ -86,12 +89,14 @@ releases:
     eol: 2007-04-30
     latest: "5.2"
     latestReleaseDate: 2002-08-30
+    extendedSupport: false
     
 -   releaseCycle: "5.1"
     releaseDate: 2001-05-25
     eol: 2005-09-30
     latest: "5.1"
     latestReleaseDate: 2001-05-25
+    extendedSupport: false
 
 -   releaseCycle: "4.5"
     releaseDate: 2000-07-28
@@ -112,6 +117,7 @@ releases:
     eol: 2001-01-31
     latest: "4.3"
     latestReleaseDate: 1998-09-11
+    extendedSupport: false
 
 -   releaseCycle: "4.2"
     releaseDate: 1998-02-27
@@ -125,54 +131,63 @@ releases:
     eol: 2000-05-31
     latest: "4.1"
     latestReleaseDate: 1997-08-29
+    extendedSupport: false
 
 -   releaseCycle: "3.7"
     releaseDate: 1996-11-08
     eol: 1999-06-30
     latest: "3.7"
     latestReleaseDate: 1996-11-08
+    extendedSupport: false
 
 -   releaseCycle: "3.6"
     releaseDate: 1995-12-22
     eol: 1998-10-31
     latest: "3.6"
     latestReleaseDate: 1995-12-22
+    extendedSupport: false
 
 -   releaseCycle: "3.2"
     releaseDate: 1996-06-21
     eol: 2000-05-31
     latest: "3.2"
     latestReleaseDate: 1996-06-21
+    extendedSupport: false
 
 -   releaseCycle: "3.1"
     releaseDate: 1994-11-25
     eol: 1998-10-31
     latest: "3.1"
     latestReleaseDate: 1994-11-25
+    extendedSupport: false
 
 -   releaseCycle: "3.0"
     releaseDate: 1994-06-03
     eol: 1997-05-31
     latest: "3.0.5"
     latestReleaseDate: 1994-06-03
+    extendedSupport: false
 
 -   releaseCycle: "2.3"
     releaseDate: 1993-12-17
     eol: 1996-05-31
     latest: "2.3"
     latestReleaseDate: 1993-12-17
+    extendedSupport: false
     
 -   releaseCycle: "2.2"
     releaseDate: 1992-09-18
     eol: 1995-03-31
     latest: "2.2"
     latestReleaseDate: 1992-09-18
+    extendedSupport: false
 
 -   releaseCycle: "2.1"
     releaseDate: 1991-05-24
     eol: 1994-06-30
     latest: "2.1.1"
     latestReleaseDate: 1992-03-06
+    extendedSupport: false
     
 ---
 

--- a/products/ibm-i.md
+++ b/products/ibm-i.md
@@ -89,7 +89,7 @@ releases:
     latestReleaseDate: 2001-05-25
 
 -   releaseCycle: "4.5"
-    releaseDate: 200-07-28
+    releaseDate: 2000-07-28
     eol: 2002-07-31
     latest: "4.5"
     latestReleaseDate: 200-07-28

--- a/products/ibm-i.md
+++ b/products/ibm-i.md
@@ -28,7 +28,7 @@ releases:
     latest: "7.5"
     latestReleaseDate: 2022-05-10
     link: https://www.ibm.com/support/pages/customer-notices-and-information-ibm-i-75
-    extendedSupportColumn: false
+    extendedSupport: false
 
 -   releaseCycle: "7.4"
     releaseDate: 2019-06-21
@@ -36,7 +36,7 @@ releases:
     latest: "7.4"
     latestReleaseDate: 2019-06-21
     link: https://www.ibm.com/support/pages/customer-notices-and-information-ibm-i-74
-    extendedSupportColumn: false
+    extendedSupport: false
 
 -   releaseCycle: "7.3"
     releaseDate: 2016-04-15
@@ -60,7 +60,7 @@ releases:
     latest: "7.1"
     latestReleaseDate: 2010-04-23
     link: https://www.ibm.com/support/pages/customer-notices-and-information-ibm-i-71
-    extendedSupportColumn: false
+    extendedSupport: false
 
 -   releaseCycle: "6.1"
     releaseDate: 2008-04-23

--- a/products/ibm-i.md
+++ b/products/ibm-i.md
@@ -92,7 +92,7 @@ releases:
     releaseDate: 2000-07-28
     eol: 2002-07-31
     latest: "4.5"
-    latestReleaseDate: 200-07-28
+    latestReleaseDate: 2000-07-28
 
 -   releaseCycle: "4.4"
     releaseDate: 1999-05-21
@@ -120,7 +120,7 @@ releases:
 
 -   releaseCycle: "3.7"
     releaseDate: 1996-11-08
-    eol: 199-06-30
+    eol: 1999-06-30
     latest: "3.7"
     latestReleaseDate: 1996-11-08
 

--- a/products/ibm-i.md
+++ b/products/ibm-i.md
@@ -191,7 +191,7 @@ releases:
     
 ---
 
-> [IBM i](https://www.ibm.com/products/ibm-i) is a fully integrated operating system, meaning the database, middleware, security, runtime and hypervisor are integrated into the stack and licensed as one solution.
+> [IBM i](https://www.ibm.com/products/ibm-i) is a fully integrated operating system, meaning the database, middleware, security, runtime and hypervisor are integrated into the stack and licensed as one solution. It was originally released in 1988 as OS/400, as the sole operating system of the IBM AS/400 line of systems. It was renamed to i5/OS in 2004, before being renamed a second time to IBM i in 2008.
 
 End of program support date will be announced with at least 12 months notice prior to the effective termination date.
 

--- a/products/ibm-i.md
+++ b/products/ibm-i.md
@@ -155,6 +155,24 @@ releases:
     latest: "3.0.5"
     latestReleaseDate: 1994-06-03
 
+-   releaseCycle: "2.3"
+    releaseDate: 1993-12-17
+    eol: 1996-05-31
+    latest: "2.3"
+    latestReleaseDate: 1993-12-17
+    
+-   releaseCycle: "2.2"
+    releaseDate: 1992-09-18
+    eol: 1995-03-31
+    latest: "2.2"
+    latestReleaseDate: 1992-09-18
+
+-   releaseCycle: "2.1"
+    releaseDate: 1991-05-24
+    eol: 1994-06-30
+    latest: "2.1.1"
+    latestReleaseDate: 1992-03-06
+    
 ---
 
 > [IBM i](https://www.ibm.com/products/ibm-i) is a fully integrated operating system, meaning the database, middleware, security, runtime and hypervisor are integrated into the stack and licensed as one solution.

--- a/products/ibm-i.md
+++ b/products/ibm-i.md
@@ -63,7 +63,7 @@ releases:
     extendedSupport: false
 
 -   releaseCycle: "6.1"
-    releaseDate: 2008-04-23
+    releaseDate: 2008-03-21
     eol: 2015-09-30
     latest: "6.1"
     latestReleaseDate: 2008-04-23

--- a/products/ibm-i.md
+++ b/products/ibm-i.md
@@ -73,8 +73,6 @@ releases:
     latest: "5.4"
     latestReleaseDate: 2006-02-14
     extendedSupport: 2017-09-30
-    
-
 -   releaseCycle: "5.3"
     releaseDate: 2004-06-11
     eol: 2009-04-30

--- a/products/ibm-i.md
+++ b/products/ibm-i.md
@@ -1,7 +1,7 @@
 ---
 title: IBM iSeries
 category: os
-tags: ibm
+tags: ibm unix-distribution
 iconSlug: ibm
 permalink: /ibm-i
 alternate_urls:


### PR DESCRIPTION
# :information_source:  About

The aim of this PR is to add [IBM i operating system](https://www.ibm.com/products/ibm-i) to `endoflife.date`.

I have mostly used hte following resources:

- https://www.ibm.com/support/pages/ibm-i-release-support
- https://www.ibm.com/support/pages/release-life-cycle

# :grey_question: Question & Feedback

Please let me know if you think we sould merge releases, like : 

- `7.5`, ... `7.1` into **7**
- Same question for `5.x`
- `4.x`
- `3.x`