### PR TITLE
Convert Ruby regexes to Python regexes

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -218,15 +218,15 @@ auto:
   # For example, for Apache Maven:
   - git: https://github.com/apache/maven.git
 
-    # Ruby-compatible regex that defines how the tags above should translate to releases
-    # (optional, default can be found on https://github.com/endoflife-date/release-data/blob/main/update.rb#L19-L20 ).
-    # Use named capturing groups to capture the version or version's parts.
+    # Python-compatible regex that defines how the tags above should translate to releases (optional).
+    # The default regex can handle versions having at least 2 digits (ex. 1.2) and at most 4 digits (ex. 1.2.3.4),
+    # with an optional leading "v"). Use named capturing groups to capture the version or version's parts.
     # Default value should work for most releases of the form a.b, a.b.c or 'v'a.b.c. It should also
     # skip over any special releases (such as nightly,beta,pre,rc...).
     regex: ^v(?<major>\d+)_(?<minor>\d+)_(?<patch>\d{1,3})_?(?<tiny>\d+)?$
 
     # A liquid template using the captured variables from the regex above that renders the final version
-    # (optional, default can be found on https://github.com/endoflife-date/release-data/blob/main/update.rb#L19-L20 ).
+    # (optional, default can handle versions having a 'major', 'minor', 'patch' and 'tiny' version).
     # You can use liquid templating here.
     template: '{{major}}.{{minor}}.{{patch}}{%if tiny %}p{{tiny}}{%endif%}'
 
@@ -316,7 +316,7 @@ releases:
     # Only provide for a release that will get much longer support than usual.
     # Alternatively, this can be set to a date when the product is not labeled
     # as LTS when it is released (ex. Angular) or when normal versions are
-    # promoted LTS after their release (ex. Jenkins). 
+    # promoted LTS after their release (ex. Jenkins).
     lts: true
 
     # End of active support date (optional if activeSupportColumn is false, else mandatory).

--- a/products/alibaba-dragonwell.md
+++ b/products/alibaba-dragonwell.md
@@ -7,7 +7,7 @@ permalink: /alibaba-dragonwell
 alternate_urls:
 -   /dragonwell
 versionCommand: java -version
-releasePolicyLink: 
+releasePolicyLink:
   https://github.com/dragonwell-project/dragonwell17/wiki/Alibaba-Dragonwell-Support
 changelogTemplate: "https://github.com/dragonwell-project/dragonwell__RELEASE_CYCLE__/wiki/Alibaba-Dragonwell-__RELEASE_CYCLE__-Standard-Edition-Release-Notes"
 releaseDateColumn: true
@@ -23,41 +23,41 @@ identifiers:
 -   repology: jdk11-dragonwell-extended
 -   repology: jdk11-dragonwell-standard
 -   purl: pkg:docker/alibabadragonwell/dragonwell
--   purl: 
+-   purl:
       pkg:oci/dragonwell?repository_url=dragonwell-registry.cn-hangzhou.cr.aliyuncs.com/dragonwell/dragonwell
 # Alibaba Cloud Linux OS plus repository, but only for x86_64 architecture
--   purl: 
+-   purl:
       pkg:rpm/aliyun/java-1.8.0-alibaba-dragonwell?repository_url=http://mirrors.aliyun.com/alinux/2.1903/plus/x86_64/
 
 # There is one repository for each major LTS release.
 # And yes, tagging at Alibaba is a mess !
 auto:
 -   git: "https://github.com/dragonwell-project/dragonwell8.git"
-    regex: '^dragonwell-standard-(?<version>[\d\.\+]+)_jdk.+-ga$'
+    regex: '^dragonwell-standard-(?P<version>[\d\.\+]+)_jdk.+-ga$'
     template: '{{version}}'
 -   git: "https://github.com/dragonwell-project/dragonwell8.git"
-    regex: '^dragonwell-(?<version>[\d\.\+]+)_jdk.+-ga$'
+    regex: '^dragonwell-(?P<version>[\d\.\+]+)_jdk.+-ga$'
     template: '{{version}}'
 -   git: "https://github.com/dragonwell-project/dragonwell8.git"
-    regex: '^dragonwell-(?<version>[\d\.\+]+)-GA$'
+    regex: '^dragonwell-(?P<version>[\d\.\+]+)-GA$'
     template: '{{version}}'
 -   git: "https://github.com/dragonwell-project/dragonwell8.git"
-    regex: '^v(?<version>[\d\.\+]+)-GA$'
+    regex: '^v(?P<version>[\d\.\+]+)-GA$'
     template: '{{version}}'
 -   git: "https://github.com/dragonwell-project/dragonwell11.git"
-    regex: '^dragonwell-standard-(?<version>[\d\.\+]+)_jdk.+-ga$'
+    regex: '^dragonwell-standard-(?P<version>[\d\.\+]+)_jdk.+-ga$'
     template: '{{version}}'
 -   git: "https://github.com/dragonwell-project/dragonwell11.git"
-    regex: '^dragonwell[-_](?<version>[\d\.\+]+)_.+-ga$'
+    regex: '^dragonwell[-_](?P<version>[\d\.\+]+)_.+-ga$'
     template: '{{version}}'
 -   git: "https://github.com/dragonwell-project/dragonwell17.git"
-    regex: '^dragonwell-standard-(?<version>17[\d\.\+]+)_jdk.+-ga$'
+    regex: '^dragonwell-standard-(?P<version>17[\d\.\+]+)_jdk.+-ga$'
     template: '{{version}}'
 -   git: "https://github.com/dragonwell-project/dragonwell17.git"
-    regex: '^dragonwell-(?<version>17[\d\.\+]+)_jdk.+-ga$'
+    regex: '^dragonwell-(?P<version>17[\d\.\+]+)_jdk.+-ga$'
     template: '{{version}}'
 -   git: "https://github.com/dragonwell-project/dragonwell17.git"
-    regex: '^jdk-(?<version>17[\d\.\+]+)-ga$'
+    regex: '^jdk-(?P<version>17[\d\.\+]+)-ga$'
     template: '{{version}}'
 
 # Do not forget to update the "auto" configuration on each new major release.
@@ -85,7 +85,7 @@ releases:
     eol: 2026-06-30
     latest: "8.16.17"
     latestReleaseDate: 2023-08-08
