### PR TITLE
[akeneo-pim] Automate releaseDate and eol retrieval

### DIFF
--- a/products/akeneo-pim.md
+++ b/products/akeneo-pim.md
@@ -4,7 +4,7 @@ category: server-app
 tags: php-runtime
 permalink: /akeneo-pim
 releasePolicyLink: https://help.akeneo.com/en_US/akeneo-pim/akeneo-pim-product-support-dates
-changelogTemplate: 
+changelogTemplate:
   https://github.com/akeneo/pim-community-dev/blob/__RELEASE_CYCLE__/CHANGELOG-__RELEASE_CYCLE__.md
 releaseLabel: "__RELEASE_CYCLE__ (__CODENAME__)"
 releaseDateColumn: true
@@ -14,6 +14,14 @@ eolWarnThreshold: 200 # march to september
 auto:
   methods:
   -   git: https://github.com/akeneo/pim-community-dev.git
+  -   release_table: https://help.akeneo.com/en_US/akeneo-pim/akeneo-pim-product-support-dates
+      regex_exclude: '^2.[1-3]' # 2.1 to 2.3 only contained enterprise fixes or improvements.
+      selector: "table:nth-of-type(1)"
+      headers_selector: "thead th"
+      rows_selector: "tbody tr"
+      mapping:
+        releaseCycle: "Version"
+        eol: "End of support date"
 
 # EOL dates are available at https://help.akeneo.com/en_US/akeneo-pim/akeneo-pim-product-support-dates
 releases:
@@ -93,7 +101,7 @@ releases:
     codename: "Fresh Hare"
     releaseDate: 2016-03-08
     eol: 2017-09-30
-    link: 
+    link:
       https://help.akeneo.com/en_US/everything-you-need-to-know-about-our-pim-versions#v15
     latest: "1.5.27"
     latestReleaseDate: 2017-09-22
@@ -102,7 +110,7 @@ releases:
     codename: "Rhapsody Rabbit"
     releaseDate: 2015-09-23
     eol: 2017-03-31
-    link: 
+    link:
       https://help.akeneo.com/en_US/everything-you-need-to-know-about-our-pim-versions#v14
     latest: "1.4.28"
     latestReleaseDate: 2016-12-13
@@ -111,7 +119,7 @@ releases:
     codename: "Hare Force"
     releaseDate: 2015-02-12
     eol: 2016-09-30
-    link: 
+    link:
       https://help.akeneo.com/en_US/everything-you-need-to-know-about-our-pim-versions#v13
     latest: "1.3.41"
     latestReleaseDate: 2016-04-01
@@ -136,7 +144,7 @@ releases:
     codename: "Hare We Go"
     releaseDate: 2014-03-06
     eol: 2016-03-31
-    link: 
+    link:
       https://help.akeneo.com/en_US/everything-you-need-to-know-about-our-pim-versions#v10
     latest: "1.0.3"
     latestReleaseDate: 2014-03-27


### PR DESCRIPTION
Use the new `release_table` auto method for retrieving and auto-updating `releaseDate` and `eol` fields based on information fetched from https://help.akeneo.com.

This must be merged after https://github.com/endoflife-date/release-data/pull/300.