### PR TITLE
[scala] Add 3.4

### DIFF
--- a/products/scala.md
+++ b/products/scala.md
@@ -21,7 +21,7 @@ auto:
 # For 3.x : support(x) = eol(x) = releaseDate(x+1)
 releases:
 -   releaseCycle: "3.4"
-    releaseDate: 2024-02-14
+    releaseDate: 2024-02-29
     support: true
     eol: false
     latest: "3.4.0"

--- a/products/scala.md
+++ b/products/scala.md
@@ -20,10 +20,17 @@ auto:
 
 # For 3.x : support(x) = eol(x) = releaseDate(x+1)
 releases:
--   releaseCycle: "3.3"
-    releaseDate: 2023-05-23
+-   releaseCycle: "3.4"
+    releaseDate: 2024-02-14
     support: true
     eol: false
+    latest: "3.4.0"
+    latestReleaseDate: 2024-02-14
+
+-   releaseCycle: "3.3"
+    releaseDate: 2023-05-23
+    support: 2024-02-14
+    eol: 2024-02-14
     latest: "3.3.2"
     latestReleaseDate: 2024-02-14
 


### PR DESCRIPTION
Not yet available on https://www.scala-lang.org/download/all.html, but should be soon. See https://github.com/lampepfl/dotty/issues/19679.