### PR TITLE
[nix] add v1.11 release note link

### DIFF
--- a/products/nix.md
+++ b/products/nix.md
@@ -7,7 +7,7 @@ alternate_urls:
 -   /nixlang
 versionCommand: nix --version
 releasePolicyLink: https://nixos.org/blog/announcements.html
-changelogTemplate: https://nixos.org/manual/nix/stable/release-notes/rl-__RELEASE_CYCLE__.html
+changelogTemplate: https://nixos.org/manual/nix/stable/release-notes/rl-__RELEASE_CYCLE__
 releaseDateColumn: true
 
 auto:
@@ -139,8 +139,7 @@ releases:
 -   releaseCycle: "1"
     releaseDate: 2012-05-11
     eol: 2018-02-22
-    # https://nixos.org/manual/nix/stable/release-notes/rl-1.html return a 404
-    link:
+    link: https://nixos.org/manual/nix/stable/release-notes/rl-1.11
     latest: "1.11.16"
     latestReleaseDate: 2017-12-20
 


### PR DESCRIPTION
The v1 release notes are available here:
https://nixos.org/manual/nix/stable/release-notes/rl-1.0

Added the link to release v1.11

Unsure if `releaseCycle` (and dates, ..) should be changed too.

Also the release notes are available with and without the `.html` suffix
* https://nixos.org/manual/nix/stable/release-notes/rl-2.19.html vs.
* https://nixos.org/manual/nix/stable/release-notes/rl-2.19

Changed it to not using the suffix as the links in the manual are without it.