### PR TITLE
Update oracle-database.md

### DIFF
--- a/products/oracle-database.md
+++ b/products/oracle-database.md
@@ -24,7 +24,7 @@ releases:
     releaseLabel: "19c"
     lts: true
     releaseDate: 2019-04-25
-    eol: 2024-04-30
+    eol: 2026-04-30
     # The first year of extended support is free.
     extendedSupport: 2027-04-30
     link: https://docs.oracle.com/en/database/oracle/oracle-database/19/whats-new.html


### PR DESCRIPTION
Premier Support (PS) ends April 30, 2024, two years of waived Extended Support (ES) fees will be in effect from May 1, 2024 until April 30, 2026. Fees will be required beginning May 01, 2026 through April 30, 2027

Oracle updated Doc ID 742060.1 with new : 
Patching End Date for 19c LTR:
April 30, 2026 with no ES/ULA