### PR TITLE
[go] update go1.19 eol for go 1.19.13 release

### DIFF
--- a/products/go.md
+++ b/products/go.md
@@ -40,7 +40,7 @@ releases:
 
 -   releaseCycle: "1.19"
     releaseDate: 2022-08-02
-    eol: 2023-08-08
+    eol: 2023-09-06
     latest: "1.19.13"
     latestReleaseDate: 2023-09-06
 


### PR DESCRIPTION
update go1.19.x release eol to match with 1.19.13 release date

<img width="1212" alt="image" src="https://github.com/endoflife-date/endoflife.date/assets/1580956/c07ae576-8919-4e31-bba2-cd4431ae71ee">
