### PR TITLE
[qt] Add 5.15.16

### DIFF
--- a/products/qt.md
+++ b/products/qt.md
@@ -72,8 +72,8 @@ releases:
 -   releaseCycle: "5.15"
     lts: true
     releaseDate: 2020-05-25
-    eol: 2025-05-26
-    extendedSupport: false
+    eol: 2023-05-26
+    extendedSupport: 2025-05-26
     latest: "5.15.16"
     latestReleaseDate: 2023-11-17
     link: https://www.qt.io/blog/commercial-lts-qt-5.15.16-released

--- a/products/qt.md
+++ b/products/qt.md
@@ -5,7 +5,7 @@ iconSlug: qt
 permalink: /qt
 versionCommand: qmake --version
 releaseImage: https://www.qt.io/hs-fs/hubfs/subscription%20timeline.png
-releasePolicyLink: 
+releasePolicyLink:
   https://cdn2.hubspot.net/hubfs/149513/_Website_Blog/Qt%20offering%20change%20FAQ-2020-01-27.pdf
 changelogTemplate: "https://www.qt.io/blog/qt-{{'__LATEST__' | drop_zero_patch}}-released"
 releaseDateColumn: true
@@ -72,10 +72,11 @@ releases:
 -   releaseCycle: "5.15"
     lts: true
     releaseDate: 2020-05-25
-    eol: 2023-05-26
+    eol: 2025-05-26
     extendedSupport: false
-    latest: "5.15.2"
-    latestReleaseDate: 2020-11-13
+    latest: "5.15.16"
+    latestReleaseDate: 2023-11-17
+    link: https://www.qt.io/blog/commercial-lts-qt-5.15.16-released
 
 -   releaseCycle: "5.14"
     releaseDate: 2019-12-11


### PR DESCRIPTION
relates to:
- https://www.qt.io/blog/qt-5.15-extended-support-for-subscription-license-holders, Qt 5.15 Long Term Support (LTS) with patch releases to five years, prolonging the life of Qt 5.15 until 26 May 2025
- https://www.qt.io/blog/commercial-lts-qt-5.15.16-released, 5.15.16 released