### PR TITLE
[python] Automate releaseDate and eol retrieval

### DIFF
--- a/products/python.md
+++ b/products/python.md
@@ -122,6 +122,12 @@ auto:
   -   git: https://github.com/python/cpython.git
       # The v is mandatory here because each branch EOL is tagged, e.g. https://github.com/python/cpython/releases/tag/3.6
       regex: ^v(?P<major>[1-9]\d*)\.(?P<minor>\d+)\.?(?P<patch>\d+)?$
+  -   release_table: https://devguide.python.org/versions/
+      selector: "table"
+      fields:
+        releaseCycle: "Branch"
+        releaseDate: "First release"
+        eol: "End of life"
 
 releases:
 -   releaseCycle: "3.12"


### PR DESCRIPTION
Based on https://devguide.python.org/versions/