### PR TITLE
[electron] update template changelog url

### DIFF
--- a/products/electron.md
+++ b/products/electron.md
@@ -6,7 +6,7 @@ iconSlug: electron
 permalink: /electron
 versionCommand: npm show electron version
 releasePolicyLink: https://www.electronjs.org/docs/latest/tutorial/electron-timelines
-changelogTemplate: "https://releases.electronjs.org/releases/stable?version={{'__LATEST__'|split:'.'|first}}#__LATEST__"
+changelogTemplate: https://releases.electronjs.org/release/v__LATEST__
 eolColumn: Supported
 releaseDateColumn: true
 

--- a/products/electron.md
+++ b/products/electron.md
@@ -6,7 +6,7 @@ iconSlug: electron
 permalink: /electron
 versionCommand: npm show electron version
 releasePolicyLink: https://www.electronjs.org/docs/latest/tutorial/electron-timelines
-changelogTemplate: "https://www.electronjs.org/releases/stable?version={{'__LATEST__'|split:'.'|first}}#__LATEST__"
+changelogTemplate: "https://releases.electronjs.org/releases/stable?version={{'__LATEST__'|split:'.'|first}}#__LATEST__"
 eolColumn: Supported
 releaseDateColumn: true
 


### PR DESCRIPTION
The old urls are redirected with an HTTP 308 status code to the new destination