### PR TITLE
Apache Kafka 3.7.0 Release Announcement

### DIFF
--- a/products/apache-kafka.md
+++ b/products/apache-kafka.md
@@ -28,6 +28,13 @@ auto:
 
 # EOL(x) = MAX(latestReleaseDate, releaseDate(X+1))
 releases:
+-   releaseCycle: "3.7"
+    releaseDate: 2024-02-27
+    eol: false
+    extendedSupport: 2026-02-09
+    latest: "3.7.0"
+    latestReleaseDate: 2024-02-27
+
 -   releaseCycle: "3.6"
     releaseDate: 2023-10-03
     eol: false

--- a/products/apache-kafka.md
+++ b/products/apache-kafka.md
@@ -37,7 +37,7 @@ releases:
 
 -   releaseCycle: "3.6"
     releaseDate: 2023-10-03
-    eol: false
+    eol: 2024-02-27
     extendedSupport: 2026-02-09
     latest: "3.6.1"
     latestReleaseDate: 2023-12-05


### PR DESCRIPTION
# :grey_question: About

Apache 3.7.0 has been released, see

![image](https://github.com/endoflife-date/endoflife.date/assets/5235127/63dd7298-8f52-4677-92fb-7d8d378d7b9b)


- [Apache Kafka 3.7.0 Release Announcement](https://kafka.apache.org/blog#apache_kafka_370_release_announcement)
- [Apache Kafka Tweet](https://twitter.com/apachekafka/status/1762545514875351511)
- [Confluent tweet](https://twitter.com/confluentinc/status/1762549934564225448)

# :point_up: NB

:point_right: upport dates should be reviewed