### PR TITLE
[wagtail] Update latest 2.12

### DIFF
--- a/products/wagtail.md
+++ b/products/wagtail.md
@@ -103,7 +103,7 @@ releases:
     releaseDate: 2021-02-02
     support: 2021-05-12
     eol: 2021-08-01
-    latest: "2.12.7"
+    latest: "2.12.6"
     latestReleaseDate: 2021-07-13
 
 -   releaseCycle: "2.11"


### PR DESCRIPTION
2.12.6 is the latest 2.12 release according to https://pypi.org/project/wagtail/#history.