### PR TITLE
[fairphone+pixel] add Active Major Android Updates

### DIFF
--- a/products/fairphone.md
+++ b/products/fairphone.md
@@ -6,7 +6,9 @@ permalink: /fairphone
 releasePolicyLink: https://forum.fairphone.com/t/fairphone-product-release-cycle/52652
 releaseColumn: false
 releaseDateColumn: true
+activeSupportColumn: Active Major Updates
 discontinuedColumn: true
+eolColumn: Security Updates
 customColumns:
 -   property: supportedAndroidVersions
     position: after-release-column
@@ -20,6 +22,7 @@ releases:
     supportedAndroidVersions: "13"
     releaseDate: 2023-09-14
     discontinued: false
+    support: true
     eol: 2031-09-14 # according to https://www.gsmarena.com/fairphone_5_goes_official_with_5_years_warranty_up_to_10_years_of_software_support-news-59724.php
     link: https://support.fairphone.com/hc/articles/18020671537041-Fairphone-5-FAQ
 
@@ -27,6 +30,7 @@ releases:
     supportedAndroidVersions: 11 - 13
     releaseDate: 2021-09-30
     discontinued: false
+    support: false
     eol: 2026-09-30
     link: https://support.fairphone.com/hc/articles/4405858220945
 
@@ -34,6 +38,7 @@ releases:
     supportedAndroidVersions: 10 - 13
     releaseDate: 2020-09-30
     discontinued: 2022-11-01
+    support: false
     eol: 2025-09-30
     link: https://support.fairphone.com/hc/articles/360048139032
 
@@ -41,6 +46,7 @@ releases:
     supportedAndroidVersions: 10 - 13
     releaseDate: 2019-09-30
     discontinued: 2021-09-01
+    support: false
     eol: 2024-09-30
     link: https://support.fairphone.com/hc/articles/360048139032
 
@@ -49,6 +55,7 @@ releases:
     releaseDate: 2015-12-21
     # https://github.com/endoflife-date/endoflife.date/pull/2656#discussion_r1131930081
     discontinued: 2019-03-31
+    support: false
     # https://www.linkedin.com/posts/fairphone_fairphone2forever-unlaunching-changeisinyourhands-activity-7038910425882615808-DS7c
     eol: 2023-03-07
     link: https://support.fairphone.com/hc/articles/360019515018
@@ -57,6 +64,7 @@ releases:
     supportedAndroidVersions: "4.2" # https://support.fairphone.com/hc/articles/6217522827281-Fairphone-1-FAQ
     releaseDate: 2013-12-01
     discontinued: 2017-07-13
+    support: false
     eol: 2017-07-13
     link: https://support.fairphone.com/hc/articles/6217522827281
 

--- a/products/pixel.md
+++ b/products/pixel.md
@@ -8,7 +8,7 @@ versionCommand: "Settings -> About Phone -> Regulatory labels"
 releasePolicyLink: https://support.google.com/nexus/answer/4457705
 releaseColumn: false
 releaseDateColumn: true
-activeSupportColumn: true
+activeSupportColumn: Active Major Updates
 discontinuedColumn: true
 eolColumn: Guaranteed Security Updates
 customColumns:


### PR DESCRIPTION
add missing Active Major Android Updates column in the Fairphone page. Rename the column in the Pixel page.