### PR TITLE
[envoy] Fix auto configuration

### DIFF
--- a/products/envoy.md
+++ b/products/envoy.md
@@ -22,6 +22,7 @@ auto:
   methods:
   -   git: https://github.com/envoyproxy/envoy.git
   -   release_table: https://github.com/envoyproxy/envoy/blob/main/RELEASES.md
+      render_javascript: true
       ignore_empty_releases: true # ignore future releases
       selector: "table"
       fields:


### PR DESCRIPTION
Looks like now GitHub markdown document require JavaScript to be rendered properly.