### PR TITLE
Quarkus 3.8 - New LTS version

### DIFF
--- a/products/quarkus.md
+++ b/products/quarkus.md
@@ -28,9 +28,17 @@ auto:
 # - eol(x) = releaseDate(x+1) for non-LTS
 # - eol(x) = releaseDate(x)+1y for LTS
 releases:
+-   releaseCycle: "3.8"
+    releaseDate: 2024-02-28
+    eol: 2024-02-28
+    lts: true
+    extendedSupport: false
+    latest: "3.8.0"
+    latestReleaseDate: 2024-02-28
+
 -   releaseCycle: "3.7"
     releaseDate: 2024-01-31
-    eol: false
+    eol: 2024-02-28
     extendedSupport: false
     latest: "3.7.4"
     latestReleaseDate: 2024-02-21

--- a/products/quarkus.md
+++ b/products/quarkus.md
@@ -30,7 +30,7 @@ auto:
 releases:
 -   releaseCycle: "3.8"
     releaseDate: 2024-02-28
-    eol: 2024-02-28
+    eol: 2025-02-28
     lts: true
     extendedSupport: false
     latest: "3.8.0"


### PR DESCRIPTION
# :grey_question: About

[Quarkus 3.8 - Our new LTS version](https://quarkus.io/blog/quarkus-3-8-released/) is out ( see [blog post](https://quarkus.io/blog/lts-releases/) for more ):

![image](https://github.com/endoflife-date/endoflife.date/assets/5235127/b664297d-1de2-47c5-a285-6587a7d2ab86)

# :bookmark: Related resources

- [Release Note](https://quarkus.io/blog/quarkus-3-8-released/)
- [Tweet](https://twitter.com/QuarkusIO/status/1762890325939442121)
- [Blog post about LTS](https://quarkus.io/blog/lts-releases/)