### PR TITLE
[silverstripe] fix release date of v2.3.13

### DIFF
--- a/products/silverstripe.md
+++ b/products/silverstripe.md
@@ -107,7 +107,7 @@ releases:
     support: false
     eol: true
     latest: "2.3.13"
-    latestReleaseDate: 2011-09-15
+    latestReleaseDate: 2012-02-01
 
 ---
 


### PR DESCRIPTION
see https://github.com/silverstripe/silverstripe-framework/releases/tag/2.3.13

reverting change in https://github.com/xini/endoflife.date/commit/c61a3fb4d84e4cd25b654e643fd9611ff1d6dc62