### PR TITLE
[azure-devops] Add update cycles for 2019-2022, update latest

### DIFF
--- a/products/azure-devops.md
+++ b/products/azure-devops.md
@@ -33,7 +33,7 @@ releases:
 
 -   releaseCycle: "2020.1"
     releaseLabel: "2020 Update 1"
-    releaseDate: 2020-08-25
+    releaseDate: 2021-05-25
     support: 2025-10-14
     eol: 2030-10-08
     latest: "2020.1.2patch10"
@@ -51,7 +51,7 @@ releases:
 
 -   releaseCycle: "2019.1"
     releaseLabel: "2019 Update 1"
-    releaseDate: 2019-03-05
+    releaseDate: 2019-08-20
     support: 2024-04-09
     eol: 2029-04-10
     latest: "2019.1.2patch6"

--- a/products/azure-devops.md
+++ b/products/azure-devops.md
@@ -63,7 +63,7 @@ releases:
     releaseDate: 2019-03-05
     support: 2024-04-09
     eol: 2029-04-10
-    latest: "2019.0.2patch16"
+    latest: "2019.0.1patch16"
     latestReleaseDate: 2023-11-14
     link: https://learn.microsoft.com/azure/devops/server/release-notes/azuredevops2019#azure-devops-server-201901-patch-16-release-date-november-14-2023
 

--- a/products/azure-devops.md
+++ b/products/azure-devops.md
@@ -13,38 +13,68 @@ activeSupportColumn: true
 releaseDateColumn: true
 
 releases:
--   releaseCycle: "2022"
+-   releaseCycle: "2022.1"
+    releaseCycleLabel: "2022 Update 1"
+    releaseDate: 2023-11-28
+    support: 2028-01-11
+    eol: 2033-01-11
+    latest: "2022.1"
+    latestReleaseDate: 2023-11-28
+    link: https://learn.microsoft.com/azure/devops/server/release-notes/azuredevops2022u1#azure-devops-server-2022-update-1-release-date-november-28-2023
+
+-   releaseCycle: "2022.0"
+    releaseCycleLabel: "2022"
     releaseDate: 2022-12-06
     support: 2028-01-11
     eol: 2033-01-11
-    latest: "2022.0.1patch4"
-    latestReleaseDate: 2023-10-10
-    link: https://learn.microsoft.com/azure/devops/server/release-notes/azuredevops2022?view=azure-devops-2020#azure-devops-server-2022-update-01-patch-4-release-date-october-10-2023
+    latest: "2022.0.1patch5"
+    latestReleaseDate: 2023-11-14
+    link: https://learn.microsoft.com/azure/devops/server/release-notes/azuredevops2022#azure-devops-server-2022-update-01-patch-5-release-date-november-14-2023
 
--   releaseCycle: "2020"
+-   releaseCycle: "2020.1"
+    releaseCycleLabel: "2020 Update 1"
     releaseDate: 2020-08-25
     support: 2025-10-14
     eol: 2030-10-08
-    latest: "2020.1.2patch9"
-    latestReleaseDate: 2023-10-10
-    link: https://learn.microsoft.com/azure/devops/server/release-notes/azuredevops2020u1?view=azure-devops-2020#azure-devops-server-2020-update-12-patch-9-release-date-october-10-2023
+    latest: "2020.1.2patch10"
+    latestReleaseDate: 2023-11-14
+    link: https://learn.microsoft.com/azure/devops/server/release-notes/azuredevops2020u1#azure-devops-server-2020-update-12-patch-10-release-date-november-14-2023
 
--   releaseCycle: "2019"
+-   releaseCycle: "2020.0"
+    releaseCycleLabel: "2020"
+    releaseDate: 2020-08-25
+    support: 2025-10-14
+    eol: 2030-10-08
+    latest: "2020.0.2patch6"
+    latestReleaseDate: 2023-11-14
+    link: https://learn.microsoft.com/azure/devops/server/release-notes/azuredevops2020#azure-devops-server-2020-update-02-patch-6-release-date-november-14-2023
+
+-   releaseCycle: "2019.1"
+    releaseCycleLabel: "2019 Update 1"
     releaseDate: 2019-03-05
     support: 2024-04-09
     eol: 2029-04-10
