### PR TITLE
[pan-os] and [pan-gp] Updates

### DIFF
--- a/products/pan-gp.md
+++ b/products/pan-gp.md
@@ -24,7 +24,7 @@ releases:
     support: 2024-09-01
     latest: "6.1.3"
     latestReleaseDate: 2023-11-21
-    link: https://docs.paloaltonetworks.com/globalprotect/6-1/globalprotect-app-release-notes
+    link: https://docs.paloaltonetworks.com/globalprotect/6-1/globalprotect-app-release-notes//globalprotect-addressed-issues
 
 -   releaseCycle: "6.0"
     releaseDate: 2022-02-22

--- a/products/pan-gp.md
+++ b/products/pan-gp.md
@@ -22,8 +22,8 @@ releases:
     releaseDate: 2022-09-01
     eol: 2024-09-01
     support: 2024-09-01
-    latest: "6.1.2"
-    latestReleaseDate: 2023-08-03
+    latest: "6.1.3"
+    latestReleaseDate: 2023-11-21
     link: https://docs.paloaltonetworks.com/globalprotect/6-1/globalprotect-app-release-notes
 
 -   releaseCycle: "6.0"

--- a/products/pan-os.md
+++ b/products/pan-os.md
@@ -47,7 +47,7 @@ releases:
 
 -   releaseCycle: "9.1"
     releaseDate: 2019-12-13
-    eol: 2023-12-13
+    eol: 2024-03-31
     latest: "9.1.16-h3"
     latestReleaseDate: 2023-10-03
     link: https://docs.paloaltonetworks.com/pan-os/9-1/pan-os-release-notes/pan-os-9-1-addressed-issues/pan-os-9-1-16-h3-addressed-issues


### PR DESCRIPTION
Updated GlobalProtect from 6.1.2 to 6.1.3.
Released: 2023-11-21

Updated eol date in pan-os 9.1.

https://www.paloaltonetworks.com/services/support/end-of-life-announcements/end-of-life-summary
