### PR TITLE
[pan-os] updated 11.1 to 11.1.1

### DIFF
--- a/products/pan-os.md
+++ b/products/pan-os.md
@@ -17,7 +17,7 @@ releases:
     latest: "11.1.1"
     latestReleaseDate: 2023-12-26
     link: 
-      https://docs.paloaltonetworks.com/pan-os/11-1/pan-os-release-notes/pan-os-11-1-1-known-and-addressed-issues/pan-os-11-1-1-known-issues
+      https://docs.paloaltonetworks.com/pan-os/11-1/pan-os-release-notes/pan-os-11-1-1-known-and-addressed-issues/pan-os-11-1-1-addressed-issues
 
 -   releaseCycle: "11.0"
     releaseDate: 2022-11-17

--- a/products/pan-os.md
+++ b/products/pan-os.md
@@ -14,10 +14,10 @@ releases:
 -   releaseCycle: "11.1"
     releaseDate: 2023-11-03
     eol: 2027-05-03
-    latest: "11.1"
-    latestReleaseDate: 2023-11-03
+    latest: "11.1.1"
+    latestReleaseDate: 2023-12-26
     link: 
-      https://docs.paloaltonetworks.com/pan-os/11-1/pan-os-release-notes/pan-os-11-1-0-known-and-addressed-issues/pan-os-11-1-0-addressed-issues
+      https://docs.paloaltonetworks.com/pan-os/11-1/pan-os-release-notes/pan-os-11-1-1-known-and-addressed-issues/pan-os-11-1-1-known-issues
 
 -   releaseCycle: "11.0"
     releaseDate: 2022-11-17


### PR DESCRIPTION
Updated Pan-OS 11.1 to 11.1.1.
Released: 2023-12-26

https://docs.paloaltonetworks.com/pan-os/11-1/pan-os-release-notes/pan-os-11-1-1-known-and-addressed-issues/pan-os-11-1-1-addressed-issues

