### PR TITLE
:sloth: Additional names for "vmware-harbor-registry"

### DIFF
--- a/products/vmware-harbor-registry.md
+++ b/products/vmware-harbor-registry.md
@@ -5,7 +5,6 @@ tags: cncf
 iconSlug: harbor
 permalink: /vmware-harbor-registry
 alternate_urls:
--   /harbor-registry
 -   /harbor
 -   /vmware-harbor
 changelogTemplate: https://docs.vmware.com/en/VMware-Harbor-Registry/services/vmware-harbor-registry/GUID-release-notes.html#v__LATEST__

--- a/products/vmware-harbor-registry.md
+++ b/products/vmware-harbor-registry.md
@@ -4,6 +4,10 @@ category: server-app
 tags: cncf
 iconSlug: harbor
 permalink: /vmware-harbor-registry
+alternate_urls:
+-   /harbor-registry
+-   /harbor
+-   /vmware-harbor
 changelogTemplate: https://docs.vmware.com/en/VMware-Harbor-Registry/services/vmware-harbor-registry/GUID-release-notes.html#v__LATEST__
 releaseDateColumn: true
 eolColumn: End of general support


### PR DESCRIPTION
# :grey_question: About

Harbor VMWare Registry (aka. `Harbor`) has been added to eol:

- https://github.com/endoflife-date/endoflife.date/issues/4230

But when I tried to get its eols from its most commonly used name `harbor`, I got this:

![image](https://github.com/endoflife-date/endoflife.date/assets/5235127/05e706d8-dbc6-478e-8010-9fab3a3fc613)

Also, in littertaure it is better known as `Harbor`:

![image](https://github.com/endoflife-date/endoflife.date/assets/5235127/6cb26652-67cf-402c-b779-7c6fe13c0d8b)


# :dart: Goal of the PR

:point_right: By merging this PR, it will be **easier to get harbor eols wile using its most commonly used name.**