### PR TITLE
[gradle] update compatibility note for gradle 8.6

### DIFF
--- a/products/gradle.md
+++ b/products/gradle.md
@@ -22,8 +22,8 @@ auto:
 releases:
 -   releaseCycle: "8"
     releaseDate: 2023-02-10
-    # Supported versions see https://docs.gradle.org/8.5/userguide/compatibility.html
-    runningJavaVersions: 8 - 20
+    # Supported versions see https://docs.gradle.org/8.6/userguide/compatibility.html
+    runningJavaVersions: 8 - 21
     testedJavaVersions: 8 - 21
     testedKotlinVersions: 1.6.10 - 1.9.10
     testedGroovyVersions: 1.5.8 - 4.0.0

--- a/products/gradle.md
+++ b/products/gradle.md
@@ -25,9 +25,9 @@ releases:
     # Supported versions see https://docs.gradle.org/8.6/userguide/compatibility.html
     runningJavaVersions: 8 - 21
     testedJavaVersions: 8 - 21
-    testedKotlinVersions: 1.6.10 - 1.9.10
+    testedKotlinVersions: 1.6.10 - 1.9.20
     testedGroovyVersions: 1.5.8 - 4.0.0
-    testedAndroidVersions: 7.3 - 8.1
+    testedAndroidVersions: 7.3 - 8.2
     support: true
     eol: false
     latest: "8.6.0"


### PR DESCRIPTION
fix jdk compatibility note for gradle 8.6

<img width="832" alt="image" src="https://github.com/endoflife-date/endoflife.date/assets/1580956/87e986af-127f-4157-b31b-5601135d8636">
