### PR TITLE
[apache-airflow] Fix auto-configuration

### DIFF
--- a/products/apache-airflow.md
+++ b/products/apache-airflow.md
@@ -21,6 +21,7 @@ auto:
   methods:
   -   pypi: apache-airflow
   -   release_table: https://github.com/apache/airflow#version-life-cycle
+      render_javascript: true
       selector: "table"
       fields:
         releaseCycle: "Version"


### PR DESCRIPTION
Looks like now GitHub markdown document require JavaScript to be rendered properly.