### PR TITLE
[mattermost] 9.5 release

### DIFF
--- a/products/mattermost.md
+++ b/products/mattermost.md
@@ -16,6 +16,12 @@ auto:
 
 # EOL date can be found on https://docs.mattermost.com/upgrade/release-lifecycle.html
 releases:
+-   releaseCycle: "9.5"
+    releaseDate: 2024-02-16
+    eol: 2024-11-15
+    latest: '9.5.0'
+    latestReleaseDate: 2024-02-16
+
 -   releaseCycle: "9.4"
     releaseDate: 2023-12-19
     eol: 2024-04-15

--- a/products/mattermost.md
+++ b/products/mattermost.md
@@ -19,7 +19,7 @@ releases:
 -   releaseCycle: "9.5"
     releaseDate: 2024-02-16
     eol: 2024-11-15
-    latest: '9.5.0'
+    latest: '9.5.1'
     latestReleaseDate: 2024-02-16
 
 -   releaseCycle: "9.4"


### PR DESCRIPTION
Release isn't final yet. Planned release date is 16th Feb: https://github.com/mattermost/mattermost/issues/25937, so we can merge around that time.