### PR TITLE
[amazon-rds-postgresql] fix EOL version 16

### DIFF
--- a/products/amazon-rds-postgresql.md
+++ b/products/amazon-rds-postgresql.md
@@ -14,7 +14,7 @@ auto:
 releases:
 -   releaseCycle: "16"
     releaseDate: 2023-11-17
-    eol: 2024-09-01
+    eol: 2028-11-01
     latest: "16.1"
     latestReleaseDate: 2023-11-17
 


### PR DESCRIPTION
I fixed the wrong EOL for amazon-rds-postgres Version 16. 
Currently the EOL for 16.1 is being used, instead of EOL for version 16.x.

Wrong Date:  
https://docs.aws.amazon.com/AmazonRDS/latest/PostgreSQLReleaseNotes/postgresql-release-calendar.html