### PR TITLE
[aws-lambda] Add .NET 8

### DIFF
--- a/products/aws-lambda.md
+++ b/products/aws-lambda.md
@@ -17,14 +17,19 @@ auto:
 # The custom script will only detect new releases and update support and eol dates based on dates found on https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html.
 # The release dates must be retrieved from announcements blog post on https://aws.amazon.com/blogs/compute/category/compute/aws-lambda/.
 releases:
+-   releaseCycle: "dotnet8"
+    releaseLabel: ".NET 8"
+    releaseDate: 2024-02-22
+    support: true
+    eol: false
+    link: https://aws.amazon.com/blogs/compute/introducing-the-net-8-runtime-for-aws-lambda/
+
 -   releaseCycle: "python3.12"
     releaseLabel: Python 3.12
     releaseDate: 2023-12-14
     support: true
     eol: false
     link: https://aws.amazon.com/about-aws/whats-new/2023/12/aws-lambda-support-python-3-12/
-    latest: "python3.12"
-    latestReleaseDate: 2023-12-14
 
 -   releaseCycle: "java21"
     releaseLabel: Java 21
@@ -32,8 +37,6 @@ releases:
     support: true
     eol: false
     link: https://aws.amazon.com/about-aws/whats-new/2023/11/aws-lambda-support-java-21/
-    latest: java21
-    latestReleaseDate: 2023-11-17
 
 -   releaseCycle: "nodejs20.x"
     releaseLabel: Node.js 20
@@ -41,8 +44,6 @@ releases:
     support: true
     eol: false
     link: https://aws.amazon.com/blogs/compute/node-js-20-x-runtime-now-available-in-aws-lambda/
-    latest: nodejs20.x
-    latestReleaseDate: 2023-11-15
 
 -   releaseCycle: "provided.al2023"
     releaseLabel: Custom Runtime (AL2023)
@@ -50,8 +51,6 @@ releases:
     support: true
     eol: false
     link: https://aws.amazon.com/blogs/compute/introducing-the-amazon-linux-2023-runtime-for-aws-lambda/
-    latest: provided.al2023
-    latestReleaseDate: 2023-11-10
 
 -   releaseCycle: "python3.11"
     releaseLabel: Python 3.11
@@ -59,8 +58,6 @@ releases:
     support: true
     eol: false
     link: https://aws.amazon.com/blogs/compute/python-3-11-runtime-now-available-in-aws-lambda/
-    latest: python3.11
-    latestReleaseDate: 2023-07-27
 
 -   releaseCycle: "ruby3.2"
     releaseLabel: Ruby 3.2
@@ -68,8 +65,6 @@ releases:
     support: true
     eol: false
     link: https://aws.amazon.com/blogs/compute/ruby-3-2-runtime-now-available-in-aws-lambda/
-    latest: ruby3.2
-    latestReleaseDate: 2023-06-07
 
 -   releaseCycle: "java17"
     releaseLabel: Java 17
@@ -77,8 +72,6 @@ releases:
     support: true
     eol: false
     link: https://aws.amazon.com/blogs/compute/java-17-runtime-now-available-on-aws-lambda/
-    latest: java17
-    latestReleaseDate: 2023-04-27
 
 -   releaseCycle: "python3.10"
     releaseLabel: Python 3.10
@@ -86,8 +79,6 @@ releases:
     support: true
     eol: false
     link: https://aws.amazon.com/blogs/compute/python-3-10-runtime-now-available-in-aws-lambda/
-    latest: python3.10
-    latestReleaseDate: 2023-04-18
 
 -   releaseCycle: "nodejs18.x"
     releaseLabel: Node.js 18
@@ -95,8 +86,6 @@ releases:
     support: true
     eol: false
     link: https://aws.amazon.com/blogs/compute/node-js-18-x-runtime-now-available-in-aws-lambda/
