### PR TITLE
Rename the 'db' category to 'database'

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,7 +45,7 @@ title: Timeturner
 # Possible values are os,database,app,lang,framework,device,service,server-app.
 # If you add a new value, please mention it in the PR Description. Some rough guidelines:
 # - os is for operating systems (and similar projects),
-# - database is for all kind of databases,
+# - database is for all kinds of database,
 # - app is for end-user applications,
 # - lang is for programming languages,
 # - framework is for application libraries, SDKs, frameworks...,

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,10 +42,10 @@ To add a new page to the website, [create a new markdown file with YAML frontmat
 title: Timeturner
 
 # Category of the product (mandatory).
-# Possible values are os,db,app,lang,framework,device,service,server-app.
+# Possible values are os,database,app,lang,framework,device,service,server-app.
 # If you add a new value, please mention it in the PR Description. Some rough guidelines:
 # - os is for operating systems (and similar projects),
-# - db is for databases,
+# - database is for all kind of databases,
 # - app is for end-user applications,
 # - lang is for programming languages,
 # - framework is for application libraries, SDKs, frameworks...,
@@ -67,7 +67,7 @@ category: os
 # - must be declared with a space-separated string,
 # - must be alphabetically ordered,
 # - must use singular (for example web-server, not web-servers),
-# - must not be an existing category (note that categories are automatically used as tags),
+# - should not be an existing category (note that categories are automatically used as tags),
 # - should be used at least three times, except for tags representing a vendor or a runtime dependency,
 # - must be added for one of the following reasons :
 #   - set a product family such as linux-distribution, web-browser, mobile-phone or web-server,

--- a/_plugins/product-data-validator.rb
+++ b/_plugins/product-data-validator.rb
@@ -14,7 +14,7 @@ require 'open-uri'
 module EndOfLifeHooks
   VERSION = '1.0.0'
   TOPIC = 'Product Validator:'
-  VALID_CATEGORIES = %w[app db device framework lang library os server-app service standard]
+  VALID_CATEGORIES = %w[app database device framework lang library os server-app service standard]
   VALID_CUSTOM_COLUMN_POSITIONS = %w[after-release-column before-latest-column after-latest-column]
 
   IGNORED_URL_PREFIXES = {

--- a/_redirects
+++ b/_redirects
@@ -42,7 +42,8 @@ layout: null
 # A few permanent redirects for removed pages
 /tags/api-gateway                  /tags/web-server
 /tags/configuration-management     /
+/tags/db                           /tags/database
 /tags/library                      /tags/framework
-/tags/managed-mysql                /tags/db
-/tags/managed-postgresql           /tags/db
+/tags/managed-mysql                /tags/database
+/tags/managed-postgresql           /tags/database
 /tags/package-manager              /tags/build-tool

--- a/products/amazon-rds-mysql.md
+++ b/products/amazon-rds-mysql.md
@@ -1,7 +1,7 @@
 ---
 title: Amazon RDS for MySQL
 category: service
-tags: amazon
+tags: amazon database
 iconSlug: amazonrds
 permalink: /amazon-rds-mysql
 releasePolicyLink:

--- a/products/amazon-rds-postgresql.md
+++ b/products/amazon-rds-postgresql.md
@@ -1,7 +1,7 @@
 ---
 title: Amazon RDS for PostgreSQL
 category: service
-tags: amazon
+tags: amazon database
 iconSlug: amazonrds
 permalink: /amazon-rds-postgresql
 releasePolicyLink:

--- a/products/apache-cassandra.md
+++ b/products/apache-cassandra.md
@@ -1,6 +1,6 @@
 ---
 title: Apache Cassandra
-category: db
+category: database
 tags: apache java-runtime
 iconSlug: apachecassandra
 permalink: /apache-cassandra

--- a/products/apache-hadoop.md
+++ b/products/apache-hadoop.md
@@ -1,6 +1,6 @@
 ---
 title: Apache Hadoop
-category: server-app # not sure if this is the best category
+category: database
 tags: apache java-runtime
 iconSlug: apachehadoop
 permalink: /apache-hadoop

--- a/products/couchbase-server.md
+++ b/products/couchbase-server.md
@@ -1,6 +1,6 @@
 ---
 title: Couchbase Server
-category: db
+category: database
 iconSlug: couchbase
 permalink: /couchbase-server
 alternate_urls:
@@ -49,7 +49,7 @@ releases:
 -   releaseCycle: "6.5"
     releaseDate: 2020-01-15
     eol: 2021-02-28
-    link: 
+    link:
       https://web.archive.org/web/20230519160357/https://docs.couchbase.com/server/6.5/release-notes/relnotes.html
     latest: "6.5.2"
     latestReleaseDate: 2021-02-15
@@ -57,7 +57,7 @@ releases:
 -   releaseCycle: "6.0"
     releaseDate: 2018-10-31
     eol: 2020-07-31
-    link: 
+    link:
       https://web.archive.org/web/20230519162206/https://docs.couchbase.com/server/6.0/release-notes/relnotes.html
     latest: "6.0.5"
     latestReleaseDate: 2022-04-30

--- a/products/elasticsearch.md
+++ b/products/elasticsearch.md
@@ -1,6 +1,6 @@
 ---
 title: Elasticsearch
-category: db
+category: database
 tags: elastic java-runtime
 iconSlug: elasticsearch
 permalink: /elasticsearch

--- a/products/etcd.md
+++ b/products/etcd.md
@@ -1,11 +1,11 @@
 ---
 title: etcd
-category: db
+category: database
 tags: cncf
 iconSlug: etcd
 permalink: /etcd
 versionCommand: etcdctl version
-releasePolicyLink: 
+releasePolicyLink:
   https://github.com/etcd-io/etcd/blob/main/Documentation/contributor-guide/branch_management.md#stable-branches
 changelogTemplate: https://github.com/etcd-io/etcd/releases/tag/v__LATEST__
 releaseDateColumn: true

--- a/products/hbase.md
+++ b/products/hbase.md
@@ -1,6 +1,6 @@
 ---
 title: Apache HBase
-category: server-app
+category: database
 tags: apache java-runtime
 permalink: /hbase
 alternate_urls:

--- a/products/mariadb.md
+++ b/products/mariadb.md
@@ -1,6 +1,6 @@
 ---
 title: MariaDB
-category: db
+category: database
 iconSlug: mariadb
 permalink: /mariadb
 versionCommand: mariadbd --version

--- a/products/memcached.md
+++ b/products/memcached.md
@@ -1,6 +1,6 @@
 ---
 title: Memcached
-category: db
+category: database
 permalink: /memcached
 versionCommand: memcached -h
 changelogTemplate: "https://github.com/memcached/memcached/wiki/ReleaseNotes{{'__LATEST__'|replace:'.',''}}"

--- a/products/mongodb.md
+++ b/products/mongodb.md
@@ -1,6 +1,6 @@
 ---
 title: MongoDB Server
-category: db
+category: database
 iconSlug: mongodb
 permalink: /mongodb
 alternate_urls:

--- a/products/mssqlserver.md
+++ b/products/mssqlserver.md
@@ -1,6 +1,6 @@
 ---
 title: Microsoft SQL Server
-category: db
+category: database
 tags: microsoft
 permalink: /mssqlserver
 alternate_urls:

--- a/products/mysql.md
+++ b/products/mysql.md
@@ -1,6 +1,6 @@
 ---
 title: MySQL
-category: db
+category: database
 tags: oracle
 iconSlug: mysql
 permalink: /mysql

--- a/products/neo4j.md
+++ b/products/neo4j.md
@@ -1,6 +1,6 @@
 ---
 title: Neo4j
-category: db
+category: database
 tags: java-runtime
 iconSlug: neo4j
 permalink: /neo4j

--- a/products/opensearch.md
+++ b/products/opensearch.md
@@ -1,6 +1,6 @@
 ---
 title: OpenSearch
-category: db
+category: database
 tags: amazon java-runtime
 iconSlug: opensearch
 permalink: /opensearch
@@ -37,7 +37,7 @@ releases:
 
 ## Support
 
-**Active Development**: The latest major version receives new features, bug fixes, and security patches. 
+**Active Development**: The latest major version receives new features, bug fixes, and security patches.
 **Maintenance Support**: includes bug fixes and security patches. New features might be back-ported as
   community contributions, but will not result in new releases.
 

--- a/products/oracle-database.md
+++ b/products/oracle-database.md
@@ -1,6 +1,6 @@
 ---
 title: Oracle Database
-category: db
+category: database
 tags: oracle
 iconSlug: oracle
 permalink: /oracle-database

--- a/products/postgresql.md
+++ b/products/postgresql.md
@@ -1,6 +1,6 @@
 ---
 title: PostgreSQL
-category: db
+category: database
 iconSlug: postgresql
 permalink: /postgresql
 alternate_urls:

--- a/products/redis.md
+++ b/products/redis.md
@@ -1,11 +1,11 @@
 ---
 title: Redis
-category: db
+category: database
 iconSlug: redis
 permalink: /redis
 versionCommand: redis-server --version
 releasePolicyLink: https://redis.io/docs/about/releases/
-changelogTemplate: 
+changelogTemplate:
   https://raw.githubusercontent.com/antirez/redis/__RELEASE_CYCLE__/00-RELEASENOTES
 activeSupportColumn: true
 releaseDateColumn: true

--- a/products/sqlite.md
+++ b/products/sqlite.md
@@ -1,6 +1,6 @@
 ---
 title: SQLite
-category: db
+category: database
 iconSlug: sqlite
 permalink: /sqlite
 alternate_urls:

--- a/products/tarantool.md
+++ b/products/tarantool.md
@@ -1,9 +1,9 @@
 ---
 title: Tarantool
-category: db
+category: database
 permalink: /tarantool
 versionCommand: $ tarantool --version
-releaseImage: 
+releaseImage:
   https://hb.bizmrg.com/tarantool-io/doc-builds/tarantool/latest/images_en/releases_calendar.svg
 releasePolicyLink: https://www.tarantool.io/en/doc/latest/release/policy/
 changelogTemplate: https://github.com/tarantool/tarantool/releases/tag/__LATEST__


### PR DESCRIPTION
A redirect has been added to redirect the old tag page URL to the new one.

An exception to the 'no category tag' rule has been made for managed databases, as using both the `service` and `database` categories would make sense for those products.

Also moved Apache Hadoop and Apache HBase from the generic `server-app` to the `database'` category.

Closes #4291.