### PR TITLE
Remove Adobe and Microsoft icons

### DIFF
--- a/products/azure-devops.md
+++ b/products/azure-devops.md
@@ -2,7 +2,6 @@
 title: Azure DevOps Server
 category: server-app
 tags: microsoft
-iconSlug: azuredevops
 permalink: /azure-devops-server
 alternate_urls:
 -   /tfs

--- a/products/azure-kubernetes-service.md
+++ b/products/azure-kubernetes-service.md
@@ -2,7 +2,6 @@
 title: Azure Kubernetes Service
 category: service
 tags: managed-kubernetes microsoft
-iconSlug: microsoftazure
 permalink: /azure-kubernetes-service
 alternate_urls:
 -   /aks

--- a/products/coldfusion.md
+++ b/products/coldfusion.md
@@ -2,7 +2,6 @@
 title: Adobe ColdFusion
 category: server-app
 tags: adobe
-iconSlug: adobe
 permalink: /coldfusion
 versionCommand: writeoutput(server.coldfusion.productversion);
 releasePolicyLink: 

--- a/products/internetexplorer.md
+++ b/products/internetexplorer.md
@@ -2,7 +2,6 @@
 title: Internet Explorer
 category: app
 tags: microsoft web-browser
-iconSlug: internetexplorer
 permalink: /internet-explorer
 alternate_urls:
 -   /ie

--- a/products/msexchange.md
+++ b/products/msexchange.md
@@ -2,7 +2,6 @@
 title: Microsoft Exchange
 category: server-app
 tags: microsoft
-iconSlug: microsoftexchange
 permalink: /msexchange
 versionCommand: Get-ExchangeServer | Format-List Name,Edition,AdminDisplayVersion
 releasePolicyLink: https://learn.microsoft.com/lifecycle/products/?terms=Exchange%20Server

--- a/products/mssharepoint.md
+++ b/products/mssharepoint.md
@@ -2,7 +2,6 @@
 title: Microsoft SharePoint
 category: server-app
 tags: microsoft
-iconSlug: microsoftsharepoint
 permalink: /sharepoint
 alternate_urls:
 -   /mssharepoint

--- a/products/mssqlserver.md
+++ b/products/mssqlserver.md
@@ -2,7 +2,6 @@
 title: Microsoft SQL Server
 category: db
 tags: microsoft
-iconSlug: microsoftsqlserver
 permalink: /mssqlserver
 alternate_urls:
 -   /mssql

--- a/products/office.md
+++ b/products/office.md
@@ -2,7 +2,6 @@
 title: Microsoft Office
 category: app
 tags: microsoft
-iconSlug: microsoftoffice
 permalink: /office
 alternate_urls:
 -   /msoffice

--- a/products/powershell.md
+++ b/products/powershell.md
@@ -2,7 +2,6 @@
 title: Microsoft PowerShell
 category: lang
 tags: microsoft
-iconSlug: powershell
 permalink: /powershell
 alternate_urls:
 -   /pwsh

--- a/products/surface.md
+++ b/products/surface.md
@@ -2,7 +2,6 @@
 title: Microsoft Surface
 category: device
 tags: microsoft
-iconSlug: windows
 permalink: /surface
 releasePolicyLink: https://learn.microsoft.com/surface/surface-driver-firmware-lifecycle-support
 releaseColumn: false

--- a/products/visualstudio.md
+++ b/products/visualstudio.md
@@ -2,7 +2,6 @@
 title: Microsoft Visual Studio
 category: app
 tags: microsoft
-iconSlug: visualstudio
 permalink: /visual-studio
 alternate_urls:
 -   /visualstudio

--- a/products/windows.md
+++ b/products/windows.md
@@ -2,7 +2,6 @@
 title: Microsoft Windows
 category: os
 tags: microsoft windows
-iconSlug: windows
 permalink: /windows
 versionCommand: winver
 releasePolicyLink: https://learn.microsoft.com/lifecycle/products/?terms=Windows

--- a/products/windowsEmbedded.md
+++ b/products/windowsEmbedded.md
@@ -2,7 +2,6 @@
 title: Microsoft Windows Embedded
 category: os
 tags: microsoft windows
-iconSlug: windows
 permalink: /windows-embedded
 alternate_urls:
 - /windowsembedded

--- a/products/windowsServer.md
+++ b/products/windowsServer.md
@@ -2,7 +2,6 @@
 title: Microsoft Windows Server
 category: os
 tags: microsoft windows
-iconSlug: windows
 permalink: /windows-server
 alternate_urls:
   - /windowsserver


### PR DESCRIPTION
As per https://github.com/simple-icons/simple-icons/issues/10016 - Simple Icons is having to remove all Adobe and Microsoft icons. This PR serves to remove them from endoflife.date before the release gets pushed through in early January.