### PR TITLE
GitLab 16.8 Release

### DIFF
--- a/products/gitlab.md
+++ b/products/gitlab.md
@@ -22,6 +22,14 @@ auto:
 # eol(x) = releaseDate(x+3)
 # Upcoming release dates are available on https://about.gitlab.com/releases/.
 releases:
+
+-   releaseCycle: "16.8"
+    releaseDate: 2024-01-18
+    support: 2024-02-15
+    eol: 2024-02-15
+    latest: "16.8"
+    latestReleaseDate: 2024-01-18
+
 -   releaseCycle: "16.7"
     releaseDate: 2023-12-20
     support: 2024-01-18


### PR DESCRIPTION
- [GitLab 16.8 has just been released](https://about.gitlab.com/releases/2024/01/18/gitlab-16-8-released/)
- [`16.9` is planned for `2024-02-15`](https://about.gitlab.com/upcoming-releases/)

**:thought_balloon: Not :100: sure for `16.7` `eol` and `support`**