### PR TITLE
[contao] update release policy link

### DIFF
--- a/products/contao.md
+++ b/products/contao.md
@@ -3,7 +3,7 @@ title: Contao
 category: server-app
 iconSlug: contao
 permalink: /contao
-releasePolicyLink: https://contao.org/release-plan.html
+releasePolicyLink: https://contao.org/release-plan
 changelogTemplate: https://github.com/contao/contao/blob/__LATEST__/CHANGELOG.md
 releaseDateColumn: true
 activeSupportColumn: true


### PR DESCRIPTION
Unsure if the new link destination should be 
* https://contao.org/release-plan or
* https://contao.org/en/release-plan