### PR TITLE
Update EOL date for Spring Framework 5.3.x

### DIFF
--- a/products/spring-framework.md
+++ b/products/spring-framework.md
@@ -42,7 +42,7 @@ releases:
     supportedJavaVersions: "8 - 21"
     supportedJakartaEEVersions: "7 - 8"
     releaseDate: 2020-10-27
-    eol: 2024-12-31
+    eol: 2024-08-31
     extendedSupport: 2026-12-31
     lts: true
     latest: "5.3.32"


### PR DESCRIPTION
See also [this blog post](https://spring.io/blog/2024/03/01/support-timeline-announcement-for-spring-framework-6-0-x-and-5-3-x)