### PR TITLE
[rust] Fix regex

### DIFF
--- a/products/rust.md
+++ b/products/rust.md
@@ -14,7 +14,6 @@ releaseDateColumn: true
 
 auto:
 -   git: https://github.com/rust-lang/rust.git
-    regex: ^<major>[1-9]\d*)\.(?<minor>\d+)\.?(?<patch>\d+)?$
 
 # eol(x) = releaseDate(x+1)
 releases:


### PR DESCRIPTION
The default regex should be good enough for rust. The previous one had some parenthesis issues, which this fixes.