### PR TITLE
Delete a few little-used tags

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -56,20 +56,24 @@ category: os
 
 # Tags of the product (optional).
 #
-# Tags :
+# Remember that no tag is better than a useless tag. So do not introduce new tags when adding a product
+# and use one of the tags listed on https://endoflife.date/tags/.
+#
+# Should you want to add a new tag, please open an issue first to discuss it with the team.
+# Moreover, any new tag must be applied in a single PR to all products that should have it.
+#
+# Rules about tags are the following:
 # - must match [a-z0-9\-]+,
 # - must be declared with a space-separated string,
 # - must be alphabetically ordered,
 # - must use singular (for example web-server, not web-servers),
-# - should be used at least twice,
+# - must not be an existing category (note that categories are automatically used as tags),
+# - should be used at least three times, except for tags representing a vendor or a runtime dependency,
 # - must be added for one of the following reasons :
 #   - set a product family such as linux-distribution, web-browser, mobile-phone or web-server,
 #   - set a product vendor such as adobe, amazon or apache,
 #   - set a runtime dependency such as java-runtime, javascript-runtime or php-runtime.
-#
-# Remember that no tag is better than a useless tag. Also, note that categories are automatically tags, but don't
-# use another category as a tag.
-tags: amazon linux
+tags: amazon linux-distribution
 
 # Simple Icons (https://simpleicons.org/) icon slug (optional).
 # Remove this property if the icon is not available on Simple Icons.
@@ -316,7 +320,7 @@ releases:
     # Only provide for a release that will get much longer support than usual.
     # Alternatively, this can be set to a date when the product is not labeled
     # as LTS when it is released (ex. Angular) or when normal versions are
-    # promoted LTS after their release (ex. Jenkins). 
+    # promoted LTS after their release (ex. Jenkins).
     lts: true
 
     # End of active support date (optional if activeSupportColumn is false, else mandatory).

--- a/_redirects
+++ b/_redirects
@@ -38,3 +38,11 @@ layout: null
 
 # Send API 404 responses in JSON
 /api/* /assets/404.json 404
+
+# A few permanent redirects for removed pages
+/tags/api-gateway                  /tags/web-server
+/tags/configuration-management     /
+/tags/library                      /tags/framework
+/tags/managed-mysql                /tags/db
+/tags/managed-postgresql           /tags/db
+/tags/package-manager              /tags/build-tool

--- a/products/amazon-rds-mysql.md
+++ b/products/amazon-rds-mysql.md
@@ -1,7 +1,7 @@
 ---
 title: Amazon RDS for MySQL
 category: service
-tags: amazon managed-mysql
+tags: amazon
 iconSlug: amazonrds
 permalink: /amazon-rds-mysql
 releasePolicyLink:

--- a/products/amazon-rds-postgresql.md
+++ b/products/amazon-rds-postgresql.md
@@ -1,10 +1,10 @@
 ---
 title: Amazon RDS for PostgreSQL
 category: service
-tags: amazon managed-postgresql
+tags: amazon
 iconSlug: amazonrds
 permalink: /amazon-rds-postgresql
-releasePolicyLink: 
+releasePolicyLink:
   https://docs.aws.amazon.com/AmazonRDS/latest/PostgreSQLReleaseNotes/postgresql-release-calendar.html
 releaseDateColumn: true
 

--- a/products/cert-manager.md
+++ b/products/cert-manager.md
@@ -1,7 +1,7 @@
 ---
 title: cert-manager
 category: app
-tags: cncf configuration-management
+tags: cncf
 permalink: /cert-manager
 alternate_urls:
 -   /cert-manager

--- a/products/kong-gateway.md
+++ b/products/kong-gateway.md
@@ -1,7 +1,7 @@
 ---
 title: Kong Gateway
 category: server-app
-tags: api-gateway
+tags: web-server
 permalink: /kong-gateway
 alternate_urls:
 -   /kong

--- a/products/puppet.md
+++ b/products/puppet.md
@@ -1,7 +1,6 @@
 ---
 title: Puppet
 category: server-app
-tags: configuration-management
 iconSlug: puppet
 permalink: /puppet
 alternate_urls:
@@ -25,7 +24,7 @@ releases:
     eol: false
     latest: "8.3.1"
     latestReleaseDate: 2023-10-26
-    link: 
+    link:
       https://www.puppet.com/docs/puppet/8/release_notes_puppet.html#release_notes_puppet_x-8-1-0
 
 -   releaseCycle: "7"
@@ -33,7 +32,7 @@ releases:
     eol: false
     latest: "7.27.0"
     latestReleaseDate: 2023-10-23
-    link: 
+    link:
       https://www.puppet.com/docs/puppet/7/release_notes_puppet.html#release_notes_puppet_x-7-25-0
 
 -   releaseCycle: "6"
@@ -41,7 +40,7 @@ releases:
     eol: 2023-02-01
     latest: "6.29.0"
     latestReleaseDate: 2023-01-24
-    link: 
+    link:
       https://www.puppet.com/docs/puppet/6/release_notes_puppet.html#release_notes_puppet
 
 -   releaseCycle: "5"
@@ -56,7 +55,7 @@ releases:
     eol: 2018-10-01 # No official source available. It was announced in the IRC channel at that time.
     latest: "4.10.13"
     latestReleaseDate: 2018-12-19
-    link: 
+    link:
       https://github.com/puppetlabs/docs-archive/blob/main/puppet/4.10/release_notes.markdown
 
 -   releaseCycle: "3"
@@ -64,7 +63,7 @@ releases:
     eol: 2017-01-01 # No official source available. It was announced in the IRC channel at that time.
     latest: "3.8.7"
     latestReleaseDate: 2016-04-25
-    link: 
+    link:
       https://github.com/puppetlabs/docs-archive/blob/main/puppet/3.8/release_notes.markdown
 
 ---

--- a/products/react.md
+++ b/products/react.md
@@ -1,6 +1,6 @@
 ---
 title: React
-category: library
+category: framework
 tags: meta javascript-runtime
 iconSlug: react
 permalink: /react

--- a/products/yarn.md
+++ b/products/yarn.md
@@ -1,7 +1,7 @@
 ---
 title: Yarn
 category: app
-tags: package-manager javascript-runtime
+tags: build-tool javascript-runtime
 iconSlug: yarn
 permalink: /yarn
 versionCommand: yarn --version


### PR DESCRIPTION
There is no point in having tags only used by one or two products, except for category tags and tags linked to company names. This removed or replace some little-used tags:

- Removed `managed-mysql` and `managed-postgresql`, which was only used by Amazon RDS products (with little chance to be used elsewhere).
- Removed `configuration-management`, which was really long and only used by cert-manager and puppet. It could be replaced in the future by something like an `infra-as-code` tag that have more chance to be used on more products.
- Replaced `api-gateway`, which was only used by Kong, by the more general tag `web-server`.
- Replaced `library` by `framework`. It which was only by React, which is indeed a library, but using framework makes sense in the context of endoflife.date.
- Replaced `package-manager`, which was used by yarn, by the more generic `build-tool` tag.

Also:
- Set up redirects for removed tags.
- Clarify a bit the documentation about tags.