### PR TITLE
Quarkus 3.6.3 released

### DIFF
--- a/products/quarkus.md
+++ b/products/quarkus.md
@@ -30,8 +30,8 @@ releases:
     releaseDate: 2023-11-29
     eol: false
     extendedSupport: false
-    latest: "3.6.1"
-    latestReleaseDate: 2023-12-06
+    latest: "3.6.3"
+    latestReleaseDate: 2023-12-13
 
 -   releaseCycle: "3.5"
     releaseDate: 2023-10-25


### PR DESCRIPTION
# :grey_question: About

[Quarkus 3.6.3 has just been released](https://quarkus.io/blog/quarkus-3-6-3-released/)
![image](https://github.com/endoflife-date/endoflife.date/assets/5235127/300fdae8-2065-4301-b4b3-023310305821)

# :scroll:  Full changelog

![image](https://github.com/endoflife-date/endoflife.date/assets/5235127/dcf8d757-a0ed-4351-badd-20365b10ea73)


You can get [the full changelog of 3.6.2](https://github.com/quarkusio/quarkus/releases/tag/3.6.2) and [3.6.3](https://github.com/quarkusio/quarkus/releases/tag/3.6.3) on GitHub.