### PR TITLE
[LibreOffice] Update to 7.6.4

### DIFF
--- a/products/libreoffice.md
+++ b/products/libreoffice.md
@@ -12,8 +12,8 @@ releases:
 -   releaseCycle: "7.6"
     releaseDate: 2023-08-21 # https://blog.documentfoundation.org/blog/2023/08/21/libreoffice-7-6-community/
     eol: 2024-06-12
-    latest: "7.6.3"
-    latestReleaseDate: 2023-11-23
+    latest: "7.6.4"
+    latestReleaseDate: 2023-12-07
 
 -   releaseCycle: "7.5"
     releaseDate: 2023-02-02 # https://blog.documentfoundation.org/blog/2023/02/02/tdf-announces-libreoffice-75-community/

--- a/products/libreoffice.md
+++ b/products/libreoffice.md
@@ -17,9 +17,9 @@ releases:
 
 -   releaseCycle: "7.5"
     releaseDate: 2023-02-02 # https://blog.documentfoundation.org/blog/2023/02/02/tdf-announces-libreoffice-75-community/
-    eol: 2023-11-30
-    latest: "7.5.8"
-    latestReleaseDate: 2023-11-02
+    eol: 2023-12-07 # https://blog.documentfoundation.org/blog/2023/12/07/libreoffice-764-and-759/
+    latest: "7.5.9"
+    latestReleaseDate: 2023-12-07
 
 -   releaseCycle: "7.4"
     releaseDate: 2022-08-18 # https://blog.documentfoundation.org/blog/2022/08/18/libreoffice-7-4-community/


### PR DESCRIPTION
https://blog.documentfoundation.org/blog/2023/12/07/libreoffice-764-and-759/

Change EOL of 7.5.x as latest update was released today