### PR TITLE
Improve date validation in product-data-validator.rb and fix a few dates

### DIFF
--- a/_plugins/product-data-validator.rb
+++ b/_plugins/product-data-validator.rb
@@ -167,6 +167,13 @@ module EndOfLifeHooks
       error_if.is_not_a_string('latest') if product.data['releaseColumn']
       error_if.is_not_a_date('latestReleaseDate') if product.data['releaseColumn'] and release.has_key?('latestReleaseDate')
       error_if.is_not_an_url('link') if release.has_key?('link') and release['link']
+
+      error_if.is_not_before('releaseDate', 'support') if product.data['releaseDateColumn'] and product.data['activeSupportColumn']
+      error_if.is_not_before('releaseDate', 'eol') if product.data['releaseDateColumn'] and product.data['eolColumn']
+      error_if.is_not_before('releaseDate', 'extendedSupport') if product.data['releaseDateColumn'] and product.data['extendedSupportColumn']
+      error_if.is_not_before('support', 'eol') if product.data['activeSupportColumn'] and product.data['eolColumn']
+      error_if.is_not_before('support', 'extendedSupport') if product.data['activeSupportColumn'] and product.data['extendedSupportColumn']
+      error_if.is_not_before('eol', 'extendedSupport') if product.data['eolColumn'] and product.data['extendedSupportColumn']
     }
 
     Jekyll.logger.debug TOPIC, "Product '#{product.name}' successfully validated in #{(Time.now - start).round(3)} seconds."
@@ -276,6 +283,15 @@ module EndOfLifeHooks
       value = @data[property]
       unless [true, false].include?(value) or value.kind_of?(String)
         declare_error(property, value, "expecting a value of type boolean or string, got #{value.class}")
+      end
+    end
+
+    def is_not_before(property1, property2)
+      value1 = @data[property1]
+      value2 = @data[property2]
+
+      if value1.respond_to?(:strftime) and value2.respond_to?(:strftime) and value1 > value2
+        declare_error(property1, value1, "expecting a value before #{property2} (#{value2})")
       end
     end
 

--- a/products/lua.md
+++ b/products/lua.md
@@ -46,9 +46,9 @@ releases:
 
 -   releaseCycle: "4.0"
     releaseDate: 2000-11-06
-    eol: 2000-02-22
+    eol: 2002-07-04
     latest: "4.0.1"
-    latestReleaseDate: 2000-02-22
+    latestReleaseDate: 2002-07-04
 
 -   releaseCycle: "3.2"
     releaseDate: 1999-07-08

--- a/products/mssqlserver.md
+++ b/products/mssqlserver.md
@@ -72,7 +72,7 @@ releases:
 -   releaseCycle: "2012"
     codename: Denali
     releaseLabel: "2012 SP4"
-    releaseDate: 2017-10-05
+    releaseDate: 2012-05-20
     support: 2017-07-11
     eol: 2022-07-12
     extendedSupport: 2025-07-08
@@ -83,7 +83,7 @@ releases:
 -   releaseCycle: "2008 R2"
     codename: Kilimanjaro
     releaseLabel: "2008 R2 SP3"
-    releaseDate: 2014-09-26
+    releaseDate: 2010-07-20
     support: 2014-07-08
     eol: 2019-07-09
     extendedSupport: 2022-07-12

--- a/products/neo4j.md
+++ b/products/neo4j.md
@@ -17,6 +17,9 @@ identifiers:
 auto:
   methods:
   -   git: https://github.com/neo4j/neo4j.git
+      # Neo4j 5.0 was a Limited Availability release only and tag date is wrong.
+      # See https://neo4j.com/developer/kb/neo4j-supported-versions/#_notes.
+      regex_exclude: '^5\.0\.\d+$'
 
 # eol(x) = releaseDate(x+1)
 # See https://support.neo4j.com/hc/en-us/articles/115013134648-Neo4j-Supported-Versions.
@@ -116,12 +119,6 @@ releases:
     eol: 2022-11-21
     latest: "5.1.0"
     latestReleaseDate: 2022-10-21
-
--   releaseCycle: "5.0"
-    releaseDate: 2022-10-28
-    eol: 2022-10-24
-    latest: "5.0.0"
-    latestReleaseDate: 2022-10-28
 
 -   releaseCycle: "4.4"
     releaseDate: 2021-12-02

--- a/products/rust.md
+++ b/products/rust.md
@@ -135,7 +135,7 @@ releases:
 
 -   releaseCycle: "1.56"
     releaseDate: 2021-10-21
-    eol: 2021-01-03
+    eol: 2021-12-03
     latest: "1.56.1"
     latestReleaseDate: 2021-11-01
 

--- a/products/ubuntu.md
+++ b/products/ubuntu.md
@@ -6,7 +6,7 @@ iconSlug: ubuntu
 permalink: /ubuntu
 versionCommand: lsb_release --release
 releasePolicyLink: https://wiki.ubuntu.com/Releases
-releaseImage: 
+releaseImage:
   https://user-images.githubusercontent.com/3691490/235072519-20107b91-af55-4fd6-ac77-946bd923acbe.png
 releaseLabel: "__RELEASE_CYCLE__ '__CODENAME__'"
 changelogTemplate: https://wiki.ubuntu.com/{{"__CODENAME__"|replace:' ',''}}/ReleaseNotes/
