### PR TITLE
[panos] Update panos 10.2.6 to 10.2.7

### DIFF
--- a/products/pan-os.md
+++ b/products/pan-os.md
@@ -20,9 +20,9 @@ releases:
 -   releaseCycle: "10.2"
     releaseDate: 2022-02-27
     eol: 2025-08-27
-    latest: "10.2.6"
-    latestReleaseDate: 2023-09-27
-    link: https://docs.paloaltonetworks.com/pan-os/10-2/pan-os-release-notes/pan-os-10-2-6-known-and-addressed-issues/pan-os-10-2-6-addressed-issues
+    latest: "10.2.7"
+    latestReleaseDate: 2023-11-09
+    link: https://docs.paloaltonetworks.com/pan-os/10-2/pan-os-release-notes/pan-os-10-2-7-known-and-addressed-issues/pan-os-10-2-7-addressed-issues
 
 -   releaseCycle: "10.1"
     releaseDate: 2021-05-31


### PR DESCRIPTION
Updated panos 10.2.6 to 10.2.7
Released: 2023/11/09

https://docs.paloaltonetworks.com/pan-os/10-2/pan-os-release-notes/pan-os-10-2-7-known-and-addressed-issues/pan-os-10-2-7-addressed-issues

There is also a bunch of hotfixes for older versions:

![image](https://github.com/endoflife-date/endoflife.date/assets/3140504/fc2e2323-7ff6-4aa0-99f2-5c14a0b48ddd)

