### PR TITLE
[terraform] update to use spdx id to avoid confusion

### DIFF
--- a/products/terraform.md
+++ b/products/terraform.md
@@ -58,7 +58,7 @@ releases:
 
 ---
 
-> [Hashicorp Terraform](https://www.terraform.io/) is a [BSL-licensed](https://www.hashicorp.com/bsl) infrastructure as code
+> [Hashicorp Terraform](https://www.terraform.io/) is a [BUSL-1.1 licensed](https://www.hashicorp.com/bsl) infrastructure as code
 > software tool by Hashicorp.
 
 Generally Available (GA) releases of active products are supported for up to two (2) years. Eligible


### PR DESCRIPTION
In the SPDX license list, BSL refers to [Boost Software License 1.0](https://spdx.org/licenses/BSL-1.0.html), while BUSL refers to [Business Source License 1.1](https://spdx.org/licenses/BUSL-1.1.html). Updating to spdx id to avoid confusion. (I checked this is the only one refers to BSL)


---

Another thing to note is BUSL-1.1 is only applicable to terraform 1.6+, while MPL-2.0 is for anything before 1.6