### PR TITLE
Simplify auto configurations

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -223,7 +223,7 @@ auto:
     # Use named capturing groups to capture the version or version's parts.
     # Default value should work for most releases of the form a.b, a.b.c or 'v'a.b.c. It should also
     # skip over any special releases (such as nightly,beta,pre,rc...).
-    regex: ^v(?<major>0|[1-9]\d*)_(?<minor>0|[1-9]\d*)_(?<patch>\d{1,3})_?(?<tiny>\d+)?$
+    regex: ^v(?<major>\d+)_(?<minor>\d+)_(?<patch>\d{1,3})_?(?<tiny>\d+)?$
 
     # A liquid template using the captured variables from the regex above that renders the final version
     # (optional, default can be found on https://github.com/endoflife-date/release-data/blob/main/update.rb#L19-L20 ).

--- a/products/docker-engine.md
+++ b/products/docker-engine.md
@@ -14,7 +14,7 @@ identifiers:
 
 auto:
 -   git: https://github.com/moby/moby.git
-    regex: ^v(?<major>0|[1-9]\d*)\.(?<minor>\d*)\.(?<patch>0|[1-9]\d*)(-ce)?$
+    regex: ^v(?<major>\d+)\.(?<minor>\d+)\.(?<patch>\d+)(-ce)?$
 
 releases:
 -   releaseCycle: "24.0"

--- a/products/dotnet.md
+++ b/products/dotnet.md
@@ -8,7 +8,7 @@ alternate_urls:
 -   /dotnetcore
 versionCommand: dotnet --version
 releasePolicyLink: https://dotnet.microsoft.com/platform/support/policy/dotnet-core
-changelogTemplate: 
+changelogTemplate:
   https://github.com/dotnet/core/blob/main/release-notes/{{"__LATEST__"|split:'.'|slice:0,2|join:'.'}}/__LATEST__/__LATEST__.md
 releaseDateColumn: true
 eolColumn: Support Status
@@ -18,7 +18,6 @@ eolColumn: Support Status
 # https://rubular.com/r/CSjmTuMTbmRBQZ
 auto:
 -   git: https://github.com/dotnet/core.git
-    regex: '^v(?<major>\d+)\.(?<minor>\d+)\.?(?<patch>\d{0,2})?$'
 
 identifiers:
 -   purl: pkg:nuget/Microsoft.NETCore.App

--- a/products/ffmpeg.md
+++ b/products/ffmpeg.md
@@ -13,7 +13,7 @@ eolColumn: Supported
 auto:
 # upstream https://git.ffmpeg.org/ffmpeg.git doesn't support filtering
 -   git: https://github.com/FFmpeg/FFmpeg.git
-    regex: '^n?(?<major>[1-9]\d*)\.(?<minor>0|[1-9]\d*)\.?(?<patch>0|[1-9]\d*)?$'
+    regex: '^n?(?<major>[1-9]\d*)\.(?<minor>\d+)\.?(?<patch>\d+)?$'
 
 # EOL date can be found on https://ffmpeg.org/olddownload.html
 releases:

--- a/products/gerrit.md
+++ b/products/gerrit.md
@@ -15,7 +15,6 @@ identifiers:
 
 auto:
 -   git: https://github.com/GerritCodeReview/gerrit.git
-    regex: ^v(?<major>[0-9]+)\.(?<minor>[0-9]+)(\.(?<patch>[0-9]+)(\.(?<tiny>[0-9]+))?)?$
 
 releases:
 -   releaseCycle: "3.8"

--- a/products/gitlab.md
+++ b/products/gitlab.md
@@ -16,7 +16,7 @@ eolWarnThreshold: 60
 auto:
 # Reference: https://rubular.com/r/mFfxB8FgXXERX4
 -   git: https://gitlab.com/gitlab-org/gitlab.git
-    regex: '^v?(?<major>[1-9]\d*)\.(?<minor>0|[1-9]\d*)\.(?<patch>0|[1-9]\d*)-ee?$'
+    regex: '^v?(?<major>[1-9]\d*)\.(?<minor>\d+)\.(?<patch>\d+)-ee?$'
 
 
 # EOL of R = releaseDate(R+3)

--- a/products/go.md
+++ b/products/go.md
@@ -22,7 +22,7 @@ identifiers:
 
 auto:
 -   git: https://github.com/golang/go.git
