### PR TITLE
[scala] add scala 3.4 and mark 3.3.x LTS release

### DIFF
--- a/products/scala.md
+++ b/products/scala.md
@@ -28,6 +28,7 @@ releases:
     latestReleaseDate: 2024-02-29
 
 -   releaseCycle: "3.3"
+    lts: true
     releaseDate: 2023-05-23
     support: true
     eol: false

--- a/products/scala.md
+++ b/products/scala.md
@@ -103,10 +103,11 @@ are named _maintenance releases_ and are maintained for a long time (because mig
 
 ## Scala 3 release policy
 
-Starting with Scala 3.3, development will be split into two lines called _Scala Next_ (for newest
-and experimental features) and _Scala LTS_ (only bug fixes, non-language changes and minor
-quality-of-life enhancements). LTS releases will be released every two years and each LTS
-release will be supported for at least three years.
+[Starting with Scala 3.3](https://www.scala-lang.org/blog/2022/08/17/long-term-compatibility-plans.html "Long-term compatibility plans for Scala 3"),
+development is split into two lines called _Scala Next_ (for newest and experimental
+features) and _Scala LTS_ (only bug fixes, non-language changes and minor
+quality-of-life enhancements). LTS releases are released every two years and each LTS
+release is supported for at least three years.
 
 ## [JDK Compatibility](https://docs.scala-lang.org/overviews/jdk-compatibility/overview.html)
 

--- a/products/scala.md
+++ b/products/scala.md
@@ -20,6 +20,13 @@ auto:
 
 # For 3.x : support(x) = eol(x) = releaseDate(x+1)
 releases:
+-   releaseCycle: "3.4"
+    releaseDate: 2024-02-29
+    support: true
+    eol: false
+    latest: "3.4.0"
+    latestReleaseDate: 2024-02-29
+
 -   releaseCycle: "3.3"
     releaseDate: 2023-05-23
     support: true
@@ -107,7 +114,8 @@ Scala’s primary platform is the Java Virtual Machine (JVM).
 
 | JDK version | Minimum Scala versions         |
 |-------------|--------------------------------|
-| 21 (ea)     | 3.3.1, 2.13.11, 2.12.18        |
+| 22 (ea)     | 3.3.4*, 2.13.12, 2.12.19       |
+| 21 (LTS)    | 3.3.1, 2.13.11, 2.12.18        |
 | 20          | 3.3.0, 2.13.11, 2.12.18        |
 | 19          | 3.2.0, 2.13.9, 2.12.16         |
 | 18          | 3.1.3, 2.13.7, 2.12.15         |
@@ -115,4 +123,10 @@ Scala’s primary platform is the Java Virtual Machine (JVM).
 | 11 (LTS)    | 3.0.0, 2.13.0, 2.12.4, 2.11.12 |
 | 8 (LTS)     | 3.0.0, 2.13.0, 2.12.0, 2.11.0  |
 
-Using the latest patch version is always recommended.
+* = forthcoming; support available in nightly builds
+
+Even when a version combination isn’t listed as supported, most features might still work.
+
+Using latest patch version of Scala is always recommended.
+
+Lightbend offers commercial support for Scala 2. The linked page includes contact information for inquiring about supported and recommended versions.

--- a/products/scala.md
+++ b/products/scala.md
@@ -101,9 +101,8 @@ A few older `2.x` releases are also maintained with bug fixes and security suppo
 are named _maintenance releases_ and are maintained for a long time (because migration between two
 `2.x` releases is difficult).
 
-## Scala 3 future release policy
+## Scala 3 release policy
 
-[The release policy of Scala 3 is about to change](https://www.scala-lang.org/blog/2022/08/17/long-term-compatibility-plans.html "Long-term compatibility plans for Scala 3").
 Starting with Scala 3.3, development will be split into two lines called _Scala Next_ (for newest
 and experimental features) and _Scala LTS_ (only bug fixes, non-language changes and minor
 quality-of-life enhancements). LTS releases will be released every two years and each LTS

--- a/products/scala.md
+++ b/products/scala.md
@@ -124,9 +124,3 @@ Scala’s primary platform is the Java Virtual Machine (JVM).
 | 8 (LTS)     | 3.0.0, 2.13.0, 2.12.0, 2.11.0  |
 
 * = forthcoming; support available in nightly builds
-
-Even when a version combination isn’t listed as supported, most features might still work.
-
-Using latest patch version of Scala is always recommended.
-
-Lightbend offers commercial support for Scala 2. The linked page includes contact information for inquiring about supported and recommended versions.


### PR DESCRIPTION
supersedes #4616

- add scala 3.4
- update scala compatibility table
- annotate 3.3.x LTS releases

cc @marcwrobel 
relates to https://github.com/Homebrew/homebrew-core/pull/164834