### PR TITLE
[nextcloud] Automate releaseDate and eol retrieval

### DIFF
--- a/products/nextcloud.md
+++ b/products/nextcloud.md
@@ -13,8 +13,13 @@ auto:
   methods:
   -   git: https://github.com/nextcloud/server.git
       regex: ^v(?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)$
+  -   release_table: https://github.com/nextcloud/server/wiki/Maintenance-and-Release-Schedule
+      selector: "table"
+      fields:
+        releaseCycle: "Version code"
+        releaseDate: "Release date"
+        eol: "End of life"
 
-# releaseDate/eol see https://github.com/nextcloud/server/wiki/Maintenance-and-Release-Schedule
 releases:
 -   releaseCycle: "28"
     releaseDate: 2023-12-11


### PR DESCRIPTION
Based on https://github.com/nextcloud/server/wiki/Maintenance-and-Release-Schedule.