### PR TITLE
[kdeplasma] Improve regex

### DIFF
--- a/products/kdeplasma.md
+++ b/products/kdeplasma.md
@@ -14,6 +14,12 @@ eolColumn: Critical bug fixes
 
 auto:
 -   git: https://github.com/KDE/plasma-desktop.git
+    # Excludes 80 or 90 minor and patch versions, such as https://kde.org/announcements/plasma/5/5.26.90/,
+    # which are disguised beta releases.
+    regex:
+    -   '^v?(?P<major>[1-9]\d*)\.(?P<minor>\d)(\.(?P<patch>\d)(\.(?P<tiny>\d+))?)?$' # single-digit minor or patch
+    -   '^v?(?P<major>[1-9]\d*)\.(?P<minor>[0-7]\d*)(\.(?P<patch>\d)(\.(?P<tiny>\d+))?)?$' # double-digits minor < 80
+    -   '^v?(?P<major>[1-9]\d*)\.(?P<minor>\d+)(\.(?P<patch>[0-7]\d*)(\.(?P<tiny>\d+))?)?$' # double-digits patch < 80
 
 releases:
 -   releaseCycle: "5.27"


### PR DESCRIPTION
Excludes 80 or 90 minor and patch versions, such as https://kde.org/announcements/plasma/5/5.26.90/, which are disguised beta releases.