### PR TITLE
Update go.md > 🌟 Go 1.21.5 and 1.20.12 are released!

### DIFF
--- a/products/go.md
+++ b/products/go.md
@@ -29,14 +29,14 @@ releases:
 -   releaseCycle: "1.21"
     releaseDate: 2023-08-08
     eol: false
-    latest: "1.21.4"
-    latestReleaseDate: 2023-11-07
+    latest: "1.21.5"
+    latestReleaseDate: 2023-12-06
 
 -   releaseCycle: "1.20"
     releaseDate: 2023-02-01
     eol: false
-    latest: "1.20.11"
-    latestReleaseDate: 2023-11-07
+    latest: "1.20.12"
+    latestReleaseDate: 2023-12-06
 
 -   releaseCycle: "1.19"
     releaseDate: 2022-08-02


### PR DESCRIPTION
# ❔ About

🌟 Go 1.21.5 and 1.20.12 are released!

🔐 Security: Includes security fixes for net/http (CVE-2023-39326), cmd/go (CVE-2023-45285), path/filepath (CVE-2023-45283 update).
📢 Announcement: https://groups.google.com/g/golang-announce/c/iLGK3x6yuNo
⬇️ Download: [https://go.dev/dl/#go1.21.5](https://t.co/p7GiE74HHs)

https://twitter.com/golang/status/1732108777791365163

![image](https://github.com/endoflife-date/endoflife.date/assets/5235127/7dcd67f3-bd00-4928-befb-90a191e4fb8f)


