### PR TITLE
Refactor and improve latest.py script

### DIFF
--- a/.github/workflows/auto-merge-release-updates.yml
+++ b/.github/workflows/auto-merge-release-updates.yml
@@ -33,7 +33,7 @@ jobs:
 
       - id: latest
         name: Update latest releases
-        run: python _auto/latest.py
+        run: python _auto/latest.py -p 'products/' -d '_data/release-data/releases'
 
       - name: Update latest and latestReleaseDate
         uses: stefanzweifel/git-auto-commit-action@v5

--- a/_auto/deploy.sh
+++ b/_auto/deploy.sh
@@ -1,16 +1,18 @@
 #!/bin/bash -e
 
 # Display context information
+echo "Current directory: $PWD"
 echo "Current commit: $(git rev-parse HEAD)"
 echo "Ruby version: $(ruby --version)"
 echo "Python version: $(python --version)"
 echo "Jekyll version: $(bundle exec jekyll --version)"
 echo "Deploy URL: $1"
 
-# Update latest product information, see https://github.com/endoflife-date/endoflife.date/pull/2081
+# See https://github.com/endoflife-date/endoflife.date/pull/2081
+echo "Updating latest product information..."
 pip install -r requirements.txt
 git submodule update --remote
-if ! python3 _auto/latest.py ; then # if the latest.py script fails...
+if ! python3 '_auto/latest.py' -p 'products/' -d '_data/release-data/releases'; then # if the latest.py script fails...
   git checkout -- products/ # ...just undo the changes, and carry on
 fi
 
@@ -20,5 +22,5 @@ if [ -n "$1" ]; then
   sed -i "/url\:/curl\: $1" _config.yml
 fi
 
-# Finally, do a full build
+echo "Building site..."
 bundle exec jekyll build --trace

--- a/products/apache-hadoop.md
+++ b/products/apache-hadoop.md
@@ -76,8 +76,8 @@ releases:
 -   releaseCycle: "2.5"
     releaseDate: 2014-09-11
     eol: 2015-11-19
-    latest: "2.5.0"
-    latestReleaseDate: 2015-11-19
+    latest: "2.5.2"
+    latestReleaseDate: 2014-11-20
 
 -   releaseCycle: "2.4"
     releaseDate: 2014-04-10

--- a/products/apache-maven.md
+++ b/products/apache-maven.md
@@ -30,7 +30,7 @@ releases:
     support: 2014-02-18
     eol: 2014-02-18
     latest: "2.2.1"
-    latestReleaseDate: 2009-11-08
+    latestReleaseDate: 2009-08-06
 
 -   releaseCycle: "1"
     releaseDate: 2004-07-13

--- a/products/exim.md
+++ b/products/exim.md
@@ -8,7 +8,7 @@ releaseDateColumn: true
 # https://rubular.com/r/oNyoh1qDT1V2eF
 auto:
 -   git: https://github.com/Exim/exim
-    regex:
+    regex: 
       ^exim-(?<major>[3-9])(\.|_)(?<minor>\d+)((\.|_)(?<patch>\d+)((\.|_)(?<tiny>\d+))?)?$
 
 identifiers:
@@ -65,7 +65,7 @@ releases:
     releaseDate: 2017-12-19
     eol: 2018-04-15
     latest: "4.90.1"
-    latestReleaseDate: 2018-02-10
+    latestReleaseDate: 2018-02-08
     link: https://github.com/Exim/exim/releases/tag/exim-4_90_1
 
 -   releaseCycle: "4.89"

--- a/products/grails.md
+++ b/products/grails.md
@@ -55,7 +55,7 @@ releases:
     support: false
     eol: 2012-05-01
     latest: "1.3.9"
-    latestReleaseDate: 2012-05-01
+    latestReleaseDate: 2015-01-16
 
 ---
 

--- a/products/laravel.md
+++ b/products/laravel.md
@@ -27,7 +27,7 @@ releases:
     support: 2024-08-06
     eol: 2025-02-04
     supportedPhpVersions: 8.1 - 8.2
-    latest: '10.37.2'
+    latest: '10.37.3'
     latestReleaseDate: 2023-12-13
 
 -   releaseCycle: "9"

--- a/products/squid.md
+++ b/products/squid.md
@@ -58,7 +58,7 @@ releases:
     releaseDate: 2015-01-13
     eol: 2018-08-07
     latest: '3.5.28'
-    latestReleaseDate: 2018-07-15
+    latestReleaseDate: 2018-07-16
 
 -   releaseCycle: "3.4"
     releaseDate: 2013-12-08

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,4 @@
-deepdiff==6.7.1
-ordered-set==4.1.0
 python-frontmatter==1.0.1
-PyYAML==6.0.1
 ruamel.yaml==0.18.5
 ruamel.yaml.clib==0.2.8
 packaging==23.2


### PR DESCRIPTION
- Add some logging (with debug logging that can be activate using the --verbose argument).
- Simplify how the script is working, by trying to match each version against the product file. The script do not try anymore to find the oldest and newest version of a cycle first.
- Refactor to use a Product and a ReleaseCycle classes. This is making the script more simple to read.
- Log latest versions that are not listed in the JSON versions file. This does necessarily not indicate an error, but it is nice to know.
- Check that the version file exists before trying to update the related product.

A few versions were updated by this new script. Each has been checked and are legit. They were probably due to bugs in the previous script version.

The script now requires explicit directory pathes arguments to work. This is mainly because it will be moved to the release-data someday. It makes more sense as it closely related to the JSON version file format, which we more subject to change than the product file format.