### PR TITLE
[Red Hat Satellite] Updated versionCommand from yum to dnf

### DIFF
--- a/products/redhat-satellite.md
+++ b/products/redhat-satellite.md
@@ -6,7 +6,11 @@ iconSlug: redhat
 permalink: /redhat-satellite
 alternate_urls:
 -   /rhsat
-versionCommand: dnf info satellite
+versionCommand: |-
+  dnf info satellite
+
+  # or, on older versions
+  yum info satellite
 releaseImage: https://access.redhat.com/sites/default/files/styles/XL%20-%20Extra%20Large/public/images/satellite_n-2_lifecycle_latest_v2.png
 releasePolicyLink: https://access.redhat.com/support/policy/updates/satellite
 changelogTemplate: "https://access.redhat.com/documentation/en-us/red_hat_satellite/__RELEASE_CYCLE__/html/release_notes/index"

--- a/products/redhat-satellite.md
+++ b/products/redhat-satellite.md
@@ -6,7 +6,7 @@ iconSlug: redhat
 permalink: /redhat-satellite
 alternate_urls:
 -   /rhsat
-versionCommand: yum info satellite
+versionCommand: dnf info satellite
 releaseImage: https://access.redhat.com/sites/default/files/styles/XL%20-%20Extra%20Large/public/images/satellite_n-2_lifecycle_latest_v2.png
 releasePolicyLink: https://access.redhat.com/support/policy/updates/satellite
 changelogTemplate: "https://access.redhat.com/documentation/en-us/red_hat_satellite/__RELEASE_CYCLE__/html/release_notes/index"


### PR DESCRIPTION
Since Satellite 6.12, only Red Hat Enterprise Linux 8 is supported. All older versions of Satellite are EOL.

In this respect, the `versionCommand` can be switched to the package manager of RHEL 8, dnf.