### PR TITLE
[panos]Updated 11.0.3-h3 to 11.0.3-h5

### DIFF
--- a/products/pan-os.md
+++ b/products/pan-os.md
@@ -33,9 +33,9 @@ releases:
 -   releaseCycle: "11.0"
     releaseDate: 2022-11-17
     eol: 2024-11-17
-    latest: "11.0.3-h3"
-    latestReleaseDate: 2024-01-15
-    link: https://docs.paloaltonetworks.com/pan-os/11-0/pan-os-release-notes/pan-os-11-0-3-known-and-addressed-issues/pan-os-11-0-3-h3-addressed-issues
+    latest: "11.0.3-h5"
+    latestReleaseDate: 2024-02-22
+    link: https://docs.paloaltonetworks.com/pan-os/11-0/pan-os-release-notes/pan-os-11-0-3-known-and-addressed-issues/pan-os-11-0-3-h5-addressed-issues
 
 -   releaseCycle: "10.2"
     releaseDate: 2022-02-27


### PR DESCRIPTION
Updated panos 11.0.3-h3 to 11.0.3-h5.

Released: 2024-02-22

https://docs.paloaltonetworks.com/pan-os/11-0/pan-os-release-notes/pan-os-11-0-3-known-and-addressed-issues/pan-os-11-0-3-h5-addressed-issues
