### PR TITLE
:bug:  Grafana 10.3 release is missing its release date

### DIFF
--- a/products/grafana.md
+++ b/products/grafana.md
@@ -26,6 +26,7 @@ releases:
     support: true
     eol: false
     latest: "10.3.1"
+    latestReleaseDate: 2024-01-23
 
 -   releaseCycle: "10.2"
     releaseDate: 2023-10-24


### PR DESCRIPTION
# :grey_question: About

Currently, as mentionned in:

- https://github.com/endoflife-date/endoflife.date/pull/4511#issuecomment-1908824435

Grafana 10.3 is missing its latest released date:

![image](https://github.com/endoflife-date/endoflife.date/assets/5235127/49534bc6-976c-4a61-9f6c-2d4fda018742)

:point_right: This PR fixes that