### PR TITLE
Add PURL identifiers for multiple products

### DIFF
--- a/products/angular.md
+++ b/products/angular.md
@@ -14,7 +14,7 @@ activeSupportWarnThreshold: 30
 eolWarnThreshold: 90
 
 identifiers:
--   purl: pkg:npm/%40angular/core
+-   purl: pkg:npm/%40angular/core # purl are url-encoded
 -   purl: pkg:github/angular/angular
 
 auto:

--- a/products/angular.md
+++ b/products/angular.md
@@ -14,7 +14,7 @@ activeSupportWarnThreshold: 30
 eolWarnThreshold: 90
 
 identifiers:
--   purl: pkg:npm/@angular/core
+-   purl: pkg:npm/%40angular/core
 -   purl: pkg:github/angular/angular
 
 auto:

--- a/products/angularjs.md
+++ b/products/angularjs.md
@@ -18,6 +18,7 @@ auto:
 identifiers:
 -   repology: angular.js
 -   purl: pkg:npm/angular
+-   purl: pkg:github/angular/angular.js
 
 releases:
 -   releaseCycle: "1.8"

--- a/products/ansible.md
+++ b/products/ansible.md
@@ -15,6 +15,9 @@ eolColumn: Supported
 
 identifiers:
 -   purl: pkg:pypi/ansible
+-   purl: pkg:deb/debian/ansible
+-   purl: pkg:apk/alpine/ansible
+-   purl: pkg:github/ansible/ansible
 -   repology: ansible
 
 auto:

--- a/products/emberjs.md
+++ b/products/emberjs.md
@@ -11,6 +11,9 @@ changelogTemplate: https://github.com/emberjs/ember.js/releases/tag/v__LATEST__
 releaseDateColumn: true
 activeSupportColumn: true
 
+identifiers:
+-   purl: pkg:github/emberjs/ember.js
+
 # NPM is more accurate than git. Version 1.0.0 to 2.11.0 are not on NPM, but 1.x and 2.x cycles are
 # not displayed on this page so it's not a big deal.
 auto:

--- a/products/firefox.md
+++ b/products/firefox.md
@@ -10,6 +10,12 @@ changelogTemplate: https://www.mozilla.org/firefox/__LATEST__/releasenotes/
 LTSLabel: "<abbr title='Extended Support Release'>ESR</abbr>"
 releaseDateColumn: true
 
+identifiers:
+-   purl:  pkg:apk/alpine/firefox
+-   purl:  pkg:deb/debian/firefox
+-   purl:  pkg:deb/firefox
+-   purl:  pkg:generic/firefox
+
 auto:
 -   custom: true
 

--- a/products/firefox.md
+++ b/products/firefox.md
@@ -12,8 +12,7 @@ releaseDateColumn: true
 
 identifiers:
 -   purl:  pkg:apk/alpine/firefox
--   purl:  pkg:deb/debian/firefox
--   purl:  pkg:deb/firefox
+-   purl:  pkg:deb/debian/firefox-esr
 -   purl:  pkg:generic/firefox
 
 auto:

--- a/products/grafana.md
+++ b/products/grafana.md
@@ -8,6 +8,9 @@ changelogTemplate: https://github.com/grafana/grafana/releases/tag/v__LATEST__
 releaseDateColumn: true
 activeSupportColumn: true
 
+identifiers:
+-   purl:  pkg:github/grafana/grafana
+
 auto:
 -   git: https://github.com/grafana/grafana
     regex: ^v(?P<major>[1-9]\d*)\.(?P<minor>\d+)\.(?P<patch>\d+)$

--- a/products/ionic.md
+++ b/products/ionic.md
@@ -13,6 +13,10 @@ eolColumn: Maintenance
 releaseDateColumn: true
 extendedSupportColumn: true
 
+identifiers:
+-   purl: pkg:github/ionic-team/ionic
+-   purl: pkg:npm/%40ionic/core
+
 auto:
 -   git: https://github.com/ionic-team/ionic-framework.git
 

