### PR TITLE
Add Oracle 23c

### DIFF
--- a/products/oracle-database.md
+++ b/products/oracle-database.md
@@ -16,6 +16,7 @@ releases:
 -   releaseCycle: "23"
     releaseLabel: "23c"
     releaseDate: 2023-09-19
+    lts: true
     eol: 2032-04-30
     extendedSupport: yes
     link: https://docs.oracle.com/en/database/oracle/oracle-database/23/whats-new.html
@@ -29,8 +30,8 @@ releases:
 
 -   releaseCycle: "19"
     releaseLabel: "19c"
-    lts: true
     releaseDate: 2019-04-25
+    lts: true
     eol: 2026-04-30
     # The first year of extended support is free.
     extendedSupport: 2027-04-30
@@ -127,7 +128,7 @@ may vary. This page documents Premier and Extended support dates for Oracle Data
 Server Releases for Linux x86-64.
 
 According to the [Release Schedule of Current Database Releases](https://support.oracle.com/knowledge/Oracle%20Database%20Products/742060_1.html)
-(November 17, 2023 update) there are two types of Oracle Database releases:
+there are two types of Oracle Database releases:
 
 - Long Term Release (LTR), which are supported for 5 years with Premier Support, followed by 3 years
   with Extended Support. Note that Oracle Corporation may offer, for some LTR, one year of free

--- a/products/oracle-database.md
+++ b/products/oracle-database.md
@@ -13,6 +13,13 @@ eolColumn: Premier Support
 extendedSupportColumn: Extended Support
 
 releases:
+-   releaseCycle: "23"
+    releaseLabel: "23c"
+    releaseDate: 2023-09-19
+    eol: 2032-04-30
+    extendedSupport: yes
+    link: https://docs.oracle.com/en/database/oracle/oracle-database/23/whats-new.html
+
 -   releaseCycle: "21"
     releaseLabel: "21c"
     releaseDate: 2021-08-13
@@ -120,7 +127,7 @@ may vary. This page documents Premier and Extended support dates for Oracle Data
 Server Releases for Linux x86-64.
 
 According to the [Release Schedule of Current Database Releases](https://support.oracle.com/knowledge/Oracle%20Database%20Products/742060_1.html)
-(february 13, 2023 update) there are two types of Oracle Database releases:
+(November 17, 2023 update) there are two types of Oracle Database releases:
 
 - Long Term Release (LTR), which are supported for 5 years with Premier Support, followed by 3 years
   with Extended Support. Note that Oracle Corporation may offer, for some LTR, one year of free


### PR DESCRIPTION
Oracle 23c has been released as the next LTS with support through 2032, per https://support.oracle.com/knowledge/Oracle%20Database%20Products/742060_1.html and https://blogs.oracle.com/database/post/oracle-database-23c-the-next-long-term-support-release

<img width="1503" alt="image" src="https://github.com/endoflife-date/endoflife.date/assets/1029558/08366e30-f8af-4c97-a91a-cff03f55a9bd">
