### PR TITLE
yocto: Fix EOL for dunfell release series

### DIFF
--- a/products/yocto.md
+++ b/products/yocto.md
@@ -74,7 +74,7 @@ releases:
     codename: 'Dunfell'
     lts: true
     releaseDate: 2020-04-21
-    eol: 2024-04-01
+    eol: 2024-04-30
     latest: "3.1.32"
     latestReleaseDate: 2024-03-07
 


### PR DESCRIPTION
According to the [weekly status on 2024-03-26](https://wiki.yoctoproject.org/wiki/2024_Yocto_Project_Weekly_Status_Archive#Yocto_Project_Weekly_Status_March_26th,_2024) there is one more release planned in the 3.1 "dunfell" series - Yocto 3.1.33 will be released on 2024-04-26. So move the corresponding EOL date to the end of the month.