@@ -230,8 +230,8 @@ releases:
 -   releaseCycle: "11.04"
     codename: "Natty Narwhal"
     lts: false
-    support: 2012-10-28
     releaseDate: 2011-04-28
+    support: 2012-10-28
     eol: 2012-10-28
     extendedSupport: false
     latest: "11.04"
@@ -240,8 +240,8 @@ releases:
 -   releaseCycle: "10.10"
     codename: "Maverick Meerkat"
     lts: false
-    support: 2012-04-10
     releaseDate: 2010-10-10
+    support: 2012-04-10
     eol: 2012-04-10
     extendedSupport: false
     latest: "10.10"
@@ -249,9 +249,9 @@ releases:
 
 -   releaseCycle: "10.04"
     codename: "Lucid Lynx"
-    support: 2013-05-09
     lts: true
     releaseDate: 2010-04-29
+    support: 2013-05-09
     eol: 2013-05-09
     extendedSupport: false
     latest: "10.04.4"
@@ -259,9 +259,9 @@ releases:
 
 -   releaseCycle: "9.10"
     codename: "Karmic Koala"
-    support: 2011-04-30
     lts: false
     releaseDate: 2009-10-29
+    support: 2011-04-30
     eol: 2011-04-30
     extendedSupport: false
     latest: "9.10"
@@ -269,9 +269,9 @@ releases:
 
 -   releaseCycle: "9.04"
     codename: "Jaunty Jackalope"
-    support: 2010-10-23
     lts: false
     releaseDate: 2009-04-23
+    support: 2010-10-23
     eol: 2010-10-23
     extendedSupport: false
     latest: "9.04"
@@ -279,19 +279,19 @@ releases:
 
 -   releaseCycle: "8.04"
     codename: "Hardy Heron"
-    support: 2013-05-09
     lts: true
     releaseDate: 2008-04-24
+    support: 2013-05-09
     eol: 2013-05-09
-    extendedSupport: 2011-05-12
+    extendedSupport: false
     latest: "8.04.4"
     latestReleaseDate: 2010-01-29
 
 -   releaseCycle: "7.10"
     codename: "Gutsy Gibbon"
-    support: 2009-04-18
     lts: false
     releaseDate: 2007-10-18
+    support: 2009-04-18
     eol: 2009-04-18
     extendedSupport: false
     latest: "7.10"
@@ -299,9 +299,9 @@ releases:
 
 -   releaseCycle: "7.04"
     codename: "Feisty Fawn"
-    support: 2008-10-19
     lts: false
     releaseDate: 2007-04-19
+    support: 2008-10-19
     eol: 2008-10-19
     extendedSupport: false
     latest: "7.04"
@@ -309,9 +309,9 @@ releases:
 
 -   releaseCycle: "6.10"
     codename: "Edgy Eft"
-    support: 2006-10-26
     lts: false
     releaseDate: 2006-10-26
+    support: 2006-10-26
     eol: 2008-04-26
     extendedSupport: false
     latest: "6.10"
@@ -319,19 +319,19 @@ releases:
 
 -   releaseCycle: "6.06"
     codename: "Dapper Drake"
-    support: 2011-06-01
     lts: true
+    support: 2011-06-01
     releaseDate: 2006-08-10
     eol: 2011-06-01
-    extendedSupport: 2009-07-14
+    extendedSupport: false
     latest: "6.06.2"
     latestReleaseDate: 2008-01-22
 
 -   releaseCycle: "5.10"
     codename: "Breezy Badger"
-    support: 2007-04-13
     lts: false
     releaseDate: 2005-10-13
+    support: 2007-04-13
     eol: 2007-04-13
     extendedSupport: false
     latest: "5.10"
@@ -339,9 +339,9 @@ releases:
 
 -   releaseCycle: "5.04"
     codename: "Hoary Hedgehog"
-    support: 2006-10-31
     lts: false
     releaseDate: 2005-04-08
+    support: 2006-10-31
     eol: 2006-10-31
     extendedSupport: false
     latest: "5.04"
@@ -349,9 +349,9 @@ releases:
 
 -   releaseCycle: "4.10"
     codename: "Warty Warthog"
-    support: 2004-10-26
     lts: false
     releaseDate: 2004-10-20
+    support: 2004-10-26
     eol: 2006-04-30
     extendedSupport: false
     latest: "4.10"

--- a/products/unity.md
+++ b/products/unity.md
@@ -58,7 +58,7 @@ releases:
 
 -   releaseCycle: "2021.3"
     releaseDate: 2022-04-11
-    eol: 2022-02-17
+    eol: 2024-04-19
     latest: "2021.3.35f1"
     latestReleaseDate: 2024-02-06
 

--- a/products/windows.md
+++ b/products/windows.md
@@ -206,7 +206,7 @@ releases:
     releaseLabel: "10 1709 (E)"
     releaseDate: 2017-10-17
     support: 2020-10-13
-    eol: 2020-09-13
+    eol: 2020-10-13
     latest: 10.0.16299
     link: https://learn.microsoft.com/lifecycle/announcements/windows-10-1709-end-of-servicing
 


### PR DESCRIPTION
Raise errors when the following constraint is not respected: `releaseDate <= support <= eol <= extendedSupport`.

Also fix a few date errors with some products.