### PR TITLE
Update RDS MySQL 5.7.44 EOL date

### DIFF
--- a/products/amazon-rds-mysql.md
+++ b/products/amazon-rds-mysql.md
@@ -4,7 +4,7 @@ category: service
 tags: amazon managed-mysql
 iconSlug: amazonrds
 permalink: /amazon-rds-mysql
-releasePolicyLink: 
+releasePolicyLink:
   https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/MySQL.Concepts.VersionMgmt.html
 releaseDateColumn: true
 
@@ -20,7 +20,7 @@ releases:
 
 -   releaseCycle: "5.7"
     releaseDate: 2016-02-22
-    eol: 2023-10-01
+    eol: 2024-02-29
     latest: "5.7.44"
     latestReleaseDate: 2023-11-02
 


### PR DESCRIPTION
AWS have extended the EOL for RDS MySQL 5.7 until End of Feb next year.

> MySQL 5.7 reached community end of life in October, 2023 and will reach RDS end of standard support on Feb 29, 2024

https://aws.amazon.com/about-aws/whats-new/2023/11/amazon-rds-mysql-new-minor-version-5-7-44/