-    link: 
+    link:
       https://github.com/dragonwell-project/dragonwell8/wiki/Alibaba-Dragonwell8-Standard-Edition-Release-Notes
 
 ---

--- a/products/apache-activemq.md
+++ b/products/apache-activemq.md
@@ -15,7 +15,7 @@ eolColumn: Support
 
 auto:
 -   git: https://github.com/apache/activemq.git
-    regex: '^activemq-(?<major>\d+)\.(?<minor>\d+)(\.(?<patch>\d+))?$'
+    regex: '^activemq-(?P<major>\d+)\.(?P<minor>\d+)(\.(?P<patch>\d+))?$'
 
 # eol(x) = releaseCycle(x+2)
 # link(x) =

--- a/products/apache-cassandra.md
+++ b/products/apache-cassandra.md
@@ -12,7 +12,7 @@ releaseDateColumn: true
 
 auto:
 -   git: https://github.com/apache/cassandra.git
-    regex: '^cassandra-(?<major>[0-9]+)\.(?<minor>[0-9]+)(\.(?<patch>[0-9]+))?$'
+    regex: '^cassandra-(?P<major>[0-9]+)\.(?P<minor>[0-9]+)(\.(?P<patch>[0-9]+))?$'
 
 releases:
 -   releaseCycle: "4.1"

--- a/products/apache-hadoop.md
+++ b/products/apache-hadoop.md
@@ -14,7 +14,7 @@ versionCommand: hadoop version
 
 auto:
 -   git: https://github.com/apache/hadoop.git
-    regex: '^(rel\/)?release-(?<major>[1-9][0-9]*)\.(?<minor>[0-9]+)(\.(?<patch>[0-9]+))?$'
+    regex: '^(rel\/)?release-(?P<major>[1-9][0-9]*)\.(?P<minor>[0-9]+)(\.(?P<patch>[0-9]+))?$'
 
 # EOL(x) = latestReleaseDate(x) (if the release is not active anymore)
 # Active releases are documented on https://cwiki.apache.org/confluence/display/HADOOP/Hadoop+Active+Release+Lines.

--- a/products/clamav.md
+++ b/products/clamav.md
@@ -8,7 +8,7 @@ releaseDateColumn: true
 
 auto:
 -   git: https://github.com/Cisco-Talos/clamav.git
-    regex: '^clamav-(?<major>[0-9]+)\.(?<minor>[0-9]+)(\.(?<patch>[0-9]+))?$'
+    regex: '^clamav-(?P<major>[0-9]+)\.(?P<minor>[0-9]+)(\.(?P<patch>[0-9]+))?$'
 
 # See https://docs.clamav.net/faq/faq-eol.html#version-support-matrix for EOL dates
 releases:

--- a/products/docker-engine.md
+++ b/products/docker-engine.md
@@ -14,7 +14,7 @@ identifiers:
 
 auto:
 -   git: https://github.com/moby/moby.git