-    latest: "2019.1.2patch5"
-    latestReleaseDate: 2023-09-12
-    link: https://learn.microsoft.com/azure/devops/server/release-notes/azuredevops2019u1?view=azure-devops-2020#azure-devops-server-2019-update-12-patch-5-release-date-september-12-2023
+    latest: "2019.1.2patch6"
+    latestReleaseDate: 2023-11-14
+    link: https://learn.microsoft.com/azure/devops/server/release-notes/azuredevops2019u1#azure-devops-server-2019-update-12-patch-6-release-date-november-14-2023
+
+-   releaseCycle: "2019.0"
+    releaseCycleLabel: "2019"
+    releaseDate: 2019-03-05
+    support: 2024-04-09
+    eol: 2029-04-10
+    latest: "2019.0.2patch16"
+    latestReleaseDate: 2023-11-14
+    link: https://learn.microsoft.com/azure/devops/server/release-notes/azuredevops2019#azure-devops-server-201901-patch-16-release-date-november-14-2023
 
 -   releaseCycle: "2018"
     releaseLabel: "TFS __RELEASE_CYCLE__"
     releaseDate: 2017-11-15
     support: 2023-01-10
     eol: 2028-01-11
-    latest: "2018.3.2patch18"
-    latestReleaseDate: 2023-09-12
-    link: https://learn.microsoft.com/visualstudio/releasenotes/tfs2018-update3#team-foundation-server-2018-update-32-patch-18
+    latest: "2018.3.2patch19"
+    latestReleaseDate: 2023-11-14
+    link: https://learn.microsoft.com/visualstudio/releasenotes/tfs2018-update3#team-foundation-server-2018-update-32-patch-19
 
 -   releaseCycle: "2017"
     releaseLabel: "TFS __RELEASE_CYCLE__"

--- a/products/azure-devops.md
+++ b/products/azure-devops.md
@@ -14,7 +14,7 @@ releaseDateColumn: true
 
 releases:
 -   releaseCycle: "2022.1"
-    releaseCycleLabel: "2022 Update 1"
+    releaseLabel: "2022 Update 1"
     releaseDate: 2023-11-28
     support: 2028-01-11
     eol: 2033-01-11
@@ -23,7 +23,7 @@ releases:
     link: https://learn.microsoft.com/azure/devops/server/release-notes/azuredevops2022u1#azure-devops-server-2022-update-1-release-date-november-28-2023
 
 -   releaseCycle: "2022.0"
-    releaseCycleLabel: "2022"
+    releaseLabel: "2022"
     releaseDate: 2022-12-06
     support: 2028-01-11
     eol: 2033-01-11
@@ -32,7 +32,7 @@ releases:
     link: https://learn.microsoft.com/azure/devops/server/release-notes/azuredevops2022#azure-devops-server-2022-update-01-patch-5-release-date-november-14-2023
 
 -   releaseCycle: "2020.1"
-    releaseCycleLabel: "2020 Update 1"
+    releaseLabel: "2020 Update 1"
     releaseDate: 2020-08-25
     support: 2025-10-14
     eol: 2030-10-08
@@ -41,7 +41,7 @@ releases:
     link: https://learn.microsoft.com/azure/devops/server/release-notes/azuredevops2020u1#azure-devops-server-2020-update-12-patch-10-release-date-november-14-2023
 
 -   releaseCycle: "2020.0"
-    releaseCycleLabel: "2020"
+    releaseLabel: "2020"
     releaseDate: 2020-08-25
     support: 2025-10-14
     eol: 2030-10-08
@@ -50,7 +50,7 @@ releases:
     link: https://learn.microsoft.com/azure/devops/server/release-notes/azuredevops2020#azure-devops-server-2020-update-02-patch-6-release-date-november-14-2023
 
 -   releaseCycle: "2019.1"
-    releaseCycleLabel: "2019 Update 1"
+    releaseLabel: "2019 Update 1"
     releaseDate: 2019-03-05
     support: 2024-04-09
     eol: 2029-04-10
@@ -59,7 +59,7 @@ releases:
     link: https://learn.microsoft.com/azure/devops/server/release-notes/azuredevops2019u1#azure-devops-server-2019-update-12-patch-6-release-date-november-14-2023
 
 -   releaseCycle: "2019.0"
-    releaseCycleLabel: "2019"
+    releaseLabel: "2019"
     releaseDate: 2019-03-05
     support: 2024-04-09
     eol: 2029-04-10


### PR DESCRIPTION
As I saw on the [blog post](https://devblogs.microsoft.com/devops/november-patches-for-azure-devops-server-and-team-foundation-server/) they are maintaining each updates cycle:
* 2022.1 (Update 1)
* 2022.0
* 2020.1 (Update 1)
* 2020.0
* 2019.1 (Update 1)
* 2019.0

I updated the release cycles accordingly and updated the latest.