### PR TITLE
[rails] Update 6.1 eol

### DIFF
--- a/products/ruby-on-rails.md
+++ b/products/ruby-on-rails.md
@@ -31,7 +31,7 @@ releases:
 
 -   releaseCycle: "6.1"
     releaseDate: 2020-12-09
-    eol: 2024-06-01 # https://github.com/rails/rails/pull/46895#issuecomment-1673353127
+    eol: false
     latest: "6.1.7.6"
     latestReleaseDate: 2023-08-22
 


### PR DESCRIPTION
It's unset EoL date of Rails 6.1.

Because Rails supports severe security issues for the last release in the previous major series.
Rails 6.1 will set EoL date when rails 8.0 released, but rails/rails repo next milestone is rails 7.2.0.

- rails maintenance policy
  - https://guides.rubyonrails.org/maintenance_policy.html

- rails/rails milestone
  - https://github.com/rails/rails/milestone/83

- Related PR
  - #3865
