### PR TITLE
[panos] Updated PAN-OS 11.1 EOL date and PAN-OS 10.1.11-h4

### DIFF
--- a/products/pan-os.md
+++ b/products/pan-os.md
@@ -13,7 +13,7 @@ eolColumn: End-of-life Date
 releases:
 -   releaseCycle: "11.1"
     releaseDate: 2023-11-03
-    eol: 2026-05-03
+    eol: 2027-05-03
     latest: "11.1"
     latestReleaseDate: 2023-11-03
     link: 

--- a/products/pan-os.md
+++ b/products/pan-os.md
@@ -38,10 +38,10 @@ releases:
 -   releaseCycle: "10.1"
     releaseDate: 2021-05-31
     eol: 2024-12-01
-    latest: "10.1.11-h1"
-    latestReleaseDate: 2023-11-02
+    latest: "10.1.11-h4"
+    latestReleaseDate: 2023-12-14
     link: 
-      https://docs.paloaltonetworks.com/pan-os/10-1/pan-os-release-notes/pan-os-10-1-11-known-and-addressed-issues/pan-os-10-1-11-h1-addressed-issues
+      https://docs.paloaltonetworks.com/pan-os/10-1/pan-os-release-notes/pan-os-10-1-11-known-and-addressed-issues/pan-os-10-1-11-h4-addressed-issues
 
 -   releaseCycle: "10.0"
     releaseDate: 2020-07-16


### PR DESCRIPTION
Updated PAN-OS 11.1 EOL date.

![image](https://github.com/endoflife-date/endoflife.date/assets/3140504/0a8833a7-ea53-4f2e-82b9-e1178bc31b97)

Updated PAN-OS 10.1.11-h4 
Released: 2023/12/14
https://docs.paloaltonetworks.com/pan-os/10-1/pan-os-release-notes/pan-os-10-1-11-known-and-addressed-issues/pan-os-10-1-11-h4-addressed-issues
