### PR TITLE
Jenkins 2.414 is EOL, add Jenkins 2.426

### DIFF
--- a/products/jenkins.md
+++ b/products/jenkins.md
@@ -30,10 +30,17 @@ releases:
     latest: "2.432"
     latestReleaseDate: 2023-11-14
 
+-   releaseCycle: "2.426"
+    lts: 2023-11-15
+    releaseDate: 2023-10-03
+    eol: false
+    latest: "2.426.1"
+    latestReleaseDate: 2023-11-15
+
 -   releaseCycle: "2.414"
     lts: 2023-08-23
     releaseDate: 2023-07-11
-    eol: false
+    eol: 2023-11-15
     latest: "2.414.3"
     latestReleaseDate: 2023-10-18
 


### PR DESCRIPTION
## Jenkins 2.414 is EOL, add Jenkins 2.426

Jenkins LTS lifecycle is 12 weeks except for the LTS lifecycle that spans the end of a calendar year.  When an LTS line spans the end of a calendar year, the life cycle is extended to 14 weeks so that the Jenkins maintainers can take 2 weeks off at the end of the year.

Data in the fields has been updated to match the 12 week life cycle
