### PR TITLE
Add TYPO3 releases 11.5.34 and 12.4.10

### DIFF
--- a/products/typo3.md
+++ b/products/typo3.md
@@ -23,8 +23,8 @@ releases:
     support: 2024-10-31
     eol: 2026-04-30
     extendedSupport: 2029-04-30
-    latest: '12.4.9'
-    latestReleaseDate: 2023-12-12
+    latest: '12.4.10'
+    latestReleaseDate: 2024-01-16
 
 -   releaseCycle: "11"
     releaseDate: 2020-12-22
@@ -32,8 +32,8 @@ releases:
     support: 2023-03-31
     eol: 2024-10-31
     extendedSupport: 2027-10-31
-    latest: "11.5.33"
-    latestReleaseDate: 2023-11-14
+    latest: "11.5.34"
+    latestReleaseDate: 2024-01-16
 
 -   releaseCycle: "10"
     releaseDate: 2019-07-23


### PR DESCRIPTION
All versions are maintenance releases and contain bug fixes only.

Announcement: https://typo3.org/article/typo3-12410-and-11534-maintenance-releases-published

Release notes:
* https://get.typo3.org/release-notes/11.5.34
* https://get.typo3.org/release-notes/12.4.10