### PR TITLE
[apache-kafka] Update 3.4 link

### DIFF
--- a/products/apache-kafka.md
+++ b/products/apache-kafka.md
@@ -51,6 +51,7 @@ releases:
     releaseDate: 2023-02-06
     eol: 2023-06-13
     extendedSupport: 2025-05-03
+    link: https://archive.apache.org/dist/kafka/__LATEST__/RELEASE_NOTES.html
     latest: "3.4.1"
     latestReleaseDate: 2023-05-26
 


### PR DESCRIPTION
The changelog has been archived and is now available at https://archive.apache.org/dist/kafka/3.4.1/RELEASE_NOTES.html.