### PR TITLE
[robo] Fix auto-configuration

### DIFF
--- a/products/robo.md
+++ b/products/robo.md
@@ -16,6 +16,7 @@ auto:
   methods:
   -   git: https://github.com/consolidation/robo.git
   -   release_table: https://github.com/consolidation/robo#branches
+      render_javascript: true
       selector: "table"
       fields:
         releaseCycle:


### PR DESCRIPTION
Looks like now GitHub markdown document require JavaScript to be rendered properly.