### PR TITLE
[sonarqube] replace sonarqube.org by sonarsource.com

### DIFF
--- a/products/sonarqube.md
+++ b/products/sonarqube.md
@@ -6,8 +6,8 @@ iconSlug: sonarqube
 permalink: /sonar
 alternate_urls:
 -   /sonarqube
-releasePolicyLink: https://www.sonarqube.org/downloads/lts/
-changelogTemplate: "https://www.sonarqube.org/sonarqube-{{'__LATEST__'|split:'.'|pop|join:'-'}}/"
+releasePolicyLink: https://www.sonarsource.com/products/sonarqube/downloads/lts/
+changelogTemplate: "https://www.sonarsource.com/products/sonarqube/whats-new/sonarqube-{{'__LATEST__'|split:'.'|pop|join:'-'}}/"
 activeSupportColumn: true
 releaseDateColumn: true
 eolColumn: Bug and Security Fixes
@@ -41,7 +41,7 @@ releases:
     lts: 2021-05-04
     latest: "8.9.10"
     latestReleaseDate: 2022-10-14
-    link: https://www.sonarqube.org/sonarqube-8-9-lts/
+    link: https://www.sonarsource.com/products/sonarqube/downloads/lts/8-9-lts/
 
 -   releaseCycle: "7"
     # https://groups.google.com/g/sonarqube/c/p3l3naFctpg/m/Sbk7fzX3AgAJ
@@ -51,11 +51,11 @@ releases:
     lts: 2019-07-01
     latest: "7.9.6"
     latestReleaseDate: 2021-03-01
-    link: https://www.sonarqube.org/sonarqube-7-9-lts/
+    link: https://web.archive.org/web/20220707010454/https://www.sonarqube.org/sonarqube-7-9-lts/
 
 ---
 
-> [SonarQube](https://www.sonarqube.org/) (formerly Sonar) is an open-source platform developed by
+> [SonarQube](https://www.sonarsource.com/products/sonarqube/) (formerly Sonar) is an open-source platform developed by
 > SonarSource for continuous inspection of code quality to perform automatic reviews with static
 > analysis of code to detect bugs and code smells on many programming languages.
 
@@ -67,4 +67,4 @@ previous major release receives LTS support (security patches and fixes of block
 next LTS is declared. This support policy is the same for the Community, Developer, Enterprise and
 Data Center editions.
 
-Release notes for all version can be found on [What's New in SonarQube](https://www.sonarqube.org/whats-new/).
+Release notes for all version can be found on [What's New in SonarQube](https://www.sonarsource.com/products/sonarqube/whats-new/).


### PR DESCRIPTION
Pages of `sonarqube.org` redirect to `sonarsource.com`

The Sonarqube 7.9 release page is not available anymore, replaced it by an `archive.org` page. (could not find a better page)