--- a/products/ionic.md
+++ b/products/ionic.md
@@ -14,7 +14,7 @@ releaseDateColumn: true
 extendedSupportColumn: true
 
 identifiers:
--   purl: pkg:github/ionic-team/ionic
+-   purl: pkg:github/ionic-team/ionic-framework
 -   purl: pkg:npm/%40ionic/core
 
 auto:

--- a/products/jquery.md
+++ b/products/jquery.md
@@ -13,7 +13,6 @@ identifiers:
 -   purl: pkg:npm/jquery
 -   purl: pkg:nuget/jQuery
 
-
 # NPM is also possible, but versions up to 1.10.2 and between 2.0.0 to 2.0.3 are not on
 # https://www.npmjs.com/package/jquery, so better it's better to keep git.
 auto:

--- a/products/jquery.md
+++ b/products/jquery.md
@@ -8,12 +8,10 @@ changelogTemplate: https://github.com/jquery/jquery/releases/tag/__LATEST__
 releaseDateColumn: true
 
 identifiers:
--   purl: pkg:github/jQuery/jQuery
--   purl: pkg:github/jquery
 -   purl: pkg:github/jquery/jquery
 -   purl: pkg:maven/org.webjars/jquery
 -   purl: pkg:npm/jquery
--   purl: pkg:nuget/jquery
+-   purl: pkg:nuget/jQuery
 
 
 # NPM is also possible, but versions up to 1.10.2 and between 2.0.0 to 2.0.3 are not on

--- a/products/jquery.md
+++ b/products/jquery.md
@@ -7,6 +7,15 @@ permalink: /jquery
 changelogTemplate: https://github.com/jquery/jquery/releases/tag/__LATEST__
 releaseDateColumn: true
 
+identifiers:
+-   purl: pkg:github/jQuery/jQuery
+-   purl: pkg:github/jquery
+-   purl: pkg:github/jquery/jquery
+-   purl: pkg:maven/org.webjars/jquery
+-   purl: pkg:npm/jquery
+-   purl: pkg:nuget/jquery
+
+
 # NPM is also possible, but versions up to 1.10.2 and between 2.0.0 to 2.0.3 are not on
 # https://www.npmjs.com/package/jquery, so better it's better to keep git.
 auto:

--- a/products/keycloak.md
+++ b/products/keycloak.md
@@ -9,6 +9,9 @@ changelogTemplate: "https://www.keycloak.org/docs/latest/release_notes/index.htm
 releaseDateColumn: true
 eolColumn: Supported
 
+identifiers:
+-   purl:  pkg:github/keycloak/keycloak
+
 auto:
 -   git: https://github.com/keycloak/keycloak.git
 

--- a/products/kubernetes.md
+++ b/products/kubernetes.md
@@ -15,6 +15,9 @@ releaseDateColumn: true
 activeSupportColumn: true
 eolColumn: Maintenance Support
 
+identifiers:
+-   purl: pkg:github/kubernetes/kubernetes
+
 auto:
 -   git: https://github.com/kubernetes/kubernetes.git
     regex: ^v(?P<major>[1-9]\d*)\.(?P<minor>\d+)\.(?P<patch>\d+)$

--- a/products/mariadb.md
+++ b/products/mariadb.md
@@ -21,6 +21,7 @@ identifiers:
 -   purl: pkg:rpm/amzn/mariadb-server
 -   purl: pkg:rpm/redhat/mariadb-server
 -   purl: pkg:rpm/centos/mariadb-server
+-   purl: pkg:rpm/opensuse/mariadb
 
 auto:
 -   git: https://github.com/MariaDB/server.git

--- a/products/neo4j.md
+++ b/products/neo4j.md
@@ -11,6 +11,9 @@ changelogTemplate: https://github.com/neo4j/neo4j/releases/tag/__LATEST__
 eolColumn: Support Status
 releaseDateColumn: true
 
+identifiers:
+-   purl:  pkg:github/neo4j/neo4j
+
 auto:
 -   git: https://github.com/neo4j/neo4j.git
 

