### PR TITLE
[panos] Updated panos 10.2.7 to 10.2.7-h3

### DIFF
--- a/products/pan-os.md
+++ b/products/pan-os.md
@@ -30,10 +30,10 @@ releases:
 -   releaseCycle: "10.2"
     releaseDate: 2022-02-27
     eol: 2025-08-27
-    latest: "10.2.7"
-    latestReleaseDate: 2023-11-09
+    latest: "10.2.7-h3"
+    latestReleaseDate: 2023-12-18
     link: 
-      https://docs.paloaltonetworks.com/pan-os/10-2/pan-os-release-notes/pan-os-10-2-7-known-and-addressed-issues/pan-os-10-2-7-addressed-issues
+      https://docs.paloaltonetworks.com/pan-os/10-2/pan-os-release-notes/pan-os-10-2-7-known-and-addressed-issues/pan-os-10-2-7-h3-addressed-issues
 
 -   releaseCycle: "10.1"
     releaseDate: 2021-05-31


### PR DESCRIPTION
Updated PAN-OS 10.2.7 to PAN-OS 10.2.7-h3.

Released: 2023-12-18

https://docs.paloaltonetworks.com/pan-os/10-2/pan-os-release-notes/pan-os-10-2-7-known-and-addressed-issues/pan-os-10-2-7-h3-addressed-issues
