### PR TITLE
Suppress support.herodevs.com link validation errors

### DIFF
--- a/_plugins/product-data-validator.rb
+++ b/_plugins/product-data-validator.rb
@@ -53,6 +53,7 @@ module EndOfLifeHooks
     'https://reload4j.qos.ch/': SUPPRESSED_BECAUSE_TIMEOUT,
     'https://support.azul.com': SUPPRESSED_BECAUSE_403,
     'https://support.fairphone.com': SUPPRESSED_BECAUSE_403,
+    'https://support.herodevs.com/hc/en-us/articles/': SUPPRESSED_BECAUSE_403,
     'https://visualstudio.microsoft.com/': SUPPRESSED_BECAUSE_CONN_FAILED,
     'https://web.archive.org': SUPPRESSED_BECAUSE_TIMEOUT,
     'https://wiki.debian.org': SUPPRESSED_BECAUSE_TIMEOUT,


### PR DESCRIPTION
Such links always return 403 despite being correct, see https://github.com/endoflife-date/endoflife.date/actions/runs/7367155220/job/20050108578.