--- a/products/nextjs.md
+++ b/products/nextjs.md
@@ -14,7 +14,6 @@ releaseDateColumn: true
 identifiers:
 -   purl: pkg:npm/next.js
 -   purl: pkg:github/vercel/next.js
--   purl: pkg:github/zeit/next.js
 
 auto:
 -   npm: next

--- a/products/nextjs.md
+++ b/products/nextjs.md
@@ -11,6 +11,11 @@ versionCommand: npx next --version
 changelogTemplate: https://github.com/vercel/next.js/releases/tag/v__LATEST__
 releaseDateColumn: true
 
+identifiers:
+-   purl: pkg:npm/next.js
+-   purl: pkg:github/vercel/next.js
+-   purl: pkg:github/zeit/next.js
+
 auto:
 -   npm: next
 

--- a/products/nexus.md
+++ b/products/nexus.md
@@ -10,6 +10,9 @@ alternate_urls:
 releaseDateColumn: true
 eolColumn: Support
 
+identifiers:
+-   purl:  pkg:github/sonatype/nexus-public
+
 auto:
 -   git: https://github.com/sonatype/nexus-public.git
     regex: '^release-(?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)-(?P<tiny>\d+)$'

--- a/products/nginx.md
+++ b/products/nginx.md
@@ -18,7 +18,6 @@ identifiers:
 -   purl: pkg:rpm/redhat/nginx
 -   purl: pkg:rpm/centos/nginx
 -   purl: pkg:apk/alpine/nginx
--   purl: pkg:ipk/nginx
 -   purl: pkg:rpm/opensuse/nginx
 
 auto:

--- a/products/nginx.md
+++ b/products/nginx.md
@@ -18,6 +18,8 @@ identifiers:
 -   purl: pkg:rpm/redhat/nginx
 -   purl: pkg:rpm/centos/nginx
 -   purl: pkg:apk/alpine/nginx
+-   purl: pkg:ipk/nginx
+-   purl: pkg:rpm/opensuse/nginx
 
 auto:
 -   git: https://github.com/nginx/nginx.git

--- a/products/numpy.md
+++ b/products/numpy.md
@@ -9,6 +9,10 @@ versionCommand: python -c "import numpy; print(numpy.__version__)"
 changelogTemplate: https://github.com/numpy/numpy/releases/tag/v__LATEST__
 releaseDateColumn: true
 
+identifiers:
+-   purl: pkg:pypi/numpy
+-   purl: pkg:github/numpy/numpy
+
 auto:
 -   pypi: numpy
 

--- a/products/perl.md
+++ b/products/perl.md
@@ -15,9 +15,6 @@ eolColumn: Critical security patches
 identifiers:
   -   purl:  pkg:apk/alpine/perl
   -   purl:  pkg:deb/debian/perl
-  -   purl:  pkg:deb/perl
-  -   purl:  pkg:ipk/perl
-  -   purl:  pkg:rpm/perl
   -   purl:  pkg:generic/perl
 
 auto:

--- a/products/perl.md
+++ b/products/perl.md
@@ -13,9 +13,9 @@ releaseDateColumn: true
 eolColumn: Critical security patches
 
 identifiers:
-  -   purl:  pkg:apk/alpine/perl
-  -   purl:  pkg:deb/debian/perl
-  -   purl:  pkg:generic/perl
+-   purl:  pkg:apk/alpine/perl
+-   purl:  pkg:deb/debian/perl
+-   purl:  pkg:generic/perl
 
 auto:
 -   git: https://github.com/Perl/perl5.git

--- a/products/perl.md
+++ b/products/perl.md
@@ -12,6 +12,14 @@ activeSupportColumn: true
 releaseDateColumn: true
 eolColumn: Critical security patches
 
+identifiers:
+  -   purl:  pkg:apk/alpine/perl
+  -   purl:  pkg:deb/debian/perl
+  -   purl:  pkg:deb/perl
+  -   purl:  pkg:ipk/perl
+  -   purl:  pkg:rpm/perl
+  -   purl:  pkg:generic/perl
+
 auto:
 -   git: https://github.com/Perl/perl5.git
     regex:

