### PR TITLE
[ovirt] Fix changelogTemplate

### DIFF
--- a/products/ovirt.md
+++ b/products/ovirt.md
@@ -3,7 +3,7 @@ title: oVirt
 category: server-app
 permalink: /ovirt
 releasePolicyLink: https://blogs.ovirt.org/2022/04/ovirt-4-4-end-of-life/
-changelogTemplate: "https://www.ovirt.org/release/__LATEST__/"
+changelogTemplate: https://github.com/oVirt/ovirt-engine/releases/tag/ovirt-engine-__LATEST__"
 releaseDateColumn: true
 
 auto:


### PR DESCRIPTION
Current changelogTemplate don't work for tiny versions, such as 4.4.10.7 (https://github.com/oVirt/ovirt-engine/releases/tag/ovirt-engine-4.4.10.7 vs https://www.ovirt.org/release/4.4.10.7/).