### PR TITLE
[mongodb] Adds 7.2 release

### DIFF
--- a/products/mongodb.md
+++ b/products/mongodb.md
@@ -36,10 +36,17 @@ auto:
 # Release dates are not in sync with https://www.mongodb.com/support-policy/lifecycles because git
 # tag dates are used by the automation.
 releases:
+-   releaseCycle: "7.2"
+    releaseLabel: "7.2 (Rapid Release)"
+    releaseDate: 2024-01-15
+    eol: false
+    latest: '7.2.0'
+    latestReleaseDate: 2024-01-15
+
 -   releaseCycle: "7.1"
     releaseLabel: "7.1 (Rapid Release)"
     releaseDate: 2023-10-04
-    eol: false
+    eol: 2024-01-31
     latest: '7.1.1'
     latestReleaseDate: 2023-11-16
 


### PR DESCRIPTION
7.2 upcoming release is now listed at https://www.mongodb.com/legal/support-policy/lifecycles.

It is still in RC: https://www.mongodb.com/docs/upcoming/release-notes/7.2/