### PR TITLE
[openssl] Update 1.1.1 link

### DIFF
--- a/products/openssl.md
+++ b/products/openssl.md
@@ -45,6 +45,7 @@ releases:
     extendedSupport: true
     latest: "1.1.1w"
     latestReleaseDate: 2023-09-12
+    link: https://www.openssl.org/news/changelog.txt
 
 -   releaseCycle: "1.1.0"
     releaseDate: 2016-08-25


### PR DESCRIPTION
https://www.openssl.org/news/cl111.txt now returns a 404.