### PR TITLE
[android] Update 4.4 to 9 EOL date

### DIFF
--- a/products/android.md
+++ b/products/android.md
@@ -14,6 +14,7 @@ releaseColumn: false
 releaseDateColumn: true
 eolColumn: Security Support
 
+# EOL is the latest security patch date for "Old version" on https://en.wikipedia.org/wiki/Android_version_history.
 releases:
 -   releaseCycle: "14"
     codename: Upside Down Cake
@@ -50,43 +51,43 @@ releases:
 -   releaseCycle: "9"
     codename: Pie
     releaseDate: 2018-08-06
-    eol: true
+    eol: 2022-01-01
     link: https://developer.android.com/about/versions/pie
 
 -   releaseCycle: "8.1"
     codename: Oreo
     releaseDate: 2017-12-05
-    eol: true
+    eol: 2021-01-10
     link: https://developer.android.com/about/versions/oreo/android-8.1
 
 -   releaseCycle: "8.0"
     codename: Oreo
     releaseDate: 2017-08-21
-    eol: true
+    eol: 2021-01-01
     link: https://developer.android.com/about/versions/oreo
 
 -   releaseCycle: "7"
     codename: Nougat
     releaseDate: 2016-08-22
-    eol: true
+    eol: 2019-10-01
     link: https://developer.android.com/about/versions/nougat
 
 -   releaseCycle: "6"
     codename: Marshmallow
     releaseDate: 2015-10-05
-    eol: true
+    eol: 2018-08-01
     link: https://developer.android.com/about/versions/marshmallow
 
 -   releaseCycle: "5"
     codename: Lollipop
     releaseDate: 2014-11-12
-    eol: true
+    eol: 2018-03-01
     link: https://developer.android.com/about/versions/lollipop
 
 -   releaseCycle: "4.4"
     codename: KitKat
     releaseDate: 2013-10-31
-    eol: true
+    eol: 2017-10-01
     link: https://developer.android.com/about/versions/kitkat
 
 -   releaseCycle: "4.1"


### PR DESCRIPTION
Update Android 4.4 to Android 9 EOL date from `true` to old version latest security patch date on https://en.wikipedia.org/wiki/Android_version_history.