### PR TITLE
[kirby] Add 3.10 with PHP 8.3 support

### DIFF
--- a/products/kirby.md
+++ b/products/kirby.md
@@ -22,6 +22,7 @@ auto:
 
 # eol(x) = releaseDate(x+1) + 2 years - 1 day
 # See also https://getkirby.com/docs/archive
+# supportedPhpVersions can be found on https://getkirby.com/docs/reference/system/requirements#php-version-support-history.
 releases:
 -   releaseCycle: "3.10" # Special release cycle for Kirby 3.9 with PHP 8.3
     codename: ""

--- a/products/kirby.md
+++ b/products/kirby.md
@@ -14,8 +14,17 @@ auto:
 -   git: https://github.com/getkirby/kirby.git
 
 # eol(x) = releaseDate(x+1) + 2 years - 1 day
-# See also https://getkirby.com/docs/archive.
+# See also https://getkirby.com/docs/archive
 releases:
+-   releaseCycle: "3.10" # Special release cycle for Kirby 3.9 with PHP 8.3
+    codename: ""
+    releaseDate: 2023-12-19
+    eol: 2025-11-27 # Assume eol(3.9)
+    latest: "3.10.0"
+    latestReleaseDate: 2023-12-19
+
+https://getkirby.com/releases
+
 -   releaseCycle: "4.0"
     codename: "A new era"
     releaseDate: 2023-11-28

--- a/products/kirby.md
+++ b/products/kirby.md
@@ -23,8 +23,6 @@ releases:
     latest: "3.10.0"
     latestReleaseDate: 2023-12-19
 
-https://getkirby.com/releases
-
 -   releaseCycle: "4.0"
     codename: "A new era"
     releaseDate: 2023-11-28

--- a/products/kirby.md
+++ b/products/kirby.md
@@ -9,6 +9,13 @@ changelogTemplate: https://github.com/getkirby/kirby/releases/tag/__LATEST__
 releaseLabel: "__RELEASE_CYCLE__{% if '__CODENAME__' != '' %} (__CODENAME__){% endif
   %}"
 releaseDateColumn: true
+customColumns:
+-   property: supportedPhpVersions
+    position: after-release-column
+    label: Supported PHP
+    description: Supported PHP versions range
+    link:
+      https://getkirby.com/docs/reference/system/requirements#php-version-support-history
 
 auto:
 -   git: https://github.com/getkirby/kirby.git
@@ -20,6 +27,7 @@ releases:
     codename: ""
     releaseDate: 2023-12-19
     eol: 2025-11-27 # Assume eol(3.9)
+    supportedPhpVersions: 8.1 - 8.3
     latest: "3.10.0"
     latestReleaseDate: 2023-12-19
 
@@ -27,6 +35,7 @@ releases:
     codename: "A new era"
     releaseDate: 2023-11-28
     eol: false
+    supportedPhpVersions: 8.1 - 8.3
     latest: "4.0.2"
     latestReleaseDate: 2023-12-19
 
@@ -34,6 +43,7 @@ releases:
     codename: "Brookesia"
     releaseDate: 2023-01-17
     eol: 2025-11-27
+    supportedPhpVersions: 8.0 - 8.2
     latest: "3.9.8"
     latestReleaseDate: 2023-11-14
 
@@ -41,6 +51,7 @@ releases:
     codename: "Rhampholeon"
     releaseDate: 2022-10-06
     eol: 2025-01-16
+    supportedPhpVersions: 8.0 - 8.1
     latest: "3.8.4.2"
     latestReleaseDate: 2023-08-10
 
@@ -48,6 +59,7 @@ releases:
     codename: "Kinyongia"
     releaseDate: 2022-06-27
     eol: 2024-10-05
+    supportedPhpVersions: 7.4 - 8.1
     latest: "3.7.5.3"
     latestReleaseDate: 2023-08-10
 
@@ -55,6 +67,7 @@ releases:
     codename: "Jungle Calumma"
     releaseDate: 2021-11-16
     eol: 2024-06-26
+    supportedPhpVersions: 7.4 - 8.1
     latest: "3.6.6.4"
     latestReleaseDate: 2023-08-10
 
@@ -62,6 +75,7 @@ releases:
     codename: "Calumma"
     releaseDate: 2020-12-15
     eol: 2023-11-15
+    supportedPhpVersions: 7.3 - 8.0
     latest: "3.5.8.4"
     latestReleaseDate: 2023-08-10
 
@@ -69,6 +83,7 @@ releases:
     codename: "Furcifer"
     releaseDate: 2020-07-07
     eol: 2021-11-16
+    supportedPhpVersions: 7.2 - 7.4
     latest: "3.4.5"
     latestReleaseDate: 2020-12-01
 
@@ -76,12 +91,14 @@ releases:
     codename: "Trioceros"
     releaseDate: 2019-11-05
     eol: 2021-11-16
+    supportedPhpVersions: 7.1 - 7.4
     latest: "3.3.6"
     latestReleaseDate: 2020-04-27
 
 -   releaseCycle: "3.2"
     codename: "Archaius"
     releaseDate: 2019-06-25
+    supportedPhpVersions: 7.1 - 7.3
     eol: 2021-11-16
     latest: "3.2.5"
     latestReleaseDate: 2019-09-24
@@ -90,12 +107,14 @@ releases:
     codename: "Chamaeleo"
     releaseDate: 2019-03-19
     eol: 2021-11-16
+    supportedPhpVersions: 7.1 - 7.3
     latest: "3.1.4"
     latestReleaseDate: 2019-05-21
 
 -   releaseCycle: "3.0"
     releaseDate: 2019-01-15
     eol: 2021-11-16
+    supportedPhpVersions: 7.1 - 7.3
     latest: "3.0.3"
     latestReleaseDate: 2019-03-05
 


### PR DESCRIPTION
https://github.com/getkirby/kirby/releases/tag/3.10.0 Special release cycle for Kirby 3.9 with PHP 8.3

Add PHP support per cycle as custom column: https://getkirby.com/docs/reference/system/requirements#php-version-support-history