--- a/products/php.md
+++ b/products/php.md
@@ -9,6 +9,12 @@ changelogTemplate: "https://www.php.net/ChangeLog-{{'__LATEST__'|split:'.'|first
 releaseDateColumn: true
 activeSupportColumn: true
 
+identifiers:
+-   purl: pkg:deb/ubuntu/php
+-   purl: pkg:deb/debian/php
+-   purl: pkg:apk/alpine/php
+-   purl: pkg:alpm/arch/php
+
 auto:
 -   custom: true
 

--- a/products/php.md
+++ b/products/php.md
@@ -12,8 +12,6 @@ activeSupportColumn: true
 identifiers:
 -   purl: pkg:deb/ubuntu/php
 -   purl: pkg:deb/debian/php
--   purl: pkg:apk/alpine/php
--   purl: pkg:alpm/arch/php
 
 auto:
 -   custom: true

--- a/products/phpmyadmin.md
+++ b/products/phpmyadmin.md
@@ -9,6 +9,12 @@ changelogTemplate: "https://github.com/phpmyadmin/phpmyadmin/blob/QA_{{'__RELEAS
 activeSupportColumn: true
 releaseDateColumn: true
 
+identifiers:
+-   purl:  pkg:apk/alpine/phpmyadmin
+-   purl:  pkg:composer/phpmyadmin/phpmyadmin
+-   purl:  pkg:deb/debian/phpmyadmin
+-   purl:  pkg:github/phpmyadmin/phpmyadmin
+
 auto:
 -   git: https://github.com/phpmyadmin/phpmyadmin.git
     regex: '^RELEASE_(?P<major>\d+)_(?P<minor>\d+)_(?P<patch>\d+)(_(?P<tiny>\d+))?$'

--- a/products/postgresql.md
+++ b/products/postgresql.md
@@ -21,6 +21,9 @@ identifiers:
 -   repology: postgresql
 -   purl: pkg:generic/postgresql
 -   purl: pkg:docker/library/postgres
+-   purl: pkg:apk/alpine/postgresql
+-   purl: pkg:deb/ubuntu/postgresql
+-   purl: pkg:rpm/opensuse/postgresql
 
 releases:
 -   releaseCycle: "16"

--- a/products/postgresql.md
+++ b/products/postgresql.md
@@ -21,9 +21,7 @@ identifiers:
 -   repology: postgresql
 -   purl: pkg:generic/postgresql
 -   purl: pkg:docker/library/postgres
--   purl: pkg:apk/alpine/postgresql
 -   purl: pkg:deb/ubuntu/postgresql
--   purl: pkg:rpm/opensuse/postgresql
 
 releases:
 -   releaseCycle: "16"

--- a/products/powershell.md
+++ b/products/powershell.md
@@ -14,6 +14,9 @@ changelogTemplate: https://github.com/PowerShell/PowerShell/releases/tag/v__LATE
 releaseDateColumn: true
 eolColumn: Support Status
 
+identifiers:
+-   purl:  pkg:github/powershell/powershell
+
 auto:
 -   git: https://github.com/PowerShell/PowerShell.git
 

--- a/products/rancher.md
+++ b/products/rancher.md
@@ -14,7 +14,7 @@ eolColumn: Limited Support
 eolWarnThreshold: 121
 
 identifiers:
--   purl: docker:rancher/rancher
+-   purl: pkg:docker/rancher/rancher
 
 auto:
 -   git: https://github.com/rancher/rancher.git

--- a/products/react.md
+++ b/products/react.md
@@ -9,6 +9,10 @@ changelogTemplate: https://github.com/facebook/react/releases/tag/v__LATEST__
 releaseDateColumn: true
 activeSupportColumn: true
 
+identifiers:
+-   purl: pkg:github/facebook/react
+-   purl: pkg:npm/react
+
 # NPM dates are more accurate than git tag dates.
 auto:
 -   npm: react

--- a/products/spring-boot.md
+++ b/products/spring-boot.md
@@ -18,6 +18,8 @@ auto:
 
 identifiers:
 -   purl: pkg:maven/org.springframework.boot/spring-boot
