### PR TITLE
Use date instead of date-time in JSON schema.

### DIFF
--- a/product-schema.json
+++ b/product-schema.json
@@ -293,7 +293,7 @@
       "oneOf": [
         {
           "type": "string",
-          "format": "date-time"
+          "format": "date"
         },
         {
           "type": "boolean"
@@ -406,15 +406,7 @@
         "eol": {
           "title": "EOL",
           "description": "Date in the format `yyyy-mm-dd` or `false` if not available.",
-          "oneOf": [
-            {
-              "type": "boolean"
-            },
-            {
-              "type": "string",
-              "format": "date-time"
-            }
-          ]
+          "$ref": "#/$defs/boolOrDate"
         },
         "activeSupportColumn": {
           "title": "Active support column",


### PR DESCRIPTION
Dates are flagged as invalid when checked against the JSON schema because it uses `date-time` format.  Changing to `date` format gives the desired behaviour.