### PR TITLE
[ffmpeg] Mark 5.0 as EOL

### DIFF
--- a/products/ffmpeg.md
+++ b/products/ffmpeg.md
@@ -42,7 +42,7 @@ releases:
 -   releaseCycle: "5.0"
     codename: Lorentz
     releaseDate: 2022-01-14
-    eol: false
+    eol: 2023-04-02
     latest: "5.0.3"
     latestReleaseDate: 2023-04-02
 


### PR DESCRIPTION
5.0.3 was the last version of the 5.0 release branch according to https://ffmpeg.org/olddownload.html.