### PR TITLE
[rabbitmq] update eol and end of support dates

### DIFF
--- a/products/rabbitmq.md
+++ b/products/rabbitmq.md
@@ -21,8 +21,8 @@ auto:
 releases:
 -   releaseCycle: "3.13"
     releaseDate: 2024-02-22
-    eol: false
-    extendedSupport: false
+    eol: 2025-03-01
+    extendedSupport: 2025-09-01
     latest: "3.13.0"
     latestReleaseDate: 2024-02-22
 


### PR DESCRIPTION

Rabbitmq updated the docs on the old dates for 3.13.0 release https://www.rabbitmq.com/docs/versions
![image](https://github.com/endoflife-date/endoflife.date/assets/1015125/6b2d72a5-f182-4e3b-a857-291df5bb070f)