-    latest: nodejs18.x
-    latestReleaseDate: 2022-11-18
 
 -   releaseCycle: "dotnet7"
     releaseLabel: .NET 7 (container-only)
@@ -104,8 +93,6 @@ releases:
     support: 2024-05-14
     eol: false
     link: https://aws.amazon.com/blogs/compute/building-serverless-net-applications-on-aws-lambda-using-net-7/
-    latest: dotnet7
-    latestReleaseDate: 2022-11-15
 
 -   releaseCycle: "nodejs16.x"
     releaseLabel: Node.js 16
@@ -113,8 +100,6 @@ releases:
     support: 2024-06-12
     eol: 2024-08-15
     link: https://aws.amazon.com/blogs/compute/node-js-16-x-runtime-now-available-in-aws-lambda/
-    latest: nodejs16.x
-    latestReleaseDate: 2022-05-12
 
 -   releaseCycle: "dotnet6"
     releaseLabel: .NET 6
@@ -122,8 +107,6 @@ releases:
     support: 2024-11-12
     eol: 2025-02-11
     link: https://aws.amazon.com/blogs/compute/introducing-the-net-6-runtime-for-aws-lambda/
-    latest: dotnet6
-    latestReleaseDate: 2022-02-24
 
 -   releaseCycle: "python3.9"
     releaseLabel: Python 3.9
@@ -131,8 +114,6 @@ releases:
     support: true
     eol: false
     link: https://aws.amazon.com/blogs/compute/python-3-9-runtime-now-available-in-aws-lambda/
-    latest: python3.9
-    latestReleaseDate: 2021-08-16
 
 -   releaseCycle: "nodejs14.x"
     releaseLabel: Node.js 14
@@ -140,8 +121,6 @@ releases:
     support: 2023-12-04
     eol: 2024-02-08
     link: https://aws.amazon.com/blogs/compute/node-js-14-x-runtime-now-available-in-aws-lambda/
-    latest: nodejs14.x
-    latestReleaseDate: 2021-02-03
 
 -   releaseCycle: "dotnet5.0"
     releaseLabel: .NET 5 (container-only)
@@ -149,8 +128,6 @@ releases:
     support: 2022-05-10
     eol: true
     link: https://aws.amazon.com/blogs/developer/net-5-aws-lambda-support-with-container-images/
-    latest: dotnet5.0
-    latestReleaseDate: 2020-12-02
 
 -   releaseCycle: "java8.al2"
     releaseLabel: Java 8 (AL2)
@@ -158,8 +135,6 @@ releases:
     support: true
     eol: false
     link: https://aws.amazon.com/about-aws/whats-new/2020/08/aws-lambda-supports-java-8/
-    latest: java8.al2
-    latestReleaseDate: 2020-08-12
 
 -   releaseCycle: "provided.al2"
     releaseLabel: Custom Runtime (AL2)
@@ -167,8 +142,6 @@ releases:
     support: true
     eol: false
     link: https://aws.amazon.com/about-aws/whats-new/2020/08/aws-lambda-supports-custom-runtimes-amazon-linux-2/
-    latest: provided.al2
-    latestReleaseDate: 2020-08-12
 
 -   releaseCycle: "dotnetcore3.1"
     releaseLabel: .NET Core 3.1
@@ -176,8 +149,6 @@ releases:
     support: 2023-04-03
     eol: 2023-05-03
     link: https://aws.amazon.com/blogs/compute/announcing-aws-lambda-supports-for-net-core-3-1/
-    latest: dotnetcore3.1
-    latestReleaseDate: 2020-03-31
 
 -   releaseCycle: "ruby2.7"
     releaseLabel: Ruby 2.7
@@ -185,8 +156,6 @@ releases:
     support: 2023-12-07
     eol: 2024-02-08
     link: https://aws.amazon.com/about-aws/whats-new/2020/02/aws-lambda-supports-ruby-2-7/
