### PR TITLE
[pan-os]Updated 10.1.12 to 10.1.13

### DIFF
--- a/products/pan-os.md
+++ b/products/pan-os.md
@@ -47,9 +47,9 @@ releases:
 -   releaseCycle: "10.1"
     releaseDate: 2021-05-31
     eol: 2024-12-01
-    latest: "10.1.12"
-    latestReleaseDate: 2024-01-25
-    link: https://docs.paloaltonetworks.com/pan-os/10-1/pan-os-release-notes/pan-os-10-1-12-known-and-addressed-issues/pan-os-10-1-12-addressed-issues
+    latest: "10.1.13"
+    latestReleaseDate: 2024-03-06
+    link: https://docs.paloaltonetworks.com/pan-os/10-1/pan-os-release-notes/pan-os-10-1-13-known-and-addressed-issues/pan-os-10-1-13-addressed-issues
 
 -   releaseCycle: "10.0"
     releaseDate: 2020-07-16


### PR DESCRIPTION
Updated Pan-OS 10.1.12 to 10.1.13

Released: 2024-03-06

https://docs.paloaltonetworks.com/pan-os/10-1/pan-os-release-notes/pan-os-10-1-13-known-and-addressed-issues/pan-os-10-1-13-addressed-issues