### PR TITLE
[pan-os] Updated 10.2.7-h3 to 10.2.8

### DIFF
--- a/products/pan-os.md
+++ b/products/pan-os.md
@@ -30,10 +30,10 @@ releases:
 -   releaseCycle: "10.2"
     releaseDate: 2022-02-27
     eol: 2025-08-27
-    latest: "10.2.7-h3"
-    latestReleaseDate: 2023-12-18
+    latest: "10.2.8"
+    latestReleaseDate: 2024-02-12
     link: 
-      https://docs.paloaltonetworks.com/pan-os/10-2/pan-os-release-notes/pan-os-10-2-7-known-and-addressed-issues/pan-os-10-2-7-h3-addressed-issues
+      https://docs.paloaltonetworks.com/pan-os/10-2/pan-os-release-notes/pan-os-10-2-8-known-and-addressed-issues/pan-os-10-2-8-addressed-issues
 
 -   releaseCycle: "10.1"
     releaseDate: 2021-05-31


### PR DESCRIPTION
Updated 10.2.7-h3 to 10.2.8

Released: 2024-02-12

https://docs.paloaltonetworks.com/pan-os/10-2/pan-os-release-notes/pan-os-10-2-8-known-and-addressed-issues/pan-os-10-2-8-addressed-issues