### PR TITLE
[dotnet] Improve regex

### DIFF
--- a/products/dotnet.md
+++ b/products/dotnet.md
@@ -8,7 +8,7 @@ alternate_urls:
 -   /dotnetcore
 versionCommand: dotnet --version
 releasePolicyLink: https://dotnet.microsoft.com/platform/support/policy/dotnet-core
-changelogTemplate: 
+changelogTemplate:
   https://github.com/dotnet/core/blob/main/release-notes/{{"__LATEST__"|split:'.'|slice:0,2|join:'.'}}/__LATEST__/__LATEST__.md
 releaseDateColumn: true
 eolColumn: Support Status
@@ -18,6 +18,9 @@ eolColumn: Support Status
 # https://rubular.com/r/CSjmTuMTbmRBQZ
 auto:
 -   git: https://github.com/dotnet/core.git
+    # Excludes 3 digit patch versions, such as https://github.com/dotnet/core/releases/tag/v3.1.201,
+    # which looks a bit special and break semver.
+    regex: '^v?(?P<major>[1-9]\d*)\.(?P<minor>\d+)(\.(?P<patch>\d{,2}))?$'
 
 identifiers:
 -   purl: pkg:nuget/Microsoft.NETCore.App


### PR DESCRIPTION
Excludes 3 digit patch versions, such as https://github.com/dotnet/core/releases/tag/v3.1.201, which looks a bit special and break semver.