### PR TITLE
[apache-maven] Update support policy

### DIFF
--- a/products/apache-maven.md
+++ b/products/apache-maven.md
@@ -11,31 +11,71 @@ versionCommand: mvn --version
 releasePolicyLink: https://maven.apache.org/docs/history.html
 changelogTemplate: "https://github.com/apache/maven/releases/tag/maven-__LATEST__"
 releaseDateColumn: true
-activeSupportColumn: true
-eolColumn: Security Support
+eolColumn: Support
 
 auto:
   methods:
   -   maven: org.apache.maven/maven-core
 
+# Before 3.8: eol(x) = releaseDate(x+1) (introduced in https://web.archive.org/web/20230615224740/https://maven.apache.org/docs/history.html)
+# Since 3.8: eol(x) = releaseDate(x+2)
 releases:
--   releaseCycle: "3"
-    releaseDate: 2010-10-04
-    support: true
+-   releaseCycle: "3.9"
+    releaseDate: 2023-01-31
     eol: false
     latest: "3.9.6"
     latestReleaseDate: 2023-11-28
 
+-   releaseCycle: "3.8"
+    releaseDate: 2021-03-30
+    eol: false
+    latest: "3.8.8"
+    latestReleaseDate: 2023-03-08
+
+-   releaseCycle: "3.6"
+    releaseDate: 2018-10-24
+    eol: 2021-03-30
+    latest: "3.6.3"
+    latestReleaseDate: 2019-11-19
+
+-   releaseCycle: "3.5"
+    releaseDate: 2017-04-03
+    eol: 2018-10-24
+    latest: "3.5.4"
+    latestReleaseDate: 2018-06-17
+
+-   releaseCycle: "3.3"
+    releaseDate: 2015-03-13
+    eol: 2017-04-03
+    latest: "3.3.9"
+    latestReleaseDate: 2015-11-10
+
+-   releaseCycle: "3.2"
+    releaseDate: 2014-02-14
+    eol: 2015-03-13
+    latest: "3.2.5"
+    latestReleaseDate: 2014-12-14
+
+-   releaseCycle: "3.1"
+    releaseDate: 2013-06-28
+    eol: 2014-02-14
+    latest: "3.1.1"
+    latestReleaseDate: 2013-09-17
+
+-   releaseCycle: "3.0"
+    releaseDate: 2010-10-04
+    eol: 2013-06-28
+    latest: "3.0.5"
+    latestReleaseDate: 2013-02-19
+
 -   releaseCycle: "2"
     releaseDate: 2006-05-07
-    support: 2014-02-18
     eol: 2014-02-18
     latest: "2.2.1"
     latestReleaseDate: 2009-08-06
 
 -   releaseCycle: "1"
     releaseDate: 2004-07-13
-    support: 2014-02-18
     eol: 2014-02-18
     latest: "1.1"
     latestReleaseDate: 2007-06-25
@@ -47,7 +87,6 @@ releases:
 > Based on the concept of a project object model (POM), Maven can manage a project's build,
 > reporting and documentation from a central piece of information.
 
-Maven is a part of the Apache Software Foundation.
-
-The Apache Maven team maintains the last version of the last two series of GA releases. GA releases
-are represented by the minor version number (e.g., in version `X.Y.Z`, `Y` is the GA release number).
+Apache Maven follows [semantic versioning](https://semver.org).
+[Since mid-2023](https://web.archive.org/web/20230615224740/https://maven.apache.org/docs/history.html),
+the Apache Maven team maintains the two last minor versions.


### PR DESCRIPTION
Since mid-2023, the two last versions are supported (as seen on https://web.archive.org/web/20230615224740/https://maven.apache.org/docs/history.html).

Also drop the active support column as dates are always the same as EOL dates, and it does not exist in the support policy.

Closes #4829.