-    regex: ^go(?<major>[1-9]\d*)\.(?<minor>0|[1-9]\d*)\.?(?<patch>0|[1-9]\d*)?$
+    regex: ^go(?<major>[1-9]\d*)\.(?<minor>\d+)\.?(?<patch>\d+)?$
 
 # eol(x) = releaseDate(x+2)
 releases:

--- a/products/gradle.md
+++ b/products/gradle.md
@@ -15,7 +15,7 @@ auto:
 -   git: https://github.com/gradle/gradle.git
     # regex to exclude versions below 3.x for tags with wrong dates see https://github.com/endoflife-date/endoflife.date/pull/3619
     # https://rubular.com/r/Q94JVYzjli8WC8
-    regex: ^v?(?<major>([3-9]|\d{2,}))\.(?<minor>0|[1-9]\d*)\.?(?<patch>0|[1-9]\d*)?$
+    regex: ^v?(?<major>([3-9]|\d{2,}))\.(?<minor>\d+)\.?(?<patch>\d+)?$
 
 # support(x) = releaseDate(x+1)
 # eol(x) = releaseDate(x+2)
@@ -118,7 +118,7 @@ releases:
 > any platform, Gradle offers a flexible model that can support the entire development lifecycle
 > from compiling and packaging code to publishing websites.
 
