### PR TITLE
[mattermost] Update ESR graph - v8.1 now (v9.5 later)

### DIFF
--- a/products/mattermost.md
+++ b/products/mattermost.md
@@ -5,7 +5,7 @@ iconSlug: mattermost
 permalink: /mattermost
 versionCommand: sudo -u mattermost /opt/mattermost/bin/mattermost version
 releasePolicyLink: https://docs.mattermost.com/upgrade/release-lifecycle.html
-releaseImage: https://docs.mattermost.com/_images/ESR_graphic.png
+releaseImage: https://docs.mattermost.com/_images/ESR2_update.png
 changelogTemplate: https://docs.mattermost.com/upgrade/version-archive.html
 LTSLabel: "<abbr title='Extended Support Release'>ESR</abbr>"
 eolWarnThreshold: 30


### PR DESCRIPTION
Mattermost updated their ESR lifecycle, v7.8 is no longer supported, so it's confusing to have the earlier graph mentioning it.

The current graph mentions v8.1 as the oldest ESR (and oldest supported) release.

v9.5 is expected to be ESR next, from its release in Feb 2024.