### PR TITLE
[pan-gp] Updated GlobalProtect to version  6.2.2

### DIFF
--- a/products/pan-gp.md
+++ b/products/pan-gp.md
@@ -14,8 +14,8 @@ releases:
     releaseDate: 2023-05-23
     eol: 2025-05-23
     support: 2025-05-23
-    latest: "6.2.1"
-    latestReleaseDate: 2023-10-09
+    latest: "6.2.2"
+    latestReleaseDate: 2023-11-22
     link: https://docs.paloaltonetworks.com/globalprotect/6-2/globalprotect-app-release-notes/globalprotect-addressed-issues
 
 -   releaseCycle: "6.1"


### PR DESCRIPTION
Updated GlobalProtect version 6.2.2

Released: 2023/11/22

https://docs.paloaltonetworks.com/globalprotect/6-2/globalprotect-app-release-notes/globalprotect-addressed-issues