-Gradle follows [Semantic Versioning](https://semver.org/). The 
+Gradle follows [Semantic Versioning](https://semver.org/). The
 [support and EOL policy](https://docs.gradle.org/current/userguide/feature_lifecycle.html#eol_support) states that each major release causes:
 - The previous major version becomes maintenance only (end of active support). It will only receive critical bug fixes and security fixes.
 - The major version before the previous one to become end-of-life (EOL), and that release line will not receive any new fixes.

--- a/products/gstreamer.md
+++ b/products/gstreamer.md
@@ -11,7 +11,7 @@ eolColumn: Supported
 
 auto:
 -   git: https://gitlab.freedesktop.org/gstreamer/gstreamer.git
-    regex: '^(?<major>[1-9]\d*)\.(?<minor>([1-9]\d*)?[02468])\.?(?<patch>0|[1-9]\d*)?$'
+    regex: '^(?<major>[1-9]\d*)\.(?<minor>([1-9]\d*)?[02468])\.?(?<patch>\d+)?$'
 
 releases:
 -   releaseCycle: "1.22"

--- a/products/hbase.md
+++ b/products/hbase.md
@@ -14,7 +14,6 @@ eolColumn: Service Status
 auto:
 -   git: https://github.com/apache/hbase.git
     regex: '^rel\/(?<major>\d+)\.(?<minor>\d+)\.(?<patch>\d+)(\.(?<tiny>\d+))?$'
-    template: "{{major}}.{{minor}}.{{patch}}{%if tiny%}.{{tiny}}{%endif%}"
 
 releases:
 -   releaseCycle: "2.5"

--- a/products/kubernetes.md
+++ b/products/kubernetes.md
@@ -7,9 +7,9 @@ alternate_urls:
 -   /k8s
 versionCommand: kubectl version
 releasePolicyLink: https://kubernetes.io/releases/patch-releases/
-releaseImage: 
+releaseImage:
   https://upload.wikimedia.org/wikipedia/en/timeline/fxdhzv3oeut1ywyfx5ubxghu9fnow69.png
-changelogTemplate: 
+changelogTemplate:
   https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-__RELEASE_CYCLE__.md
 releaseDateColumn: true
 activeSupportColumn: true
@@ -17,7 +17,7 @@ eolColumn: Maintenance Support
 
 auto:
 -   git: https://github.com/kubernetes/kubernetes.git
-    regex: ^v(?<major>[1-9]\d*)\.(?<minor>0|[1-9]\d*)\.(?<patch>0|[1-9]\d*)$
+    regex: ^v(?<major>[1-9]\d*)\.(?<minor>\d+)\.(?<patch>\d+)$
 
 # Support and EOL dates can be found on https://kubernetes.io/releases/patch-releases/#detailed-release-history-for-active-branches
 releases:

--- a/products/mongodb.md
+++ b/products/mongodb.md
@@ -29,7 +29,7 @@ identifiers:
 
 auto:
 -   git: https://github.com/mongodb/mongo.git
-    regex: ^r(?<major>0|[1-9]\d*)\.(?<minor>0|[1-9]\d*)\.(?<patch>0|[1-9]\d*)$
+    regex: ^r(?<major>\d+)\.(?<minor>\d+)\.(?<patch>\d+)$
 
 # Dates are not in sync with https://www.mongodb.com/support-policy/lifecycles because we are using
 # git tag dates.

--- a/products/nextcloud.md
+++ b/products/nextcloud.md
@@ -11,7 +11,7 @@ releaseDateColumn: true
 
 auto:
 -   git: https://github.com/nextcloud/server.git
-    regex: ^v(?<major>0|[1-9]\d*)\.(?<minor>0|[1-9]\d*)\.(?<patch>0|[1-9]\d*)$
+    regex: ^v(?<major>\d+)\.(?<minor>\d+)\.(?<patch>\d+)$
 
 releases:
 -   releaseCycle: "27"

--- a/products/nginx.md
+++ b/products/nginx.md
@@ -21,7 +21,7 @@ identifiers:
 # https://rubular.com/r/bVKLuLKLLrHCTI
 auto:
 -   git: https://github.com/nginx/nginx.git
-    regex: ^release-(?<major>0|[1-9]\d*)\.(?<minor>0|[1-9]\d*)\.(?<patch>0|[1-9]\d*)$
+    regex: ^release-(?<major>\d+)\.(?<minor>\d+)\.(?<patch>\d+)$
 
 # eol(x) = releaseDate(x+2)
 releases:

--- a/products/openzfs.md
+++ b/products/openzfs.md
@@ -15,7 +15,7 @@ eolColumn: Critical bug fixes
 auto:
 -   git: https://github.com/openzfs/zfs.git
     regex:
-      ^zfs-(?<major>0|[1-9]\d*)\.(?<minor>0|[1-9]\d*)\.(?<patch>0|([1-9]|[1-8]\d|9[0-8]))$
+      ^zfs-(?<major>\d+)\.(?<minor>\d+)\.(?<patch>0|([1-9]|[1-8]\d|9[0-8]))$
 
 # non-LTS: eol(x) = releaseDate(x+1)
 # LTS: eol(x) = estimation: releaseDate(x) plus 2 years

--- a/products/phpmyadmin.md
+++ b/products/phpmyadmin.md
@@ -12,8 +12,6 @@ releaseDateColumn: true
 auto:
 -   git: https://github.com/phpmyadmin/phpmyadmin.git
     regex: '^RELEASE_(?<major>\d+)_(?<minor>\d+)_(?<patch>\d+)(_(?<tiny>\d+))?$'
-    template: '{{major}}.{{minor}}.{{patch}}{%if tiny %}.{{tiny}}{%endif%}'
-
 
 identifiers:
 -   repology: phpmyadmin

--- a/products/postgresql.md
+++ b/products/postgresql.md
@@ -16,7 +16,7 @@ releaseDateColumn: true
 auto:
 -   git: https://github.com/postgres/postgres.git
   # https://rubular.com/r/KlemgnguNe0e5X
-    regex: ^REL_?(?<major>[1-9]\d*)_(?<minor>0|[1-9]\d*)_?(?<patch>\d+)?$
+    regex: ^REL_?(?<major>[1-9]\d*)_(?<minor>\d+)_?(?<patch>\d+)?$
 
 identifiers:
 -   repology: postgresql

--- a/products/python.md
+++ b/products/python.md
@@ -120,7 +120,7 @@ identifiers:
 auto:
 -   git: https://github.com/python/cpython.git
     # The v is mandatory here because each branch EOL is tagged, e.g. https://github.com/python/cpython/releases/tag/3.6
-    regex: ^v(?<major>[1-9]\d*)\.(?<minor>0|[1-9]\d*)\.?(?<patch>0|[1-9]\d*)?$
+    regex: ^v(?<major>[1-9]\d*)\.(?<minor>\d+)\.?(?<patch>\d+)?$
 
 releases:
 -   releaseCycle: "3.12"

--- a/products/rabbitmq.md
+++ b/products/rabbitmq.md
@@ -13,8 +13,8 @@ extendedSupportColumn: Extended Commercial Support
 
 auto:
 -   git: https://github.com/rabbitmq/rabbitmq-server.git
-    regex: 
-      ^(rabbitmq_v(?<major>[1-9]\d*)_(?<minor>0|[1-9]\d*)_(?<patch>0|[1-9]\d*)|v(?<major>[1-9]\d*)\.(?<minor>0|[1-9]\d*)\.(?<patch>0|[1-9]\d*))$
+    regex:
+      ^(rabbitmq_v(?<major>[1-9]\d*)_(?<minor>\d+)_(?<patch>\d+)|v(?<major>[1-9]\d*)\.(?<minor>\d+)\.(?<patch>\d+))$
 
 releases:
 -   releaseCycle: "3.12"

--- a/products/ruby-on-rails.md
+++ b/products/ruby-on-rails.md
@@ -15,9 +15,6 @@ releaseDateColumn: true
 
 auto:
 -   git: https://github.com/rails/rails.git
-    regex:
-      v(?<major>[1-9]\d*)\.(?<minor>0|[1-9]\d*)\.(?<patch>0|[1-9]\d*)(\.(?<tiny>0|[1-9]\d*))?$
-    template: "{{major}}.{{minor}}.{{patch}}{%if tiny %}.{{tiny}}{%endif%}"
 
 releases:
 -   releaseCycle: "7.1"

--- a/products/ruby.md
+++ b/products/ruby.md
@@ -14,7 +14,7 @@ auto:
 -   git: https://github.com/ruby/ruby.git
     # See https://www.ruby-lang.org/en/news/2013/12/21/ruby-version-policy-changes-with-2-1-0/
     # The meaning of patch and tiny below is as per the new policy
-    regex: ^v(?<major>0|[1-9]\d*)_(?<minor>0|[1-9]\d*)_(?<patch>\d{1,3})_?(?<tiny>\d+)?$
+    regex: ^v(?<major>\d+)_(?<minor>\d+)_(?<patch>\d{1,3})_?(?<tiny>\d+)?$
     template: '{{major}}.{{minor}}.{{patch}}{%if tiny %}p{{tiny}}{%endif%}'
 
 identifiers:

--- a/products/spring-boot.md
+++ b/products/spring-boot.md
@@ -15,7 +15,7 @@ extendedSupportColumn: Commercial Support
 auto:
 -   git: https://github.com/spring-projects/spring-boot.git
 # See https://rubular.com/r/stJ20etRIblK0J for reference
-    regex: '^v?(?<major>[1-9]\d*)\.(?<minor>0|[1-9]\d*)\.(?<patch>0|[1-9]\d*)(\.RELEASE)?$'
+    regex: '^v?(?<major>[1-9]\d*)\.(?<minor>\d+)\.(?<patch>\d+)(\.RELEASE)?$'
 
 identifiers:
 -   purl: pkg:maven/org.springframework.boot/spring-boot

--- a/products/spring-framework.md
+++ b/products/spring-framework.md
@@ -16,7 +16,7 @@ extendedSupportColumn: Commercial Support
 auto:
 -   git: https://github.com/spring-projects/spring-framework.git
   # See https://rubular.com/r/XQUdQN2MHdmmCD for reference
-    regex: '^v?(?<major>[1-9]\d*)\.(?<minor>0|[1-9]\d*)\.(?<patch>0|[1-9]\d*)(\.RELEASE)?$'
+    regex: '^v?(?<major>[1-9]\d*)\.(?<minor>\d+)\.(?<patch>\d+)(\.RELEASE)?$'
 
 releases:
 -   releaseCycle: "6.0"

--- a/products/varnish.md
+++ b/products/varnish.md
@@ -14,7 +14,7 @@ identifiers:
 
 auto:
 -   git: https://github.com/varnishcache/varnish-cache.git
-    regex: ^varnish-(?<major>0|[1-9]\d*)\.(?<minor>0|[1-9]\d*)\.(?<patch>0|[1-9]\d*)$
+    regex: ^varnish-(?<major>\d+)\.(?<minor>\d+)\.(?<patch>\d+)$
 
 # EOL dates can be found on https://varnish-cache.org/releases/
 releases:

--- a/products/yocto.md
+++ b/products/yocto.md
@@ -15,7 +15,7 @@ eolColumn: Support Status
 
 auto:
 -   git: https://github.com/yoctoproject/poky.git
-    regex: '^yocto-(?<major>[1-9]\d*)\.(?<minor>0|[1-9]\d*)\.?(?<patch>0|[1-9]\d*)?$'
+    regex: '^yocto-(?<major>[1-9]\d*)\.(?<minor>\d+)\.?(?<patch>\d+)?$'
 
 # for eol see https://wiki.yoctoproject.org/wiki/Releases
 releases:


### PR DESCRIPTION
- drop regexes identical to or compatible with the default regex,
- drop template expressions identical to or compatible with the default template expression,
- simplify 0|[1-9]\d* to \d+ in regexes.