### PR TITLE
:clap: Ubuntu 22.04.4 LTS is Available

### DIFF
--- a/products/ubuntu.md
+++ b/products/ubuntu.md
@@ -65,8 +65,8 @@ releases:
     support: 2024-09-30
     eol: 2027-04-01
     extendedSupport: 2032-04-09
-    latest: "22.04.3"
-    latestReleaseDate: 2023-08-10
+    latest: "22.04.4"
+    latestReleaseDate: 2024-02-22
 
 -   releaseCycle: "21.10"
     codename: "Impish Indri"


### PR DESCRIPTION
# :grey_question: About

Ubuntu 22.04.4 LTS is Available:

![image](https://github.com/endoflife-date/endoflife.date/assets/5235127/8ceb9bb8-6f92-47ed-87f7-fceef1996cee)

# :dart: Goal

Merging this PR will update the latest version, see:

- [Tweet](https://twitter.com/omgubuntu/status/1760733042967277945)
- [Ubuntu 22.04.4 LTS is Available to Download](https://www.omgubuntu.co.uk/2024/02/ubuntu-22-04-4-released)

# :information_source: More

> 
> Ubuntu 22.04.4 LTS is the fourth point release and results in a brand-new installation image (ISO) that integrates all of the security patches, bug fixes, and software updates released since last August’s Ubuntu 22.04.3 image.
> 
> Additionally, Ubuntu 22.04.4 ships atop a new hardware enablement stack (HWE) composed of [Linux kernel 6.5](https://www.omgubuntu.co.uk/2023/08/linux-kernel-6-5-features) (bringing support for newer hardware, file system tweaks, and security updates) and [Mesa 23.2.1](https://docs.mesa3d.org/relnotes/23.2.1.html) (offering improved graphics support).
> 
> Package updates include Thunderbird 115.6, and Mozilla Firefox 122 (which will auto-update to the most recent release at the time of install in the background after a user logs in and connects to the internet).
> 
> See the Ubuntu Discourse for a full(er) [comparison of changes](https://discourse.ubuntu.com/t/jammy-jellyfish-point-release-changes/29835?u=d0od) between Ubuntu 22.04.3 and Ubuntu 22.04.4.