### PR TITLE
[Elasticsearch] Add ES 8 and ES 7 EOL in the description

### DIFF
--- a/products/elasticsearch.md
+++ b/products/elasticsearch.md
@@ -46,6 +46,10 @@ releases:
 > Elasticsearch is a search engine that provides a distributed, multitenant-capable full-text search
 > engine with an HTTP web interface and schema-free JSON documents.
 
+**Elasticsearch 8** will receive updates until the later of 2024-08-10 or 6 months after the release date of 9.0 (TBD).
+
+**Elasticsearch 7** will receive updates until the later of 2023-08-01 or the release date of 9.0 (TDB).
+
 Elasticsearch is part of the [Elastic Stack](https://www.elastic.co/elastic-stack/), also known as the
 [ELK Stack](https://www.elastic.co/what-is/elk-stack). It shares the same support policy as the
 other products in the Elastic Stack (Kibana, Logstash, Beats...).

--- a/products/elasticsearch.md
+++ b/products/elasticsearch.md
@@ -25,7 +25,7 @@ auto:
 releases:
 -   releaseCycle: "8"
     releaseDate: 2022-02-10
-    eol: 2024-08-10 # later of 2024-08-10 or 6 months after the release date of 9.0
+    eol: false # later of 2024-08-10 or 6 months after the release date of 9.0
     latest: "8.12.2"
     latestReleaseDate: 2024-02-22
 
@@ -46,10 +46,6 @@ releases:
 > Elasticsearch is a search engine that provides a distributed, multitenant-capable full-text search
 > engine with an HTTP web interface and schema-free JSON documents.
 
-**Elasticsearch 8** will receive updates until the later of 2024-08-10 or 6 months after the release date of 9.0 (TBD).
-
-**Elasticsearch 7** will receive updates until the later of 2023-08-01 or the release date of 9.0 (TDB).
-
 Elasticsearch is part of the [Elastic Stack](https://www.elastic.co/elastic-stack/), also known as the
 [ELK Stack](https://www.elastic.co/what-is/elk-stack). It shares the same support policy as the
 other products in the Elastic Stack (Kibana, Logstash, Beats...).
@@ -57,6 +53,11 @@ other products in the Elastic Stack (Kibana, Logstash, Beats...).
 Elastic Stack product releases follow [Semantic Versioning](https://semver.org/). Elastic provides
 maintenance for each major release series for the longest of 30 months after the GA date of the
 major release or 6 months after the GA date of the subsequent major release.
+
+Therefore:
+
+* **Elasticsearch 8** will receive updates until 6 months after the release date of 9.0 (TBD).
+* **Elasticsearch 7** will receive updates until the release date of 9.0 (TDB).
 
 End of life dates for Elasticsearch can be found on the [Elastic product EOL dates page](https://www.elastic.co/support/eol).
 Support for various operating systems can also be found on the [Elastic support matrix page](https://www.elastic.co/support/matrix).


### PR DESCRIPTION
because the date-only fields in the table can't be used for that.

It's important because those dates are already not correct as with ES 9 not being released as of 2024-02-26, ES 7 and ES 6 will be supported until at least 2024-08-26.