### PR TITLE
[sapmachine] Update EOL dates

### DIFF
--- a/products/sapmachine.md
+++ b/products/sapmachine.md
@@ -13,13 +13,13 @@ auto:
     regex: '^sapmachine-(?P<version>[\d\.]+)$'
     template: '{{version}}'
 
-# LTS : EOL dates can be found on https://github.com/SAP/SapMachine/wiki/Security-Updates,-Maintenance-and-Support
+# LTS : EOL dates can be found on https://github.com/SAP/SapMachine/wiki/Maintenance-and-Support
 # non-LTS : EOL(x) = releaseDate(x+1) (exact date for future releases can be found on https://www.java.com/releases/)
 releases:
 -   releaseCycle: "21"
     lts: true
     releaseDate: 2023-09-18
-    eol: false
+    eol: 2028-09-01
     latest: '21.0.2'
     latestReleaseDate: 2024-01-16
 
@@ -44,7 +44,7 @@ releases:
 -   releaseCycle: "17"
     lts: true
     releaseDate: 2021-09-14
-    eol: 2026-09-30
+    eol: 2026-09-01
     latest: '17.0.10'
     latestReleaseDate: 2024-01-16
 
@@ -81,7 +81,7 @@ releases:
 -   releaseCycle: "11"
     lts: true
     releaseDate: 2019-01-16
-    eol: 2024-12-31
+    eol: 2024-12-01
     latest: '11.0.22'
     latestReleaseDate: 2024-01-16
 


### PR DESCRIPTION
See https://github.com/SAP/SapMachine/wiki/Maintenance-and-Support. Also used start of month instead of end of month.

Closes #4476.