-    regex: ^v(?<major>\d+)\.(?<minor>\d+)\.(?<patch>\d+)(-ce)?$
+    regex: ^v(?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(-ce)?$
 
 releases:
 -   releaseCycle: "24.0"

--- a/products/dotnet.md
+++ b/products/dotnet.md
@@ -13,14 +13,11 @@ changelogTemplate:
 releaseDateColumn: true
 eolColumn: Support Status
 
-# The regex ignores 3 digit patch versions, which are incorrect tags upstream
-# such as https://github.com/dotnet/core/releases/tag/v3.1.201
-# https://rubular.com/r/CSjmTuMTbmRBQZ
 auto:
 -   git: https://github.com/dotnet/core.git
     # Excludes 3 digit patch versions, such as https://github.com/dotnet/core/releases/tag/v3.1.201,
-    # which looks a bit special and break semver.
-    regex: '^v?(?P<major>[1-9]\d*)\.(?P<minor>\d+)(\.(?P<patch>\d{,2}))?$'
+    # which looks a bit special and break semver (see https://regex101.com/r/oDhccW/1).
+    regex: '^v?(?P<major>[1-9]\d*)\.(?P<minor>\d+)(\.(?P<patch>\d{1,2}))?$'
 
 identifiers:
 -   purl: pkg:nuget/Microsoft.NETCore.App

--- a/products/erlang.md
+++ b/products/erlang.md
@@ -12,7 +12,7 @@ releaseDateColumn: true
 
 auto:
 -   git: https://github.com/erlang/otp.git
-    regex: ^OTP-(?<version>\d+(\.\d+){0,3})$
+    regex: ^OTP-(?P<version>\d+(\.\d+){0,3})$
     template: "{{version}}"
 
 # eol(x) = MAX(releaseDate(x) + 3 years, latestReleaseDate(x))

--- a/products/exim.md
+++ b/products/exim.md
@@ -5,11 +5,10 @@ permalink: /exim
 releasePolicyLink: https://github.com/Exim/exim/wiki/EximReleasePolicy
 releaseDateColumn: true
 
-# https://rubular.com/r/oNyoh1qDT1V2eF
 auto:
 -   git: https://github.com/Exim/exim
-    regex: 
-      ^exim-(?<major>[3-9])(\.|_)(?<minor>\d+)((\.|_)(?<patch>\d+)((\.|_)(?<tiny>\d+))?)?$
+    # https://regex101.com/r/jDuVex/1
+    regex: ^exim-(?P<major>[3-9])(\.|_)(?P<minor>\d+)((\.|_)(?P<patch>\d+)((\.|_)(?P<tiny>\d+))?)?$
 
 identifiers:
 -   repology: exim

--- a/products/ffmpeg.md
+++ b/products/ffmpeg.md
@@ -13,7 +13,7 @@ eolColumn: Supported
 auto:
 # upstream https://git.ffmpeg.org/ffmpeg.git doesn't support filtering
 -   git: https://github.com/FFmpeg/FFmpeg.git
-    regex: '^n?(?<major>[1-9]\d*)\.(?<minor>\d+)\.?(?<patch>\d+)?$'
+    regex: '^n?(?P<major>[1-9]\d*)\.(?P<minor>\d+)\.?(?P<patch>\d+)?$'
 
 # EOL date can be found on https://ffmpeg.org/olddownload.html
 releases:

--- a/products/gitlab.md
+++ b/products/gitlab.md
@@ -14,9 +14,8 @@ eolColumn: Maintenance Support
 eolWarnThreshold: 60
 
 auto:
-# Reference: https://rubular.com/r/mFfxB8FgXXERX4
 -   git: https://gitlab.com/gitlab-org/gitlab.git
-    regex: '^v?(?<major>[1-9]\d*)\.(?<minor>\d+)\.(?<patch>\d+)-ee?$'
+    regex: '^v?(?P<major>[1-9]\d*)\.(?P<minor>\d+)\.(?P<patch>\d+)-ee?$'
 
 
 # support(x) = releaseDate(x+1)

--- a/products/go.md
+++ b/products/go.md
@@ -22,7 +22,7 @@ identifiers:
 
 auto:
 -   git: https://github.com/golang/go.git
-    regex: ^go(?<major>[1-9]\d*)\.(?<minor>\d+)\.?(?<patch>\d+)?$
+    regex: ^go(?P<major>[1-9]\d*)\.(?P<minor>\d+)\.?(?P<patch>\d+)?$
 
 # eol(x) = releaseDate(x+2)
 releases:

--- a/products/godot.md
+++ b/products/godot.md
@@ -14,7 +14,7 @@ releaseDateColumn: true
 
 auto:
 -   git: https://github.com/godotengine/godot.git
-    regex: ^(?<version>\d+(\.\d+){1,3})-stable$
+    regex: ^(?P<version>\d+(\.\d+){1,3})-stable$
     template: "{{version}}"
 
 # Do not forget to remove the link after the first patch release.

--- a/products/gradle.md
+++ b/products/gradle.md
@@ -13,9 +13,9 @@ eolColumn: Critical Bug and Security Fixes
 
 auto:
 -   git: https://github.com/gradle/gradle.git
-    # regex to exclude versions below 3.x for tags with wrong dates see https://github.com/endoflife-date/endoflife.date/pull/3619
-    # https://rubular.com/r/Q94JVYzjli8WC8
-    regex: ^v?(?<major>([3-9]|\d{2,}))\.(?<minor>\d+)\.?(?<patch>\d+)?$
+    # Regex to exclude versions below 3.x for tags with wrong dates (https://github.com/endoflife-date/endoflife.date/pull/3619).
+    # See https://regex101.com/r/UutXqX/1.
+    regex: ^v?(?P<major>([3-9]|\d{2,}))\.(?P<minor>\d+)\.?(?P<patch>\d+)?$
 
 # support(x) = releaseDate(x+1)
 # eol(x) = releaseDate(x+2)

--- a/products/gstreamer.md
+++ b/products/gstreamer.md
@@ -11,7 +11,7 @@ eolColumn: Supported
 
 auto:
 -   git: https://gitlab.freedesktop.org/gstreamer/gstreamer.git
-    regex: '^(?<major>[1-9]\d*)\.(?<minor>([1-9]\d*)?[02468])\.?(?<patch>\d+)?$'
+    regex: '^(?P<major>[1-9]\d*)\.(?P<minor>([1-9]\d*)?[02468])\.?(?P<patch>\d+)?$'
 
 releases:
 -   releaseCycle: "1.22"

--- a/products/hbase.md
+++ b/products/hbase.md
@@ -13,7 +13,7 @@ eolColumn: Service Status
 
 auto:
 -   git: https://github.com/apache/hbase.git
-    regex: '^rel\/(?<major>\d+)\.(?<minor>\d+)\.(?<patch>\d+)(\.(?<tiny>\d+))?$'
+    regex: '^rel\/(?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(\.(?P<tiny>\d+))?$'
 
 releases:
 -   releaseCycle: "2.5"

--- a/products/jenkins.md
+++ b/products/jenkins.md
@@ -11,7 +11,7 @@ eolColumn: Support
 
 auto:
 -   git: https://github.com/jenkinsci/jenkins.git
-    regex: '^jenkins-(?<major>[0-9]+)\.(?<minor>[0-9]+)(\.(?<patch>[0-9]+))?$'
+    regex: '^jenkins-(?P<major>[0-9]+)\.(?P<minor>[0-9]+)(\.(?P<patch>[0-9]+))?$'
 
 # releaseCycle 2 catches weekly releases, other releases are LTS.
 #

--- a/products/kubernetes.md
+++ b/products/kubernetes.md
@@ -7,9 +7,9 @@ alternate_urls:
 -   /k8s
 versionCommand: kubectl version
 releasePolicyLink: https://kubernetes.io/releases/patch-releases/
-releaseImage: 
+releaseImage:
   https://upload.wikimedia.org/wikipedia/en/timeline/fxdhzv3oeut1ywyfx5ubxghu9fnow69.png
-changelogTemplate: 
+changelogTemplate:
   https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-__RELEASE_CYCLE__.md
 releaseDateColumn: true
 activeSupportColumn: true
@@ -17,7 +17,7 @@ eolColumn: Maintenance Support
 
 auto:
 -   git: https://github.com/kubernetes/kubernetes.git
-    regex: ^v(?<major>[1-9]\d*)\.(?<minor>\d+)\.(?<patch>\d+)$
+    regex: ^v(?P<major>[1-9]\d*)\.(?P<minor>\d+)\.(?P<patch>\d+)$
 
 # Support and EOL dates can be found on https://kubernetes.io/releases/patch-releases/#detailed-release-history-for-active-branches
 releases:

--- a/products/mariadb.md
+++ b/products/mariadb.md
@@ -24,20 +24,27 @@ identifiers:
 
 auto:
 -   git: https://github.com/MariaDB/server.git
-    # This is not a complicated regex. It only marks the first GA release in each release cycle
-    # So we drop any releases before the GA ones
-    # 5.5.29, 10.0.12, 10.1.18, 10.2.6, 10.3.7, 10.4.6, 10.6.3, 10.5.4, 10.7.2
-    # The regex is ^mariadb-(A|B|C|D)$ where A,B,C,D are sub-matches for each of the cycles
-    # Each cycle itself looks like (?<major>X)\.(?<minor>Y)\.(?<patch>R)
-    # Where X -> Major number, Y = Minor Number
-    # And R is a regex that only matches GA release patch numbers in that cycle. ie
-    # Greater than or equal to the first GA release in that cycle.
-    # For e.g. for matching 10.0.12 -> 10.0.99, we use (?<major>10)\.(?<minor>0)\.(?<patch>(1[2-9]|[2-9]\d))
-    # where (1[2-9]|[2-9]\d) matches 12-19 OR 2-digit numbers starting from 2-9 (ie 20-99)
-    # See https://rubular.com/r/jbw5wsv80lhy9h for sample testcases before you edit.
-    # Note: This will need to be edited when a new GA release is made in a new release cycle
-    regex: 
-      ^mariadb-((?<major>5)\.(?<minor>5)\.(?<patch>(29|[3-9]\d))|(?<major>10)\.(?<minor>0)\.(?<patch>(1[2-9]|[2-9]\d))|(?<major>10)\.(?<minor>1)\.(?<patch>(1[8-9]|[2-9]\d))|(?<major>10)\.(?<minor>2)\.(?<patch>([6-9]|\d{2}))|(?<major>11)\.(?<minor>0)\.(?<patch>([2-9]|\d{2}))|(?<major>11)\.(?<minor>1)\.(?<patch>([2-9]|\d{2}))|(?<major>10)\.(?<minor>4)\.(?<patch>([6-9]|\d{2}))|(?<major>10)\.(?<minor>3)\.(?<patch>([7-9]|\d{2}))|(?<major>10)\.(?<minor>4)\.(?<patch>([6-9]|\d{2}))|(?<major>10)\.(?<minor>5)\.(?<patch>([4-9]|\d{2}))|(?<major>10)\.(?<minor>6)\.(?<patch>([3-9]|\d{2}))|(?<major>10)\.(?<minor>7)\.(?<patch>([2-9]|\d{2}))|(?<major>10)\.(?<minor>8)\.(?<patch>([3-9]|\d{2}))|(?<major>10)\.(?<minor>9)\.(?<patch>([2-9]|\d{2}))|(?<major>10)\.(?<minor>10)\.(?<patch>([2-9]|\d{2}))|(?<major>10)\.(?<minor>11)\.(?<patch>([2-9]|\d{2})))$
+    # Drop any releases before the GA ones.
+    # Each regex looks like (?P<major>X)\.(?P<minor>Y)\.(?P<patch>Z), where X is the major, Y the minor
+    # and Z a regex that only matches GA release patch numbers in that cycle.
+    # Note: This needs to be edited when a new release cycle (a new GA release) is added.
+    regex:
+    -   ^mariadb-(?P<major>5)\.(?P<minor>5)\.(?P<patch>(29|[3-9]\d))$
+    -   ^mariadb-(?P<major>10)\.(?P<minor>0)\.(?P<patch>(1[2-9]|[2-9]\d))$
+    -   ^mariadb-(?P<major>10)\.(?P<minor>1)\.(?P<patch>(1[8-9]|[2-9]\d))$
+    -   ^mariadb-(?P<major>10)\.(?P<minor>2)\.(?P<patch>([6-9]|\d{2}))$
+    -   ^mariadb-(?P<major>10)\.(?P<minor>4)\.(?P<patch>([6-9]|\d{2}))$
+    -   ^mariadb-(?P<major>10)\.(?P<minor>3)\.(?P<patch>([7-9]|\d{2}))$
+    -   ^mariadb-(?P<major>10)\.(?P<minor>4)\.(?P<patch>([6-9]|\d{2}))$
+    -   ^mariadb-(?P<major>10)\.(?P<minor>5)\.(?P<patch>([4-9]|\d{2}))$
+    -   ^mariadb-(?P<major>10)\.(?P<minor>6)\.(?P<patch>([3-9]|\d{2}))$
+    -   ^mariadb-(?P<major>10)\.(?P<minor>7)\.(?P<patch>([2-9]|\d{2}))$
+    -   ^mariadb-(?P<major>10)\.(?P<minor>8)\.(?P<patch>([3-9]|\d{2}))$
+    -   ^mariadb-(?P<major>10)\.(?P<minor>9)\.(?P<patch>([2-9]|\d{2}))$
+    -   ^mariadb-(?P<major>10)\.(?P<minor>10)\.(?P<patch>([2-9]|\d{2}))$
+    -   ^mariadb-(?P<major>10)\.(?P<minor>11)\.(?P<patch>([2-9]|\d{2}))$
+    -   ^mariadb-(?P<major>11)\.(?P<minor>0)\.(?P<patch>([2-9]|\d{2}))$
+    -   ^mariadb-(?P<major>11)\.(?P<minor>1)\.(?P<patch>([2-9]|\d{2}))$
 
 releases:
 -   releaseCycle: "11.2"

--- a/products/microsoft-build-of-openjdk.md
+++ b/products/microsoft-build-of-openjdk.md
@@ -12,13 +12,13 @@ releaseDateColumn: true
 # There is one repository for each major LTS release.
 auto:
 -   git: "https://github.com/microsoft/openjdk-jdk11u.git"
-    regex: '^jdk-(?<version>[\d\.]+)-ga$'
+    regex: '^jdk-(?P<version>[\d\.]+)-ga$'
     template: '{{version}}'
 -   git: "https://github.com/microsoft/openjdk-jdk17u.git"
-    regex: '^jdk-(?<version>[\d\.]+)-ga$'
+    regex: '^jdk-(?P<version>[\d\.]+)-ga$'
     template: '{{version}}'
 -   git: "https://github.com/microsoft/openjdk-jdk21u.git"
-    regex: '^jdk-(?<version>[\d\.]+)-ga$'
+    regex: '^jdk-(?P<version>[\d\.]+)-ga$'
     template: '{{version}}'
 
 # Do not forget to update the "auto" configuration on each new major release.

--- a/products/mongodb.md
+++ b/products/mongodb.md
@@ -29,7 +29,7 @@ identifiers:
 
 auto:
 -   git: https://github.com/mongodb/mongo.git
-    regex: ^r(?<major>\d+)\.(?<minor>\d+)\.(?<patch>\d+)$
+    regex: ^r(?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)$
 
 # Dates are not in sync with https://www.mongodb.com/support-policy/lifecycles because we are using
 # git tag dates.

--- a/products/mysql.md
+++ b/products/mysql.md
@@ -6,20 +6,23 @@ iconSlug: mysql
 permalink: /mysql
 versionCommand: mysqld --version
 releasePolicyLink: https://www.oracle.com/us/support/library/lifetime-support-technology-069183.pdf
-releaseImage: 
+releaseImage:
   https://blogs.oracle.com/content/published/api/v1.1/assets/CONT32EABEA4FBCC4464BD35F58CEEA2EAFD/Medium?format=jpg&channelToken=32954b2a813146c9b9a4fa99364eba8e
 changelogTemplate: "https://dev.mysql.com/doc/relnotes/mysql/__RELEASE_CYCLE__/en/news-{{'__LATEST__'|replace:'.','-'}}.html"
 releaseDateColumn: true
 activeSupportColumn: Premier Support
 eolColumn: Extended Support
 
-# Regex takes into account the first GA release in each cycle (in parentheses)
+# Regexes take into account the first GA release in each cycle.
 # https://dev.mysql.com/doc/refman/8.2/en/faqs-general.html#faq-mysql-version-ga
-# See https://rubular.com/r/qi5jDueXMwunrS.
 auto:
 -   git: https://github.com/mysql/mysql-server.git
-    regex: 
-      ^mysql-(?<v>(5\.5\.([8-9]|\d{2}))|(5\.6\.\d{2})|(5\.7\.([9]|\d{2}))|(8\.0\.(1[1-9]|[2-9]\d))|(8\.[1-9]\.\d+))$
+    regex:
+    -   ^mysql-(?P<v>5\.5\.([8-9]|\d{2})$
+    -   ^mysql-(?P<v>5\.6\.\d{2})$
+    -   ^mysql-(?P<v>5\.7\.([9]|\d{2}))$
+    -   ^mysql-(?P<v>8\.0\.(1[1-9]|[2-9]\d))$
+    -   ^mysql-(?P<v>8\.[1-9]\.\d+)$
     template: "{{v}}"
 
 # dates below are for:

--- a/products/nextcloud.md
+++ b/products/nextcloud.md
@@ -11,7 +11,7 @@ releaseDateColumn: true
 
 auto:
 -   git: https://github.com/nextcloud/server.git
-    regex: ^v(?<major>\d+)\.(?<minor>\d+)\.(?<patch>\d+)$
+    regex: ^v(?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)$
 
 # releaseDate/eol see https://github.com/nextcloud/server/wiki/Maintenance-and-Release-Schedule
 releases:

--- a/products/nexus.md
+++ b/products/nexus.md
@@ -12,8 +12,7 @@ eolColumn: Support
 
 auto:
 -   git: https://github.com/sonatype/nexus-public.git
-    # See https://rubular.com/r/607xFn4zIA4fDw for reference
-    regex: '^release-(?<major>\d+)\.(?<minor>\d+)\.(?<patch>\d+)-(?<tiny>\d+)$'
+    regex: '^release-(?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)-(?P<tiny>\d+)$'
     template: '{{major}}.{{minor}}.{{patch}}-{{tiny}}'
 
 releases:

--- a/products/nginx.md
+++ b/products/nginx.md
@@ -18,10 +18,9 @@ identifiers:
 -   purl: pkg:rpm/centos/nginx
 -   purl: pkg:apk/alpine/nginx
 
-# https://rubular.com/r/bVKLuLKLLrHCTI
 auto:
 -   git: https://github.com/nginx/nginx.git
-    regex: ^release-(?<major>\d+)\.(?<minor>\d+)\.(?<patch>\d+)$
+    regex: ^release-(?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)$
 
 # eol(x) = releaseDate(x+2)
 releases:

--- a/products/openssl.md
+++ b/products/openssl.md
@@ -12,7 +12,7 @@ extendedSupportColumn: Premium support
 
 auto:
 -   git: https://github.com/openssl/openssl.git
-    regex: '^[o|O]pen[s|S][s|S][l|L][-|_](?<major>\d+)[\.|_](?<minor>\d+)[\.|_](?<patch>\d+\w{0,2})?$'
+    regex: '^[o|O]pen[s|S][s|S][l|L][-|_](?P<major>\d+)[\.|_](?P<minor>\d+)[\.|_](?P<patch>\d+\w{0,2})?$'
 
 # EOL dates and LTS infos on https://www.openssl.org/policies/releasestrat.html
 releases:

--- a/products/openwrt.md
+++ b/products/openwrt.md
@@ -12,10 +12,8 @@ changelogTemplate: "https://openwrt.org/releases/{{'__LATEST__'|split:'.'|pop|jo
 releaseDateColumn: true
 activeSupportColumn: true
 
-# https://rubular.com/r/yAjCDkpr90mU0w
 auto:
 -   git: https://github.com/openwrt/openwrt.git
-    regex: ^v(?<major>\d+\.\d+)\.(?<minor>\d+)$
 
 # EOL(R)=MAX(releaseDate(R+1)+6m, releaseDate(R)+1y)
 # Support(R) = releaseDate(R+1)

--- a/products/openzfs.md
+++ b/products/openzfs.md
@@ -14,7 +14,7 @@ eolColumn: Critical bug fixes
 # Ignore the 2.1.99 release, since that's a pre-release (See talk page)
 auto:
 -   git: https://github.com/openzfs/zfs.git
-    regex: ^zfs-(?<major>\d+)\.(?<minor>\d+)\.(?<patch>0|([1-9]|[1-8]\d|9[0-8]))$
+    regex: ^zfs-(?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>0|([1-9]|[1-8]\d|9[0-8]))$
 
 # non-LTS: eol(x) = releaseDate(x+1)
 # LTS: eol(x) = estimation: releaseDate(x) plus 2 years

--- a/products/perl.md
+++ b/products/perl.md
@@ -4,7 +4,7 @@ category: lang
 iconSlug: perl
 permalink: /perl
 versionCommand: perl -v
-releaseImage: 
+releaseImage:
   https://www.versio.io/img/product-release-version-end-of-life/Perl_Foundation-Perl.jpg
 releasePolicyLink: https://perldoc.perl.org/perlpolicy#MAINTENANCE-AND-SUPPORT
 changelogTemplate: "https://perldoc.perl.org/__LATEST__/perldelta"
@@ -12,18 +12,17 @@ activeSupportColumn: true
 releaseDateColumn: true
 eolColumn: Critical security patches
 
-# We split the regex into two to deal with differing policies, and tagging schemes before/after 5.26
-# - before 5.26 -> perl-x.00y, perl-x.00y_z, perl-x.00y.z, perl-x.00y.zabc
-# - after  5.26 -> vx.y.z
-#
-# This regex is returning 5.7.x and 5.9.x versions even if it shouldn't (odd versions are
-# 'development' version since 5.6). But considering those are not listed on
-# https://endoflife.date/perl it's an acceptable inconvenient.
-#
-# See https://rubular.com/r/CUbQrJOw8jlOeS
 auto:
 -   git: https://github.com/Perl/perl5.git
-    regex: '^(v(?<major>\d+)\.(?<minor>[1-9]*[02468])\.(?<patch>\d+)?|perl-(?<major>\d+)\.(?<minor>\d+))((\.|\_)(?<patch>\d?\w+))?$'
+    regex:
+    # After  5.26 -> vx.y.z (odd versions are 'development' version since 5.6)
+    # See https://regex101.com/r/eK40Ks/1.
+    - '^v(?P<major>\d+)\.(?P<minor>[1-9]*[02468])\.(?P<patch>\d+)?$'
+    # Before 5.26 -> perl-x.00y, perl-x.00y_z, perl-x.00y.z, perl-x.00y.zabc
+    # This regex is returning 5.7.x and 5.9.x versions even if it shouldn't (odd versions are 'development' version since 5.6).
+    # But considering those are not listed on https://endoflife.date/perl it's an acceptable inconvenient.
+    # See https://regex101.com/r/wGccaP/1.
+    - '^perl-(?P<major>\d+)\.(?P<minor>\d+)([._](?P<patch>\d?\w+))?$'
 
 # Development releases are not listed here, and:
 # - eol dates are always releaseDate + 3 YEARS

--- a/products/phpbb.md
+++ b/products/phpbb.md
@@ -6,10 +6,9 @@ permalink: /phpbb
 releaseDateColumn: true
 activeSupportColumn: true
 
-# https://rubular.com/r/Bw8rQ9JJR5RoEc
 auto:
 -   git: https://github.com/phpbb/phpbb.git
-    regex: ^release-(?<major>\d+)\.(?<minor>\d+)\.(?<patch>\d+)$
+    regex: ^release-(?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)$
 
 releases:
 -   releaseCycle: "3.3"

--- a/products/phpmyadmin.md
+++ b/products/phpmyadmin.md
@@ -11,7 +11,7 @@ releaseDateColumn: true
 
 auto:
 -   git: https://github.com/phpmyadmin/phpmyadmin.git
-    regex: '^RELEASE_(?<major>\d+)_(?<minor>\d+)_(?<patch>\d+)(_(?<tiny>\d+))?$'
+    regex: '^RELEASE_(?P<major>\d+)_(?P<minor>\d+)_(?P<patch>\d+)(_(?P<tiny>\d+))?$'
 
 identifiers:
 -   repology: phpmyadmin

--- a/products/postfix.md
+++ b/products/postfix.md
@@ -9,7 +9,7 @@ releaseDateColumn: true
 # We ignore tags before 3.3 because they don't have the correct date
 auto:
 -   git: https://github.com/vdukhovni/postfix.git
-    regex: ^v(?<major>[3-9])\.(?<minor>[3-9])\.(?<patch>\d+)$
+    regex: ^v(?P<major>[3-9])\.(?P<minor>[3-9])\.(?P<patch>\d+)$
 
 # eol(R) = releaseDate(R+4)
 releases:

--- a/products/postgresql.md
+++ b/products/postgresql.md
@@ -15,8 +15,7 @@ releaseDateColumn: true
 
 auto:
 -   git: https://github.com/postgres/postgres.git
-  # https://rubular.com/r/KlemgnguNe0e5X
-    regex: ^REL_?(?<major>[1-9]\d*)_(?<minor>\d+)_?(?<patch>\d+)?$
+    regex: ^REL_?(?P<major>[1-9]\d*)_(?P<minor>\d+)_?(?P<patch>\d+)?$
 
 identifiers:
 -   repology: postgresql

--- a/products/python.md
+++ b/products/python.md
@@ -120,7 +120,7 @@ identifiers:
 auto:
 -   git: https://github.com/python/cpython.git
     # The v is mandatory here because each branch EOL is tagged, e.g. https://github.com/python/cpython/releases/tag/3.6
-    regex: ^v(?<major>[1-9]\d*)\.(?<minor>\d+)\.?(?<patch>\d+)?$
+    regex: ^v(?P<major>[1-9]\d*)\.(?P<minor>\d+)\.?(?P<patch>\d+)?$
 
 releases:
 -   releaseCycle: "3.12"

--- a/products/rabbitmq.md
+++ b/products/rabbitmq.md
@@ -13,8 +13,8 @@ extendedSupportColumn: Extended Commercial Support
 
 auto:
 -   git: https://github.com/rabbitmq/rabbitmq-server.git
-    regex: 
-      ^(rabbitmq_v(?<major>[1-9]\d*)_(?<minor>\d+)_(?<patch>\d+)|v(?<major>[1-9]\d*)\.(?<minor>\d+)\.(?<patch>\d+))$
+    regex:
+      ^(rabbitmq_v(?P<major>[1-9]\d*)_(?P<minor>\d+)_(?P<patch>\d+)|v(?P<major>[1-9]\d*)\.(?P<minor>\d+)\.(?P<patch>\d+))$
 
 releases:
 -   releaseCycle: "3.12"

--- a/products/ruby.md
+++ b/products/ruby.md
@@ -14,7 +14,7 @@ auto:
 -   git: https://github.com/ruby/ruby.git
     # See https://www.ruby-lang.org/en/news/2013/12/21/ruby-version-policy-changes-with-2-1-0/
     # The meaning of patch and tiny below is as per the new policy
-    regex: ^v(?<major>\d+)_(?<minor>\d+)_(?<patch>\d{1,3})_?(?<tiny>\d+)?$
+    regex: ^v(?P<major>\d+)_(?P<minor>\d+)_(?P<patch>\d{1,3})_?(?P<tiny>\d+)?$
     template: '{{major}}.{{minor}}.{{patch}}{%if tiny %}p{{tiny}}{%endif%}'
 
 identifiers:

--- a/products/salt.md
+++ b/products/salt.md
@@ -7,9 +7,9 @@ permalink: /salt
 alternate_urls:
 -   /saltstack
 versionCommand: salt --version
-releasePolicyLink: 
+releasePolicyLink:
   https://docs.saltproject.io/salt/install-guide/en/latest/topics/salt-version-support-lifecycle.html
-releaseImage: 
+releaseImage:
   https://docs.saltproject.io/salt/install-guide/en/latest/_images/salt-release-timeline.png
 changelogTemplate: https://docs.saltproject.io/en/__RELEASE_CYCLE__/topics/releases/__LATEST__.html
 eolColumn: CVE & Critical Support
@@ -17,9 +17,8 @@ activeSupportColumn: true
 releaseDateColumn: true
 
 auto:
-# https://rubular.com/r/ELfj6SIxS0dZk7
 -   git: https://github.com/saltstack/salt.git
-    regex: ^v(?<version>([1-9]\d*)(\.\d+){0,3})$
+    regex: ^v(?P<version>([1-9]\d*)(\.\d+){0,3})$
     template: "{{version}}"
 
 identifiers:

--- a/products/solr.md
+++ b/products/solr.md
@@ -11,14 +11,13 @@ releasePolicyLink: https://solr.apache.org/downloads.html#about-versions-and-sup
 changelogTemplate: "https://solr.apache.org/docs/{{'__LATEST__'|replace:'.','_'}}/changes/Changes.html"
 releaseDateColumn: true
 
-# https://rubular.com/r/WWOqtBih7muRFz
 auto:
 -   git: https://github.com/apache/lucene-solr.git
-    regex: '^releases\/lucene-solr\/(?<version>\d+\.\d+(.\d+)?)$'
+    regex: '^releases\/lucene-solr\/(?P<version>\d+\.\d+(.\d+)?)$'
     template: '{{version}}'
 -   git: https://github.com/apache/solr.git
     # Only pick new release from the new repo
-    regex: '^releases\/solr\/(?<version>\d+\.\d+(.\d+)?)$'
+    regex: '^releases\/solr\/(?P<version>\d+\.\d+(.\d+)?)$'
     template: '{{version}}'
 
 releases:

--- a/products/sonarqube.md
+++ b/products/sonarqube.md
@@ -14,7 +14,7 @@ eolColumn: Bug and Security Fixes
 
 auto:
 -   git: https://github.com/SonarSource/sonarqube.git
-    regex: ^(?<major>\d+)\.(?<minor>\d+)(\.(?<patch>\d+))?(\.(?<build>\d+))?$
+    regex: ^(?P<major>\d+)\.(?P<minor>\d+)(\.(?P<patch>\d+))?(\.(?P<build>\d+))?$
 
 releases:
 -   releaseCycle: "10"

--- a/products/spring-boot.md
+++ b/products/spring-boot.md
@@ -14,8 +14,7 @@ extendedSupportColumn: Commercial Support
 
 auto:
 -   git: https://github.com/spring-projects/spring-boot.git
-# See https://rubular.com/r/stJ20etRIblK0J for reference
-    regex: '^v?(?<major>[1-9]\d*)\.(?<minor>\d+)\.(?<patch>\d+)(\.RELEASE)?$'
+    regex: '^v?(?P<major>[1-9]\d*)\.(?P<minor>\d+)\.(?P<patch>\d+)(\.RELEASE)?$'
 
 identifiers:
 -   purl: pkg:maven/org.springframework.boot/spring-boot

--- a/products/spring-framework.md
+++ b/products/spring-framework.md
@@ -6,17 +6,16 @@ iconSlug: spring
 permalink: /spring-framework
 alternate_urls:
 -   /spring
-releasePolicyLink: 
+releasePolicyLink:
   https://github.com/spring-projects/spring-framework/wiki/Spring-Framework-Versions
 changelogTemplate: https://github.com/spring-projects/spring-framework/releases/tag/v__LATEST__
 releaseDateColumn: true
 eolColumn: OSS support
 extendedSupportColumn: Commercial Support
 
-# See https://rubular.com/r/XQUdQN2MHdmmCD for reference
 auto:
 -   git: https://github.com/spring-projects/spring-framework.git
-    regex: '^v?(?<major>[1-9]\d*)\.(?<minor>\d+)\.(?<patch>\d+)(\.RELEASE)?$'
+    regex: '^v?(?P<major>[1-9]\d*)\.(?P<minor>\d+)\.(?P<patch>\d+)(\.RELEASE)?$'
 
 # EOL and extended support date available on https://spring.io/projects/spring-framework#support.
 # Supported Java/Jakarta EE versions available on https://github.com/spring-projects/spring-framework/wiki/Spring-Framework-Versions#jdk-version-range.
@@ -55,7 +54,7 @@ releases:
     releaseDate: 2019-09-30
     eol: 2021-12-31
     extendedSupport: 2023-12-31
-    link: 
+    link:
       https://github.com/spring-projects/spring-framework/releases/tag/v__LATEST__.RELEASE
     latest: "5.2.25"
     latestReleaseDate: 2023-07-13
@@ -66,7 +65,7 @@ releases:
     releaseDate: 2018-09-21
     eol: 2020-12-31
     extendedSupport: 2022-12-31
-    link: 
+    link:
       https://github.com/spring-projects/spring-framework/releases/tag/v__LATEST__.RELEASE
     latest: "5.1.20"
     latestReleaseDate: 2020-12-09
@@ -77,7 +76,7 @@ releases:
     releaseDate: 2017-09-28
     eol: 2020-12-31
     extendedSupport: false
-    link: 
+    link:
       https://github.com/spring-projects/spring-framework/releases/tag/v__LATEST__.RELEASE
     latest: "5.0.20"
     latestReleaseDate: 2020-12-09
@@ -88,7 +87,7 @@ releases:
     releaseDate: 2016-06-10
     eol: 2020-12-31
     extendedSupport: false
-    link: 
+    link:
       https://github.com/spring-projects/spring-framework/releases/tag/v__LATEST__.RELEASE
     latest: "4.3.30"
     latestReleaseDate: 2020-12-09
@@ -99,7 +98,7 @@ releases:
     releaseDate: 2012-12-13
     eol: 2016-12-31
     extendedSupport: false
-    link: 
+    link:
       https://github.com/spring-projects/spring-framework/releases/tag/v__LATEST__.RELEASE
     latest: "3.2.18"
     latestReleaseDate: 2016-12-21

--- a/products/sqlite.md
+++ b/products/sqlite.md
@@ -14,7 +14,7 @@ eolColumn: Support Status
 # This git mirror only contains versions from 3.6.10.
 auto:
 -   git: https://github.com/sqlite/sqlite.git
-    regex: '^version-(?<major>\d+)\.(?<minor>\d+)(\.(?<patch>\d+))?$'
+    regex: '^version-(?P<major>\d+)\.(?P<minor>\d+)(\.(?P<patch>\d+))?$'
 
 releases:
 -   releaseCycle: "3"

--- a/products/squid.md
+++ b/products/squid.md
@@ -6,7 +6,7 @@ alternate_urls:
 -   /squid-cache
 versionCommand: squid -v
 releasePolicyLink: https://wiki.squid-cache.org/ReleaseSchedule
-changelogTemplate: 
+changelogTemplate:
   http://www.squid-cache.org/Versions/v{{'__RELEASE_CYCLE__'|split:'.'|first}}/__RELEASE_CYCLE__/
 releaseDateColumn: true
 
@@ -19,18 +19,23 @@ identifiers:
 -   purl: pkg:rpm/centos/squid
 -   purl: pkg:apk/alpine/squid
 
-# https://rubular.com/r/mwE2FvyQrDjXzx
 # v4+ has stable releases as major.minor
 # v2,3 had stable releases as major.minor.patch, where patch=0 was for RC releases.
-# v2 sources are now archived in a separate repo, we use that as well
-# the squidadm repository is the one where releases are made
 auto:
+# v2 sources are now archived in a separate repo, we use that as well
 -   git: https://github.com/squid-cache/squid2.git
-    regex: 
-      ^SQUID_((?<major>(2|3))_(?<minor>\d)_((STABLE)?(?<patch>\d+))|(?<major>[4-9])_(?<minor>\d+))$
+    regex:
+    # https://regex101.com/r/yMRzJO/1
+    -   ^SQUID_(?P<major>[2-3])_(?P<minor>\d)_((STABLE)?(?P<patch>\d+))$
+    # https://regex101.com/r/psotaU/1
+    -   ^SQUID_(?P<major>[4-9])_(?P<minor>\d+)$
+# the squidadm repository is the one where releases are made
 -   git: https://github.com/squidadm/squid.git
-    regex: 
-      ^SQUID_((?<major>(2|3))_(?<minor>\d)_((STABLE)?(?<patch>\d+))|(?<major>[4-9])_(?<minor>\d+))$
+    regex:
+    # https://regex101.com/r/yMRzJO/1
+    -   ^SQUID_(?P<major>[2-3])_(?P<minor>\d)_((STABLE)?(?P<patch>\d+))$
+    # https://regex101.com/r/psotaU/1
+    -   ^SQUID_(?P<major>[4-9])_(?P<minor>\d+)$
 
 releases:
 -   releaseCycle: "6"

--- a/products/umbraco.md
+++ b/products/umbraco.md
@@ -14,7 +14,7 @@ eolColumn: Security
 
 auto:
 -   git: https://github.com/umbraco/Umbraco-CMS.git
-    regex: ^release-(?<major>\d+)\.(?<minor>\d+)\.(?<patch>\d+)$
+    regex: ^release-(?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)$
 
 # Only tracking major releases here, even if regressions are fixed on the last three minors.
 # This is because the LTS model is based on major versions, and maintaining so many minor versions
@@ -84,7 +84,7 @@ releases:
     eol: 2018-05-01
     latest: '6.2.6'
     latestReleaseDate: 2016-03-03
-    link: 
+    link:
       https://umbraco.com/products/knowledge-center/long-term-support-and-end-of-life/umbraco-6-end-of-life-eol/
 
 ---

--- a/products/varnish.md
+++ b/products/varnish.md
@@ -14,7 +14,7 @@ identifiers:
 
 auto:
 -   git: https://github.com/varnishcache/varnish-cache.git
-    regex: ^varnish-(?<major>\d+)\.(?<minor>\d+)\.(?<patch>\d+)$
+    regex: ^varnish-(?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)$
 
 # EOL dates can be found on https://varnish-cache.org/releases/
 releases:

--- a/products/wordpress.md
+++ b/products/wordpress.md
@@ -16,7 +16,7 @@ customColumns:
     position: after-release-column
     label: Supported PHP
     description: Supported PHP versions range
-    link: 
+    link:
       https://make.wordpress.org/core/handbook/references/php-compatibility-and-wordpress-versions/
 
 # This regex drops '.0' from versions because x.y.0 releases are always referred as x.y.
@@ -26,7 +26,7 @@ customColumns:
 # See https://github.com/endoflife-date/endoflife.date/pull/2768#issuecomment-1491875624.
 auto:
 -   git: https://github.com/WordPress/wordpress-develop.git
-    regex: '^(?<major>\d+)\.(?<minor>\d+)\.?(?<patch>[1-9][0-9.]*)?'
+    regex: '^(?P<major>\d+)\.(?P<minor>\d+)\.?(?P<patch>[1-9][0-9.]*)?'
 
 identifiers:
 -   repology: wordpress

--- a/products/yocto.md
+++ b/products/yocto.md
@@ -15,7 +15,7 @@ eolColumn: Support Status
 
 auto:
 -   git: https://github.com/yoctoproject/poky.git
-    regex: '^yocto-(?<major>[1-9]\d*)\.(?<minor>\d+)\.?(?<patch>\d+)?$'
+    regex: '^yocto-(?P<major>[1-9]\d*)\.(?P<minor>\d+)\.?(?P<patch>\d+)?$'
 
 # for eol see https://wiki.yoctoproject.org/wiki/Releases
 releases:


### PR DESCRIPTION
Now that the git auto method is written in Python, there is no need to have Ruby regexes anymore. This converts all Ruby regexes to Python regexes. The change is in fact really simple : every occurrences of `(?<` were just replaced by `(?P<`.

Also took the opportunity to:

- split some complicated regexes into multiple ones,
- update the contributing documentation,
- replace or remove (for simpler regexes) the rubular links.