### PR TITLE
[new product]  privatebin

### DIFF
--- a/products/privatebin.md
+++ b/products/privatebin.md
@@ -64,5 +64,4 @@ releases:
 > Data is encrypted and decrypted in the browser using 256bit AES in Galois Counter mode.
 
 
-A major release is identified by a change in the first (X) or second (Y) digit in the following
-versioning nomenclature: `Version X.Y.Z.`
+PrivateBin follows [SemVer](https://semver.org/). Only the latest version is supported.

--- a/products/privatebin.md
+++ b/products/privatebin.md
@@ -5,7 +5,7 @@ tags: pastebin encryption privacy-security
 permalink: /privatebin
 alternate_urls:
 -   /private-bin
-#releasePolicyLink: https://support.hashicorp.com/hc/articles/360021185113
+releasePolicyLink: https://github.com/PrivateBin/PrivateBin?tab=security-ov-file#readme
 changelogTemplate: https://github.com/hashicorp/vault/releases/tag/__LATEST__
 releaseDateColumn: true
 #versionCommand: vault --version

--- a/products/privatebin.md
+++ b/products/privatebin.md
@@ -3,7 +3,7 @@ title:  PrivateBin
 category: server-app
 permalink: /privatebin
 releasePolicyLink: https://github.com/PrivateBin/PrivateBin?tab=security-ov-file#readme
-changelogTemplate: https://github.com/hashicorp/vault/releases/tag/__LATEST__
+changelogTemplate: https://github.com/PrivateBin/PrivateBin/releases/tag/__LATEST__
 releaseDateColumn: true
 
 auto:

--- a/products/privatebin.md
+++ b/products/privatebin.md
@@ -15,8 +15,8 @@ releases:
 -   releaseCycle: "1.7"
     releaseDate: 2024-02-12
     eol: false
-    latest: "1.7.1"
-    latestReleaseDate: 2024-02-12
+    latest: "1.7.4"
+    latestReleaseDate: 2024-07-09
 
 -   releaseCycle: "1.6"
     releaseDate: 2023-09-12

--- a/products/privatebin.md
+++ b/products/privatebin.md
@@ -59,9 +59,8 @@ releases:
     latestReleaseDate: 2017-10-11 
 ---
 
-> [PrivateBin](https://privatebin.info/) is a minimalist, open source online [pastebin](https://en.wikipedia.org/wiki/Pastebin)
-> where the server has zero knowledge of pasted data.
-> Data is encrypted and decrypted in the browser using 256bit AES in Galois Counter mode.
+> [PrivateBin](https://privatebin.info/) is a minimalist, open source [Pastebin](https://pastebin.com/) where the server
+> has zero knowledge of pasted data.
 
 
 PrivateBin follows [SemVer](https://semver.org/). Only the latest version is supported.

--- a/products/privatebin.md
+++ b/products/privatebin.md
@@ -1,0 +1,68 @@
+  ---
+title:  PrivateBin
+category: server-app
+tags: pastebin encryption privacy-security
+permalink: /privatebin
+alternate_urls:
+-   /private-bin
+#releasePolicyLink: https://support.hashicorp.com/hc/articles/360021185113
+changelogTemplate: https://github.com/hashicorp/vault/releases/tag/__LATEST__
+releaseDateColumn: true
+#versionCommand: vault --version
+
+auto:
+  methods:
+  -   git: https://github.com/PrivateBin/PrivateBin.git
+
+# eol(x) = release(x+3)
+releases:
+-   releaseCycle: "1.7"
+    releaseDate: 2024-02-12
+    eol: false
+    latest: "1.7.1"
+    latestReleaseDate: 2024-02-12
+
+-   releaseCycle: "1.6"
+    releaseDate: 2023-09-12
+    eol: 2024-02-12
+    latest: "1.6.2"
+    latestReleaseDate: 2023-12-15
+
+-   releaseCycle: "1.5"
+    releaseDate: 2022-12-11
+    eol: 2023-09-12
+    latest: "1.5.2"
+    latestReleaseDate: 2023-07-09
+
+-   releaseCycle: "1.4"
+    releaseDate: 2022-04-09
+    eol: 2022-12-11
+    latest: "1.4.0"
+    latestReleaseDate: 2022-04-09
+
+-   releaseCycle: "1.3"
+    releaseDate: 2019-07-10
+    eol: 2022-04-09
+    latest: "1.3.5"
+    latestReleaseDate: 2021-04-06
+
+-   releaseCycle: "1.2"
+    releaseDate: 2018-07-22
+    eol: 2019-07-10
+    latest: "1.2.3"
+    latestReleaseDate: 2020-02-16
+
+-   releaseCycle: "1.1"
+    releaseDate: 2016-12-26
+    eol: 2018-07-22
+    latest: "1.1.1"
+    latestReleaseDate: 2017-10-11 
+---
+
+> [PrivateBin](https://privatebin.info/) is a minimalist, open source online [pastebin](https://en.wikipedia.org/wiki/Pastebin)
+> where the server has zero knowledge of pasted data.
+> Data is encrypted and decrypted in the browser using 256bit AES in Galois Counter mode.
+
+
+A major release is identified by a change in the first (X) or second (Y) digit in the following
+versioning nomenclature: `Version X.Y.Z.`

--- a/products/privatebin.md
+++ b/products/privatebin.md
@@ -3,8 +3,6 @@ title:  PrivateBin
 category: server-app
 tags: pastebin encryption privacy-security
 permalink: /privatebin
-alternate_urls:
--   /private-bin
 releasePolicyLink: https://github.com/PrivateBin/PrivateBin?tab=security-ov-file#readme
 changelogTemplate: https://github.com/hashicorp/vault/releases/tag/__LATEST__
 releaseDateColumn: true

--- a/products/privatebin.md
+++ b/products/privatebin.md
@@ -1,4 +1,4 @@
-  ---
+---
 title:  PrivateBin
 category: server-app
 tags: pastebin encryption privacy-security

--- a/products/privatebin.md
+++ b/products/privatebin.md
@@ -8,7 +8,6 @@ alternate_urls:
 releasePolicyLink: https://github.com/PrivateBin/PrivateBin?tab=security-ov-file#readme
 changelogTemplate: https://github.com/hashicorp/vault/releases/tag/__LATEST__
 releaseDateColumn: true
-#versionCommand: vault --version
 
 auto:
   methods:

--- a/products/privatebin.md
+++ b/products/privatebin.md
@@ -57,6 +57,13 @@ releases:
     eol: 2018-07-22
     latest: "1.1.1"
     latestReleaseDate: 2017-10-11 
+
+-   releaseCycle: "1.0"
+    releaseDate: 2016-08-25
+    eol: 2016-12-26
+    latest: "1.0"
+    latestReleaseDate: 2016-08-25
+
 ---
 
 > [PrivateBin](https://privatebin.info/) is a minimalist, open source [Pastebin](https://pastebin.com/) where the server

--- a/products/privatebin.md
+++ b/products/privatebin.md
@@ -1,7 +1,6 @@
 ---
 title:  PrivateBin
 category: server-app
-tags: pastebin encryption privacy-security
 permalink: /privatebin
 releasePolicyLink: https://github.com/PrivateBin/PrivateBin?tab=security-ov-file#readme
 changelogTemplate: https://github.com/hashicorp/vault/releases/tag/__LATEST__

--- a/products/privatebin.md
+++ b/products/privatebin.md
@@ -14,7 +14,7 @@ auto:
   methods:
   -   git: https://github.com/PrivateBin/PrivateBin.git
 
-# eol(x) = release(x+3)
+# eol(x) = releaseDate(x+1)
 releases:
 -   releaseCycle: "1.7"
     releaseDate: 2024-02-12


### PR DESCRIPTION
# :information_source:  About PrivateBin

- :octocat: https://github.com/PrivateBin/PrivateBin
- :house: https://privatebin.info/

# :point_up: NBs

- For now there is no _releasePolicyLink_
- I cannot find the proper command to get `privatebin` version (I guess for security reasons)

Please let me know it's a blocking issue and I'll complete the following issue

- https://github.com/PrivateBin/PrivateBin/issues/1243
- https://github.com/simple-icons/simple-icons/issues/10500