### PR TITLE
[kdeplasma] Exclude 80/90 minor and patch version

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -222,12 +222,15 @@ auto:
   # For example, for Apache Maven:
   - git: https://github.com/apache/maven.git
 
-    # Python-compatible regex that defines how the tags above should translate to releases (optional).
+    # Python-compatible regex that defines how the tags above should translate to versions (optional).
     # The default regex can handle versions having at least 2 digits (ex. 1.2) and at most 4 digits (ex. 1.2.3.4),
     # with an optional leading "v"). Use named capturing groups to capture the version or version's parts.
     # Default value should work for most releases of the form a.b, a.b.c or 'v'a.b.c. It should also
     # skip over any special releases (such as nightly,beta,pre,rc...).
     regex: ^v(?<major>\d+)_(?<minor>\d+)_(?<patch>\d{1,3})_?(?<tiny>\d+)?$
+
+    # Python-compatible regex that defines which tags should be excluded (optional).
+    regex_exclude: ^v99.99.99$
 
     # A liquid template using the captured variables from the regex above that renders the final version
     # (optional, default can handle versions having a 'major', 'minor', 'patch' and 'tiny' version).

--- a/product-schema.json
+++ b/product-schema.json
@@ -85,6 +85,9 @@
               "regex": {
                 "$ref": "#/$defs/regex"
               },
+              "regex_exclude": {
+                "$ref": "#/$defs/regex"
+              },
               "template": {
                 "$ref": "#/$defs/template"
               }
@@ -103,6 +106,9 @@
                 "type": "string"
               },
               "regex": {
+                "$ref": "#/$defs/regex"
+              },
+              "regex_exclude": {
                 "$ref": "#/$defs/regex"
               },
               "template": {
@@ -125,6 +131,9 @@
               "regex": {
                 "$ref": "#/$defs/regex"
               },
+              "regex_exclude": {
+                "$ref": "#/$defs/regex"
+              },
               "template": {
                 "$ref": "#/$defs/template"
               }
@@ -143,17 +152,10 @@
                 "type": "string"
               },
               "regex": {
-                "oneOf": [
-                  {
-                    "$ref": "#/$defs/regex"
-                  },
-                  {
-                    "type": "array",
-                    "items": {
-                      "$ref": "#/$defs/regex"
-                    }
-                  }
-                ]
+                "$ref": "#/$defs/regex"
+              },
+              "regex_exclude": {
+                "$ref": "#/$defs/regex"
               },
               "template": {
                 "$ref": "#/$defs/template"
@@ -184,17 +186,10 @@
                 "type": "string"
               },
               "regex": {
-                "oneOf": [
-                  {
-                    "$ref": "#/$defs/regex"
-                  },
-                  {
-                    "type": "array",
-                    "items": {
-                      "$ref": "#/$defs/regex"
-                    }
-                  }
-                ]
+                "$ref": "#/$defs/regex"
+              },
+              "regex_exclude": {
+                "$ref": "#/$defs/regex"
               }
             },
             "required": [
@@ -211,6 +206,9 @@
                 "type": "string"
               },
               "regex": {
+                "$ref": "#/$defs/regex"
+              },
+              "regex_exclude": {
                 "$ref": "#/$defs/regex"
               },
               "template": {
@@ -233,6 +231,9 @@
               "regex": {
                 "$ref": "#/$defs/regex"
               },
+              "regex_exclude": {
+                "$ref": "#/$defs/regex"
+              },
               "template": {
                 "$ref": "#/$defs/template"
               }
@@ -251,6 +252,9 @@
                 "type": "string"
               },
               "regex": {
+                "$ref": "#/$defs/regex"
+              },
+              "regex_exclude": {
                 "$ref": "#/$defs/regex"
               },
               "template": {
@@ -311,8 +315,18 @@
     },
     "regex": {
       "title": "Regex",
-      "description": "Regex which will be used to filter the releases.",
-      "type": "string"
+      "description": "Regex which will be used to filter the versions.",
+      "oneOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      ]
     },
     "customColumn": {
       "type": "object",

--- a/products/kdeplasma.md
+++ b/products/kdeplasma.md
@@ -14,12 +14,10 @@ eolColumn: Critical bug fixes
 
 auto:
 -   git: https://github.com/KDE/plasma-desktop.git
-    # Excludes 80 or 90 minor and patch versions, such as https://kde.org/announcements/plasma/5/5.26.90/,
-    # which are disguised beta releases.
-    regex:
-    -   '^v?(?P<major>[1-9]\d*)\.(?P<minor>\d)(\.(?P<patch>\d)(\.(?P<tiny>\d+))?)?$' # single-digit minor or patch
-    -   '^v?(?P<major>[1-9]\d*)\.(?P<minor>[0-7]\d*)(\.(?P<patch>\d)(\.(?P<tiny>\d+))?)?$' # double-digits minor < 80
-    -   '^v?(?P<major>[1-9]\d*)\.(?P<minor>\d+)(\.(?P<patch>[0-7]\d*)(\.(?P<tiny>\d+))?)?$' # double-digits patch < 80
+    # 80/90 minor and patch versions, such as https://kde.org/announcements/plasma/5/5.26.90/, are disguised beta releases
+    regex_exclude:
+    -   '^v?(\d+)\.([8-9]\d+)(\.(\d+)(\.(\d+))?)?$' # double-digits minor >= 80
+    -   '^v?(\d+)\.(\d+)(\.([8-9]\d+)(\.(\d+))?)?$' # double-digits patch >= 80
 
 releases:
 -   releaseCycle: "5.27"


### PR DESCRIPTION
Such as https://kde.org/announcements/plasma/5/5.26.90/, as those are disguised beta releases.