### PR TITLE
[postgresql] Automate releaseDate and eol retrieval

### DIFF
--- a/products/postgresql.md
+++ b/products/postgresql.md
@@ -17,6 +17,12 @@ auto:
   methods:
   -   git: https://github.com/postgres/postgres.git
       regex: ^REL_?(?P<major>[1-9]\d*)_(?P<minor>\d+)_?(?P<patch>\d+)?$
+  -   release_table: https://www.postgresql.org/support/versioning/
+      selector: "table"
+      fields:
+        releaseCycle: "Version"
+        releaseDate: "First Release"
+        eol: "Final Release"
 
 identifiers:
 -   repology: postgresql


### PR DESCRIPTION
Based on https://www.postgresql.org/support/versioning/.