### PR TITLE
[nokia] new products and one eol update

### DIFF
--- a/products/nokia.md
+++ b/products/nokia.md
@@ -11,35 +11,38 @@ releasePolicyLink: https://www.nokia.com/phones/en_int/security-updates
 releaseDateColumn: true
 releaseColumn: false
 
+# EOL estimation if not explicitly announced by Nokia on product page
+# * for C line: eol(x) = releaseDate(x) + 2 years
+# * for rest: eol(x) = releaseDate(x) + 3 years
 releases:
 -   releaseCycle: "Nokia C210"
     releaseDate: 2023-09-14
-    eol: 2025-09-14
+    eol: 2025-09-14 # estimated releaseDate(x) + 2 years
     link: https://www.nokia.com/phones/en_us/nokia-c-210
 
 -   releaseCycle: "Nokia G310 5G"
     releaseDate: 2023-08-24
-    eol: 2026-08-24
+    eol: 2026-08-24 # estimated releaseDate(x) + 3 years
     link: https://www.nokia.com/phones/en_us/nokia-g-310
 
 -   releaseCycle: "Nokia G42 5G"
     releaseDate: 2023-06-28
-    eol: 2026-06-28
+    eol: 2026-06-28 # Product page: 3 years of monthly security updates and 2 years of OS upgrades.
     link: https://www.nokia.com/phones/en_int/nokia-g-42
 
 -   releaseCycle: "Nokia C300"
     releaseDate: 2023-06-14
-    eol: 2025-06-14
+    eol: 2025-06-14 # estimated releaseDate(x) + 2 years
     link: https://www.nokia.com/phones/en_us/nokia-c-300
 
 -   releaseCycle: "Nokia C110"
     releaseDate: 2023-06-14
-    eol: 2025-06-14
+    eol: 2025-06-14 # estimated releaseDate(x) + 2 years
     link: https://www.nokia.com/phones/en_us/nokia-c-110
 
 -   releaseCycle: "Nokia XR21"
     releaseDate: 2023-05-24
-    eol: 2027-05-24
+    eol: 2027-05-24 # Product page: With 4 years of monthly security updates
     link: https://www.nokia.com/phones/en_int/nokia-xr-21
 
 -   releaseCycle: "Nokia C32"
@@ -54,7 +57,7 @@ releases:
 
 -   releaseCycle: "Nokia T21"
     releaseDate: 2022-09-01
-    eol: 2025-09-01
+    eol: 2025-09-01 # Product page: 3 years of monthly security updates
     link: https://www.nokia.com/phones/en_int/nokia-t-21
 
 -   releaseCycle: "Nokia X30 5G"

--- a/products/nokia.md
+++ b/products/nokia.md
@@ -12,9 +12,34 @@ releaseDateColumn: true
 releaseColumn: false
 
 releases:
+-   releaseCycle: "Nokia C210"
+    releaseDate: 2023-09-14
+    eol: false
+    link: https://www.nokia.com/phones/en_us/nokia-c-210
+
+-   releaseCycle: "Nokia G310 5G"
+    releaseDate: 2023-08-24
+    eol: false
+    link: https://www.nokia.com/phones/en_us/nokia-g-310
+
+-   releaseCycle: "Nokia G42 5G"
+    releaseDate: 2023-06-28
+    eol: 2026-06-28
+    link: https://www.nokia.com/phones/en_int/nokia-g-42
+
+-   releaseCycle: "Nokia C300"
+    releaseDate: 2023-06-14
+    eol: false
+    link: https://www.nokia.com/phones/en_us/nokia-c-300
+
+-   releaseCycle: "Nokia C110"
+    releaseDate: 2023-06-14
+    eol: false
+    link: https://www.nokia.com/phones/en_us/nokia-c-110
+
 -   releaseCycle: "Nokia XR21"
     releaseDate: 2023-05-24
-    eol: false
+    eol: 2027-05-24
     link: https://www.nokia.com/phones/en_int/nokia-xr-21
 
 -   releaseCycle: "Nokia C32"
@@ -26,6 +51,11 @@ releases:
     releaseDate: 2023-02-17
     eol: 2026-04-01
     link: https://www.nokia.com/phones/en_int/nokia-g-22
+
+-   releaseCycle: "Nokia T21"
+    releaseDate: 2022-09-01
+    eol: 2025-09-01
+    link: https://www.nokia.com/phones/en_int/nokia-t-21
 
 -   releaseCycle: "Nokia X30 5G"
     releaseDate: 2022-09-01

--- a/products/nokia.md
+++ b/products/nokia.md
@@ -14,12 +14,12 @@ releaseColumn: false
 releases:
 -   releaseCycle: "Nokia C210"
     releaseDate: 2023-09-14
-    eol: false
+    eol: 2025-09-14
     link: https://www.nokia.com/phones/en_us/nokia-c-210
 
 -   releaseCycle: "Nokia G310 5G"
     releaseDate: 2023-08-24
-    eol: false
+    eol: 2026-08-24
     link: https://www.nokia.com/phones/en_us/nokia-g-310
 
 -   releaseCycle: "Nokia G42 5G"
@@ -29,12 +29,12 @@ releases:
 
 -   releaseCycle: "Nokia C300"
     releaseDate: 2023-06-14
-    eol: false
+    eol: 2025-06-14
     link: https://www.nokia.com/phones/en_us/nokia-c-300
 
 -   releaseCycle: "Nokia C110"
     releaseDate: 2023-06-14
-    eol: false
+    eol: 2025-06-14
     link: https://www.nokia.com/phones/en_us/nokia-c-110
 
 -   releaseCycle: "Nokia XR21"


### PR DESCRIPTION
New products:

* C210 https://www.gsmarena.com/nokia_c210-12472.php no en_int page not on security-updates page
* G310 https://www.gsmarena.com/nokia_g310-12471.php no en_int page not on security-updates page
* G42 https://www.gsmarena.com/nokia_g42-12381.php; 2026-06-28 EoL is from "3 years of monthly security updates and 2 years of OS upgrades." on the product page
* C300 https://www.gsmarena.com/nokia_c300-12322.php no en_int page not on security-updates page
* C110 https://www.gsmarena.com/nokia_c110-12321.php no en_int page not on security-updates page
* T21 https://www.gsmarena.com/nokia_t21-11823.php; 2025-09-01 EoL is from "3 years of monthly security updates" on the product page

Update:

* XR21 product page reads "With 4 years of monthly security updates"; thus EoL updated to 2027-05-24