### PR TITLE
[apache-camel] Add 4.2

### DIFF
--- a/products/apache-camel.md
+++ b/products/apache-camel.md
@@ -25,9 +25,16 @@ auto:
 #   Camel may never release patches for non-LTS, but they can still be considered active.
 #   See https://github.com/endoflife-date/endoflife.date/pull/2328#discussion_r1086927567.
 releases:
+-   releaseCycle: "4.2"
+    releaseDate: 2023-11-15
+    eol: false
+    supportedJavaVersions: 17, 21
+    latest: "4.2.0"
+    latestReleaseDate: 2023-11-15
+
 -   releaseCycle: "4.1"
     releaseDate: 2023-10-06
-    eol: false
+    eol: 2023-11-15
     supportedJavaVersions: 17
     latest: "4.1.0"
     latestReleaseDate: 2023-10-06


### PR DESCRIPTION
This is not an LTS release and it is the first release that officially supports Java 21. See https://camel.apache.org/blog/2023/11/camel42-whatsnew/.