### PR TITLE
Linux Mint : more alias (`linux-mint` and `mint`)

### DIFF
--- a/products/linuxmint.md
+++ b/products/linuxmint.md
@@ -4,6 +4,9 @@ category: os
 tags: linux-distribution
 iconSlug: linuxmint
 permalink: /linuxmint
+alternate_urls:
+-   /linux-mint
+-   /mint
 versionCommand: cat /etc/linuxmint/info
 releasePolicyLink: https://linuxmint.com/download_all.php
 releaseLabel: "__RELEASE_CYCLE__ '__CODENAME__'"

--- a/products/linuxmint.md
+++ b/products/linuxmint.md
@@ -6,7 +6,6 @@ iconSlug: linuxmint
 permalink: /linuxmint
 alternate_urls:
 -   /linux-mint
--   /mint
 versionCommand: cat /etc/linuxmint/info
 releasePolicyLink: https://linuxmint.com/download_all.php
 releaseLabel: "__RELEASE_CYCLE__ '__CODENAME__'"


### PR DESCRIPTION
# :grey_question: About

While testing : 

- https://github.com/endoflife-date/endoflife.date/pull/4448

on `eol`, I felt on the following usecases while trying to find Linux Mint from : 

- `linux-mint` (looks pretty natural)
- `mint` (the distro's shortname)

![image](https://github.com/endoflife-date/endoflife.date/assets/5235127/9c144ed3-4af7-4b3d-ba17-6be1844a02d3)

![image](https://github.com/endoflife-date/endoflife.date/assets/5235127/51e5f5c4-e0d4-4297-b315-cfccdec7f8ed)

# :dart: Goal

The goal is this PR is to add these alias to make end-user UX even better :sloth: 