### PR TITLE
[apache-activemq] Add 6.1

### DIFF
--- a/products/apache-activemq.md
+++ b/products/apache-activemq.md
@@ -25,22 +25,29 @@ auto:
 # - y <= 9 and z > 9 : "https://activemq.apache.org/activemq-{{'__LATEST__'|replace_first:'.','00'|replace_first:'.','0'}}-release"
 # - y <= 9 and z <= 9 : "https://activemq.apache.org/activemq-{{'__LATEST__'|replace:'.','00'}}-release"
 releases:
+-   releaseCycle: "6.1"
+    releaseDate: 2024-03-05
+    eol: false # still listed on https://activemq.apache.org/components/classic/download/
+    latest: "6.1.0"
+    latestReleaseDate: 2024-03-05
+    link: "https://activemq.apache.org/activemq-{{'__LATEST__'|replace:'.','00'}}-release"
+
 -   releaseCycle: "6.0"
     releaseDate: 2023-11-14
-    eol: false # still listed on https://activemq.apache.org/
+    eol: false # still listed on https://activemq.apache.org/components/classic/download/
     latest: "6.0.1"
     latestReleaseDate: 2023-11-30
     link: "https://activemq.apache.org/activemq-{{'__LATEST__'|replace:'.','00'}}-release"
 
 -   releaseCycle: "5.18"
     releaseDate: 2023-03-18
-    eol: false # still listed on https://activemq.apache.org/
+    eol: false # still listed on https://activemq.apache.org/components/classic/download/
     latest: "5.18.3"
     latestReleaseDate: 2023-10-24
 
 -   releaseCycle: "5.17"
     releaseDate: 2022-03-09
-    eol: false # still listed on https://activemq.apache.org/
+    eol: false # still listed on https://activemq.apache.org/components/classic/download/
     latest: "5.17.6"
     latestReleaseDate: 2023-10-25
 

--- a/products/apache-activemq.md
+++ b/products/apache-activemq.md
@@ -26,10 +26,10 @@ auto:
 # - y <= 9 and z <= 9 : "https://activemq.apache.org/activemq-{{'__LATEST__'|replace:'.','00'}}-release"
 releases:
 -   releaseCycle: "6.1"
-    releaseDate: 2024-03-05
+    releaseDate: 2024-03-15
     eol: false # still listed on https://activemq.apache.org/components/classic/download/
     latest: "6.1.0"
-    latestReleaseDate: 2024-03-05
+    latestReleaseDate: 2024-03-15
     link: "https://activemq.apache.org/activemq-{{'__LATEST__'|replace:'.','00'}}-release"
 
 -   releaseCycle: "6.0"

--- a/products/apache-activemq.md
+++ b/products/apache-activemq.md
@@ -30,7 +30,7 @@ releases:
     eol: false # still listed on https://activemq.apache.org/components/classic/download/
     latest: "6.1.0"
     latestReleaseDate: 2024-03-15
-    link: "https://activemq.apache.org/activemq-{{'__LATEST__'|replace:'.','00'}}-release"
+    link: https://activemq.apache.org/components/classic/download/classic-06-01-00
 
 -   releaseCycle: "6.0"
     releaseDate: 2023-11-14


### PR DESCRIPTION
Not yet listed on https://activemq.apache.org/.