+-   purl: pkg:maven/spring-boot/spring-boot
+-   purl: pkg:github/spring-projects/spring-boot
 
 # EOL dates can be found on https://spring.io/projects/spring-boot#support
 releases:

--- a/products/spring-boot.md
+++ b/products/spring-boot.md
@@ -18,7 +18,6 @@ auto:
 
 identifiers:
 -   purl: pkg:maven/org.springframework.boot/spring-boot
--   purl: pkg:maven/spring-boot/spring-boot
 -   purl: pkg:github/spring-projects/spring-boot
 
 # EOL dates can be found on https://spring.io/projects/spring-boot#support

--- a/products/sqlite.md
+++ b/products/sqlite.md
@@ -11,6 +11,13 @@ changelogTemplate: "https://www.sqlite.org/changes.html#version_{{'__LATEST__'|r
 releaseDateColumn: true
 eolColumn: Support Status
 
+identifiers:
+-   purl:  pkg:generic/sqlite
+-   purl:  pkg:apk/alpine/sqlite
+-   purl:  pkg:github/sqlite/sqlite
+-   purl:  pkg:rpm/sqlite
+
+
 # This git mirror only contains versions from 3.6.10.
 auto:
 -   git: https://github.com/sqlite/sqlite.git

--- a/products/sqlite.md
+++ b/products/sqlite.md
@@ -16,7 +16,6 @@ identifiers:
 -   purl:  pkg:apk/alpine/sqlite
 -   purl:  pkg:github/sqlite/sqlite
 
-
 # This git mirror only contains versions from 3.6.10.
 auto:
 -   git: https://github.com/sqlite/sqlite.git

--- a/products/sqlite.md
+++ b/products/sqlite.md
@@ -15,7 +15,6 @@ identifiers:
 -   purl:  pkg:generic/sqlite
 -   purl:  pkg:apk/alpine/sqlite
 -   purl:  pkg:github/sqlite/sqlite
--   purl:  pkg:rpm/sqlite
 
 
 # This git mirror only contains versions from 3.6.10.

--- a/products/terraform.md
+++ b/products/terraform.md
@@ -9,6 +9,10 @@ releasePolicyLink: https://support.hashicorp.com/hc/articles/360021185113
 changelogTemplate: https://github.com/hashicorp/terraform/blob/v__LATEST__/CHANGELOG.md
 releaseDateColumn: true
 
+identifiers:
+-   purl:  pkg:github/hashicorp/terraform
+-   purl:  pkg:generic/terraform
+
 auto:
 -   git: https://github.com/hashicorp/terraform.git
 

--- a/products/tomcat.md
+++ b/products/tomcat.md
@@ -12,6 +12,7 @@ releaseDateColumn: true
 identifiers:
 -   repology: tomcat
 -   purl: pkg:maven/org.apache.tomcat/tomcat
+-   purl: pkg:github/apache/tomcat
 
 auto:
 -   maven: org.apache.tomcat/tomcat

--- a/products/zookeeper.md
+++ b/products/zookeeper.md
@@ -16,6 +16,7 @@ identifiers:
 -   purl: pkg:maven/org.apache.zookeeper/zookeeper
 -   purl: pkg:github/apache/zookeeper
 -   purl: pkg:docker/library/zookeeper
+-   purl: pkg:deb/debian/zookeeper
 
 auto:
 -   maven: org.apache.zookeeper/zookeeper


### PR DESCRIPTION
PURL identifiers have been added for the following products:

- Angular (corrected encoding from @angular to %40angular)
- AngularJS
- Ansible
- Ember.js
- Firefox
- Grafana
- Ionic
- jquery
- keycloak
- kubernetes
- mariadb
- neo4j
- nextjs
- nexus
- nginx
- numpy
- perl
- php
- phpmyadmin
- postgresql
- powershell
- rancher
- react
- spring-boot
- sqlite
- terraform
- tomcat
- zookeper

Additionally, the missing 'pkg:' prefix has been added for the Rancher