-    latest: ruby2.7
-    latestReleaseDate: 2020-02-19
 
 -   releaseCycle: "nodejs12.x"
     releaseLabel: Node.js 12
@@ -194,8 +163,6 @@ releases:
     support: 2023-03-31
     eol: 2023-04-30
     link: https://aws.amazon.com/blogs/compute/node-js-12-x-runtime-now-available-in-aws-lambda/
-    latest: nodejs12.x
-    latestReleaseDate: 2019-11-18
 
 -   releaseCycle: "python3.8"
     releaseLabel: Python 3.8
@@ -203,8 +170,6 @@ releases:
     support: 2024-10-14
     eol: 2025-01-07
     link: https://aws.amazon.com/blogs/compute/python-3-8-runtime-now-available-in-aws-lambda/
-    latest: python3.8
-    latestReleaseDate: 2019-11-18
 
 -   releaseCycle: "java11"
     releaseLabel: Java 11
@@ -212,8 +177,6 @@ releases:
     support: true
     eol: false
     link: https://aws.amazon.com/blogs/compute/java-11-runtime-now-available-in-aws-lambda/
-    latest: java11
-    latestReleaseDate: 2019-11-18
 
 -   releaseCycle: "nodejs10.x"
     releaseLabel: Node.js 10
@@ -221,8 +184,6 @@ releases:
     support: 2021-07-30
     eol: 2022-02-14
     link: https://aws.amazon.com/about-aws/whats-new/2019/05/aws_lambda_adds_support_for_node_js_v10/
-    latest: nodejs10.x
-    latestReleaseDate: 2019-05-15
 
 -   releaseCycle: "ruby2.5"
     releaseLabel: Ruby 2.5
@@ -230,8 +191,6 @@ releases:
     support: 2021-07-30
     eol: 2022-03-31
     link: https://aws.amazon.com/blogs/compute/announcing-ruby-support-for-aws-lambda/
-    latest: ruby2.5
-    latestReleaseDate: 2018-11-29
 
 -   releaseCycle: "provided"
     releaseLabel: Custom Runtime (AL1)
@@ -239,8 +198,6 @@ releases:
     support: 2024-01-08
     eol: 2024-03-12
     link: https://aws.amazon.com/about-aws/whats-new/2018/11/aws-lambda-now-supports-custom-runtimes-and-layers/
-    latest: provided.al2023
-    latestReleaseDate: 2023-11-10
 
 -   releaseCycle: "python3.7"
     releaseLabel: Python 3.7
@@ -248,8 +205,6 @@ releases:
     support: 2023-12-04
     eol: 2024-02-08
     link: https://aws.amazon.com/blogs/compute/python-3-7-runtime-now-available-in-aws-lambda/
-    latest: python3.7
-    latestReleaseDate: 2018-11-19
 
 -   releaseCycle: "dotnetcore2.1"
     releaseLabel: .NET Core 2.1
@@ -257,8 +212,6 @@ releases:
     support: 2022-01-05
     eol: 2022-04-13
     link: https://aws.amazon.com/blogs/developer/aws-lambda-net-core-2-1-support-released/
-    latest: dotnetcore2.1
-    latestReleaseDate: 2018-07-09
 
 -   releaseCycle: "nodejs8.10"
     releaseLabel: Node.js 8.10
@@ -266,8 +219,6 @@ releases:
     support: 2020-03-06
     eol: 2020-03-06
     link: https://aws.amazon.com/blogs/compute/node-js-8-10-runtime-now-available-in-aws-lambda/
-    latest: nodejs8.10
-    latestReleaseDate: 2018-04-02
 
 -   releaseCycle: "dotnetcore2.0"
     releaseLabel: .NET Core 2.0
@@ -275,8 +226,6 @@ releases:
     support: 2019-05-30
     eol: 2019-05-30
     link: https://aws.amazon.com/blogs/developer/aws-lambda-net-core-2-0-support-released/
