### PR TITLE
[lineageos] Fix duplicate releases tag

### DIFF
--- a/products/lineageos.md
+++ b/products/lineageos.md
@@ -21,7 +21,6 @@ releases:
     link: https://lineageos.org/Changelog-28/
     androidVersion: 14
 
-releases:
 -   releaseCycle: "20"
     releaseDate: 2022-12-31
     eol: false


### PR DESCRIPTION
It prevents `latest.py` to run (see https://github.com/endoflife-date/endoflife.date/pull/4893).