### PR TITLE
[apache-activemq] Add 6.0

### DIFF
--- a/products/apache-activemq.md
+++ b/products/apache-activemq.md
@@ -24,6 +24,12 @@ auto:
 # - y <= 9 and z > 9 : "https://activemq.apache.org/activemq-{{'__LATEST__'|replace_first:'.','00'|replace_first:'.','0'}}-release"
 # - y <= 9 and z <= 9 : "https://activemq.apache.org/activemq-{{'__LATEST__'|replace:'.','00'}}-release"
 releases:
+-   releaseCycle: "6.0"
+    releaseDate: 2023-11-12
+    eol: false # still listed on https://activemq.apache.org/
+    latest: "6.0.0"
+    latestReleaseDate: 2023-11-12
+
 -   releaseCycle: "5.18"
     releaseDate: 2023-03-18
     eol: false # still listed on https://activemq.apache.org/

--- a/products/apache-activemq.md
+++ b/products/apache-activemq.md
@@ -25,10 +25,10 @@ auto:
 # - y <= 9 and z <= 9 : "https://activemq.apache.org/activemq-{{'__LATEST__'|replace:'.','00'}}-release"
 releases:
 -   releaseCycle: "6.0"
-    releaseDate: 2023-11-12
+    releaseDate: 2023-11-17
     eol: false # still listed on https://activemq.apache.org/
     latest: "6.0.0"
-    latestReleaseDate: 2023-11-12
+    latestReleaseDate: 2023-11-17
 
 -   releaseCycle: "5.18"
     releaseDate: 2023-03-18


### PR DESCRIPTION
Not yet listed on https://activemq.apache.org/components/classic/download/
-> keeping it draft