### PR TITLE
[aws-lambda] Add Amazon Linux 2023, Node.js 20 and Java 21

### DIFF
--- a/products/aws-lambda.md
+++ b/products/aws-lambda.md
@@ -38,7 +38,7 @@ releases:
 
 -   releaseCycle: "provided.al2023"
     releaseLabel: Custom Runtime (AL2023)
-    releaseDate: 2023-11-15
+    releaseDate: 2023-11-10
     support: true
     eol: false
     link: 

--- a/products/aws-lambda.md
+++ b/products/aws-lambda.md
@@ -25,24 +25,21 @@ releases:
     releaseDate: 2023-11-17
     support: true
     eol: false
-    link: 
-      https://aws.amazon.com/about-aws/whats-new/2023/11/aws-lambda-support-java-21/
+    link: https://aws.amazon.com/about-aws/whats-new/2023/11/aws-lambda-support-java-21/
 
 -   releaseCycle: "nodejs20.x"
     releaseLabel: Node.js 20
     releaseDate: 2023-11-15
     support: true
     eol: false
-    link: 
-      https://aws.amazon.com/blogs/compute/node-js-20-x-runtime-now-available-in-aws-lambda/
+    link: https://aws.amazon.com/blogs/compute/node-js-20-x-runtime-now-available-in-aws-lambda/
 
 -   releaseCycle: "provided.al2023"
     releaseLabel: Custom Runtime (AL2023)
     releaseDate: 2023-11-10
     support: true
     eol: false
-    link: 
-      https://aws.amazon.com/blogs/compute/introducing-the-amazon-linux-2023-runtime-for-aws-lambda/
+    link: https://aws.amazon.com/blogs/compute/introducing-the-amazon-linux-2023-runtime-for-aws-lambda/
 
 -   releaseCycle: "python3.11"
     releaseLabel: Python 3.11

--- a/products/aws-lambda.md
+++ b/products/aws-lambda.md
@@ -20,6 +20,30 @@ auto:
 # in https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html. If support date
 # is provided but not EOL date, EOL date is set to support date + 1 month.
 releases:
+-   releaseCycle: "java21"
+    releaseLabel: Java 21
+    releaseDate: 2023-11-17
+    support: true
+    eol: false
+    link: 
+      https://aws.amazon.com/about-aws/whats-new/2023/11/aws-lambda-support-java-21/
+
+-   releaseCycle: "nodejs20.x"
+    releaseLabel: Node.js 20
+    releaseDate: 2023-11-15
+    support: true
+    eol: false
+    link: 
+      https://aws.amazon.com/blogs/compute/node-js-20-x-runtime-now-available-in-aws-lambda/
+
+-   releaseCycle: "provided.al2023"
+    releaseLabel: Custom Runtime (AL2023)
+    releaseDate: 2023-11-15
+    support: true
+    eol: false
+    link: 
+      https://aws.amazon.com/blogs/compute/introducing-the-amazon-linux-2023-runtime-for-aws-lambda/
+
 -   releaseCycle: "python3.11"
     releaseLabel: Python 3.11
     releaseDate: 2023-07-27


### PR DESCRIPTION
See https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html.