### PR TITLE
[traefik] Add 2.11, update support for 2.10, update eol for 2.10-1.7

### DIFF
--- a/products/traefik.md
+++ b/products/traefik.md
@@ -23,87 +23,94 @@ auto:
 # Table with releaseCycles/releaseDate/support: https://doc.traefik.io/traefik/deprecation/releases
 # Estimation: support(x) = releaseDate(x+1)
 releases:
--   releaseCycle: "2.10"
-    releaseDate: 2023-04-24
+-   releaseCycle: "2.11"
+    releaseDate: 2024-02-12
     support: true
     eol: false
+    latest: "2.11.0"
+    latestReleaseDate: 2024-02-12
+
+-   releaseCycle: "2.10"
+    releaseDate: 2023-04-24
+    support: 2024-02-12
+    eol: 2024-02-12
     latest: "2.10.7"
     latestReleaseDate: 2023-12-06
 
 -   releaseCycle: "2.9"
     releaseDate: 2022-10-03
     support: 2023-04-24
-    eol: true
+    eol: 2023-04-24
     latest: "2.9.10"
     latestReleaseDate: 2023-04-06
 
 -   releaseCycle: "2.8"
     releaseDate: 2022-06-29
     support: 2022-10-03
-    eol: true
+    eol: 2022-10-03
     latest: "2.8.8"
     latestReleaseDate: 2022-09-30
 
 -   releaseCycle: "2.7"
     releaseDate: 2022-05-24
     support: 2022-06-29
-    eol: true
+    eol: 2022-06-29
     latest: "2.7.3"
     latestReleaseDate: 2022-06-29
 
 -   releaseCycle: "2.6"
     releaseDate: 2022-01-24
     support: 2022-05-24
-    eol: true
+    eol: 2022-05-24
     latest: "2.6.7"
     latestReleaseDate: 2022-05-24
 
 -   releaseCycle: "2.5"
     releaseDate: 2021-08-17
     support: 2022-01-24
-    eol: true
+    eol: 2022-01-24
     latest: "2.5.7"
     latestReleaseDate: 2022-01-20
 
 -   releaseCycle: "2.4"
     releaseDate: 2021-01-19
     support: 2021-08-17
-    eol: true
+    eol: 2021-08-17
     latest: "2.4.14"
     latestReleaseDate: 2021-08-16
 
 -   releaseCycle: "2.3"
     releaseDate: 2020-09-23
     support: 2021-01-19
-    eol: true
+    eol: 2021-01-19
     latest: "2.3.7"
     latestReleaseDate: 2021-01-11
 
 -   releaseCycle: "2.2"
     releaseDate: 2020-03-25
     support: 2020-09-23
-    eol: true
+    eol: 2020-09-23
     latest: "2.2.11"
     latestReleaseDate: 2020-09-07
 
 -   releaseCycle: "2.1"
     releaseDate: 2019-12-11
     support: 2020-03-25
-    eol: true
+    eol: 2020-03-25
     latest: "2.1.9"
     latestReleaseDate: 2020-03-23
 
 -   releaseCycle: "2.0"
     releaseDate: 2019-09-16
     support: 2019-12-11
-    eol: true
+    eol: 2019-12-11
     latest: "2.0.7"
     latestReleaseDate: 2019-12-09
 
 -   releaseCycle: "1.7"
     releaseDate: 2018-09-24
     support: 2021-12-31
-    eol: true
+    eol: 2021-12-31
     latest: "1.7.34"
     latestReleaseDate: 2021-12-10
 


### PR DESCRIPTION
https://github.com/traefik/traefik/releases/tag/v2.11.0

2.11 not yet on https://doc.traefik.io/traefik/deprecation/releases/ and 2.10 not yet updated -> applied estimation `support(x) = releaseDate(x+1)`

Update eol for 2.10-1.7
https://doc.traefik.io/traefik/deprecation/releases/:
> Only the latest minor will be on active support at any given time

plus the pattern of the past releasesCycles