-    latest: dotnetcore2.0
-    latestReleaseDate: 2018-01-15
 
 -   releaseCycle: "go1.x"
     releaseLabel: Go 1.x
@@ -284,8 +233,6 @@ releases:
     support: 2024-01-08
     eol: 2024-03-12
     link: https://aws.amazon.com/blogs/compute/announcing-go-support-for-aws-lambda/
-    latest: go1.x
-    latestReleaseDate: 2018-01-15
 
 -   releaseCycle: "nodejs4.3-edge"
     releaseLabel: Node.js 4.3 edge
@@ -293,8 +240,6 @@ releases:
     support: 2020-03-05
     eol: 2020-04-30 # probably a mistake, but it's what the official documentation says
     link: https://aws.amazon.com/about-aws/whats-new/2017/07/lambda-at-edge-now-generally-available/
-    latest: nodejs4.3-edge
-    latestReleaseDate: 2017-07-17
 
 -   releaseCycle: "python3.6"
     releaseLabel: Python 3.6
@@ -302,8 +247,6 @@ releases:
     support: 2022-07-18
     eol: 2022-08-29
     link: https://aws.amazon.com/about-aws/whats-new/2017/04/aws-lambda-supports-python-3-6/
-    latest: python3.6
-    latestReleaseDate: 2017-04-18
 
 -   releaseCycle: "nodejs6.10"
     releaseLabel: Node.js 6.10
@@ -311,8 +254,6 @@ releases:
     support: 2019-08-12
     eol: true
     link: https://aws.amazon.com/about-aws/whats-new/2017/03/aws-lambda-supports-node-js-6-10/
-    latest: nodejs6.10
-    latestReleaseDate: 2017-03-22
 
 -   releaseCycle: "dotnetcore1.0"
     releaseLabel: .NET Core 1.0
@@ -320,8 +261,6 @@ releases:
     support: 2019-06-27
     eol: 2019-07-30
     link: https://aws.amazon.com/blogs/compute/announcing-c-sharp-support-for-aws-lambda/
-    latest: dotnetcore1.0
-    latestReleaseDate: 2016-12-01
 
 -   releaseCycle: "nodejs4.3"
     releaseLabel: Node.js 4.3
@@ -329,8 +268,6 @@ releases:
     support: 2020-03-05
     eol: 2020-03-05
     link: https://aws.amazon.com/blogs/compute/node-js-4-3-2-runtime-now-available-on-lambda/
-    latest: nodejs4.3-edge
-    latestReleaseDate: 2017-07-17
 
 -   releaseCycle: "python2.7"
     releaseLabel: Python 2.7
@@ -338,8 +275,6 @@ releases:
     support: 2021-07-15
     eol: 2022-05-30
     link: https://aws.amazon.com/about-aws/whats-new/2015/10/aws-lambda-supports-python-versioning-scheduled-jobs-and-5-minute-functions/
-    latest: python2.7
-    latestReleaseDate: 2015-10-08
 
 -   releaseCycle: "java8"
     releaseLabel: Java 8 (AL1)
@@ -347,8 +282,6 @@ releases:
     support: 2024-01-08
     eol: 2024-03-12
     link: https://aws.amazon.com/about-aws/whats-new/2015/06/aws-lambda-supports-java/
-    latest: java8.al2
-    latestReleaseDate: 2020-08-12
 
 -   releaseCycle: "nodejs"
     releaseLabel: Node.js 0.10
@@ -356,8 +289,6 @@ releases:
     support: false
     eol: 2016-10-31
     link: https://aws.amazon.com/blogs/aws/run-code-cloud/
-    latest: nodejs
-    latestReleaseDate: 2014-11-13
 
 ---
 


### PR DESCRIPTION
See https://aws.amazon.com/blogs/compute/introducing-the-net-8-runtime-for-aws-lambda/.

Also removed latest and latestReleaseDate fields as they were unused.