### PR TITLE
Rename support fields to align with eol fields

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -124,25 +124,21 @@ releaseLabel: "MoM Timeturner __RELEASE_CYCLE__ (__CODENAME__)"
 # Prefer using an HTML abbr tag, if possible.
 LTSLabel: "<abbr title='Extra Long Support'>ELS</abbr>"
 
-# Whether the "End of Life" column should be displayed (optional, default = true).
+# Whether the "End Of Life" column should be displayed (optional, default = true).
 # The value of this property can be set to any string to override the default column label.
 eolColumn: Security Support
 
 # Threshold at which the background color of the cycle's "eol" cell changes to indicate
 # that the EOL date is approaching (optional, default = 121 days).
-# If a fixed EOL calculation is taken the rule of thumb one third of the time can be applied.
-# e.g. eol = releaseDate + 6w -> 2w eolWarnThreshold: 14
 eolWarnThreshold: 121
 
-# Whether the "Active Support" column should be displayed (optional, default = false).
+# Whether the "End Of Active Support" column should be displayed (optional, default = false).
 # The value of this property can be set to any string to override the default column label.
-activeSupportColumn: Active Support
+eoasColumn: Active Support
 
-# Threshold at which the background color of the cycle's "activeSupport" cell changes to indicate
+# Threshold at which the background color of the cycle's "eoas" cell changes to indicate
 # that the end of active support date is approaching (optional, default = 121 days).
-# If a fixed support calculation is taken the rule of thumb one third of the time can be applied.
-# e.g. activeSupport = releaseDate + 3w -> 1w activeSupportWarnThreshold: 7
-activeSupportWarnThreshold: 121
+eoasWarnThreshold: 121
 
 # Whether the "Latest" column should be displayed (optional, default = true).
 # The value of this property can be set to any string to override the default column label.
@@ -162,13 +158,13 @@ discontinuedColumn: Discontinued
 # that the discontinued date is approaching (optional, default = 121 days).
 discontinuedWarnThreshold: 121
 
-# Whether the "Extended Support" column should be displayed (optional, default = false).
+# Whether the "End Of Extended Support" column should be displayed (optional, default = false).
 # The value of this property can be set to any string to override the default column label.
-extendedSupportColumn: Extended Support
+eoesColumn: Extended Support
 
-# Threshold at which the background color of the cycle's "extendedSupport" cell changes to indicate
+# Threshold at which the background color of the cycle's "eoes" cell changes to indicate
 # that the extended support date is approaching (optional, default = 121 days).
-extendedSupportWarnThreshold: 121
+eoesWarnThreshold: 121
 
 # Custom columns configuration (optional).
 # Custom columns are columns that will be added to the releases table and populated based on a
@@ -332,30 +328,40 @@ releases:
     # promoted LTS after their release (ex. Jenkins).
     lts: true
 
-    # End of active support date (optional if activeSupportColumn is false, else mandatory).
-    # This is where bug fixes usually stop coming in.
-    # Use valid dates, and do not add quotes around dates.
-    # Alternatively, set to true|false if the date has not been decided yet.
-    support: 2018-01-31
+    # End Of Active Support date (mandatory if eoasColumn is true, else MUST NOT be set).
+    # This can be either a date (must be valid and not quoted) or a boolean value (when
+    # the date is not known or has not been decided yet).
+    # - When a date is used, this is the date where bug fixes stop coming in.
+    # - When a boolean is used, it must be set to true if the release cycle is not supported
+    #   anymore, and false otherwise.
+    eoas: 2018-01-31
 
-    # EOL date (mandatory).
-    # This is where all support stops (including security support).
-    # In case there is extended/commercial support available, pick the date that would apply to the
-    # majority of users (and use the extendedSupport field if necessary).
-    # Use valid dates, and do not add quotes around dates.
-    # Alternatively, set to true|false the date has not been decided yet.
+    # End Of Life date (mandatory).
+    # This can be either a date (must be valid and not quoted) or a boolean value (when
+    # the date is not known or has not been decided yet).
+    # - When a date is used, this is where all support stops, including security support.
+    #   Note that this date reflects what is true for the majority of users (you may use the
+    #   eoes field if possible/necessary).
+    # - When a boolean is used, it must be set to true if the release cycle is End Of Life,
+    #   and false otherwise.
     eol: 2019-01-01
 
-    # End of extended/commercial support date (optional if extendedSupportColumn is false, else mandatory).
-    # Note that extended/commercial support is different from Long-Term Support. Extended/commercial
-    # support must be used only when additional support is available after EOL, usually against payment.
-    # Use valid dates, and do not add quotes around dates.
-    # Alternatively, set to true|false if the date has not been decided yet.
-    extendedSupport: 2020-01-01
+    # End Of Extended/commercial Support date (optional if eoesColumn is true, else SHOULD NOT be set).
+    # This can be either a date (must be valid and not quoted), a boolean value (when
+    # the date is not known or has not been decided yet), or null.
+    # - When a date is used, this is where the extended support period stops.
+    # - When a boolean is used, it must be set to true if the extended support period is over,
+    #   and false otherwise.
+    # - When null is used, it means that there is no extended/commercial support for the given
+    #   release cycle.
+    eoes: 2020-01-01
 
-    # Whether this is a "discontinued" release (optional).
-    # Can be set to true/false.
-    # Only use if discontinuedColumn is set to true.
+    # Discontinuation date (mandatory if discontinuedColumn is true, else MUST NOT be set).
+    # This can be either a date (must be valid and not quoted) or a boolean value (when
+    # the date is not known or has not been decided yet).
+    # - When a date is used, this is the date where the release cycle is discontinued.
+    # - When a boolean is used, it must be set to true if the release cycle is discontinued,
+    #   and false otherwise.
     discontinued: true
 
     # Latest release for the release cycle (optional if releaseColumn is false, else mandatory).

--- a/_config.yml
+++ b/_config.yml
@@ -85,15 +85,15 @@ defaults:
       discontinuedColumn: false
       discontinuedColumnLabel: 'Discontinued'
       discontinuedWarnThreshold: 121
-      activeSupportColumn: false
-      activeSupportColumnLabel: 'Active Support'
-      activeSupportWarnThreshold: 121
+      eoasColumn: false
+      eoasColumnLabel: 'Active Support'
+      eoasWarnThreshold: 121
       eolColumn: true
       eolColumnLabel: 'Security Support'
       eolWarnThreshold: 121
-      extendedSupportColumn: false
-      extendedSupportColumnLabel: 'Extended Support'
-      extendedSupportWarnThreshold: 121
+      eoesColumn: false
+      eoesColumnLabel: 'Extended Support'
+      eoesWarnThreshold: 121
       customColumns: []
       LTSLabel: '<abbr title="Long Term Support">LTS</abbr>'
 

--- a/_layouts/product.html
+++ b/_layouts/product.html
@@ -41,9 +41,9 @@ layout: default
       {% for column in customColumnsAfterRelease %}{% include custom-column-th.html column=column %}{% assign colCount = colCount | plus:1 %}{% endfor %}
       {% if page.releaseDateColumn %}<th>{{ page.releaseDateColumnLabel }}</th>{% assign colCount = colCount | plus:1 %}{% endif %}
       {% if page.discontinuedColumn %}<th>{{ page.discontinuedColumnLabel }}</th>{% assign colCount = colCount | plus:1 %}{% endif %}
-      {% if page.activeSupportColumn %}<th>{{ page.activeSupportColumnLabel }}</th>{% assign colCount = colCount | plus:1 %}{% endif %}
+      {% if page.eoasColumn %}<th>{{ page.eoasColumnLabel }}</th>{% assign colCount = colCount | plus:1 %}{% endif %}
       {% if page.eolColumn %}<th>{{ page.eolColumnLabel }}</th>{% assign colCount = colCount | plus:1 %}{% endif %}
-      {% if page.extendedSupportColumn %}<th>{{ page.extendedSupportColumnLabel }}</th>{% assign colCount = colCount | plus:1 %}{% endif %}
+      {% if page.eoesColumn %}<th>{{ page.eoesColumnLabel }}</th>{% assign colCount = colCount | plus:1 %}{% endif %}
       {% for column in customColumnsBeforeLatest %}{% include custom-column-th.html column=column %}{% assign colCount = colCount | plus:1 %}{% endfor %}
       {% if page.releaseColumn %}<th>{{ page.releaseColumnLabel }}</th>{% assign colCount = colCount | plus:1 %}{% endif %}
       {% for column in customColumnsAfterLatest %}{% include custom-column-th.html column=column %}{% assign colCount = colCount | plus:1 %}{% endfor %}
@@ -86,16 +86,16 @@ layout: default
     </td>
     {% endif %}
 
-    {% if page.activeSupportColumn %}
+    {% if page.eoasColumn %}
     {%- assign colorClass = 'bg-green-000' %}
-    {%- if r.days_toward_support < page.activeSupportWarnThreshold %}{% assign colorClass = 'bg-yellow-200' %}{% endif %}
-    {%- if r.days_toward_support < 0 %}{% assign colorClass = 'bg-red-000' %}{% endif %}
+    {%- if r.days_toward_eoas < page.eoasWarnThreshold %}{% assign colorClass = 'bg-yellow-200' %}{% endif %}
+    {%- if r.days_toward_eoas < 0 %}{% assign colorClass = 'bg-red-000' %}{% endif %}
     <td class="{{ colorClass }}">
-    {% if r.active_support_until %}
-      {% if r.is_active_support_over %}Ended{% else %}Ends{% endif %}
-      {{ r.active_support_until | timeago }} <div>({{ r.active_support_until | date_to_string }})</div>
+    {% if r.eoas_from %}
+      {% if r.is_eoas %}Ended{% else %}Ends{% endif %}
+      {{ r.eoas_from | timeago }} <div>({{ r.eoas_from | date_to_string }})</div>
     {% else %}
-      {% if r.is_active_support_over %}No{% else %}Yes{% endif %}
+      {% if r.is_eoas %}No{% else %}Yes{% endif %}
     {% endif %}
     </td>
     {% endif %}
@@ -114,17 +114,17 @@ layout: default
     </td>
     {% endif %}
 
-    {% if page.extendedSupportColumn %}
+    {% if page.eoesColumn %}
     {%- assign colorClass = 'bg-green-000' %}
-    {%- if r.days_toward_extendedSupport < page.extendedSupportWarnThreshold %}{% assign colorClass = 'bg-yellow-200' %}{% endif %}
-    {%- if r.days_toward_extendedSupport < 0 %}{% assign colorClass = 'bg-red-000' %}{% endif %}
-    {%- if r.extendedSupport == false %}{% assign colorClass = 'bg-grey-lt-100' %}{% endif %}
+    {%- if r.days_toward_eoes < page.eoesWarnThreshold %}{% assign colorClass = 'bg-yellow-200' %}{% endif %}
+    {%- if r.days_toward_eoes < 0 or r.eoes == true %}{% assign colorClass = 'bg-red-000' %}{% endif %}
+    {%- if r.eoes == null %}{% assign colorClass = 'bg-grey-lt-100' %}{% endif %}
     <td class="{{ colorClass }}">
-      {% if r.extended_support_until %}
-        {% if r.is_extended_support_over %}Ended{% else %}Ends{% endif %}
-        {{ r.extended_support_until | timeago }} <div>({{ r.extended_support_until | date_to_string }})</div>
+      {% if r.eoes_from %}
+        {% if r.is_eoes %}Ended{% else %}Ends{% endif %}
+        {{ r.eoes_from | timeago }} <div>({{ r.eoes_from | date_to_string }})</div>
       {% else %}
-        {% if r.is_extended_support_over %}Unavailable{% else %}Yes{% endif %}
+        {% if r.is_eoes == null %}Unavailable{% else %}{% if r.is_eoes %}No{% else %}Yes{% endif %}{% endif %}
       {% endif %}
     </td>
     {% endif %}

--- a/_plugins/create-icalendar-files.rb
+++ b/_plugins/create-icalendar-files.rb
@@ -56,11 +56,11 @@ def notification_message(product, cycle, type)
   case type
   when 'eol' then
     message += ' will become End-of-life.'
-  when 'support' then
+  when 'eoas' then
     message += ' will end active development.'
   when 'release' then
     message += ' will be released.'
-  when 'extendedSupport' then
+  when 'eoes' then
     message += ' will end extended support.'
   end
 end
@@ -71,7 +71,7 @@ def process_product(product)
   cal = Icalendar::Calendar.new
   product.release_cycles.each do |cycle|
     cycle.fetch('data').each do |key, item|
-      next if !['release', 'support', 'eol', 'extendedSupport'].include?(key) || !item.instance_of?(Date)
+      next if !['release', 'eoas', 'eol', 'eoes'].include?(key) || !item.instance_of?(Date)
       event = cal.event
       event.dtstart = Icalendar::Values::Date.new(item)
       event.dtend = Icalendar::Values::Date.new(item + 1)

--- a/_plugins/create-json-files.rb
+++ b/_plugins/create-json-files.rb
@@ -37,6 +37,22 @@ class Product
     hash.fetch('releases').map do |release|
       name = release.delete('releaseCycle')
       release['lts'] = release['lts'] || false
+
+      # To keep backward compatibility following the renaming of support and extendedSupport fields.
+      # See https://github.com/endoflife-date/endoflife.date/issues/4923.
+      if release.has_key?('eoas')
+        eoas = release.delete('eoas')
+        release['support'] = eoas.respond_to?(:strftime) ? eoas : !eoas
+      end
+      if hash.has_key?('eoesColumn')
+        if release.has_key?('eoes')
+          eoes = release.delete('eoes')
+          release['extendedSupport'] = eoes.respond_to?(:strftime) ? eoes : !eoes
+        else
+          release['extendedSupport'] = false
+        end
+      end
+
       { 'name' => name, 'data' => release }
     end
   end

--- a/_plugins/product-data-enricher.rb
+++ b/_plugins/product-data-enricher.rb
@@ -7,22 +7,22 @@
 # - Computed fields, injected by ProductDataEnricher, use the snake case notation (example: end_of_life).
 #
 # Here is a list of computed fields :
-# - is_maintained (in cycles) : whether the product cycle is still supported (mandatory)
-# - can_be_hidden (in cycles) : whether the product cycle can be hidden when displaying the product page (mandatory)
-# - is_lts (in cycles) : whether the product cycle is currently in its LTS phase (mandatory)
-# - lts_from (in cycles) : the LTS phase start date for the product cycle (optional, only if lts is a Date)
-# - is_active_support_over (in cycles) : whether the product cycle has reach the end of active support (optional, only if support is set)
-# - active_support_until (in cycles) : end of the product cycle support phase date (optional, only if support is set to a Date)
-# - is_eol (in cycles) : whether the product cycle is currently eol (optional, only if eol is set)
-# - eol_from (in cycles) : EOL date of the product cycle (optional, only if eol is set to a Date)
-# - is_discontinued (in cycles) : whether the product cycle is currently discontinued (optional, only if discontinued is set)
-# - discontinued_from (in cycles) : discontinuation date of the product cycle (optional, only if discontinued is set to a Date)
-# - is_extended_support_over (in cycles) : whether the product cycle has reach the end of extended support (optional, only if extendedSupport is set)
-# - extended_support_until (in cycles) : end of the product cycle extended support phase date (optional, only if extendedSupport is set to a Date)
-# - days_toward_support (in cycles) : number of days toward the end of support for the cycle (optional, only if support is set)
+# - is_maintained (in cycles) : whether the release cycle is still supported (mandatory)
+# - can_be_hidden (in cycles) : whether the release cycle can be hidden when displaying the product page (mandatory)
+# - is_lts (in cycles) : whether the release cycle is currently in its LTS phase (mandatory)
+# - lts_from (in cycles) : the LTS phase start date for the release cycle (optional, only if lts is a Date)
+# - is_eoas (in cycles) : whether the release cycle has reach the end of active support (optional, only if eoas is set)
+# - eoas_from (in cycles) : end of the release cycle active support phase date (optional, only if eoas is set to a Date)
+# - is_eol (in cycles) : whether the release cycle is currently eol (optional, only if eol is set)
+# - eol_from (in cycles) : EOL date of the release cycle (optional, only if eol is set to a Date)
+# - is_discontinued (in cycles) : whether the release cycle is currently discontinued (optional, only if discontinued is set)
+# - discontinued_from (in cycles) : discontinuation date of the release cycle (optional, only if discontinued is set to a Date)
+# - is_eoes (in cycles) : whether the release cycle has reach the end of extended support (optional, only if eoes is set)
+# - eoes_from (in cycles) : end of the release cycle extended support phase date (optional, only if eoes is set to a Date)
+# - days_toward_eoas (in cycles) : number of days toward the end of active support for the cycle (optional, only if eoas is set)
 # - days_toward_eol (in cycles) : number of days toward the EOL of the cycle (optional, only if eol is set)
 # - days_toward_discontinued (in cycles) : number of days toward the discontinuation of the cycle (optional, only if discontinued is set)
-# - days_toward_extendedSupport (in cycles) : number of days toward the end of extended support for the cycle (optional, only if extendedSupport is set)
+# - days_toward_eoes (in cycles) : number of days toward the end of extended support for the cycle (optional, only if eoes is set)
 module Jekyll
   class ProductDataEnricher
     class << self
@@ -86,7 +86,7 @@ module Jekyll
 
       # Set properly the column presence/label if it was overridden.
       def set_overridden_columns_label(page)
-        date_column_names = %w[releaseDateColumn releaseColumn discontinuedColumn activeSupportColumn eolColumn extendedSupportColumn]
+        date_column_names = %w[releaseDateColumn releaseColumn discontinuedColumn eoasColumn eolColumn eoesColumn]
         date_column_names.each { |date_column|
           if page.data[date_column].is_a? String
             page.data[date_column + 'Label'] = page.data[date_column]
@@ -164,8 +164,8 @@ module Jekyll
       def enrich_release(page, cycle)
         set_cycle_id(cycle)
         set_cycle_lts_fields(cycle)
-        set_cycle_active_support_fields(cycle)
-        set_cycle_extended_support_fields(cycle)
+        set_cycle_eoas_fields(cycle)
+        set_cycle_eoes_fields(cycle)
         set_cycle_eol_fields(cycle)
         set_cycle_discontinued_fields(cycle)
         set_cycle_link(page, cycle)
@@ -190,16 +190,16 @@ module Jekyll
         explode_date_or_boolean_field(cycle, 'lts', 'is_lts', 'lts_from')
       end
 
-      # Explode support to is_active_support_over (boolean) and active_support_until (Date).
+      # Explode eoas to is_eoas (boolean) and eoas_from (Date).
       # See explode_date_or_boolean_field(...) for more information.
-      def set_cycle_active_support_fields(cycle)
-        explode_date_or_boolean_field(cycle, 'support', 'is_active_support_over', 'active_support_until', true)
+      def set_cycle_eoas_fields(cycle)
+        explode_date_or_boolean_field(cycle, 'eoas', 'is_eoas', 'eoas_from')
       end
 
-      # Explode extendedSupport to is_extended_support_over (boolean) and extended_support_until (Date).
+      # Explode eoes to is_eoes (boolean) and eoes_from (Date).
       # See explode_date_or_boolean_field(...) for more information.
-      def set_cycle_extended_support_fields(cycle)
-        explode_date_or_boolean_field(cycle, 'extendedSupport', 'is_extended_support_over', 'extended_support_until', true)
+      def set_cycle_eoes_fields(cycle)
+        explode_date_or_boolean_field(cycle, 'eoes', 'is_eoes', 'eoes_from')
       end
 
       # Explode eol to is_eol (boolean) and eol_from (Date).
@@ -214,14 +214,14 @@ module Jekyll
         explode_date_or_boolean_field(cycle, 'discontinued', 'is_discontinued', 'discontinued_from')
       end
 
-      # Some product cycle fields (field_name) can be either a date or a boolean.
+      # Some release cycle fields (field_name) can be either a date or a boolean.
       # This function create two additional variables, one of boolean type (boolean_field_name) and
       # the other of Date type (date_field_name) to simplify usages in templates or Jekyll plugins.
       #
       # The invert parameter must be set according to the date nature. If it's a start date
-      # (example : the eol field) set it to false, if it's an end date (example : the support field)
+      # (example : the eol field) set it to false, if it's an end date (example : the eoas field)
       # set it to true.
-      def explode_date_or_boolean_field(cycle, field_name, boolean_field_name, date_field_name, invert = false)
+      def explode_date_or_boolean_field(cycle, field_name, boolean_field_name, date_field_name)
         unless cycle.has_key?(field_name)
           return
         end
@@ -231,7 +231,7 @@ module Jekyll
           cycle[boolean_field_name] = (Date.today > value)
           cycle[date_field_name] = value
         else
-          cycle[boolean_field_name] = invert ? !value : value
+          cycle[boolean_field_name] = value
           cycle[date_field_name] = nil
         end
       end
@@ -272,10 +272,10 @@ module Jekyll
         end
       end
 
-      # Compute the number of days toward now for all cycle's dates (support, eol...), and add those
-      # values to the cycle's data in new fields (days_toward_support, days_toward_eol...).
+      # Compute the number of days toward now for all cycle's dates (eoas, eol...), and add those
+      # values to the cycle's data in new fields (days_toward_eoas, days_toward_eol...).
       def compute_days_toward_now_for_all_dates(cycle)
-        %w[support eol discontinued extendedSupport].each { |field|
+        %w[eoas eol discontinued eoes].each { |field|
           next unless cycle.has_key?(field)
 
           field_value = cycle[field] # either a date or a boolean
@@ -283,25 +283,23 @@ module Jekyll
 
           if field_value.is_a?(Date)
             cycle[new_field_name] = days_toward_now(field_value)
-          elsif %w[eol discontinued].include?(field)
-            cycle[new_field_name] = field_value ? -4096 : 4096 # if eol     is true, then negative days
           else
-            cycle[new_field_name] = field_value ? 4096 : -4096 # if support is true, then positive days
+            cycle[new_field_name] = field_value ? -4096 : 4096
           end
         }
       end
 
       # Compute whether the cycle is still maintained and add the result to the cycle's data.
       #
-      # A cycle is maintained if at least one of the active support / eol / discontinued / extended
-      # support dates is in the future or is true.
+      # A cycle is maintained if at least one of the eoas / eol / discontinued / eoes dates
+      # is in the future or is true.
       #
       # This function must be executed after compute_days_toward_now_for_all_dates because it makes
       # use of the fields injected by this function.
       def set_is_maintained(cycle)
         is_maintained = false
 
-        %w[days_toward_support days_toward_eol days_toward_discontinued days_toward_extendedSupport].each { |days_toward_field|
+        %w[days_toward_eoas days_toward_eol days_toward_discontinued days_toward_eoes].each { |days_toward_field|
           if cycle.has_key?(days_toward_field) and cycle[days_toward_field] >= 0
             is_maintained = true
             break

--- a/_plugins/product-data-validator.rb
+++ b/_plugins/product-data-validator.rb
@@ -130,14 +130,14 @@ module EndOfLifeHooks
     error_if.is_not_a_string('LTSLabel')
     error_if.is_not_a_boolean_nor_a_string('eolColumn')
     error_if.is_not_a_number('eolWarnThreshold')
-    error_if.is_not_a_boolean_nor_a_string('activeSupportColumn')
-    error_if.is_not_a_number('activeSupportWarnThreshold')
+    error_if.is_not_a_boolean_nor_a_string('eoasColumn')
+    error_if.is_not_a_number('eoasWarnThreshold')
     error_if.is_not_a_boolean_nor_a_string('releaseColumn')
     error_if.is_not_a_boolean_nor_a_string('releaseDateColumn')
     error_if.is_not_a_boolean_nor_a_string('discontinuedColumn')
     error_if.is_not_a_number('discontinuedWarnThreshold')
-    error_if.is_not_a_boolean_nor_a_string('extendedSupportColumn')
-    error_if.is_not_a_number('extendedSupportWarnThreshold')
+    error_if.is_not_a_boolean_nor_a_string('eoesColumn')
+    error_if.is_not_a_number('eoesWarnThreshold')
     error_if.is_not_an_array('identifiers')
     error_if.is_not_an_array('releases')
 
@@ -162,21 +162,21 @@ module EndOfLifeHooks
       error_if.is_not_a_string('codename') if release.has_key?('codename')
       error_if.is_not_a_date('releaseDate') if product.data['releaseDateColumn']
       error_if.too_far_in_future('releaseDate') if product.data['releaseDateColumn']
-      error_if.is_not_a_boolean_nor_a_date('support') if product.data['activeSupportColumn']
+      error_if.is_not_a_boolean_nor_a_date('eoas') if product.data['eoasColumn']
       error_if.is_not_a_boolean_nor_a_date('eol') if product.data['eolColumn']
       error_if.is_not_a_boolean_nor_a_date('discontinued') if product.data['discontinuedColumn']
-      error_if.is_not_a_boolean_nor_a_date('extendedSupport') if product.data['extendedSupportColumn']
+      error_if.is_not_a_boolean_nor_a_date('eoes') if product.data['eoesColumn'] and release.has_key?('eoes')
       error_if.is_not_a_boolean_nor_a_date('lts') if release.has_key?('lts')
       error_if.is_not_a_string('latest') if product.data['releaseColumn']
       error_if.is_not_a_date('latestReleaseDate') if product.data['releaseColumn'] and release.has_key?('latestReleaseDate')
       error_if.is_not_an_url('link') if release.has_key?('link') and release['link']
 
-      error_if.is_not_before('releaseDate', 'support') if product.data['releaseDateColumn'] and product.data['activeSupportColumn']
+      error_if.is_not_before('releaseDate', 'eoas') if product.data['releaseDateColumn'] and product.data['eoasColumn']
       error_if.is_not_before('releaseDate', 'eol') if product.data['releaseDateColumn'] and product.data['eolColumn']
-      error_if.is_not_before('releaseDate', 'extendedSupport') if product.data['releaseDateColumn'] and product.data['extendedSupportColumn']
-      error_if.is_not_before('support', 'eol') if product.data['activeSupportColumn'] and product.data['eolColumn']
-      error_if.is_not_before('support', 'extendedSupport') if product.data['activeSupportColumn'] and product.data['extendedSupportColumn']
-      error_if.is_not_before('eol', 'extendedSupport') if product.data['eolColumn'] and product.data['extendedSupportColumn']
+      error_if.is_not_before('releaseDate', 'eoes') if product.data['releaseDateColumn'] and product.data['eoesColumn']
+      error_if.is_not_before('eoas', 'eol') if product.data['eoasColumn'] and product.data['eolColumn']
+      error_if.is_not_before('eoas', 'eoes') if product.data['eoasColumn'] and product.data['eoesColumn']
+      error_if.is_not_before('eol', 'eoes') if product.data['eolColumn'] and product.data['eoesColumn']
     }
 
     Jekyll.logger.debug TOPIC, "Product '#{product.name}' successfully validated in #{(Time.now - start).round(3)} seconds."

--- a/product-schema.json
+++ b/product-schema.json
@@ -422,20 +422,20 @@
           "description": "Date in the format `yyyy-mm-dd` or `false` if not available.",
           "$ref": "#/$defs/boolOrDate"
         },
-        "activeSupportColumn": {
+        "eoasColumn": {
           "title": "Active support column",
           "description": "Name of the active support column or `false` to disable the column.",
           "type": "boolean"
         },
-        "support": {
+        "eoas": {
           "$ref": "#/$defs/boolOrDate"
         },
-        "extendedSupportColumn": {
+        "eoesColumn": {
           "title": "Extended support column",
           "description": "Name of the extended support column or `false` to disable the column.",
           "type": "boolean"
         },
-        "extendedSupport": {
+        "eoes": {
           "$ref": "#/$defs/boolOrDate"
         },
         "discontinuedColumn": {
@@ -496,34 +496,34 @@
         {
           "if": {
             "properties": {
-              "activeSupportColumn": {
+              "eoasColumn": {
                 "type": "string"
               }
             },
             "required": [
-              "activeSupportColumn"
+              "eoasColumn"
             ]
           },
           "then": {
             "required": [
-              "support"
+              "eoas"
             ]
           }
         },
         {
           "if": {
             "properties": {
-              "extendedSupportColumn": {
+              "eoesColumn": {
                 "type": "string"
               }
             },
             "required": [
-              "extendedSupportColumn"
+              "eoesColumn"
             ]
           },
           "then": {
             "required": [
-              "extendedSupport"
+              "eoes"
             ]
           }
         },

--- a/products/almalinux.md
+++ b/products/almalinux.md
@@ -7,7 +7,7 @@ permalink: /almalinux
 versionCommand: cat /etc/redhat-release
 releasePolicyLink: https://blog.cloudlinux.com/announcing-open-sourced-community-driven-rhel-fork-by-cloudlinux
 changelogTemplate: https://wiki.almalinux.org/release-notes/__LATEST__.html
-activeSupportColumn: true
+eoasColumn: true
 releaseDateColumn: true
 
 identifiers:
@@ -22,7 +22,7 @@ auto:
 releases:
 -   releaseCycle: "9"
     releaseDate: 2022-05-26
-    support: 2027-05-31
+    eoas: 2027-05-31
     eol: 2032-05-31
     latest: "9.3"
     latestReleaseDate: 2023-11-13
@@ -30,7 +30,7 @@ releases:
 
 -   releaseCycle: "8"
     releaseDate: 2021-03-30
-    support: 2024-05-01
+    eoas: 2024-05-01
     eol: 2029-03-01
     latest: "8.9"
     latestReleaseDate: 2023-11-21

--- a/products/amazon-cdk.md
+++ b/products/amazon-cdk.md
@@ -20,7 +20,7 @@ identifiers:
 releases:
 -   releaseCycle: "2"
     releaseDate: 2021-12-01
-    support: true
+    eoas: false
     eol: false
     latest: "2.135.0"
     latestReleaseDate: 2024-04-01

--- a/products/amazon-linux.md
+++ b/products/amazon-linux.md
@@ -7,7 +7,7 @@ permalink: /amazon-linux
 versionCommand: cat /etc/system-release
 releasePolicyLink: https://docs.aws.amazon.com/AL2/latest/relnotes/relnotes-al2.html
 changelogTemplate: "https://docs.aws.amazon.com/AL2/latest/relnotes/relnotes-{{'__LATEST_RELEASE_DATE__'|replace:'-',''}}.html"
-activeSupportColumn: Standard Support
+eoasColumn: Standard Support
 eolColumn: Security Support
 releaseDateColumn: true
 
@@ -27,7 +27,7 @@ auto:
 releases:
 -   releaseCycle: '2023'
     releaseDate: 2023-03-01
-    support: 2025-03-15
+    eoas: 2025-03-15
     eol: 2028-03-15
     latest: "2023.3.20240312.0"
     latestReleaseDate: 2024-03-16
@@ -35,7 +35,7 @@ releases:
 
 -   releaseCycle: '2'
     releaseDate: 2018-06-26
-    support: 2025-06-30
+    eoas: 2025-06-30
     eol: 2025-06-30
     latest: "2.0.20240306.2"
     latestReleaseDate: 2024-03-16
@@ -44,7 +44,7 @@ releases:
 -   releaseCycle: '2018.03'
     releaseLabel: 'AMI 2018.03'
     releaseDate: 2018-04-25
-    support: 2020-12-31
+    eoas: 2020-12-31
     eol: 2023-12-31
     latest: "2018.03.0.20231218.0"
     link: https://aws.amazon.com/amazon-linux-ami/2018.03-release-notes/
@@ -53,7 +53,7 @@ releases:
 -   releaseCycle: '2017.09'
     releaseLabel: 'AMI 2017.09'
     releaseDate: 2017-11-03
-    support: 2020-12-31
+    eoas: 2020-12-31
     eol: 2023-12-31
     latest: "2017.09.1.20180409"
     link: https://aws.amazon.com/blogs/aws/now-available-amazon-linux-ami-2017-09/
@@ -62,7 +62,7 @@ releases:
 -   releaseCycle: '2017.03'
     releaseLabel: 'AMI 2017.03'
     releaseDate: 2017-04-07
-    support: 2020-12-31
+    eoas: 2020-12-31
     eol: 2023-12-31
     latest: "2017.03.1.20170812"
     link: https://aws.amazon.com/blogs/aws/amazon-inspector-update-assessment-reporting-proxy-support-and-more/     # "Amazon Linux 2017.03 Support – This new version of the Amazon Linux AMI is launching today and Inspector supports it now."
@@ -71,7 +71,7 @@ releases:
 -   releaseCycle: '2016.09'
     releaseLabel: 'AMI 2016.09'
     releaseDate: 2016-11-16
-    support: 2020-12-31
+    eoas: 2020-12-31
     eol: 2023-12-31
     latest: "2016.09.1.20161221"
     link: https://aws.amazon.com/blogs/aws/now-available-amazon-linux-ami-2016-09/
@@ -80,7 +80,7 @@ releases:
 -   releaseCycle: '2016.03'
     releaseLabel: 'AMI 2016.03'
     releaseDate: 2016-03-22
-    support: 2020-12-31
+    eoas: 2020-12-31
     eol: 2023-12-31
     latest: "2016.03"
     link: https://aws.amazon.com/amazon-linux-ami/2016.03-release-notes/
@@ -88,7 +88,7 @@ releases:
 -   releaseCycle: '2015.09'
     releaseLabel: 'AMI 2015.09'
     releaseDate: 2015-09-22
-    support: 2020-12-31
+    eoas: 2020-12-31
     eol: 2023-12-31
     latest: "2015.09"
     link: https://aws.amazon.com/blogs/aws/now-available-amazon-linux-ami-2015-09/
@@ -96,7 +96,7 @@ releases:
 -   releaseCycle: '2015.03'
     releaseLabel: 'AMI 2015.03'
     releaseDate: 2015-03-24
-    support: 2020-12-31
+    eoas: 2020-12-31
     eol: 2023-12-31
     latest: "2015.03"
     link: https://aws.amazon.com/blogs/aws/now-available-amazon-linux-ami-2015-03/
@@ -104,7 +104,7 @@ releases:
 -   releaseCycle: '2014.09'
     releaseLabel: 'AMI 2014.09'
     releaseDate: 2014-09-23
-    support: 2020-12-31
+    eoas: 2020-12-31
     eol: 2023-12-31
     latest: "2014.09"
     link: https://aws.amazon.com/blogs/aws/amazon-linux-ami-2014-09/
@@ -112,7 +112,7 @@ releases:
 -   releaseCycle: '2014.03'
     releaseLabel: 'AMI 2014.03'
     releaseDate: 2014-03-27
-    support: 2020-12-31
+    eoas: 2020-12-31
     eol: 2023-12-31
     latest: "2014.03"
     link: https://aws.amazon.com/blogs/aws/amazon-linux-ami-201403-is-now-available/
@@ -120,7 +120,7 @@ releases:
 -   releaseCycle: '2013.09'
     releaseLabel: 'AMI 2013.09'
     releaseDate: 2013-09-30
-    support: 2020-12-31
+    eoas: 2020-12-31
     eol: 2023-12-31
     latest: "2013.09"
     link: https://aws.amazon.com/blogs/aws/amazon-linux-ami-201309-now-available/
@@ -128,7 +128,7 @@ releases:
 -   releaseCycle: '2013.03'
     releaseLabel: 'AMI 2013.03'
     releaseDate: 2013-03-27
-    support: 2020-12-31
+    eoas: 2020-12-31
     eol: 2023-12-31
     latest: "2013.03"
     link: https://aws.amazon.com/blogs/aws/amazon-linux-ami-201303-now-available/
@@ -136,7 +136,7 @@ releases:
 -   releaseCycle: '2012.09'
     releaseLabel: 'AMI 2012.09'
     releaseDate: 2012-10-11
-    support: 2020-12-31
+    eoas: 2020-12-31
     eol: 2023-12-31
     latest: "2012.09"
     link: https://aws.amazon.com/blogs/aws/amazon-linux-ami-201209-now-available/
@@ -144,7 +144,7 @@ releases:
 -   releaseCycle: '2012.03'
     releaseLabel: 'AMI 2012.03'
     releaseDate: 2012-03-28
-    support: 2020-12-31
+    eoas: 2020-12-31
     eol: 2023-12-31
     latest: "2012.03"
     link: https://aws.amazon.com/blogs/aws/updated-amazon-linux-ami-201203-now-available/
@@ -152,7 +152,7 @@ releases:
 -   releaseCycle: '2011.09'
     releaseLabel: 'AMI 2011.09'
     releaseDate: 2011-09-26
-    support: 2020-12-31
+    eoas: 2020-12-31
     eol: 2023-12-31
     latest: "2011.09"
     link: https://aws.amazon.com/blogs/aws/amazon-linux-ami-production-status-new-features/
@@ -160,7 +160,7 @@ releases:
 -   releaseCycle: '2010.11'
     releaseLabel: 'AMI 2010.11'
     releaseDate: 2010-12-01
-    support: 2020-12-31
+    eoas: 2020-12-31
     eol: 2023-12-31
     latest: "2010.11"
     link: https://aws.amazon.com/blogs/aws/amazon-linux-ami-2010111-released/

--- a/products/angular.md
+++ b/products/angular.md
@@ -8,9 +8,9 @@ versionCommand: ng version
 releasePolicyLink: https://angular.io/guide/releases
 changelogTemplate: https://github.com/angular/angular/releases/tag/__LATEST__
 releaseDateColumn: true
-activeSupportColumn: true
-extendedSupportColumn: Commercial Support
-activeSupportWarnThreshold: 30
+eoasColumn: true
+eoesColumn: Commercial Support
+eoasWarnThreshold: 30
 eolWarnThreshold: 90
 
 identifiers:
@@ -24,82 +24,82 @@ auto:
 releases:
 -   releaseCycle: "17"
     releaseDate: 2023-11-08
-    support: 2024-05-08
+    eoas: 2024-05-08
     eol: 2025-05-15
     latest: "17.3.2"
     latestReleaseDate: 2024-03-28
-    extendedSupport: true
+    eoes: false
 
 -   releaseCycle: "16"
     releaseDate: 2023-05-03
-    support: 2023-11-08
+    eoas: 2023-11-08
     eol: 2024-11-08
     latest: "16.2.12"
     latestReleaseDate: 2023-11-02
-    extendedSupport: true
+    eoes: false
 
 -   releaseCycle: "15"
-    support: 2023-05-03
+    eoas: 2023-05-03
     eol: 2024-05-18
     latest: "15.2.10"
     releaseDate: 2022-11-16
     lts: 2023-05-03
     latestReleaseDate: 2023-10-04
-    extendedSupport: true
+    eoes: false
 
 -   releaseCycle: "14"
-    support: 2022-11-18
+    eoas: 2022-11-18
     eol: 2023-11-18
     latest: "14.3.0"
     releaseDate: 2022-06-02
     lts: 2022-12-02
     latestReleaseDate: 2023-03-13
-    extendedSupport: true
+    eoes: false
 
 -   releaseCycle: "13"
-    support: 2022-06-02
+    eoas: 2022-06-02
     eol: 2023-05-04
     latest: "13.4.0"
     latestReleaseDate: 2023-04-06
     releaseDate: 2021-11-03
     lts: 2022-05-04
-    extendedSupport: true
+    eoes: false
 
 -   releaseCycle: "12"
     lts: 2021-11-12
-    support: 2021-11-12
+    eoas: 2021-11-12
     eol: 2022-11-12
     latest: "12.2.17"
     latestReleaseDate: 2022-11-22
     releaseDate: 2021-05-13
-    extendedSupport: true
+    eoes: false
 
 -   releaseCycle: "11"
     lts: 2021-05-11
-    support: 2021-05-11
+    eoas: 2021-05-11
     eol: 2022-05-11
     latest: "11.2.14"
     latestReleaseDate: 2021-05-12
     releaseDate: 2020-11-11
-    extendedSupport: true
+    eoes: false
 
 -   releaseCycle: "10"
     lts: 2020-12-24
-    support: 2020-12-24
+    eoas: 2020-12-24
     eol: 2021-12-24
     latest: "10.2.5"
     latestReleaseDate: 2021-04-21
     releaseDate: 2020-06-24
-    extendedSupport: true
+    eoes: false
 
 -   releaseCycle: "9"
     lts: 2020-08-06
-    support: 2020-08-06
+    eoas: 2020-08-06
     eol: 2021-08-06
     latest: "9.1.13"
     latestReleaseDate: 2020-12-16
     releaseDate: 2020-02-06
-    extendedSupport: true
+    eoes: false
 
 ---
 
@@ -115,7 +115,7 @@ months, with 1-3 minor releases for every major release. There is an
 [update guide](https://angular.io/guide/updating "Keeping your Angular projects up-to-date")
 available.
 
-Commercial support is available for all deprecated versions of Angular through the 
-[HeroDevs Never-Ending Support](https://www.herodevs.com/support/nes-angular) initiative. 
- 
+Commercial support is available for all deprecated versions of Angular through the
+[HeroDevs Never-Ending Support](https://www.herodevs.com/support/nes-angular) initiative.
+
 *[LTS]: Long Term Support

--- a/products/angularjs.md
+++ b/products/angularjs.md
@@ -10,7 +10,7 @@ releasePolicyLink: https://docs.angularjs.org/misc/version-support-status
 changelogTemplate: https://github.com/angular/angular.js/blob/v__LATEST__/CHANGELOG.md
 releaseDateColumn: true
 eolColumn: Support
-extendedSupportColumn: Extended Long Term Support
+eoesColumn: Extended Long Term Support
 
 auto:
   methods:
@@ -26,63 +26,56 @@ releases:
     lts: true
     releaseDate: 2020-06-04
     eol: 2021-12-31
-    extendedSupport: true
+    eoes: false
     latest: "1.8.3"
     latestReleaseDate: 2022-04-07
 
 -   releaseCycle: "1.7"
     releaseDate: 2018-05-11
     eol: 2021-12-31
-    extendedSupport: false
     latest: "1.7.9"
     latestReleaseDate: 2019-11-19
 
 -   releaseCycle: "1.6"
     releaseDate: 2016-12-08
     eol: 2021-12-31
-    extendedSupport: false
     latest: "1.6.10"
     latestReleaseDate: 2018-04-17
 
 -   releaseCycle: "1.5"
     releaseDate: 2016-02-05
     eol: 2021-12-31
-    extendedSupport: true
+    eoes: false
     latest: "1.5.11"
     latestReleaseDate: 2017-01-12
 
 -   releaseCycle: "1.4"
     releaseDate: 2015-05-27
     eol: 2021-12-31
-    extendedSupport: false
     latest: "1.4.14"
     latestReleaseDate: 2016-10-11
 
 -   releaseCycle: "1.3"
     releaseDate: 2014-10-13
     eol: 2021-12-31
-    extendedSupport: false
     latest: "1.3.20"
     latestReleaseDate: 2015-09-29
 
 -   releaseCycle: "1.2"
     releaseDate: 2013-11-23
     eol: 2021-12-31
-    extendedSupport: false
     latest: "1.2.32"
     latestReleaseDate: 2016-10-11
 
 -   releaseCycle: "1.1"
     releaseDate: 2013-11-23
     eol: 2021-12-31
-    extendedSupport: false
     latest: "1.1.5"
     latestReleaseDate: 2013-11-23
 
 -   releaseCycle: "1.0"
     releaseDate: 2013-11-23
     eol: 2021-12-31
-    extendedSupport: false
     latest: "1.0.8"
     latestReleaseDate: 2013-11-23
 

--- a/products/antixlinux.md
+++ b/products/antixlinux.md
@@ -7,10 +7,10 @@ alternate_urls:
 -   /antixlinux
 -   /antix-linux
 versionCommand: cat /etc/os-release
-releasePolicyLink: 
+releasePolicyLink:
   https://www.antixforum.com/forums/topic/when-is-end-of-support-for-stable-antix-versions-17-19/#post-26424
 releaseLabel: "__RELEASE_CYCLE__ (__CODENAME__)"
-activeSupportColumn: true
+eoasColumn: true
 releaseDateColumn: true
 
 identifiers:
@@ -21,22 +21,22 @@ auto:
   -   distrowatch: antix
       regex: '^Distribution Release: antiX (?P<major>\d)\.(?P<minor>\d)$'
 
-# support(x) = Corresponding Debian support(x)
-# EOL(x) = Corresponding Debian EOL(x)
+# eoas(x) = Corresponding Debian eoas(x)
+# eol(x) = Corresponding Debian eol(x)
 releases:
 -   releaseCycle: "23"
     codename: "Arditi del Popolo" # Bookworm
     releaseDate: 2023-08-28
     latest: "23"
     latestReleaseDate: 2023-08-28
-    support: 2026-06-10
+    eoas: 2026-06-10
     eol: 2028-06-10
     link: https://antixlinux.com/antix-23-released/
 
 -   releaseCycle: "21"
     codename: "Grup Yorum" # Bullseye
     releaseDate: 2021-10-31
-    support: 2024-06-30
+    eoas: 2024-06-30
     eol: 2026-06-30
     latest: "22"
     latestReleaseDate: 2022-10-19
@@ -45,7 +45,7 @@ releases:
 -   releaseCycle: "19"
     codename: "Grup Yorum" # Buster
     releaseDate: 2019-10-17
-    support: 2022-09-10
+    eoas: 2022-09-10
     eol: 2024-06-30
     latest: "19.5"
     latestReleaseDate: 2022-01-25
@@ -54,7 +54,7 @@ releases:
 -   releaseCycle: "17"
     codename: "Helen Keller" # Stretch
     releaseDate: 2017-10-24
-    support: 2020-06-05
+    eoas: 2020-06-05
     eol: 2022-06-30
     latest: "17.4.1"
     latestReleaseDate: 2019-03-28
@@ -63,7 +63,7 @@ releases:
 -   releaseCycle: "16"
     codename: "Berta Cáceres"
     releaseDate: 2016-06-27
-    support: 2018-06-23
+    eoas: 2018-06-23
     eol: 2020-06-30
     latest: "16.3"
     latestReleaseDate: 2017-12-21
@@ -72,7 +72,7 @@ releases:
 -   releaseCycle: "15"
     codename: "Berta Cáceres"
     releaseDate: 2015-06-30
-    support: 2018-06-23
+    eoas: 2018-06-23
     eol: 2020-06-30
     latest: "15"
     latestReleaseDate: 2015-06-30

--- a/products/apache-airflow.md
+++ b/products/apache-airflow.md
@@ -10,7 +10,7 @@ versionCommand: airflow version
 releasePolicyLink: https://github.com/apache/airflow#version-life-cycle
 changelogTemplate: "https://airflow.apache.org/docs/apache-airflow/stable/release_notes.html#airflow-{{'__LATEST__'|replace:'.','-'}}-__LATEST_RELEASE_DATE__"
 releaseDateColumn: true
-activeSupportColumn: Active Support
+eoasColumn: Active Support
 eolColumn: Limited Support
 
 identifiers:
@@ -25,41 +25,41 @@ auto:
       selector: "table"
       fields:
         releaseCycle: "Version"
-        support: "Limited Support"
+        eoas: "Limited Support"
         eol: "EOL/Terminated"
 
 releases:
 -   releaseCycle: "2"
     releaseDate: 2020-12-17
-    support: true
+    eoas: false
     eol: false
     latest: "2.8.4"
     latestReleaseDate: 2024-03-25
 
 -   releaseCycle: "1.10"
     releaseDate: 2018-08-27
-    support: 2020-12-17
+    eoas: 2020-12-17
     eol: 2021-06-17
     latest: "1.10.15"
     latestReleaseDate: 2021-03-17
 
 -   releaseCycle: "1.9"
     releaseDate: 2018-01-02
-    support: 2018-08-27
+    eoas: 2018-08-27
     eol: 2018-08-27
     latest: "1.9.0"
     latestReleaseDate: 2018-01-02
 
 -   releaseCycle: "1.8"
     releaseDate: 2017-05-09
-    support: 2018-01-03
+    eoas: 2018-01-03
     eol: 2018-01-03
     latest: "1.8.2"
     latestReleaseDate: 2017-09-04
 
 -   releaseCycle: "1.7"
     releaseDate: 2016-03-28
-    support: 2017-03-19
+    eoas: 2017-03-19
     eol: 2017-03-19
     latest: "1.7.1.2"
     latestReleaseDate: 2017-05-20

--- a/products/apache-groovy.md
+++ b/products/apache-groovy.md
@@ -11,7 +11,7 @@ versionCommand: groovy --version
 releasePolicyLink: https://groovy.apache.org/versioning.html
 changelogTemplate: https://groovy-lang.org/changelogs/changelog-__LATEST__.html
 releaseDateColumn: true
-activeSupportColumn: true
+eoasColumn: true
 eolColumn: Bug and Security Fixes
 
 auto:
@@ -23,27 +23,27 @@ releases:
 -   releaseCycle: "4.0"
     releaseDate: 2022-01-25
     eol: false
-    support: true
+    eoas: false
     latest: "4.0.20"
     latestReleaseDate: 2024-03-10
 
 -   releaseCycle: "3.0"
     releaseDate: 2020-02-10
-    support: false
+    eoas: true
     eol: false
     latest: "3.0.21"
     latestReleaseDate: 2024-03-01
 
 -   releaseCycle: "2.5"
     releaseDate: 2018-05-30
-    support: false
+    eoas: true
     eol: false
     latest: "2.5.23"
     latestReleaseDate: 2023-08-22
 
 -   releaseCycle: "2.4"
     releaseDate: 2015-01-21
-    support: false
+    eoas: true
     eol: true
     latest: "2.4.21"
     latestReleaseDate: 2020-12-03

--- a/products/apache-hadoop.md
+++ b/products/apache-hadoop.md
@@ -17,7 +17,7 @@ auto:
   -   git: https://github.com/apache/hadoop.git
       regex: '^(rel\/)?release-(?P<major>[1-9][0-9]*)\.(?P<minor>[0-9]+)(\.(?P<patch>[0-9]+))?$'
 
-# EOL(x) = announceDate(https://www.mail-archive.com/hdfs-dev@hadoop.apache.org) or latestReleaseDate(x) (if the release is not active anymore)
+# eol(x) = announceDate(https://www.mail-archive.com/hdfs-dev@hadoop.apache.org) or latestReleaseDate(x) (if the release is not active anymore)
 # Active releases are documented on https://cwiki.apache.org/confluence/display/HADOOP/Hadoop+Active+Release+Lines.
 releases:
 -   releaseCycle: "3.4"

--- a/products/apache-kafka.md
+++ b/products/apache-kafka.md
@@ -9,7 +9,7 @@ alternate_urls:
 changelogTemplate: https://downloads.apache.org/kafka/__LATEST__/RELEASE_NOTES.html
 releaseDateColumn: true
 eolColumn: Support
-extendedSupportColumn: Confluent Platform Standard End of Support
+eoesColumn: Confluent Platform Standard End of Support
 # https://stackoverflow.com/a/51782038/374236
 versionCommand: ${KAFKA_HOME}/bin/kafka-topics.sh --version
 
@@ -22,35 +22,35 @@ auto:
         releaseCycle:
           column: "apache kafkaâ®"
           regex: '^(?P<value>\d+\.\d+)\.x$'
-        extendedSupport: "Standard End of Support"
+        eoes: "Standard End of Support"
 
-# EOL(x) = MAX(latestReleaseDate, releaseDate(X+1))
+# eol(x) = MAX(latestReleaseDate, releaseDate(X+1))
 releases:
 -   releaseCycle: "3.7"
     releaseDate: 2024-02-26
     eol: false
-    extendedSupport: 2026-02-09
+    eoes: 2026-02-09
     latest: "3.7.0"
     latestReleaseDate: 2024-02-26
 
 -   releaseCycle: "3.6"
     releaseDate: 2023-10-03
     eol: 2024-02-27
-    extendedSupport: 2026-02-09
+    eoes: 2026-02-09
     latest: "3.6.1"
     latestReleaseDate: 2023-12-05
 
 -   releaseCycle: "3.5"
     releaseDate: 2023-06-13
     eol: 2023-10-03
-    extendedSupport: 2025-08-25
+    eoes: 2025-08-25
     latest: "3.5.2"
     latestReleaseDate: 2023-12-08
 
 -   releaseCycle: "3.4"
     releaseDate: 2023-02-06
     eol: 2023-06-13
-    extendedSupport: 2025-05-03
+    eoes: 2025-05-03
     link: https://archive.apache.org/dist/kafka/__LATEST__/RELEASE_NOTES.html
     latest: "3.4.1"
     latestReleaseDate: 2023-05-26
@@ -58,7 +58,7 @@ releases:
 -   releaseCycle: "3.3"
     releaseDate: 2022-09-28
     eol: 2023-02-06
-    extendedSupport: 2024-11-04
+    eoes: 2024-11-04
     link: https://archive.apache.org/dist/kafka/__LATEST__/RELEASE_NOTES.html
     latest: "3.3.2"
     latestReleaseDate: 2023-01-11
@@ -66,7 +66,7 @@ releases:
 -   releaseCycle: "3.2"
     releaseDate: 2022-05-09
     eol: 2022-09-28
-    extendedSupport: 2024-07-06
+    eoes: 2024-07-06
     link: https://archive.apache.org/dist/kafka/__LATEST__/RELEASE_NOTES.html
     latest: "3.2.3"
     latestReleaseDate: 2022-09-17
@@ -74,7 +74,7 @@ releases:
 -   releaseCycle: "3.1"
     releaseDate: 2022-01-21
     eol: 2022-09-19
-    extendedSupport: 2024-04-05
+    eoes: 2024-04-05
     link: https://archive.apache.org/dist/kafka/__LATEST__/RELEASE_NOTES.html
     latest: "3.1.2"
     latestReleaseDate: 2022-09-09
@@ -82,7 +82,7 @@ releases:
 -   releaseCycle: "3.0"
     releaseDate: 2021-09-20
     eol: 2022-09-19
-    extendedSupport: 2023-10-27
+    eoes: 2023-10-27
     link: https://archive.apache.org/dist/kafka/__LATEST__/RELEASE_NOTES.html
     latest: "3.0.2"
     latestReleaseDate: 2022-09-12
@@ -90,7 +90,7 @@ releases:
 -   releaseCycle: "2.8"
     releaseDate: 2021-04-18
     eol: 2022-09-19
-    extendedSupport: 2023-06-08
+    eoes: 2023-06-08
     link: https://archive.apache.org/dist/kafka/__LATEST__/RELEASE_NOTES.html
     latest: "2.8.2"
     latestReleaseDate: 2022-09-09
@@ -98,7 +98,7 @@ releases:
 -   releaseCycle: "2.7"
     releaseDate: 2020-12-19
     eol: 2021-11-15
-    extendedSupport: 2023-02-09
+    eoes: 2023-02-09
     link: https://archive.apache.org/dist/kafka/__LATEST__/RELEASE_NOTES.html
     latest: "2.7.2"
     latestReleaseDate: 2021-10-12
@@ -106,7 +106,7 @@ releases:
 -   releaseCycle: "2.6"
     releaseDate: 2020-08-03
     eol: 2021-11-15
-    extendedSupport: 2022-09-24
+    eoes: 2022-09-24
     link: https://archive.apache.org/dist/kafka/__LATEST__/RELEASE_NOTES.html
     latest: "2.6.3"
     latestReleaseDate: 2021-11-12
@@ -114,7 +114,7 @@ releases:
 -   releaseCycle: "2.5"
     releaseDate: 2020-04-14
     eol: 2020-08-10
-    extendedSupport: 2022-04-24
+    eoes: 2022-04-24
     link: https://archive.apache.org/dist/kafka/__LATEST__/RELEASE_NOTES.html
     latest: "2.5.1"
     latestReleaseDate: 2020-08-10
@@ -122,7 +122,7 @@ releases:
 -   releaseCycle: "2.4"
     releaseDate: 2019-12-14
     eol: 2020-04-15
-    extendedSupport: 2022-01-10
+    eoes: 2022-01-10
     link: https://archive.apache.org/dist/kafka/__LATEST__/RELEASE_NOTES.html
     latest: "2.4.1"
     latestReleaseDate: 2020-03-10
@@ -130,7 +130,7 @@ releases:
 -   releaseCycle: "2.3"
     releaseDate: 2019-06-24
     eol: 2019-12-16
-    extendedSupport: 2021-07-19
+    eoes: 2021-07-19
     link: https://archive.apache.org/dist/kafka/__LATEST__/RELEASE_NOTES.html
     latest: "2.3.1"
     latestReleaseDate: 2019-10-24
@@ -138,7 +138,7 @@ releases:
 -   releaseCycle: "2.2"
     releaseDate: 2019-03-22
     eol: 2019-12-01
-    extendedSupport: 2021-03-28
+    eoes: 2021-03-28
     link: https://archive.apache.org/dist/kafka/__LATEST__/RELEASE_NOTES.html
     latest: "2.2.2"
     latestReleaseDate: 2019-12-01
@@ -146,7 +146,7 @@ releases:
 -   releaseCycle: "2.1"
     releaseDate: 2018-11-20
     eol: 2019-03-22
-    extendedSupport: 2020-12-14
+    eoes: 2020-12-14
     link: https://archive.apache.org/dist/kafka/__LATEST__/RELEASE_NOTES.html
     latest: "2.1.1"
     latestReleaseDate: 2019-02-15
@@ -154,7 +154,7 @@ releases:
 -   releaseCycle: "2.0"
     releaseDate: 2018-07-28
     eol: 2018-11-20
-    extendedSupport: 2020-07-31
+    eoes: 2020-07-31
     link: https://archive.apache.org/dist/kafka/__LATEST__/RELEASE_NOTES.html
     latest: "2.0.1"
     latestReleaseDate: 2018-11-08
@@ -162,7 +162,7 @@ releases:
 -   releaseCycle: "1.1"
     releaseDate: 2018-03-28
     eol: 2018-07-30
-    extendedSupport: 2020-04-16
+    eoes: 2020-04-16
     link: https://archive.apache.org/dist/kafka/__LATEST__/RELEASE_NOTES.html
     latest: "1.1.1"
     latestReleaseDate: 2018-07-18
@@ -170,7 +170,7 @@ releases:
 -   releaseCycle: "1.0"
     releaseDate: 2017-10-31
     eol: 2018-07-08
-    extendedSupport: 2019-11-28
+    eoes: 2019-11-28
     link: https://archive.apache.org/dist/kafka/__LATEST__/RELEASE_NOTES.html
     latest: "1.0.2"
     latestReleaseDate: 2018-07-08
@@ -178,7 +178,7 @@ releases:
 -   releaseCycle: "0.11"
     releaseDate: 2017-06-28
     eol: 2018-07-02
-    extendedSupport: 2019-08-01
+    eoes: 2019-08-01
     link: https://archive.apache.org/dist/kafka/__LATEST__/RELEASE_NOTES.html
     latest: "0.11.0.3"
     latestReleaseDate: 2018-07-02
@@ -186,7 +186,7 @@ releases:
 -   releaseCycle: "0.10"
     releaseDate: 2016-05-22
     eol: 2018-07-02
-    extendedSupport: 2019-03-02
+    eoes: 2019-03-02
     link: https://archive.apache.org/dist/kafka/__LATEST__/RELEASE_NOTES.html
     latest: "0.10.2.2"
     latestReleaseDate: 2018-07-02
@@ -194,7 +194,7 @@ releases:
 -   releaseCycle: "0.9"
     releaseDate: 2015-11-23
     eol: 2016-05-22
-    extendedSupport: 2017-12-07
+    eoes: 2017-12-07
     link: https://archive.apache.org/dist/kafka/__LATEST__/RELEASE_NOTES.html
     latest: "0.9.0.1"
     latestReleaseDate: 2016-02-19
@@ -202,7 +202,6 @@ releases:
 -   releaseCycle: "0.8"
     releaseDate: 2013-12-03
     eol: 2015-11-23
-    extendedSupport: false
     link: https://archive.apache.org/dist/kafka/__LATEST__/RELEASE_NOTES.html
     latest: "0.8.2.2"
     latestReleaseDate: 2015-10-02
@@ -210,7 +209,6 @@ releases:
 -   releaseCycle: "0.7"
     releaseDate: 2012-01-04
     eol: 2013-12-03
-    extendedSupport: false
     link: https://archive.apache.org/dist/kafka/old_releases/kafka-0.7.2-incubating/RELEASE-NOTES.html
     latest: "0.7.2"
     latestReleaseDate: 2012-10-10

--- a/products/api-platform.md
+++ b/products/api-platform.md
@@ -7,88 +7,88 @@ versionCommand: composer show api-platform/core | grep versions
 releasePolicyLink: https://api-platform.com/docs/extra/releases/
 changelogTemplate: https://github.com/api-platform/core/releases/tag/v__LATEST__
 releaseDateColumn: true
-activeSupportColumn: true
+eoasColumn: true
 
 auto:
   methods:
   -   git: https://github.com/api-platform/core.git
 
-# support(x) = releaseDate(x+1)
+# eoas(x) = releaseDate(x+1)
 # eol(x) = releaseDate(x+2)
 releases:
 -   releaseCycle: "3.2"
     releaseDate: 2023-10-12
-    support: true
+    eoas: false
     eol: false
     latest: "3.2.19"
     latestReleaseDate: 2024-03-29
 
 -   releaseCycle: "3.1"
     releaseDate: 2023-01-23
-    support: 2023-10-12
+    eoas: 2023-10-12
     eol: false
     latest: "3.1.27"
     latestReleaseDate: 2024-03-29
 
 -   releaseCycle: "3.0"
     releaseDate: 2022-09-15
-    support: 2023-01-23
+    eoas: 2023-01-23
     eol: 2023-10-12
     latest: "3.0.12"
     latestReleaseDate: 2023-02-28
 
 -   releaseCycle: "2.7"
     releaseDate: 2022-09-15
-    support: 2023-01-27
+    eoas: 2023-01-27
     eol: 2023-01-27
     latest: "2.7.18"
     latestReleaseDate: 2024-03-19
 
 -   releaseCycle: "2.6"
     releaseDate: 2021-01-22
-    support: 2022-09-15
+    eoas: 2022-09-15
     eol: 2022-09-15
     latest: "2.6.8"
     latestReleaseDate: 2022-01-11
 
 -   releaseCycle: "2.5"
     releaseDate: 2019-09-30
-    support: 2021-01-22
+    eoas: 2021-01-22
     eol: 2022-09-15
     latest: "2.5.10"
     latestReleaseDate: 2021-01-22
 
 -   releaseCycle: "2.4"
     releaseDate: 2019-03-22
-    support: 2019-09-30
+    eoas: 2019-09-30
     eol: 2021-01-22
     latest: "2.4.7"
     latestReleaseDate: 2019-09-17
 
 -   releaseCycle: "2.3"
     releaseDate: 2018-07-06
-    support: 2019-03-22
+    eoas: 2019-03-22
     eol: 2019-09-30
     latest: "2.3.6"
     latestReleaseDate: 2019-01-15
 
 -   releaseCycle: "2.2"
     releaseDate: 2018-02-16
-    support: 2018-07-06
+    eoas: 2018-07-06
     eol: 2019-03-22
     latest: "2.2.10"
     latestReleaseDate: 2019-01-15
 
 -   releaseCycle: "2.1"
     releaseDate: 2017-09-08
-    support: 2018-02-16
+    eoas: 2018-02-16
     eol: 2018-07-06
     latest: "2.1.6"
     latestReleaseDate: 2018-02-12
 
 -   releaseCycle: "2.0"
     releaseDate: 2016-11-24
-    support: 2017-09-08
+    eoas: 2017-09-08
     eol: 2018-02-16
     latest: "2.0.11"
     latestReleaseDate: 2017-09-08

--- a/products/aws-lambda.md
+++ b/products/aws-lambda.md
@@ -7,7 +7,7 @@ permalink: /aws-lambda
 releasePolicyLink: https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html
 releaseDateColumn: true
 releaseColumn: false
-activeSupportColumn: Standard Support
+eoasColumn: Standard Support
 eolColumn: Deprecated Support
 
 auto:
@@ -20,273 +20,273 @@ releases:
 -   releaseCycle: "dotnet8"
     releaseLabel: ".NET 8"
     releaseDate: 2024-02-22
-    support: true
+    eoas: false
     eol: false
     link: https://aws.amazon.com/blogs/compute/introducing-the-net-8-runtime-for-aws-lambda/
 
 -   releaseCycle: "python3.12"
     releaseLabel: Python 3.12
     releaseDate: 2023-12-14
-    support: true
+    eoas: false
     eol: false
     link: https://aws.amazon.com/about-aws/whats-new/2023/12/aws-lambda-support-python-3-12/
 
 -   releaseCycle: "java21"
     releaseLabel: Java 21
     releaseDate: 2023-11-17
-    support: true
+    eoas: false
     eol: false
     link: https://aws.amazon.com/about-aws/whats-new/2023/11/aws-lambda-support-java-21/
 
 -   releaseCycle: "nodejs20.x"
     releaseLabel: Node.js 20
     releaseDate: 2023-11-15
-    support: true
+    eoas: false
     eol: false
     link: https://aws.amazon.com/blogs/compute/node-js-20-x-runtime-now-available-in-aws-lambda/
 
 -   releaseCycle: "provided.al2023"
     releaseLabel: Custom Runtime (AL2023)
     releaseDate: 2023-11-10
-    support: true
+    eoas: false
     eol: false
     link: https://aws.amazon.com/blogs/compute/introducing-the-amazon-linux-2023-runtime-for-aws-lambda/
 
 -   releaseCycle: "python3.11"
     releaseLabel: Python 3.11
     releaseDate: 2023-07-27
-    support: true
+    eoas: false
     eol: false
     link: https://aws.amazon.com/blogs/compute/python-3-11-runtime-now-available-in-aws-lambda/
 
 -   releaseCycle: "ruby3.2"
     releaseLabel: Ruby 3.2
     releaseDate: 2023-06-07
-    support: true
+    eoas: false
     eol: false
     link: https://aws.amazon.com/blogs/compute/ruby-3-2-runtime-now-available-in-aws-lambda/
 
 -   releaseCycle: "java17"
     releaseLabel: Java 17
     releaseDate: 2023-04-27
-    support: true
+    eoas: false
     eol: false
     link: https://aws.amazon.com/blogs/compute/java-17-runtime-now-available-on-aws-lambda/
 
 -   releaseCycle: "python3.10"
     releaseLabel: Python 3.10
     releaseDate: 2023-04-18
-    support: true
+    eoas: false
     eol: false
     link: https://aws.amazon.com/blogs/compute/python-3-10-runtime-now-available-in-aws-lambda/
 
 -   releaseCycle: "nodejs18.x"
     releaseLabel: Node.js 18
     releaseDate: 2022-11-18
-    support: true
+    eoas: false
     eol: false
     link: https://aws.amazon.com/blogs/compute/node-js-18-x-runtime-now-available-in-aws-lambda/
 
 -   releaseCycle: "dotnet7"
     releaseLabel: .NET 7 (container-only)
     releaseDate: 2022-11-15
-    support: 2024-05-14
+    eoas: 2024-05-14
     eol: false
     link: https://aws.amazon.com/blogs/compute/building-serverless-net-applications-on-aws-lambda-using-net-7/
 
 -   releaseCycle: "nodejs16.x"
     releaseLabel: Node.js 16
     releaseDate: 2022-05-12
-    support: 2024-06-12
+    eoas: 2024-06-12
     eol: 2024-08-15
     link: https://aws.amazon.com/blogs/compute/node-js-16-x-runtime-now-available-in-aws-lambda/
 
 -   releaseCycle: "dotnet6"
     releaseLabel: .NET 6
     releaseDate: 2022-02-24
-    support: 2024-11-12
+    eoas: 2024-11-12
     eol: 2025-02-11
     link: https://aws.amazon.com/blogs/compute/introducing-the-net-6-runtime-for-aws-lambda/
 
 -   releaseCycle: "python3.9"
     releaseLabel: Python 3.9
     releaseDate: 2021-08-16
-    support: true
+    eoas: false
     eol: false
     link: https://aws.amazon.com/blogs/compute/python-3-9-runtime-now-available-in-aws-lambda/
 
 -   releaseCycle: "nodejs14.x"
     releaseLabel: Node.js 14
     releaseDate: 2021-02-03
-    support: 2023-12-04
+    eoas: 2023-12-04
     eol: 2024-02-08
     link: https://aws.amazon.com/blogs/compute/node-js-14-x-runtime-now-available-in-aws-lambda/
 
 -   releaseCycle: "dotnet5.0"
     releaseLabel: .NET 5 (container-only)
     releaseDate: 2020-12-02
-    support: 2022-05-10
+    eoas: 2022-05-10
     eol: true
     link: https://aws.amazon.com/blogs/developer/net-5-aws-lambda-support-with-container-images/
 
 -   releaseCycle: "java8.al2"
     releaseLabel: Java 8 (AL2)
     releaseDate: 2020-08-12
-    support: true
+    eoas: false
     eol: false
     link: https://aws.amazon.com/about-aws/whats-new/2020/08/aws-lambda-supports-java-8/
 
 -   releaseCycle: "provided.al2"
     releaseLabel: Custom Runtime (AL2)
     releaseDate: 2020-08-12
-    support: true
+    eoas: false
     eol: false
     link: https://aws.amazon.com/about-aws/whats-new/2020/08/aws-lambda-supports-custom-runtimes-amazon-linux-2/
 
 -   releaseCycle: "dotnetcore3.1"
     releaseLabel: .NET Core 3.1
     releaseDate: 2020-03-31
-    support: 2023-04-03
+    eoas: 2023-04-03
     eol: 2023-05-03
     link: https://aws.amazon.com/blogs/compute/announcing-aws-lambda-supports-for-net-core-3-1/
 
 -   releaseCycle: "ruby2.7"
     releaseLabel: Ruby 2.7
     releaseDate: 2020-02-19
-    support: 2023-12-07
+    eoas: 2023-12-07
     eol: 2024-02-08
     link: https://aws.amazon.com/about-aws/whats-new/2020/02/aws-lambda-supports-ruby-2-7/
 
 -   releaseCycle: "nodejs12.x"
     releaseLabel: Node.js 12
     releaseDate: 2019-11-18
-    support: 2023-03-31
+    eoas: 2023-03-31
     eol: 2023-04-30
     link: https://aws.amazon.com/blogs/compute/node-js-12-x-runtime-now-available-in-aws-lambda/
 
 -   releaseCycle: "python3.8"
     releaseLabel: Python 3.8
     releaseDate: 2019-11-18
-    support: 2024-10-14
+    eoas: 2024-10-14
     eol: 2025-01-07
     link: https://aws.amazon.com/blogs/compute/python-3-8-runtime-now-available-in-aws-lambda/
 
 -   releaseCycle: "java11"
     releaseLabel: Java 11
     releaseDate: 2019-11-18
-    support: true
+    eoas: false
     eol: false
     link: https://aws.amazon.com/blogs/compute/java-11-runtime-now-available-in-aws-lambda/
 
 -   releaseCycle: "nodejs10.x"
     releaseLabel: Node.js 10
     releaseDate: 2019-05-15
-    support: 2021-07-30
+    eoas: 2021-07-30
     eol: 2022-02-14
     link: https://aws.amazon.com/about-aws/whats-new/2019/05/aws_lambda_adds_support_for_node_js_v10/
 
 -   releaseCycle: "ruby2.5"
     releaseLabel: Ruby 2.5
     releaseDate: 2018-11-29
-    support: 2021-07-30
+    eoas: 2021-07-30
     eol: 2022-03-31
     link: https://aws.amazon.com/blogs/compute/announcing-ruby-support-for-aws-lambda/
 
 -   releaseCycle: "provided"
     releaseLabel: Custom Runtime (AL1)
     releaseDate: 2018-11-29
-    support: 2024-01-08
+    eoas: 2024-01-08
     eol: 2024-03-12
     link: https://aws.amazon.com/about-aws/whats-new/2018/11/aws-lambda-now-supports-custom-runtimes-and-layers/
 
 -   releaseCycle: "python3.7"
     releaseLabel: Python 3.7
     releaseDate: 2018-11-19
-    support: 2023-12-04
+    eoas: 2023-12-04
     eol: 2024-02-08
     link: https://aws.amazon.com/blogs/compute/python-3-7-runtime-now-available-in-aws-lambda/
 
 -   releaseCycle: "dotnetcore2.1"
     releaseLabel: .NET Core 2.1
     releaseDate: 2018-07-09
-    support: 2022-01-05
+    eoas: 2022-01-05
     eol: 2022-04-13
     link: https://aws.amazon.com/blogs/developer/aws-lambda-net-core-2-1-support-released/
 
 -   releaseCycle: "nodejs8.10"
     releaseLabel: Node.js 8.10
     releaseDate: 2018-04-02
-    support: 2020-03-06
+    eoas: 2020-03-06
     eol: 2020-03-06
     link: https://aws.amazon.com/blogs/compute/node-js-8-10-runtime-now-available-in-aws-lambda/
 
 -   releaseCycle: "dotnetcore2.0"
     releaseLabel: .NET Core 2.0
     releaseDate: 2018-01-15
-    support: 2019-05-30
+    eoas: 2019-05-30
     eol: 2019-05-30
     link: https://aws.amazon.com/blogs/developer/aws-lambda-net-core-2-0-support-released/
 
 -   releaseCycle: "go1.x"
     releaseLabel: Go 1.x
     releaseDate: 2018-01-15
-    support: 2024-01-08
+    eoas: 2024-01-08
     eol: 2024-03-12
     link: https://aws.amazon.com/blogs/compute/announcing-go-support-for-aws-lambda/
 
 -   releaseCycle: "nodejs4.3-edge"
     releaseLabel: Node.js 4.3 edge
     releaseDate: 2017-07-17
-    support: 2020-03-05
+    eoas: 2020-03-05
     eol: 2020-04-30 # probably a mistake, but it's what the official documentation says
     link: https://aws.amazon.com/about-aws/whats-new/2017/07/lambda-at-edge-now-generally-available/
 
 -   releaseCycle: "python3.6"
     releaseLabel: Python 3.6
     releaseDate: 2017-04-18
-    support: 2022-07-18
+    eoas: 2022-07-18
     eol: 2022-08-29
     link: https://aws.amazon.com/about-aws/whats-new/2017/04/aws-lambda-supports-python-3-6/
 
 -   releaseCycle: "nodejs6.10"
     releaseLabel: Node.js 6.10
     releaseDate: 2017-03-22
-    support: 2019-08-12
+    eoas: 2019-08-12
     eol: true
     link: https://aws.amazon.com/about-aws/whats-new/2017/03/aws-lambda-supports-node-js-6-10/
 
 -   releaseCycle: "dotnetcore1.0"
     releaseLabel: .NET Core 1.0
     releaseDate: 2016-12-01
-    support: 2019-06-27
+    eoas: 2019-06-27
     eol: 2019-07-30
     link: https://aws.amazon.com/blogs/compute/announcing-c-sharp-support-for-aws-lambda/
 
 -   releaseCycle: "nodejs4.3"
     releaseLabel: Node.js 4.3
     releaseDate: 2016-04-07
-    support: 2020-03-05
+    eoas: 2020-03-05
     eol: 2020-03-05
     link: https://aws.amazon.com/blogs/compute/node-js-4-3-2-runtime-now-available-on-lambda/
 
 -   releaseCycle: "python2.7"
     releaseLabel: Python 2.7
     releaseDate: 2015-10-08
-    support: 2021-07-15
+    eoas: 2021-07-15
     eol: 2022-05-30
     link: https://aws.amazon.com/about-aws/whats-new/2015/10/aws-lambda-supports-python-versioning-scheduled-jobs-and-5-minute-functions/
 
 -   releaseCycle: "java8"
     releaseLabel: Java 8 (AL1)
     releaseDate: 2015-06-15
-    support: 2024-01-08
+    eoas: 2024-01-08
     eol: 2024-03-12
     link: https://aws.amazon.com/about-aws/whats-new/2015/06/aws-lambda-supports-java/
 
 -   releaseCycle: "nodejs"
     releaseLabel: Node.js 0.10
     releaseDate: 2014-11-13
-    support: false
+    eoas: true
     eol: 2016-10-31
     link: https://aws.amazon.com/blogs/aws/run-code-cloud/
 

--- a/products/azul-zulu.md
+++ b/products/azul-zulu.md
@@ -10,7 +10,7 @@ versionCommand: java -version
 releasePolicyLink: https://www.azul.com/products/azul-support-roadmap/
 releaseDateColumn: true
 eolColumn: Support
-extendedSupportColumn: true
+eoesColumn: true
 customColumns:
 -   property: latestJdkVersion
     position: after-latest-column
@@ -38,7 +38,7 @@ releases:
 -   releaseCycle: "22"
     releaseDate: 2024-03-19 # https://docs.azul.com/core/release/22-ga/release-notes/release-notes
     eol: 2024-09-17
-    extendedSupport: 2025-03-17
+    eoes: 2025-03-17
     latest: "22.28.93"
     latestJdkVersion: "22.0.0+36"
     latestReleaseDate: 2024-03-19
@@ -48,7 +48,7 @@ releases:
     lts: true
     releaseDate: 2023-09-19 # https://docs.azul.com/core/zulu-openjdk/release-notes/21-ga
     eol: 2031-09-30
-    extendedSupport: 2033-09-30
+    eoes: 2033-09-30
     latest: "21.32.17"
     latestJdkVersion: "21.0.2+13"
     latestReleaseDate: 2024-01-16
@@ -58,7 +58,7 @@ releases:
     releaseLabel: "20 (<abbr title='Short Term Support'>STS</abbr>)"
     releaseDate: 2023-03-21 # https://docs.azul.com/core/zulu-openjdk/release-notes/20-ga
     eol: 2023-09-19
-    extendedSupport: 2024-03-31
+    eoes: 2024-03-31
     latest: "20.32.11"
     latestJdkVersion: "20.0.2+9"
     latestReleaseDate: 2023-07-18
@@ -68,7 +68,7 @@ releases:
     releaseLabel: "19 (<abbr title='Short Term Support'>STS</abbr>)"
     releaseDate: 2022-09-20 # https://docs.azul.com/core/zulu-openjdk/release-notes/19-ga
     eol: 2023-03-31
-    extendedSupport: 2023-09-30
+    eoes: 2023-09-30
     latest: "19.32.13"
     latestJdkVersion: "19.0.2+7"
     latestReleaseDate: 2023-01-17
@@ -78,7 +78,7 @@ releases:
     releaseLabel: "18 (<abbr title='Short Term Support'>STS</abbr>)"
     releaseDate: 2022-03-12 # https://docs.azul.com/core/zulu-openjdk/release-notes/18-ga
     eol: 2022-09-30
-    extendedSupport: 2023-03-31
+    eoes: 2023-03-31
     latest: "18.32.13"
     latestJdkVersion: "18.0.2.1+1"
     latestReleaseDate: 2022-08-22
@@ -88,7 +88,7 @@ releases:
     lts: true
     releaseDate: 2021-09-15 # https://docs.azul.com/core/zulu-openjdk/release-notes/17-ga
     eol: 2029-09-30
-    extendedSupport: 2031-09-30
+    eoes: 2031-09-30
     latest: "17.48.15"
     latestJdkVersion: "17.0.10+7"
     latestReleaseDate: 2024-01-16
@@ -98,7 +98,7 @@ releases:
     releaseLabel: "16 (<abbr title='Short Term Support'>STS</abbr>)"
     releaseDate: 2021-03-16 # https://docs.azul.com/core/zulu-release-notes/16-ga/ZuluReleaseNotes/Title.htm
     eol: 2021-09-30
-    extendedSupport: 2022-03-31
+    eoes: 2022-03-31
     latest: "16.32.15"
     latestJdkVersion: "16.0.2+7"
     latestReleaseDate: 2021-07-24
@@ -108,7 +108,7 @@ releases:
     releaseLabel: "15 (<abbr title='Medium Term Support'>MTS</abbr>)"
     releaseDate: 2020-09-15
     eol: 2023-03-31
-    extendedSupport: 2024-03-31
+    eoes: 2024-03-31
     latest: "15.46.17"
     latestJdkVersion: "15.0.10+5"
     latestReleaseDate: 2023-01-17
@@ -118,7 +118,7 @@ releases:
     releaseLabel: "14 (<abbr title='Short Term Support'>STS</abbr>)"
     releaseDate: 2020-03-17
     eol: 2020-09-30
-    extendedSupport: 2021-03-31
+    eoes: 2021-03-31
     latest: "14.29.23"
     latestJdkVersion: "14.0.2+12"
     latestReleaseDate: 2020-07-17
@@ -127,7 +127,7 @@ releases:
     releaseLabel: "13 (<abbr title='Medium Term Support'>MTS</abbr>)"
     releaseDate: 2019-09-17
     eol: 2023-03-31
-    extendedSupport: 2024-03-31
+    eoes: 2024-03-31
     latest: "13.54.17"
     latestJdkVersion: "13.0.14+5"
     latestReleaseDate: 2023-01-17
@@ -137,7 +137,7 @@ releases:
     releaseLabel: "12 (<abbr title='Short Term Support'>STS</abbr>)"
     releaseDate: 2019-03-19
     eol: 2019-09-30
-    extendedSupport: 2020-03-31
+    eoes: 2020-03-31
     latest: "12.3.11"
     latestJdkVersion: "12.0.2+3"
     latestReleaseDate: 2019-07-16
@@ -146,7 +146,7 @@ releases:
     lts: true
     releaseDate: 2018-09-25
     eol: 2026-09-30
-    extendedSupport: 2028-09-30
+    eoes: 2028-09-30
     latest: "11.70.15"
     latestJdkVersion: "11.0.22+7"
     latestReleaseDate: 2024-01-16
@@ -157,7 +157,7 @@ releases:
     # https://www.azul.com/blog/zulu-10-has-landed/
     releaseDate: 2018-03-27
     eol: 2018-09-30
-    extendedSupport: 2019-03-31
+    eoes: 2019-03-31
     latest: "10.3.5"
     latestJdkVersion: "10.0.2+13"
     latestReleaseDate: 2018-07-26
@@ -166,7 +166,7 @@ releases:
     releaseLabel: "9 (<abbr title='Short Term Support'>STS</abbr>)"
     releaseDate: 2017-09-21
     eol: 2018-03-31
-    extendedSupport: 2018-09-30
+    eoes: 2018-09-30
     latest: "9.0.7.1"
     latestJdkVersion: "9u7"
     latestReleaseDate: 2018-04-27
@@ -175,7 +175,7 @@ releases:
     lts: true
     releaseDate: 2014-04-08 # https://www.azul.com/newsroom/azul-systems-extends-zulu-runtime-for-java-to-support-java-8/
     eol: 2030-12-31
-    extendedSupport: 2032-12-31
+    eoes: 2032-12-31
     latest: "8.76.0.17"
     latestJdkVersion: "8u402-b06"
     latestReleaseDate: 2024-01-16
@@ -185,7 +185,7 @@ releases:
     lts: true
     releaseDate: 2013-09-25 # http://web.archive.org/web/20131006021330/http://msopentech.com/blog/2013/09/25/azul-systems-releases-zulu-an-openjdk-build-for-windows-azure-in-partnership-with-ms-open-tech/
     eol: 2022-07-31
-    extendedSupport: 2027-12-31
+    eoes: 2027-12-31
     latest: "7.56"
     latestJdkVersion: "7u352-b01"
     latestReleaseDate: 2022-07-19
@@ -195,7 +195,7 @@ releases:
     lts: true
     releaseDate: 2014-01-21 # https://www.azul.com/newsroom/azul-systems-extends-zulu-to-support-java-6-and-major-linux-distributions/
     eol: 2018-12-31
-    extendedSupport: 2027-12-31
+    eoes: 2027-12-31
     latest: "N/A" # could not find the exact version
     latestJdkVersion: "6u211" # the latest public Oracle JDK 7
     latestReleaseDate: 2018-10-16

--- a/products/azure-devops.md
+++ b/products/azure-devops.md
@@ -8,14 +8,14 @@ alternate_urls:
 -   /azure-devops
 -   /team-foundation-server
 releasePolicyLink: https://learn.microsoft.com/lifecycle/products/?terms=Azure%20DevOps%20Server
-activeSupportColumn: true
+eoasColumn: true
 releaseDateColumn: true
 
 releases:
 -   releaseCycle: "2022.1"
     releaseLabel: "2022 Update 1"
     releaseDate: 2023-11-28
-    support: 2028-01-11
+    eoas: 2028-01-11
     eol: 2033-01-11
     latest: "2022.1patch3"
     latestReleaseDate: 2024-03-12
@@ -24,7 +24,7 @@ releases:
 -   releaseCycle: "2022.0"
     releaseLabel: "2022"
     releaseDate: 2022-12-06
-    support: 2028-01-11
+    eoas: 2028-01-11
     eol: 2033-01-11
     latest: "2022.0.1patch5"
     latestReleaseDate: 2023-11-14
@@ -33,7 +33,7 @@ releases:
 -   releaseCycle: "2020.1"
     releaseLabel: "2020 Update 1"
     releaseDate: 2021-05-25
-    support: 2025-10-14
+    eoas: 2025-10-14
     eol: 2030-10-08
     latest: "2020.1.2patch13"
     latestReleaseDate: 2024-03-12
@@ -42,7 +42,7 @@ releases:
 -   releaseCycle: "2020.0"
     releaseLabel: "2020"
     releaseDate: 2020-08-25
-    support: 2025-10-14
+    eoas: 2025-10-14
     eol: 2030-10-08
     latest: "2020.0.2patch6"
     latestReleaseDate: 2023-11-14
@@ -51,7 +51,7 @@ releases:
 -   releaseCycle: "2019.1"
     releaseLabel: "2019 Update 1"
     releaseDate: 2019-08-20
-    support: 2024-04-09
+    eoas: 2024-04-09
     eol: 2029-04-10
     latest: "2019.1.2patch8"
     latestReleaseDate: 2024-03-12
@@ -60,7 +60,7 @@ releases:
 -   releaseCycle: "2019.0"
     releaseLabel: "2019"
     releaseDate: 2019-03-05
-    support: 2024-04-09
+    eoas: 2024-04-09
     eol: 2029-04-10
     latest: "2019.0.1patch16"
     latestReleaseDate: 2023-11-14
@@ -69,7 +69,7 @@ releases:
 -   releaseCycle: "2018"
     releaseLabel: "TFS __RELEASE_CYCLE__"
     releaseDate: 2017-11-15
-    support: 2023-01-10
+    eoas: 2023-01-10
     eol: 2028-01-11
     latest: "2018.3.2patch19"
     latestReleaseDate: 2023-11-14
@@ -78,7 +78,7 @@ releases:
 -   releaseCycle: "2017"
     releaseLabel: "TFS __RELEASE_CYCLE__"
     releaseDate: 2016-11-16
-    support: 2022-01-11
+    eoas: 2022-01-11
     eol: 2027-01-11
     latest: "2017.3.1patch15"
     latestReleaseDate: 2022-05-17
@@ -87,7 +87,7 @@ releases:
 -   releaseCycle: "2015"
     releaseLabel: "TFS __RELEASE_CYCLE__"
     releaseDate: 2015-07-30
-    support: 2020-10-13
+    eoas: 2020-10-13
     eol: 2025-10-14
     latest: "2015.4.2patch8"
     latestReleaseDate: 2022-05-17
@@ -96,7 +96,7 @@ releases:
 -   releaseCycle: "2013"
     releaseLabel: "TFS __RELEASE_CYCLE__"
     releaseDate: 2014-01-15
-    support: 2019-04-09
+    eoas: 2019-04-09
     eol: 2024-04-09
     latest: "2013.5"
     latestReleaseDate: 2015-07-20
@@ -105,7 +105,7 @@ releases:
 -   releaseCycle: "2012"
     releaseLabel: "TFS __RELEASE_CYCLE__"
     releaseDate: 2012-10-31
-    support: 2019-01-09
+    eoas: 2019-01-09
     eol: 2023-01-10
     latest: "2012.4"
     latestReleaseDate: 2013-11-13
@@ -114,7 +114,7 @@ releases:
 -   releaseCycle: "2010"
     releaseLabel: "TFS __RELEASE_CYCLE__"
     releaseDate: 2010-06-29
-    support: 2015-07-14
+    eoas: 2015-07-14
     eol: 2020-07-14
     latest: "2010.SP1"
     latestReleaseDate: 2011-03-08
@@ -123,7 +123,7 @@ releases:
 -   releaseCycle: "2005"
     releaseLabel: "TFS __RELEASE_CYCLE__"
     releaseDate: 2006-06-17
-    support: 2011-07-12
+    eoas: 2011-07-12
     eol: 2016-07-12
     latest: "2005.SP2"
     latestReleaseDate: 2007-03-21

--- a/products/bazel.md
+++ b/products/bazel.md
@@ -8,7 +8,7 @@ releasePolicyLink: https://bazel.build/release
 releaseImage: https://blog.bazel.build/assets/lts_timeline.png
 changelogTemplate: "https://github.com/bazelbuild/bazel/releases/tag/__LATEST__"
 releaseDateColumn: true
-activeSupportColumn: true
+eoasColumn: true
 
 auto:
   methods:
@@ -23,13 +23,13 @@ auto:
         eol: "End of support"
 
 # latestVersion and eol on https://bazel.build/release
-# support(x) = releaseDate(x+1)
+# eoas(x) = releaseDate(x+1)
 # eol(x) = releaseDate(x) + 3 years
 releases:
 -   releaseCycle: "7"
     lts: true
     releaseDate: 2023-12-11
-    support: true # releaseDate(8)
+    eoas: false # releaseDate(8)
     eol: 2026-12-31
     latest: "7.1.1"
     latestReleaseDate: 2024-03-21
@@ -37,7 +37,7 @@ releases:
 -   releaseCycle: "6"
     lts: true
     releaseDate: 2022-12-19
-    support: 2023-12-11 # releaseDate(7)
+    eoas: 2023-12-11 # releaseDate(7)
     eol: 2025-12-31
     latest: "6.5.0"
     latestReleaseDate: 2024-01-23
@@ -45,7 +45,7 @@ releases:
 -   releaseCycle: "5"
     lts: true
     releaseDate: 2022-01-19
-    support: 2022-12-19 # releaseDate(6)
+    eoas: 2022-12-19 # releaseDate(6)
     eol: 2025-01-31
     latest: "5.4.1"
     latestReleaseDate: 2023-04-19
@@ -53,7 +53,7 @@ releases:
 -   releaseCycle: "4"
     lts: true
     releaseDate: 2021-01-21
-    support: 2022-01-19 # releaseDate(5)
+    eoas: 2022-01-19 # releaseDate(5)
     eol: 2024-01-31
     latest: "4.2.4"
     latestReleaseDate: 2023-04-20

--- a/products/bellsoft-liberica.md
+++ b/products/bellsoft-liberica.md
@@ -11,7 +11,7 @@ releasePolicyLink: https://bell-sw.com/roadmap/
 changelogTemplate: "https://docs.bell-sw.com/liberica-jdk/{{'__LATEST__'|replace:'+','b'}}/general/release-notes/"
 releaseDateColumn: true
 eolColumn: Public support
-extendedSupportColumn: Commercial support
+eoesColumn: Commercial support
 
 identifiers:
 # Official Docker Images
@@ -51,7 +51,6 @@ releases:
 -   releaseCycle: "22"
     releaseDate: 2024-03-20
     eol: 2024-09-17
-    extendedSupport: false
     latest: "22+37"
     latestReleaseDate: 2024-03-20
 
@@ -59,7 +58,7 @@ releases:
     lts: true
     releaseDate: 2023-09-20
     eol: false # Temurin EOL date not yet announced
-    extendedSupport: 2032-03-31
+    eoes: 2032-03-31
     latest: "21.0.2+15"
     latestReleaseDate: 2024-01-23
     link: https://docs.bell-sw.com/liberica-jdk/21.0.2b14/general/release-notes/ # no link yet for 21.0.2+15
@@ -67,21 +66,18 @@ releases:
 -   releaseCycle: "20"
     releaseDate: 2023-03-22
     eol: 2023-09-19
-    extendedSupport: false
     latest: "20.0.2+10"
     latestReleaseDate: 2023-07-20
 
 -   releaseCycle: "19"
     releaseDate: 2022-09-21
     eol: 2023-03-21
-    extendedSupport: false
     latest: "19.0.2+9"
     latestReleaseDate: 2023-01-18
 
 -   releaseCycle: "18"
     releaseDate: 2022-03-23
     eol: 2022-09-20
-    extendedSupport: false
     latest: "18.0.2.1+1"
     latestReleaseDate: 2022-08-25
     link: https://docs.bell-sw.com/liberica-jdk/18.0.2b10/general/release-notes/
@@ -90,7 +86,7 @@ releases:
     lts: true
     releaseDate: 2021-09-17
     eol: 2027-10-31
-    extendedSupport: 2030-03-31
+    eoes: 2030-03-31
     latest: "17.0.10+14"
     latestReleaseDate: 2024-01-23
     link: https://docs.bell-sw.com/liberica-jdk/17.0.10b13/general/release-notes/ # no link yet for 17.0.10+14
@@ -98,14 +94,12 @@ releases:
 -   releaseCycle: "16"
     releaseDate: 2021-03-19
     eol: 2021-09-14
-    extendedSupport: false
     latest: "16.0.2+7"
     latestReleaseDate: 2021-07-23
 
 -   releaseCycle: "15"
     releaseDate: 2020-09-17
     eol: 2021-03-16
-    extendedSupport: false
     latest: "15.0.2+10"
     latestReleaseDate: 2021-01-22
     link: https://docs.bell-sw.com/liberica-jdk/15.0.2b8/general/release-notes/
@@ -113,21 +107,18 @@ releases:
 -   releaseCycle: "14"
     releaseDate: 2020-03-19
     eol: 2020-09-16
-    extendedSupport: false
     latest: "14.0.2+13"
     latestReleaseDate: 2020-07-14
 
 -   releaseCycle: "13"
     releaseDate: 2019-09-26
     eol: 2020-03-17
-    extendedSupport: false
     latest: "13.0.2+9"
     latestReleaseDate: 2020-01-16
 
 -   releaseCycle: "12"
     releaseDate: 2019-03-22
     eol: 2019-09-17
-    extendedSupport: false
     latest: "12.0.2"
     latestReleaseDate: 2019-07-20
     link: https://docs.bell-sw.com/liberica-jdk/12.0.2b10/general/release-notes/
@@ -136,7 +127,7 @@ releases:
     lts: true
     releaseDate: 2018-10-08
     eol: 2024-10-31
-    extendedSupport: 2027-03-31
+    eoes: 2027-03-31
     latest: "11.0.22+12"
     latestReleaseDate: 2024-01-17
 
@@ -144,7 +135,6 @@ releases:
     # This is an approximation from Oracle JDK release date
     releaseDate: 2018-03-21
     eol: 2018-09-25
-    extendedSupport: false
     latest: "10.0.2"
     # last modified date of the files in https://download.bell-sw.com/java/10.0.2/bellsoft-jdk10.0.2-linux-amd64.deb
     latestReleaseDate: 2018-08-24
@@ -155,7 +145,7 @@ releases:
     lts: true
     releaseDate: 2018-11-01
     eol: 2026-11-30
-    extendedSupport: 2031-03-31
+    eoes: 2031-03-31
     latest: "8u402+7"
     latestReleaseDate: 2024-01-17
 
@@ -163,7 +153,7 @@ releases:
     lts: true
     releaseDate: 2011-07-11
     eol: 2022-07-31
-    extendedSupport: 2026-03-31
+    eoes: 2026-03-31
     latest: "unknown"
     link: null
 
@@ -171,7 +161,7 @@ releases:
     lts: true
     releaseDate: 2006-12-12
     eol: 2018-12-31
-    extendedSupport: 2026-03-31
+    eoes: 2026-03-31
     latest: "unknown"
     link: null
 

--- a/products/blender.md
+++ b/products/blender.md
@@ -8,7 +8,7 @@ releasePolicyLink: https://developer.blender.org/docs/handbook/release_process/r
 releaseImage: https://code.blender.org/wp-content/uploads/2023/02/blender-release-schedule-2023.png
 changelogTemplate: https://www.blender.org/download/releases/{{"__RELEASE_CYCLE__" | replace:'.','-'}}/
 releaseDateColumn: true
-activeSupportColumn: true
+eoasColumn: true
 eolColumn: Critical bug fixes
 
 auto:
@@ -19,14 +19,14 @@ auto:
 releases:
 -   releaseCycle: "4.1"
     releaseDate: 2024-03-25
-    support: true
+    eoas: false
     eol: false
     latest: "4.1.0"
     latestReleaseDate: 2024-03-25
 
 -   releaseCycle: "4.0"
     releaseDate: 2023-11-14
-    support: 2024-03-25
+    eoas: 2024-03-25
     eol: 2024-03-25
     latest: "4.0.2"
     latestReleaseDate: 2023-12-05
@@ -34,21 +34,21 @@ releases:
 -   releaseCycle: "3.6"
     lts: true
     releaseDate: 2023-06-27
-    support: 2025-07-01
+    eoas: 2025-07-01
     eol: 2025-07-01
     latest: "3.6.10"
     latestReleaseDate: 2024-03-18
 
 -   releaseCycle: "3.5"
     releaseDate: 2023-03-29
-    support: 2023-07-01
+    eoas: 2023-07-01
     eol: 2023-07-01
     latest: "3.5.1"
     latestReleaseDate: 2023-04-25
 
 -   releaseCycle: "3.4"
     releaseDate: 2022-12-07
-    support: 2023-04-01
+    eoas: 2023-04-01
     eol: 2023-04-01
     latest: "3.4.1"
     latestReleaseDate: 2022-12-20
@@ -56,28 +56,28 @@ releases:
 -   releaseCycle: "3.3"
     lts: true
     releaseDate: 2022-09-07
-    support: 2024-09-01
+    eoas: 2024-09-01
     eol: 2024-09-01
     latest: "3.3.17"
     latestReleaseDate: 2024-03-19
 
 -   releaseCycle: "3.2"
     releaseDate: 2022-06-08
-    support: 2022-09-07
+    eoas: 2022-09-07
     eol: 2022-09-07
     latest: "3.2.2"
     latestReleaseDate: 2022-08-03
 
 -   releaseCycle: "3.1"
     releaseDate: 2022-03-09
-    support: 2022-06-08
+    eoas: 2022-06-08
     eol: 2022-06-08
     latest: "3.1.2"
     latestReleaseDate: 2022-04-01
 
 -   releaseCycle: "3.0"
     releaseDate: 2021-12-03
-    support: 2022-03-09
+    eoas: 2022-03-09
     eol: 2022-03-09
     latest: "3.0.1"
     latestReleaseDate: 2022-01-26
@@ -85,7 +85,7 @@ releases:
 -   releaseCycle: "2.93"
     lts: true
     releaseDate: 2021-06-02
-    support: 2023-06-01
+    eoas: 2023-06-01
     eol: 2023-06-01
     latest: "2.93.18"
     latestReleaseDate: 2023-05-23
@@ -93,7 +93,7 @@ releases:
 -   releaseCycle: "2.83"
     lts: true
     releaseDate: 2020-06-03
-    support: 2020-08-31
+    eoas: 2020-08-31
     eol: 2022-06-01
     latest: "2.83.20"
     latestReleaseDate: 2022-04-20

--- a/products/bootstrap.md
+++ b/products/bootstrap.md
@@ -7,8 +7,8 @@ permalink: /bootstrap
 releasePolicyLink: https://github.com/twbs/release
 changelogTemplate: https://github.com/twbs/bootstrap/releases/tag/v__LATEST__
 releaseDateColumn: true
-activeSupportColumn: true
-extendedSupportColumn: Commercial Support
+eoasColumn: true
+eoesColumn: Commercial Support
 eolColumn: Critical Support
 
 identifiers:
@@ -28,34 +28,32 @@ releases:
 -   releaseCycle: "5"
     lts: true
     releaseDate: 2021-05-05
-    support: true
+    eoas: false
     eol: false
-    extendedSupport: false
     latest: "5.3.3"
     latestReleaseDate: 2024-02-20
 
 -   releaseCycle: "4"
     lts: true
     releaseDate: 2018-01-18
-    support: false
+    eoas: true
     eol: 2023-01-01
-    extendedSupport: true
+    eoes: false
     latest: "4.6.2"
     latestReleaseDate: 2022-07-19
 
 -   releaseCycle: "3"
     releaseDate: 2013-08-19
-    support: false
+    eoas: true
     eol: 2019-07-24
-    extendedSupport: true
+    eoes: false
     latest: "3.4.1"
     latestReleaseDate: 2019-02-13
 
 -   releaseCycle: "2"
     releaseDate: 2012-01-31
-    support: false
+    eoas: true
     eol: 2013-08-19
-    extendedSupport: false
     latest: "2.3.2"
     latestReleaseDate: 2013-07-26
 

--- a/products/cakephp.md
+++ b/products/cakephp.md
@@ -10,7 +10,7 @@ alternate_urls:
 versionCommand: php bin/cake.php version
 releasePolicyLink: https://github.com/cakephp/cakephp/wiki
 changelogTemplate: https://github.com/cakephp/cakephp/releases/__LATEST__
-activeSupportColumn: true
+eoasColumn: true
 releaseDateColumn: true
 
 auto:
@@ -25,7 +25,7 @@ releases:
     codename: "Strawberry"
     releaseDate: 2023-10-14
     supportedPhpVersions: 7.4+
-    support: 2025-09-09
+    eoas: 2025-09-09
     eol: 2026-09-09
     latest: "4.5.4"
     latestReleaseDate: 2024-03-01
@@ -34,7 +34,7 @@ releases:
     codename: "Chiffon"
     releaseDate: 2023-09-09
     supportedPhpVersions: 8.1+
-    support: true
+    eoas: false
     eol: false
     latest: "5.0.6"
     latestReleaseDate: 2024-03-08
@@ -43,7 +43,7 @@ releases:
     codename: "Strawberry"
     releaseDate: 2022-06-06
     supportedPhpVersions: 7.4+
-    support: 2023-10-15
+    eoas: 2023-10-15
     eol: 2026-09-09
     latest: "4.4.18"
     latestReleaseDate: 2023-09-22
@@ -52,7 +52,7 @@ releases:
     codename: "Strawberry"
     releaseDate: 2021-10-23
     supportedPhpVersions: 7.2+
-    support: 2022-06-07
+    eoas: 2022-06-07
     eol: 2026-09-09
     latest: "4.3.11"
     latestReleaseDate: 2023-01-05
@@ -61,7 +61,7 @@ releases:
     codename: "Red Velvet"
     releaseDate: 2021-06-19
     supportedPhpVersions: 5.6 - 7.4
-    support: 2021-12-15
+    eoas: 2021-12-15
     eol: 2022-12-15
     latest: "3.10.5"
     latestReleaseDate: 2023-01-01
@@ -70,7 +70,7 @@ releases:
     codename: "Strawberry"
     releaseDate: 2020-12-20
     supportedPhpVersions: 7.2+
-    support: 2021-10-24
+    eoas: 2021-10-24
     eol: 2023-10-14
     latest: "4.2.12"
     latestReleaseDate: 2023-01-06
@@ -79,7 +79,7 @@ releases:
     codename: "Strawberry"
     releaseDate: 2020-07-04
     supportedPhpVersions: 7.2+
-    support: 2020-12-21
+    eoas: 2020-12-21
     eol: true
     latest: "4.1.7"
     latestReleaseDate: 2020-12-12
@@ -88,7 +88,7 @@ releases:
     codename: "Red Velvet"
     releaseDate: 2020-06-20
     supportedPhpVersions: 5.6 - 7.4
-    support: 2021-06-20
+    eoas: 2021-06-20
     eol: true
     latest: "3.9.10"
     latestReleaseDate: 2021-05-30
@@ -97,7 +97,7 @@ releases:
     codename: "Strawberry"
     releaseDate: 2019-12-15
     supportedPhpVersions: 7.2+
-    support: 2020-07-05
+    eoas: 2020-07-05
     eol: true
     latest: "4.0.10"
     latestReleaseDate: 2020-12-07
@@ -106,7 +106,7 @@ releases:
     codename: "Red Velvet"
     releaseDate: 2019-06-26
     supportedPhpVersions: 5.6 - 7.4
-    support: 2020-06-21
+    eoas: 2020-06-21
     eol: true
     latest: "3.8.13"
     latestReleaseDate: 2020-06-19
@@ -115,7 +115,7 @@ releases:
     codename: "Red Velvet"
     releaseDate: 2018-12-08
     supportedPhpVersions: 5.6 - 7.4
-    support: 2019-06-27
+    eoas: 2019-06-27
     eol: true
     latest: "3.7.9"
     latestReleaseDate: 2019-06-19
@@ -124,7 +124,7 @@ releases:
     codename: "Red Velvet"
     releaseDate: 2018-04-14
     supportedPhpVersions: 5.6 - 7.4
-    support: 2018-12-09
+    eoas: 2018-12-09
     eol: true
     latest: "3.6.15"
     latestReleaseDate: 2019-04-23
@@ -133,7 +133,7 @@ releases:
     codename: "Red Velvet"
     releaseDate: 2017-08-18
     supportedPhpVersions: 5.6 - 7.4
-    support: 2018-04-15
+    eoas: 2018-04-15
     eol: true
     latest: "3.5.18"
     latestReleaseDate: 2019-04-23
@@ -141,7 +141,7 @@ releases:
 -   releaseCycle: "2.10"
     releaseDate: 2017-07-22
     supportedPhpVersions: 5.4 - 7.4
-    support: 2020-12-15
+    eoas: 2020-12-15
     eol: 2021-06-15
     latest: "2.10.24"
     latestReleaseDate: 2020-12-15
@@ -150,7 +150,7 @@ releases:
     codename: "Red Velvet"
     releaseDate: 2017-02-12
     supportedPhpVersions: 5.6 - 7.4
-    support: 2017-08-19
+    eoas: 2017-08-19
     eol: true
     latest: "3.4.14"
     latestReleaseDate: 2018-05-20
@@ -158,7 +158,7 @@ releases:
 -   releaseCycle: "2.9"
     releaseDate: 2016-09-18
     supportedPhpVersions: 5.4 - 7.4
-    support: false
+    eoas: true
     eol: true
     latest: "2.9.9"
     latestReleaseDate: 2017-05-25
@@ -167,7 +167,7 @@ releases:
     codename: "Red Velvet"
     releaseDate: 2016-08-12
     supportedPhpVersions: 5.5 - 7.4
-    support: 2017-02-13
+    eoas: 2017-02-13
     eol: true
     latest: "3.3.16"
     latestReleaseDate: 2017-04-06
@@ -175,7 +175,7 @@ releases:
 -   releaseCycle: "2.8"
     releaseDate: 2016-02-06
     supportedPhpVersions: 5.4 - 7.4
-    support: false
+    eoas: true
     eol: true
     latest: "2.8.9"
     latestReleaseDate: 2016-09-18
@@ -184,7 +184,7 @@ releases:
     codename: "Red Velvet"
     releaseDate: 2016-01-29
     supportedPhpVersions: 5.5 - 7.4
-    support: 2016-08-13
+    eoas: 2016-08-13
     eol: true
     latest: "3.2.14"
     latestReleaseDate: 2016-08-12
@@ -193,7 +193,7 @@ releases:
     codename: "Red Velvet"
     releaseDate: 2015-09-19
     supportedPhpVersions: 5.4 - 7.4
-    support: 2016-01-16
+    eoas: 2016-01-16
     eol: 2017-02-13
     latest: "3.1.14"
     latestReleaseDate: 2016-11-25
@@ -201,7 +201,7 @@ releases:
 -   releaseCycle: "2.7"
     releaseDate: 2015-07-11
     supportedPhpVersions: 5.4 - 7.4
-    support: false
+    eoas: true
     eol: true
     latest: "2.7.11"
     latestReleaseDate: 2016-03-13
@@ -210,7 +210,7 @@ releases:
     codename: "Red Velvet"
     releaseDate: 2015-03-22
     supportedPhpVersions: 5.4 - 7.4
-    support: 2015-09-20
+    eoas: 2015-09-20
     eol: true
     latest: "3.0.19"
     latestReleaseDate: 2016-11-25
@@ -218,7 +218,7 @@ releases:
 -   releaseCycle: "2.6"
     releaseDate: 2014-12-23
     supportedPhpVersions: 5.4 - 7.4
-    support: false
+    eoas: true
     eol: true
     latest: "2.6.13"
     latestReleaseDate: 2016-03-13
@@ -226,7 +226,7 @@ releases:
 -   releaseCycle: "2.5"
     releaseDate: 2014-05-12
     supportedPhpVersions: 5.4 - 7.4
-    support: false
+    eoas: true
     eol: true
     latest: "2.5.9"
     latestReleaseDate: 2015-08-06
@@ -234,7 +234,7 @@ releases:
 -   releaseCycle: "2.4"
     releaseDate: 2013-08-30
     supportedPhpVersions: 5.4 - 7.4
-    support: false
+    eoas: true
     eol: true
     latest: "2.4.10"
     latestReleaseDate: 2014-05-17
@@ -242,7 +242,7 @@ releases:
 -   releaseCycle: "2.3"
     releaseDate: 2013-01-28
     supportedPhpVersions: 5.4 - 7.4
-    support: false
+    eoas: true
     eol: true
     latest: "2.3.10"
     latestReleaseDate: 2013-08-30
@@ -250,7 +250,7 @@ releases:
 -   releaseCycle: "2.2"
     releaseDate: 2012-07-01
     supportedPhpVersions: 5.4 - 7.4
-    support: false
+    eoas: true
     eol: true
     latest: "2.2.9"
     latestReleaseDate: 2013-07-17
@@ -258,7 +258,7 @@ releases:
 -   releaseCycle: "2.1"
     releaseDate: 2012-03-04
     supportedPhpVersions: 5.4 - 7.4
-    support: false
+    eoas: true
     eol: true
     latest: "2.1.5"
     latestReleaseDate: 2012-07-14
@@ -267,7 +267,7 @@ releases:
 -   releaseCycle: "2.0"
     releaseDate: 2011-10-16
     supportedPhpVersions: 5.4 - 7.4
-    support: false
+    eoas: true
     eol: true
     latest: "2.0.6"
     latestReleaseDate: 2012-02-05
@@ -275,7 +275,7 @@ releases:
 
 -   releaseCycle: "1.3"
     releaseDate: 2010-04-25
-    support: 2015-11-01
+    eoas: 2015-11-01
     eol: 2015-11-01
     latest: "1.3.21"
     latestReleaseDate: 2015-10-31

--- a/products/centos-stream.md
+++ b/products/centos-stream.md
@@ -6,7 +6,7 @@ iconSlug: centos
 permalink: /centos-stream
 versionCommand: cat /etc/redhat-release
 releasePolicyLink: https://centos.org/stream9/
-activeSupportColumn: true
+eoasColumn: true
 releaseDateColumn: true
 
 identifiers:
@@ -16,14 +16,14 @@ identifiers:
 releases:
 -   releaseCycle: "9"
     releaseDate: 2021-09-15
-    support: 2027-05-31
+    eoas: 2027-05-31
     eol: 2027-05-31
     latest: "9"
     link: https://blog.centos.org/2021/12/introducing-centos-stream-9/
 
 -   releaseCycle: "8"
     releaseDate: 2019-09-24
-    support: 2024-05-31
+    eoas: 2024-05-31
     eol: 2024-05-31
     latest: "8"
     link: http://web.archive.org/web/20230417021744/https://wiki.centos.org/Manuals/ReleaseNotes/CentOSStream

--- a/products/centos.md
+++ b/products/centos.md
@@ -6,7 +6,7 @@ iconSlug: centos
 permalink: /centos
 versionCommand: cat /etc/redhat-release
 releasePolicyLink: https://wiki.centos.org/About(2f)Product.html
-activeSupportColumn: true
+eoasColumn: true
 releaseDateColumn: true
 
 identifiers:
@@ -16,28 +16,28 @@ identifiers:
 releases:
 -   releaseCycle: "8"
     releaseDate: 2019-09-24
-    support: 2021-12-31
+    eoas: 2021-12-31
     eol: 2021-12-31
     latest: "8 (2111)"
     link: https://web.archive.org/web/20230711113909/https://wiki.centos.org/Manuals/ReleaseNotes/CentOS8.2111
 
 -   releaseCycle: "7"
     releaseDate: 2014-07-07
-    support: 2020-08-06
+    eoas: 2020-08-06
     eol: 2024-06-30
     latest: "7 (2009)"
     link: https://web.archive.org/web/20230711113909/https://wiki.centos.org/Manuals/ReleaseNotes/CentOS7.2009
 
 -   releaseCycle: "6"
     releaseDate: 2011-07-10
-    support: 2017-05-10
+    eoas: 2017-05-10
     eol: 2020-11-30
     latest: "6.10"
     link: https://web.archive.org/web/20230711113909/https://wiki.centos.org/Manuals/ReleaseNotes/CentOS6.10
 
 -   releaseCycle: "5"
     releaseDate: 2007-04-12
-    support: 2014-01-31
+    eoas: 2014-01-31
     eol: 2017-03-31
     latest: "5.11"
     link: https://web.archive.org/web/20230711113909/https://wiki.centos.org/Manuals/ReleaseNotes/CentOS5.11

--- a/products/centreon.md
+++ b/products/centreon.md
@@ -6,7 +6,7 @@ permalink: /centreon
 releasePolicyLink: https://docs.centreon.com/docs/releases/lifecycle/
 changelogTemplate: "https://docs.centreon.com/docs/__RELEASE_CYCLE__/releases/centreon-os/#{{'__LATEST__'|replace:'.',''}}"
 releaseDateColumn: true
-activeSupportColumn: Phase 1 support
+eoasColumn: Phase 1 support
 eolColumn: Phase 2 support
 
 auto:
@@ -22,34 +22,34 @@ auto:
           regex: '^Centreon\s+(?P<value>\d+\.\d+).*$'
         eol: "End of support"
 
-# support(x) = releaseDate(x) + 1 year (rounded to the end of the month).
+# eoas(x) = releaseDate(x) + 1 year (rounded to the end of the month).
 # eol(x) = releaseDate(x) + 2 years (rounded to the end of the month).
 # See also https://docs.centreon.com/docs/releases/lifecycle/.
 releases:
 -   releaseCycle: '23.10'
     releaseDate: 2023-10-30
-    support: 2024-10-31
+    eoas: 2024-10-31
     eol: 2025-10-31
     latest: '23.10.10'
     latestReleaseDate: 2024-03-14
 
 -   releaseCycle: '23.04'
     releaseDate: 2023-04-26
-    support: 2024-04-30
+    eoas: 2024-04-30
     eol: 2025-04-30
     latest: '23.04.16'
     latestReleaseDate: 2024-03-14
 
 -   releaseCycle: '22.10'
     releaseDate: 2022-10-26
-    support: 2023-10-31
+    eoas: 2023-10-31
     eol: 2024-10-31
     latest: '22.10.20'
     latestReleaseDate: 2024-03-14
 
 -   releaseCycle: '22.04'
     releaseDate: 2022-05-18
-    support: 2023-05-31
+    eoas: 2023-05-31
     eol: 2024-05-31
     latest: '22.04.22'
     latestReleaseDate: 2024-03-14
@@ -57,16 +57,16 @@ releases:
 
 -   releaseCycle: '21.10'
     releaseDate: 2021-11-02
-    support: 2022-11-30
+    eoas: 2022-11-30
     eol: 2023-11-30
     latest: '21.10.17'
     latestReleaseDate: 2023-11-17
     link: https://archives-docs.centreon.com/21.10/docs/releases/centreon-core/#211017
 
-# 21.04 and lower were supported for 18 months (support(x) = eol(x) - 1 year).
+# 21.04 and lower were supported for 18 months (eoas(x) = eol(x) - 1 year).
 -   releaseCycle: '21.04'
     releaseDate: 2021-04-21
-    support: 2021-10-31
+    eoas: 2021-10-31
     eol: 2022-10-31
     latest: '21.04.20'
     latestReleaseDate: 2022-10-12
@@ -74,7 +74,7 @@ releases:
 
 -   releaseCycle: '20.10'
     releaseDate: 2020-10-19
-    support: 2021-05-31
+    eoas: 2021-05-31
     eol: 2022-05-31
     latest: '20.10.18'
     latestReleaseDate: 2022-06-09
@@ -82,7 +82,7 @@ releases:
 
 -   releaseCycle: '20.04'
     releaseDate: 2020-04-20
-    support: 2020-10-31
+    eoas: 2020-10-31
     eol: 2021-10-31
     latest: '20.04.20'
     latestReleaseDate: 2021-11-19
@@ -90,7 +90,7 @@ releases:
 
 -   releaseCycle: '19.10'
     releaseDate: 2019-10-15
-    support: 2020-04-30
+    eoas: 2020-04-30
     eol: 2021-04-30
     latest: '19.10.23'
     latestReleaseDate: 2021-05-04
@@ -98,7 +98,7 @@ releases:
 
 -   releaseCycle: '19.04'
     releaseDate: 2019-04-24
-    support: 2019-10-31
+    eoas: 2019-10-31
     eol: 2020-10-31
     latest: '19.04.20'
     latestReleaseDate: 2020-11-19
@@ -106,7 +106,7 @@ releases:
 
 -   releaseCycle: '18.10'
     releaseDate: 2018-10-24
-    support: 2019-04-30
+    eoas: 2019-04-30
     eol: 2020-04-30
     latest: '18.10.12'
     latestReleaseDate: 2020-02-24

--- a/products/chef-infra-server.md
+++ b/products/chef-infra-server.md
@@ -9,7 +9,7 @@ alternate_urls:
 versionCommand: chef-server-ctl version
 releasePolicyLink: https://docs.chef.io/versions/
 changelogTemplate: https://docs.chef.io/release_notes_server/#__LATEST__
-activeSupportColumn: true
+eoasColumn: true
 releaseDateColumn: true
 
 identifiers:
@@ -19,40 +19,40 @@ auto:
   methods:
   -   custom: chef-infra-server
 
-# support(x) = releaseDate(x+1)
+# eoas(x) = releaseDate(x+1)
 # eol(x) = releaseDate(x+2) or the date documented on https://docs.chef.io/versions/
 releases:
 -   releaseCycle: "15"
     releaseDate: 2022-06-13
-    support: true
+    eoas: false
     eol: false
     latest: "15.9.27"
     latestReleaseDate: 2024-03-11
 
 -   releaseCycle: "14"
     releaseDate: 2020-06-08
-    support: 2022-06-13
+    eoas: 2022-06-13
     eol: false
     latest: "14.16.19"
     latestReleaseDate: 2022-06-07
 
 -   releaseCycle: "13"
     releaseDate: 2019-05-31
-    support: 2020-06-08
+    eoas: 2020-06-08
     eol: 2021-06-30 # https://www.chef.io/blog/announcing-the-chef-infra-server-13-deprecation
     latest: "13.2.0"
     latestReleaseDate: 2020-04-10
 
 -   releaseCycle: "12"
     releaseDate: 2014-11-25
-    support: 2019-05-31
+    eoas: 2019-05-31
     eol: 2020-12-31 # https://web.archive.org/web/20210613113759/https://docs.chef.io/versions/
     latest: "12.19.31"
     latestReleaseDate: 2019-03-07
 
 -   releaseCycle: "11"
     releaseDate: 2013-02-04 # https://www.chef.io/blog/chef-11-released
-    support: 2014-11-25
+    eoas: 2014-11-25
     eol: 2018-12-31 # https://www.chef.io/blog/end-of-life-announcement-for-chef-reporting-enterprise-chef-server-11-and-chef-analytics
     latest: "11.1.7"
     latestReleaseDate: 2014-06-19

--- a/products/citrix-apps-desktops.md
+++ b/products/citrix-apps-desktops.md
@@ -13,142 +13,127 @@ releasePolicyLink: https://www.citrix.com/support/product-lifecycle/product-matr
 changelogTemplate: https://docs.citrix.com/en-us/citrix-virtual-apps-desktops/__RELEASE_CYCLE__/whats-new.html
 
 LTSLabel: "<abbr title='Long Term Service Release'>LTSR</abbr>"
-activeSupportColumn: true
+eoasColumn: true
 releaseDateColumn: true
-extendedSupportColumn: true
+eoesColumn: true
 
 releases:
 -   releaseCycle: "2311"
     releaseDate: 2023-12-21
-    support: true # not yet on https://www.citrix.com/support/product-lifecycle/product-matrix.html
+    eoas: false # not yet on https://www.citrix.com/support/product-lifecycle/product-matrix.html
     eol: false # not yet on https://www.citrix.com/support/product-lifecycle/product-matrix.html
-    extendedSupport: false
     latest: "2311"
     latestReleaseDate: 2023-12-21
     link: https://docs.citrix.com/en-us/citrix-virtual-apps-desktops/whats-new.html # move to next new releaseCycle
 
 -   releaseCycle: "2308"
     releaseDate: 2023-09-14
-    support: 2024-03-14
+    eoas: 2024-03-14
     eol: 2025-03-14
-    extendedSupport: false
     latest: "2308"
     latestReleaseDate: 2023-09-14
 
 -   releaseCycle: "2305"
     releaseDate: 2023-05-31
-    support: 2023-11-30
+    eoas: 2023-11-30
     eol: 2024-11-30
-    extendedSupport: false
     latest: "2305"
     latestReleaseDate: 2023-05-31
 
 -   releaseCycle: "2303"
     releaseDate: 2023-03-20
-    support: 2023-09-20
+    eoas: 2023-09-20
     eol: 2024-09-20
-    extendedSupport: false
     latest: "2303"
     latestReleaseDate: 2023-03-20
 
 -   releaseCycle: "2212"
     releaseDate: 2022-12-19
-    support: 2023-06-19
+    eoas: 2023-06-19
     eol: 2024-06-19
-    extendedSupport: false
     latest: "2212"
     latestReleaseDate: 2022-12-19
 
 -   releaseCycle: "2209"
     releaseDate: 2022-09-29
-    support: 2023-03-29
+    eoas: 2023-03-29
     eol: 2024-03-29
-    extendedSupport: false
     latest: "2209"
     latestReleaseDate: 2022-09-29
 
 -   releaseCycle: "2206"
     releaseDate: 2022-06-28
-    support: 2022-12-28
+    eoas: 2022-12-28
     eol: 2023-12-28
-    extendedSupport: false
     latest: "2206"
     latestReleaseDate: 2022-06-28
 
 -   releaseCycle: "2203"
     releaseDate: 2022-03-23
     lts: true
-    support: 2027-03-23
+    eoas: 2027-03-23
     eol: 2027-03-23
-    extendedSupport: 2032-03-23
+    eoes: 2032-03-23
     link: https://docs.citrix.com/en-us/citrix-virtual-apps-desktops/2203-ltsr/whats-new/cumulative-update-3.html
     latest: "2203 CU3"
     latestReleaseDate: 2023-06-01
 
 -   releaseCycle: "2112"
     releaseDate: 2021-12-13
-    support: 2022-06-14
+    eoas: 2022-06-14
     eol: 2023-06-14
-    extendedSupport: false
     latest: "2112"
     latestReleaseDate: 2021-12-13
 
 -   releaseCycle: "2109"
     releaseDate: 2021-09-27
-    support: 2022-03-27
+    eoas: 2022-03-27
     eol: 2023-03-27
-    extendedSupport: false
     latest: "2109"
     latestReleaseDate: 2021-09-27
 
 -   releaseCycle: "2106"
     releaseDate: 2021-06-16
-    support: 2021-12-16
+    eoas: 2021-12-16
     eol: 2022-12-16
-    extendedSupport: false
     latest: "2106"
     latestReleaseDate: 2021-06-16
 
 -   releaseCycle: "2103"
     releaseDate: 2021-03-17
-    support: 2021-09-17
+    eoas: 2021-09-17
     eol: 2022-09-17
-    extendedSupport: false
     latest: "2103"
     latestReleaseDate: 2021-03-17
 
 -   releaseCycle: "2012"
     releaseDate: 2020-12-14
-    support: 2021-06-14
+    eoas: 2021-06-14
     eol: 2022-06-14
-    extendedSupport: false
     latest: "2012"
     latestReleaseDate: 2020-12-14
     link: http://web.archive.org/web/20220625230254/https://docs.citrix.com/en-us/citrix-virtual-apps-desktops/2012/whats-new.html
 
 -   releaseCycle: "2009"
     releaseDate: 2020-09-29
-    support: 2021-03-29
+    eoas: 2021-03-29
     eol: 2022-03-29
-    extendedSupport: false
     latest: "2009"
     latestReleaseDate: 2020-09-29
     link: http://web.archive.org/web/20220120022043/https://docs.citrix.com/en-us/citrix-virtual-apps-desktops/2009/whats-new.html
 
 -   releaseCycle: "2006"
     releaseDate: 2020-06-17
-    support: 2020-12-17
+    eoas: 2020-12-17
     eol: 2021-12-17
-    extendedSupport: false
     latest: "2006"
     latestReleaseDate: 2020-06-17
     link: http://web.archive.org/web/20211129090147/https://docs.citrix.com/en-us/citrix-virtual-apps-desktops/2006/whats-new.html
 
 -   releaseCycle: "2003"
     releaseDate: 2020-03-26
-    support: 2020-09-26
+    eoas: 2020-09-26
     eol: 2021-09-26
-    extendedSupport: false
     latest: "2003"
     latestReleaseDate: 2020-03-26
     link: http://web.archive.org/web/20211130125819/https://docs.citrix.com/en-us/citrix-virtual-apps-desktops/2003/whats-new.html
@@ -156,9 +141,9 @@ releases:
 -   releaseCycle: "1912"
     releaseDate: 2019-12-18
     lts: true
-    support: 2024-12-18
+    eoas: 2024-12-18
     eol: 2024-12-18
-    extendedSupport: 2029-12-18
+    eoes: 2029-12-18
     latest: "1912 CU8"
     latestReleaseDate: 2023-09-11
     link: https://docs.citrix.com/en-us/citrix-virtual-apps-desktops/1912-ltsr/whats-new/cumulative-update-8.html
@@ -167,9 +152,9 @@ releases:
     releaseLabel: XenDesktop __RELEASE_CYCLE__
     lts: true
     releaseDate: 2017-08-15
-    support: 2022-08-15
+    eoas: 2022-08-15
     eol: 2022-08-15
-    extendedSupport: 2027-08-15
+    eoes: 2027-08-15
     latest: "7.15 CU9"
     latestReleaseDate: 2022-07-08
     link: https://docs.citrix.com/en-us/xenapp-and-xendesktop/7-15-ltsr/whats-new/cumulative-update-9.html

--- a/products/ckeditor.md
+++ b/products/ckeditor.md
@@ -5,21 +5,20 @@ iconSlug: ckeditor4
 permalink: /ckeditor
 releasePolicyLink: https://ckeditor.com/docs/ckeditor5/latest/updating/versioning-policy.html
 
-activeSupportColumn: true
+eoasColumn: true
 releaseColumn: false
-extendedSupportColumn: true
+eoesColumn: true
 
 releases:
 -   releaseCycle: "5"
-    support: true
+    eoas: false
     eol: false
-    extendedSupport: false
 
 -   releaseCycle: "4"
     lts: true
-    support: false
+    eoas: true
     eol: 2023-06-30
-    extendedSupport: 2026-12-01
+    eoes: 2026-12-01
 
 ---
 

--- a/products/cockroachdb.md
+++ b/products/cockroachdb.md
@@ -10,7 +10,7 @@ versionCommand: cockroach version
 releasePolicyLink: https://www.cockroachlabs.com/docs/releases/release-support-policy
 changelogTemplate: https://www.cockroachlabs.com/docs/releases/v__RELEASE_CYCLE__
 releaseDateColumn: true
-activeSupportColumn: Maintenance Support
+eoasColumn: Maintenance Support
 eolColumn: Assistance Support
 
 auto:
@@ -23,104 +23,104 @@ auto:
           column: "Version"
           regex: '^v?(?P<value>\d+\.\d+).*$'
         releaseDate: "Release Date"
-        support: "Maintenance Support ends"
+        eoas: "Maintenance Support ends"
         eol: "Assistance Support ends (EOL Date)"
 
 releases:
 -   releaseCycle: "23.2"
     releaseDate: 2024-01-12
-    support: 2025-02-05
+    eoas: 2025-02-05
     eol: 2025-08-05
     latest: "23.2.3"
     latestReleaseDate: 2024-03-13
 
 -   releaseCycle: "23.1"
     releaseDate: 2023-05-08
-    support: 2024-05-15
+    eoas: 2024-05-15
     eol: 2024-11-15
     latest: "23.1.17"
     latestReleaseDate: 2024-03-13
 
 -   releaseCycle: "22.2"
     releaseDate: 2022-11-15
-    support: 2023-12-05
+    eoas: 2023-12-05
     eol: 2024-06-05
     latest: "22.2.19"
     latestReleaseDate: 2024-02-23
 
 -   releaseCycle: "22.1"
     releaseDate: 2022-05-04
-    support: 2023-05-24
+    eoas: 2023-05-24
     eol: 2023-11-24
     latest: "22.1.22"
     latestReleaseDate: 2023-08-01
 
 -   releaseCycle: "21.2"
     releaseDate: 2021-10-26
-    support: 2022-11-16
+    eoas: 2022-11-16
     eol: 2023-05-16
     latest: "21.2.17"
     latestReleaseDate: 2022-10-12
 
 -   releaseCycle: "21.1"
     releaseDate: 2021-05-10
-    support: 2022-05-18
+    eoas: 2022-05-18
     eol: 2022-11-18
     latest: "21.1.21"
     latestReleaseDate: 2022-08-08
 
 -   releaseCycle: "20.2"
     releaseDate: 2020-10-30
-    support: 2021-11-10
+    eoas: 2021-11-10
     eol: 2022-05-10
     latest: "20.2.19"
     latestReleaseDate: 2022-02-03
 
 -   releaseCycle: "20.1"
     releaseDate: 2020-05-04
-    support: 2021-05-12
+    eoas: 2021-05-12
     eol: 2021-11-12
     latest: "20.1.17"
     latestReleaseDate: 2021-05-11
 
 -   releaseCycle: "19.2"
     releaseDate: 2019-11-07
-    support: 2020-11-12
+    eoas: 2020-11-12
     eol: 2021-05-12
     latest: "19.2.12"
     latestReleaseDate: 2021-01-12
 
 -   releaseCycle: "19.1"
     releaseDate: 2019-04-24
-    support: 2020-04-30
+    eoas: 2020-04-30
     eol: 2020-10-30
     latest: "19.1.11"
     latestReleaseDate: 2020-06-29
 
 -   releaseCycle: "2.1"
     releaseDate: 2018-10-25
-    support: 2019-10-30
+    eoas: 2019-10-30
     eol: 2020-04-30
     latest: "2.1.11"
     latestReleaseDate: 2020-01-22
 
 -   releaseCycle: "2.0"
     releaseDate: 2018-04-03
-    support: 2019-04-04
+    eoas: 2019-04-04
     eol: 2019-10-04
     latest: "2.0.7"
     latestReleaseDate: 2018-11-28
 
 -   releaseCycle: "1.1"
     releaseDate: 2017-10-04
-    support: 2018-10-12
+    eoas: 2018-10-12
     eol: 2019-04-12
     latest: "1.1.9"
     latestReleaseDate: 2018-10-01
 
 -   releaseCycle: "1.0"
     releaseDate: 2017-05-08
-    support: 2018-05-10
+    eoas: 2018-05-10
     eol: 2018-11-10
     latest: "1.0.7"
     latestReleaseDate: 2018-02-11

--- a/products/coldfusion.md
+++ b/products/coldfusion.md
@@ -8,7 +8,7 @@ releasePolicyLink: https://helpx.adobe.com/x-productkb/policy-pricing/policy_ent
 changelogTemplate: https://helpx.adobe.com/coldfusion/kb/coldfusion-__RELEASE_CYCLE__-updates.html
 releaseDateColumn: true
 eolColumn: Core Support
-extendedSupportColumn: true
+eoesColumn: true
 
 auto:
   methods:
@@ -21,42 +21,42 @@ releases:
 -   releaseCycle: "2023"
     releaseDate: 2022-05-16
     eol: 2028-05-16
-    extendedSupport: 2029-05-16
+    eoes: 2029-05-16
     latest: "2023.0.7.330663"
     latestReleaseDate: 2024-03-12
 
 -   releaseCycle: "2021"
     releaseDate: 2020-11-11
     eol: 2025-11-10
-    extendedSupport: 2026-11-10
+    eoes: 2026-11-10
     latest: "2021.0.13.330286"
     latestReleaseDate: 2024-03-12
 
 -   releaseCycle: "2018"
     releaseDate: 2018-07-12
     eol: 2023-07-13
-    extendedSupport: 2024-07-13
+    eoes: 2024-07-13
     latest: "2018.0.19.330149"
     latestReleaseDate: 2023-07-19
 
 -   releaseCycle: "2016"
     releaseDate: 2016-02-16
     eol: 2021-02-17
-    extendedSupport: 2022-02-17
+    eoes: 2022-02-17
     latest: "2016.0.17.325979"
     latestReleaseDate: 2021-03-22
 
 -   releaseCycle: "11"
     releaseDate: 2014-04-29
     eol: 2019-04-30
-    extendedSupport: 2021-04-30
+    eoes: 2021-04-30
     latest: "11.0.19.314546"
     latestReleaseDate: 2019-06-11
 
 -   releaseCycle: "10"
     releaseDate: 2012-05-15
     eol: 2017-05-16
-    extendedSupport: 2019-05-16
+    eoes: 2019-05-16
     latest: "10.0.23.302580"
     latestReleaseDate: 2017-04-25
 

--- a/products/containerd.md
+++ b/products/containerd.md
@@ -5,7 +5,7 @@ iconSlug: containerd
 permalink: /containerd
 versionCommand: containerd --version
 releasePolicyLink: https://containerd.io/releases/
-activeSupportColumn: Active Support
+eoasColumn: Active Support
 eolColumn: Extended Support
 changelogTemplate: "https://github.com/containerd/containerd/releases/tag/v__LATEST__"
 releaseDateColumn: true
@@ -25,7 +25,7 @@ auto:
 releases:
 -   releaseCycle: "1.7"
     releaseDate: 2023-03-10
-    support: true # releaseDate(2.0) + 6 months
+    eoas: false # releaseDate(2.0) + 6 months
     eol: false # eol(1.6)
     latest: "1.7.14"
     latestReleaseDate: 2024-03-11
@@ -33,49 +33,49 @@ releases:
 -   releaseCycle: "1.6"
     releaseDate: 2022-02-15
     lts: true
-    support: true # same as EOL because it's an LTS.
+    eoas: false # same as EOL because it's an LTS.
     eol: false # max(February 15, 2025 or releaseDate(next LTS) + 6 months
     latest: "1.6.30"
     latestReleaseDate: 2024-03-11
 
 -   releaseCycle: "1.5"
     releaseDate: 2021-05-03
-    support: 2022-08-15 # releaseDate(1.6) + 6 months
+    eoas: 2022-08-15 # releaseDate(1.6) + 6 months
     eol: 2023-02-28
     latest: "1.5.18"
     latestReleaseDate: 2023-02-15
 
 -   releaseCycle: "1.4"
     releaseDate: 2020-08-17
-    support: 2021-11-03 # https://web.archive.org/web/20220206124158/https://containerd.io/releases/
+    eoas: 2021-11-03 # https://web.archive.org/web/20220206124158/https://containerd.io/releases/
     eol: 2022-03-03
     latest: "1.4.13"
     latestReleaseDate: 2022-03-02
 
 -   releaseCycle: "1.3"
     releaseDate: 2019-09-26
-    support: 2021-03-04 # no information about the end of support
+    eoas: 2021-03-04 # no information about the end of support
     eol: 2021-03-04
     latest: "1.3.10"
     latestReleaseDate: 2021-03-04
 
 -   releaseCycle: "1.2"
     releaseDate: 2018-10-24
-    support: 2020-03-26 # https://web.archive.org/web/20200408081910/https://containerd.io/releases/
+    eoas: 2020-03-26 # https://web.archive.org/web/20200408081910/https://containerd.io/releases/
     eol: 2020-10-15
     latest: "1.2.14"
     latestReleaseDate: 2020-10-15
 
 -   releaseCycle: "1.1"
     releaseDate: 2018-04-23
-    support: 2019-10-23 # no information about the end of support
+    eoas: 2019-10-23 # no information about the end of support
     eol: 2019-10-23
     latest: "1.1.8"
     latestReleaseDate: 2019-09-26
 
 -   releaseCycle: "1.0"
     releaseDate: 2017-12-04
-    support: 2018-12-05 # no information about the end of support
+    eoas: 2018-12-05 # no information about the end of support
     eol: 2018-12-05
     latest: "1.0.3"
     latestReleaseDate: 2018-04-02

--- a/products/contao.md
+++ b/products/contao.md
@@ -6,39 +6,39 @@ permalink: /contao
 releasePolicyLink: https://contao.org/release-plan
 changelogTemplate: https://github.com/contao/contao/blob/__LATEST__/CHANGELOG.md
 releaseDateColumn: true
-activeSupportColumn: true
+eoasColumn: true
 
 auto:
   methods:
   -   git: https://github.com/contao/contao.git
 
-# support and eol available on https://contao.org/release-plan.
+# eoas and eol available on https://contao.org/release-plan.
 releases:
 -   releaseCycle: "5.3"
     lts: true
     releaseDate: 2024-02-16
-    support: 2027-02-14
+    eoas: 2027-02-14
     eol: 2028-02-14
     latest: "5.3.3"
     latestReleaseDate: 2024-03-22
 
 -   releaseCycle: "5.2"
     releaseDate: 2023-08-15
-    support: 2024-02-14
+    eoas: 2024-02-14
     eol: 2024-02-14
     latest: "5.2.10"
     latestReleaseDate: 2024-02-16
 
 -   releaseCycle: "5.1"
     releaseDate: 2023-02-16
-    support: 2023-08-14
+    eoas: 2023-08-14
     eol: 2023-08-14
     latest: "5.1.11"
     latestReleaseDate: 2023-08-01
 
 -   releaseCycle: "5.0"
     releaseDate: 2022-08-18
-    support: 2023-02-14
+    eoas: 2023-02-14
     eol: 2023-02-14
     latest: "5.0.10"
     latestReleaseDate: 2023-02-16
@@ -46,28 +46,28 @@ releases:
 -   releaseCycle: "4.13"
     lts: true
     releaseDate: 2022-02-17
-    support: 2025-02-14
+    eoas: 2025-02-14
     eol: 2026-02-14
     latest: "4.13.39"
     latestReleaseDate: 2024-03-20
 
 -   releaseCycle: "4.12"
     releaseDate: 2021-08-19
-    support: 2022-01-14
+    eoas: 2022-01-14
     eol: 2022-01-14
     latest: "4.12.7"
     latestReleaseDate: 2022-02-18
 
 -   releaseCycle: "4.11"
     releaseDate: 2021-02-17
-    support: 2021-08-14
+    eoas: 2021-08-14
     eol: 2021-08-14
     latest: "4.11.9"
     latestReleaseDate: 2021-08-24
 
 -   releaseCycle: "4.10"
     releaseDate: 2020-08-18
-    support: 2021-02-14
+    eoas: 2021-02-14
     eol: 2021-02-14
     latest: "4.10.7"
     latestReleaseDate: 2021-02-16
@@ -75,7 +75,7 @@ releases:
 -   releaseCycle: "4.9"
     lts: true
     releaseDate: 2020-02-18
-    support: 2023-02-14
+    eoas: 2023-02-14
     eol: 2024-02-14
     latest: "4.9.42"
     latestReleaseDate: 2023-07-25
@@ -83,7 +83,7 @@ releases:
 -   releaseCycle: "4.4"
     lts: true
     releaseDate: 2017-06-15
-    support: 2020-12-14
+    eoas: 2020-12-14
     eol: 2021-12-14
     latest: "4.4.57"
     latestReleaseDate: 2021-08-23
@@ -91,7 +91,7 @@ releases:
 -   releaseCycle: "3.5"
     lts: true
     releaseDate: 2015-06-05
-    support: 2018-06-30
+    eoas: 2018-06-30
     eol: 2019-05-31
     link: null
     latest: "3.5.40"

--- a/products/craft-cms.md
+++ b/products/craft-cms.md
@@ -10,7 +10,7 @@ alternate_urls:
 versionCommand: composer show craftcms/cms |grep versions
 releasePolicyLink: https://craftcms.com/knowledge-base/supported-versions
 changelogTemplate: https://craftcms.com/docs/{{__RELEASE_CYCLE__}}.x/
-activeSupportColumn: true
+eoasColumn: true
 releaseDateColumn: true
 
 auto:
@@ -22,34 +22,34 @@ auto:
         releaseCycle:
           column: "Major Version"
           regex: '^Craft\sCMS\s(?P<value>[0-9.]+)$'
-        support: "Full Support Until"
+        eoas: "Full Support Until"
         eol: "Security Support Until"
 
 releases:
 -   releaseCycle: "5"
     releaseDate: 2024-03-26
-    support: true
+    eoas: false
     eol: false
     latest: '5.0.0'
     latestReleaseDate: 2024-03-26
 
 -   releaseCycle: "4"
     releaseDate: 2022-05-04
-    support: 2025-03-30
+    eoas: 2025-03-30
     eol: 2026-03-30
     latest: '4.8.6'
     latestReleaseDate: 2024-03-26
 
 -   releaseCycle: "3"
     releaseDate: 2018-04-04
-    support: 2023-04-30
+    eoas: 2023-04-30
     eol: 2024-04-30
     latest: '3.9.12'
     latestReleaseDate: 2024-03-19
 
 -   releaseCycle: "2"
     releaseDate: 2014-04-01
-    support: 2020-01-31
+    eoas: 2020-01-31
     eol: 2022-01-31
     latest: "2.9.2"
     latestReleaseDate: 2020-03-06

--- a/products/dbt-core.md
+++ b/products/dbt-core.md
@@ -9,69 +9,69 @@ alternate_urls:
 releasePolicyLink: https://docs.getdbt.com/docs/dbt-versions/core
 changelogTemplate: https://github.com/dbt-labs/dbt-core/releases/tag/v__LATEST__
 releaseDateColumn: true
-activeSupportColumn: Active Support
+eoasColumn: Active Support
 eolColumn: Critical Support
 
 auto:
   methods:
   -   git: https://github.com/dbt-labs/dbt-core.git
 
-# support(x) = releaseDate(x+1)
+# eoas(x) = releaseDate(x+1)
 # eol(x) = releaseDate(x) + 1 year
 # See https://docs.getdbt.com/docs/dbt-versions/core
 releases:
 -   releaseCycle: "1.7"
     releaseDate: 2023-11-02
-    support: true
+    eoas: false
     eol: 2024-11-02
     latest: "1.7.11"
     latestReleaseDate: 2024-03-28
 
 -   releaseCycle: "1.6"
     releaseDate: 2023-07-31
-    support: 2023-11-02
+    eoas: 2023-11-02
     eol: 2024-07-30
     latest: "1.6.11"
     latestReleaseDate: 2024-03-28
 
 -   releaseCycle: "1.5"
     releaseDate: 2023-04-27
-    support: 2023-07-31
+    eoas: 2023-07-31
     eol: 2024-04-27
     latest: "1.5.11"
     latestReleaseDate: 2024-03-28
 
 -   releaseCycle: "1.4"
     releaseDate: 2023-01-25
-    support: 2023-04-27
+    eoas: 2023-04-27
     eol: 2024-01-25
     latest: "1.4.9"
     latestReleaseDate: 2023-10-11
 
 -   releaseCycle: "1.3"
     releaseDate: 2022-10-11
-    support: 2023-01-25
+    eoas: 2023-01-25
     eol: 2023-10-12
     latest: "1.3.7"
     latestReleaseDate: 2023-10-11
 
 -   releaseCycle: "1.2"
     releaseDate: 2022-07-26
-    support: 2022-10-12
+    eoas: 2022-10-12
     eol: 2023-07-26
     latest: "1.2.6"
     latestReleaseDate: 2023-04-19
 
 -   releaseCycle: "1.1"
     releaseDate: 2022-04-28
-    support: 2022-07-26
+    eoas: 2022-07-26
     eol: 2023-04-28
     latest: "1.1.5"
     latestReleaseDate: 2023-04-19
 
 -   releaseCycle: "1.0"
     releaseDate: 2021-12-03
-    support: 2022-04-28
+    eoas: 2022-04-28
     eol: 2022-12-03
     latest: "1.0.9"
     latestReleaseDate: 2023-01-05

--- a/products/debian.md
+++ b/products/debian.md
@@ -9,7 +9,7 @@ releasePolicyLink: https://wiki.debian.org/DebianReleases
 releaseLabel: "__RELEASE_CYCLE__ (__CODENAME__)"
 releaseDateColumn: true
 eolColumn: Debian Security Support
-extendedSupportColumn: Debian <abbr title="Long Term Support">LTS</abbr>
+eoesColumn: Debian <abbr title="Long Term Support">LTS</abbr>
 
 identifiers:
 -   cpe: cpe:2.3:o:debian:debian_linux
@@ -35,7 +35,7 @@ releases:
     codename: "Bookworm"
     releaseDate: 2023-06-10
     eol: 2026-06-10
-    extendedSupport: 2028-06-10
+    eoes: 2028-06-10
     link: https://www.debian.org/News/2023/20230610
     latest: "12.5"
     latestReleaseDate: 2024-02-10
@@ -44,7 +44,7 @@ releases:
     codename: "Bullseye"
     releaseDate: 2021-08-14
     eol: 2024-07-31
-    extendedSupport: 2026-06-30
+    eoes: 2026-06-30
     link: https://www.debian.org/News/2023/20230429
     latest: "11.9"
     latestReleaseDate: 2024-02-10
@@ -53,7 +53,7 @@ releases:
     codename: "Buster"
     releaseDate: 2019-07-06
     eol: 2022-09-10
-    extendedSupport: 2024-06-30
+    eoes: 2024-06-30
     link: https://www.debian.org/News/2022/20220910
     latest: "10.13"
     latestReleaseDate: 2022-09-10
@@ -62,7 +62,7 @@ releases:
     codename: "Stretch"
     releaseDate: 2017-06-17
     eol: 2020-07-18
-    extendedSupport: 2022-07-01
+    eoes: 2022-07-01
     link: https://www.debian.org/News/2020/20200718
     latest: "9.13"
     latestReleaseDate: 2020-07-18
@@ -71,7 +71,7 @@ releases:
     codename: "Jessie"
     releaseDate: 2015-04-25
     eol: 2018-06-17
-    extendedSupport: 2020-06-30
+    eoes: 2020-06-30
     link: https://www.debian.org/News/2018/20180623
     latest: "8.11"
     latestReleaseDate: 2018-06-23
@@ -80,7 +80,7 @@ releases:
     codename: "Wheezy"
     releaseDate: 2013-05-04
     eol: 2016-04-25
-    extendedSupport: 2018-05-31
+    eoes: 2018-05-31
     link: https://www.debian.org/News/2016/2016060402
     latest: "7.11"
     latestReleaseDate: 2016-06-04
@@ -89,7 +89,7 @@ releases:
     codename: "Squeeze"
     releaseDate: 2011-02-06
     eol: 2014-05-31
-    extendedSupport: 2016-02-29
+    eoes: 2016-02-29
     link: https://www.debian.org/News/2014/20140719
     latest: "6.0.10"
     latestReleaseDate: 2014-07-19

--- a/products/devuan.md
+++ b/products/devuan.md
@@ -17,7 +17,7 @@ auto:
       regex: '^Distribution Release: Devuan GNU\+Linux (?P<major>\d)\.(?P<minor>\d)(?:\.(?P<patch>\d))?$'
 
 # lts(x) = eol(corresponding Debian version)
-# eol(x) = extendedSupport(corresponding Debian version)
+# eol(x) = eoes(corresponding Debian version)
 releases:
 -   releaseCycle: "5"
     codename: "Daedalus"

--- a/products/django.md
+++ b/products/django.md
@@ -8,7 +8,7 @@ versionCommand: python -c "import django; print(django.get_version())"
 releasePolicyLink: https://www.djangoproject.com/download/#supported-versions
 releaseImage: https://static.djangoproject.com/img/release-roadmap.4cf783b31fbe.png
 changelogTemplate: https://docs.djangoproject.com/en/__RELEASE_CYCLE__/releases/__LATEST__/
-activeSupportColumn: true
+eoasColumn: true
 releaseDateColumn: true
 customColumns:
 -   property: supportedPythonVersions
@@ -33,7 +33,7 @@ auto:
         releaseCycle:
           column: "Release Series"
           regex: '^(?P<value>\d+\.\d+).*$'
-        support: "End of mainstream support1"
+        eoas: "End of mainstream support1"
         eol: "End of extended support2"
   -   release_table: https://www.djangoproject.com/download/#unsupported-versions
       selector: "table.django-unsupported-versions"
@@ -43,7 +43,7 @@ auto:
         releaseCycle:
           column: "Release Series"
           regex: '^(?P<value>\d+\.\d+).*$'
-        support: "End of mainstream support1"
+        eoas: "End of mainstream support1"
         eol: "End of extended support2"
   -   release_table: https://docs.djangoproject.com/en/stable/faq/install/
       selector: "table"
@@ -56,7 +56,7 @@ auto:
 releases:
 -   releaseCycle: "5.0"
     releaseDate: 2023-12-04
-    support: 2024-08-31
+    eoas: 2024-08-31
     eol: 2025-04-30
     supportedPythonVersions: "3.10 - 3.12"
     latest: "5.0.3"
@@ -65,7 +65,7 @@ releases:
 -   releaseCycle: "4.2"
     lts: true
     releaseDate: 2023-04-03
-    support: 2023-12-04
+    eoas: 2023-12-04
     eol: 2026-04-30
     supportedPythonVersions: "3.8 - 3.12 (added in 4.2.8)"
     latest: "4.2.11"
@@ -73,7 +73,7 @@ releases:
 
 -   releaseCycle: "4.1"
     releaseDate: 2022-08-03
-    support: 2023-04-05
+    eoas: 2023-04-05
     eol: 2023-12-01
     supportedPythonVersions: "3.8 - 3.11 (added in 4.1.3)"
     latest: "4.1.13"
@@ -81,7 +81,7 @@ releases:
 
 -   releaseCycle: "4.0"
     releaseDate: 2021-12-07
-    support: 2022-08-03
+    eoas: 2022-08-03
     eol: 2023-04-01
     supportedPythonVersions: "3.8 - 3.10"
     latest: "4.0.10"
@@ -90,7 +90,7 @@ releases:
 -   releaseCycle: "3.2"
     lts: true
     releaseDate: 2021-04-06
-    support: 2021-12-07
+    eoas: 2021-12-07
     eol: 2024-04-30
     latest: "3.2.25"
     supportedPythonVersions: "3.6 - 3.10 (added in 3.2.9)"
@@ -98,7 +98,7 @@ releases:
 
 -   releaseCycle: "3.1"
     releaseDate: 2020-08-04
-    support: 2021-04-06
+    eoas: 2021-04-06
     eol: 2021-12-07
     supportedPythonVersions: "3.6 - 3.9 (added in 3.1.3)"
     latest: "3.1.14"
@@ -106,7 +106,7 @@ releases:
 
 -   releaseCycle: "3.0"
     releaseDate: 2019-12-02
-    support: 2020-08-03
+    eoas: 2020-08-03
     eol: 2021-04-06
     supportedPythonVersions: "3.6 - 3.9 (added in 3.0.11)"
     latest: "3.0.14"
@@ -115,7 +115,7 @@ releases:
 -   releaseCycle: "2.2"
     lts: true
     releaseDate: 2019-04-01
-    support: 2019-12-02
+    eoas: 2019-12-02
     eol: 2022-04-11
     supportedPythonVersions: "3.5 - 3.9 (added in 2.2.17)"
     latest: "2.2.28"
@@ -123,7 +123,7 @@ releases:
 
 -   releaseCycle: "2.1"
     releaseDate: 2018-08-01
-    support: 2019-04-01
+    eoas: 2019-04-01
     eol: 2019-12-02
     supportedPythonVersions: "3.5 - 3.7"
     latest: "2.1.15"
@@ -131,7 +131,7 @@ releases:
 
 -   releaseCycle: "2.0"
     releaseDate: 2017-12-02
-    support: 2018-08-01
+    eoas: 2018-08-01
     eol: 2019-04-01
     supportedPythonVersions: "3.4 - 3.7"
     latest: "2.0.13"
@@ -140,7 +140,7 @@ releases:
 -   releaseCycle: "1.11"
     lts: true
     releaseDate: 2017-04-04
-    support: 2017-12-02
+    eoas: 2017-12-02
     eol: 2020-04-01
     supportedPythonVersions: "2.7 - 3.7 (added in 1.11.17)"
     latest: "1.11.29"

--- a/products/drupal.md
+++ b/products/drupal.md
@@ -7,8 +7,8 @@ permalink: /drupal
 versionCommand: drush status
 releasePolicyLink: https://www.drupal.org/about/core/policies/core-release-cycles/schedule
 changelogTemplate: https://www.drupal.org/project/drupal/releases/__LATEST__
-extendedSupportColumn: Commercial Support
-activeSupportColumn: true
+eoesColumn: Commercial Support
+eoasColumn: true
 releaseDateColumn: true
 
 auto:
@@ -23,104 +23,93 @@ identifiers:
 -   purl: pkg:docker/bitnami/drupal-nginx
 -   purl: pkg:github/drupal/core
 
-# support(x) = releaseDate(x+1)
+# eoas(x) = releaseDate(x+1)
 # eol(x) = releaseDate(x+2)
 # Minor releases usually happen on the third Wednesday every six months.
 releases:
 -   releaseCycle: "10.2"
     releaseDate: 2023-12-15
-    support: 2024-06-19
+    eoas: 2024-06-19
     eol: 2024-12-18
-    extendedSupport: false
     latest: "10.2.4"
     latestReleaseDate: 2024-03-06
 
 -   releaseCycle: "10.1"
     releaseDate: 2023-06-22
-    support: 2023-12-15
+    eoas: 2023-12-15
     eol: 2024-06-19
-    extendedSupport: false
     latest: "10.1.8"
     latestReleaseDate: 2024-01-16
 
 -   releaseCycle: "10.0"
     releaseDate: 2022-12-15
-    support: 2023-06-21
+    eoas: 2023-06-21
     eol: 2023-12-15
-    extendedSupport: false
     latest: "10.0.11"
     latestReleaseDate: 2023-09-19
 
 -   releaseCycle: "9.5"
     releaseDate: 2022-12-15
-    support: 2023-06-21
+    eoas: 2023-06-21
     eol: 2023-11-01
-    extendedSupport: false
     latest: "9.5.11"
     latestReleaseDate: 2023-09-19
 
 -   releaseCycle: "9.4"
     releaseDate: 2022-06-15
-    support: 2022-12-14
+    eoas: 2022-12-14
     eol: 2023-06-21
-    extendedSupport: false
     latest: "9.4.15"
     latestReleaseDate: 2023-05-03
 
 -   releaseCycle: "9.3"
     releaseDate: 2021-12-08
-    support: 2022-06-15
+    eoas: 2022-06-15
     eol: 2022-12-14
-    extendedSupport: false
     latest: "9.3.22"
     latestReleaseDate: 2022-09-28
 
 -   releaseCycle: "9.2"
     releaseDate: 2021-06-16
-    support: 2021-12-08
+    eoas: 2021-12-08
     eol: 2022-06-15
-    extendedSupport: false
     latest: "9.2.21"
     latestReleaseDate: 2022-06-10
 
 -   releaseCycle: "9.1"
     releaseDate: 2020-12-02
-    support: 2021-06-16
+    eoas: 2021-06-16
     eol: 2021-12-08
-    extendedSupport: false
     latest: "9.1.15"
     latestReleaseDate: 2021-11-24
 
 -   releaseCycle: "9.0"
     releaseDate: 2020-06-03
-    support: 2020-12-02
+    eoas: 2020-12-02
     eol: 2021-06-16
-    extendedSupport: false
     latest: "9.0.14"
     latestReleaseDate: 2021-05-25
 
 -   releaseCycle: "8.9"
     releaseDate: 2020-06-03
-    support: 2020-12-01
+    eoas: 2020-12-01
     eol: 2021-11-02
-    extendedSupport: false
     latest: "8.9.20"
     latestReleaseDate: 2021-11-17
 
 -   releaseCycle: "8.8"
     releaseDate: 2019-12-04
-    support: 2020-06-03
+    eoas: 2020-06-03
     eol: 2020-12-01
-    extendedSupport: false
     latest: "8.8.12"
     latestReleaseDate: 2020-11-25
 
 -   releaseCycle: "7"
     lts: true
     releaseDate: 2011-01-05
-    support: 2015-11-19
+    eoas: 2015-11-19
     eol: 2025-01-05
-    extendedSupport: true
+    eoes: false
     latest: "7.100"
     latestReleaseDate: 2024-03-06
 
@@ -135,6 +124,6 @@ bugs and security issues that have been reported are fixed and are released duri
 (US time). The final minor release in major release cycle is a long-term support (LTS) release and
 has extended security coverage.
 
-**Drupal 7** will receive security coverage 
+**Drupal 7** will receive security coverage
 [until January 5th 2025](https://www.drupal.org/about/core/policies/core-release-cycles/schedule#s-drupal-7-and-9-end-of-life-dates)
 with commercial support available post end-of-life through Drupal's [Certified D7 End of Life Support Partners](https://www.drupal.org/about/drupal-7/d7eol/partners#commercial-support).

--- a/products/eclipse-jetty.md
+++ b/products/eclipse-jetty.md
@@ -9,9 +9,9 @@ alternate_urls:
 releasePolicyLink: https://eclipse.dev/jetty/download.php
 changelogTemplate: https://github.com/jetty/jetty.project/releases/tag/jetty-__LATEST__
 releaseDateColumn: true
-activeSupportColumn: "Community Support"
+eoasColumn: "Community Support"
 eolColumn: true
-extendedSupportColumn: "Extended Support"
+eoesColumn: "Extended Support"
 
 identifiers:
 -   purl: pkg:maven/org.eclipse.jetty/jetty-server
@@ -27,9 +27,9 @@ releases:
     minJvmVersion: 17
     servletVersion: 3.1 - 6.0
     jspVersion: 2.3 - 3.1
-    support: true
+    eoas: false
     eol: false
-    extendedSupport: true
+    eoes: false
     latest: "12.0.7"
     latestReleaseDate: 2024-02-29
 
@@ -38,9 +38,9 @@ releases:
     servletVersion: 5.0
     jspVersion: 3.0
     releaseDate: 2020-12-02
-    support: 2024-01-01 # https://github.com/jetty/jetty.project/issues/10485
+    eoas: 2024-01-01 # https://github.com/jetty/jetty.project/issues/10485
     eol: false # currently estimated to 2025-01-01, see https://github.com/jetty/jetty.project/issues/10485
-    extendedSupport: 2025-01-01 # estimated, see https://github.com/jetty/jetty.project/issues/10485
+    eoes: 2025-01-01 # estimated, see https://github.com/jetty/jetty.project/issues/10485
     latest: "11.0.20"
     latestReleaseDate: 2024-01-29
 
@@ -49,9 +49,9 @@ releases:
     servletVersion: 4.0
     jspVersion: 2.3
     releaseDate: 2020-12-02
-    support: 2024-01-01 # https://github.com/jetty/jetty.project/issues/10485
+    eoas: 2024-01-01 # https://github.com/jetty/jetty.project/issues/10485
     eol: false # currently estimated to 2025-01-01, see https://github.com/jetty/jetty.project/issues/10485
-    extendedSupport: true
+    eoes: false
     latest: "10.0.20"
     latestReleaseDate: 2024-01-29
 
@@ -60,9 +60,9 @@ releases:
     servletVersion: 3.1
     jspVersion: 2.3
     releaseDate: 2016-12-07
-    support: 2022-06-01 # https://github.com/jetty/jetty.project/issues/7958
+    eoas: 2022-06-01 # https://github.com/jetty/jetty.project/issues/7958
     eol: false # currently estimated to 2025-01-01, see https://github.com/jetty/jetty.project/issues/7958
-    extendedSupport: true
+    eoes: false
     latest: "9.4.53.v20231009"
     latestReleaseDate: 2023-10-10
 
@@ -71,9 +71,8 @@ releases:
     servletVersion: 3.1
     jspVersion: 2.3
     releaseDate: 2015-06-01
-    support: 2020-12-07 # https://www.eclipse.org/lists/jetty-announce/msg00140.html
+    eoas: 2020-12-07 # https://www.eclipse.org/lists/jetty-announce/msg00140.html
     eol: 2020-12-07 # https://www.eclipse.org/lists/jetty-announce/msg00140.html
-    extendedSupport: false
     latest: "9.3.30.v20211001"
     latestReleaseDate: 2021-10-01
 
@@ -82,9 +81,8 @@ releases:
     servletVersion: 3.1
     jspVersion: 2.3
     releaseDate: 2014-05-23
-    support: 2018-03-08 # https://www.eclipse.org/lists/jetty-announce/msg00116.html
+    eoas: 2018-03-08 # https://www.eclipse.org/lists/jetty-announce/msg00116.html
     eol: 2018-03-08 # https://www.eclipse.org/lists/jetty-announce/msg00116.html
-    extendedSupport: false
     latest: "9.2.30.v20200428"
     latestReleaseDate: 2020-04-28
 
@@ -93,9 +91,8 @@ releases:
     servletVersion: 3.1
     jspVersion: 2.3
     releaseDate: 2013-11-15
-    support: 2014-12-31 # only year provided on https://eclipse.dev/jetty/download.php, used end of the year
+    eoas: 2014-12-31 # only year provided on https://eclipse.dev/jetty/download.php, used end of the year
     eol: 2014-12-31 # only year provided on https://eclipse.dev/jetty/download.php, used end of the year
-    extendedSupport: false
     latest: "9.1.6.v20160112"
     latestReleaseDate: 2016-01-12
 
@@ -104,9 +101,8 @@ releases:
     servletVersion: 3.1-beta
     jspVersion: 2.3
     releaseDate: 2013-03-08
-    support: 2013-12-31 # only year provided on https://eclipse.dev/jetty/download.php, used end of the year
+    eoas: 2013-12-31 # only year provided on https://eclipse.dev/jetty/download.php, used end of the year
     eol: 2013-12-31 # only year provided on https://eclipse.dev/jetty/download.php, used end of the year
-    extendedSupport: false
     latest: "9.0.7.v20131107"
     latestReleaseDate: 2013-11-07
 
@@ -115,9 +111,8 @@ releases:
     servletVersion: 3.0
     jspVersion: 2.2
     releaseDate: 2011-09-01
-    support: 2014-12-31 # only year provided on https://eclipse.dev/jetty/download.php, used end of the year
+    eoas: 2014-12-31 # only year provided on https://eclipse.dev/jetty/download.php, used end of the year
     eol: 2014-12-31 # only year provided on https://eclipse.dev/jetty/download.php, used end of the year
-    extendedSupport: false
     latest: "8.2.0.v20160908"
     latestReleaseDate: 2016-09-08
 
@@ -126,9 +121,8 @@ releases:
     servletVersion: 2.5
     jspVersion: 2.1
     releaseDate: 2009-10-05
-    support: 2014-12-31 # only year provided on https://eclipse.dev/jetty/download.php, used end of the year
+    eoas: 2014-12-31 # only year provided on https://eclipse.dev/jetty/download.php, used end of the year
     eol: 2014-12-31 # only year provided on https://eclipse.dev/jetty/download.php, used end of the year
-    extendedSupport: false
     latest: "7.6.21.v20160908"
     latestReleaseDate: 2016-09-08
 

--- a/products/eks.md
+++ b/products/eks.md
@@ -12,7 +12,7 @@ releasePolicyLink: https://docs.aws.amazon.com/eks/latest/userguide/kubernetes-v
 changelogTemplate: "https://github.com/aws/eks-distro/releases/tag/v{{'__LATEST__'|replace:'.','-'}}"
 releaseDateColumn: true
 eolColumn: End of Support
-extendedSupportColumn: true
+eoesColumn: true
 
 auto:
   methods:
@@ -22,90 +22,85 @@ auto:
       fields:
         releaseCycle: "Kubernetes version"
         eol: "End of standard support"
-        extendedSupport: "End of extended support"
+        eoes: "End of extended support"
 
 releases:
 -   releaseCycle: "1.29"
     releaseDate: 2024-01-23
     eol: 2025-03-23
-    extendedSupport: 2026-03-23
+    eoes: 2026-03-23
     latest: '1.29-eks-4'
     latestReleaseDate: 2024-03-20
 
 -   releaseCycle: "1.28"
     releaseDate: 2023-09-26
     eol: 2024-11-26
-    extendedSupport: 2025-11-26
+    eoes: 2025-11-26
     latest: '1.28-eks-10'
     latestReleaseDate: 2024-03-20
 
 -   releaseCycle: "1.27"
     releaseDate: 2023-05-24
     eol: 2024-07-24
-    extendedSupport: 2025-07-24
+    eoes: 2025-07-24
     latest: '1.27-eks-14'
     latestReleaseDate: 2024-03-20
 
 -   releaseCycle: "1.26"
     releaseDate: 2023-04-11
     eol: 2024-06-11
-    extendedSupport: 2025-06-11
+    eoes: 2025-06-11
     latest: '1.26-eks-15'
     latestReleaseDate: 2024-03-20
 
 -   releaseCycle: "1.25"
     releaseDate: 2023-02-21
     eol: 2024-05-01
-    extendedSupport: 2025-05-01
+    eoes: 2025-05-01
     latest: '1.25-eks-16'
     latestReleaseDate: 2024-03-20
 
 -   releaseCycle: "1.24"
     releaseDate: 2022-11-15
     eol: 2024-01-31
-    extendedSupport: 2025-01-31
+    eoes: 2025-01-31
     latest: '1.24-eks-19'
     latestReleaseDate: 2024-03-20
 
 -   releaseCycle: "1.23"
     releaseDate: 2022-08-11
     eol: 2023-10-11
-    extendedSupport: 2024-10-11
+    eoes: 2024-10-11
     latest: '1.23-eks-21'
     latestReleaseDate: 2024-03-20
 
 -   releaseCycle: "1.22"
     releaseDate: 2022-04-04
     eol: 2023-06-04
-    extendedSupport: false
     latest: '1.22-eks-14'
     latestReleaseDate: 2023-06-30
 
 -   releaseCycle: "1.21"
     releaseDate: 2021-07-19
     eol: 2023-02-15
-    extendedSupport: false
     latest: '1.21-eks-18'
     latestReleaseDate: 2023-06-09
 
 -   releaseCycle: "1.20"
     releaseDate: 2021-05-18
     eol: 2022-11-01
-    extendedSupport: false
     latest: '1.20-eks-14'
     latestReleaseDate: 2023-05-05
 
 -   releaseCycle: "1.19"
     releaseDate: 2021-02-16
     eol: 2022-08-01
-    extendedSupport: false
     latest: "1.19-eks-11"
     latestReleaseDate: 2022-08-15
 
 -   releaseCycle: "1.18"
     releaseDate: 2020-10-13
     eol: 2022-08-15 # Official EOL was on March 31, but it got fixes till August (see link below)
-    extendedSupport: false
     # Last mention for 1.18 was on Sep 2022
     # https://github.com/awsdocs/amazon-eks-user-guide/blob/306ec81574cb60ae47b8dbc8834d6c9d0dd3fe66/doc_source/platform-versions.md
     latest: "1.18-eks-13"

--- a/products/elixir.md
+++ b/products/elixir.md
@@ -6,103 +6,103 @@ permalink: /elixir
 versionCommand: elixir --version
 releasePolicyLink: https://hexdocs.pm/elixir/compatibility-and-deprecations.html
 changelogTemplate: https://github.com/elixir-lang/elixir/blob/v__RELEASE_CYCLE__/CHANGELOG.md
-activeSupportColumn: true
+eoasColumn: true
 releaseDateColumn: true
 
 auto:
   methods:
   -   git: https://github.com/elixir-lang/elixir.git
 
-# support(x) = releaseDate(x+1) (or true if not yet released)
+# eoas(x) = releaseDate(x+1) (or true if not yet released)
 # eol(x) = releaseDate(x+5) (or false if not yet released)
 releases:
 -   releaseCycle: "1.16"
     releaseDate: 2023-12-22
-    support: true # release date of 1.17
+    eoas: false # release date of 1.17
     eol: false # release date of 1.21
     latest: "1.16.2"
     latestReleaseDate: 2024-03-10
 
 -   releaseCycle: "1.15"
     releaseDate: 2023-06-19
-    support: 2023-12-22 # release date of 1.16
+    eoas: 2023-12-22 # release date of 1.16
     eol: false # release date of 1.20
     latest: "1.15.7"
     latestReleaseDate: 2023-10-14
 
 -   releaseCycle: "1.14"
     releaseDate: 2022-09-01
-    support: 2023-06-19 # release date of 1.15
+    eoas: 2023-06-19 # release date of 1.15
     eol: false # release date of 1.19
     latest: "1.14.5"
     latestReleaseDate: 2023-05-22
 
 -   releaseCycle: "1.13"
     releaseDate: 2021-12-03
-    support: 2022-09-01 # release date of 1.14
+    eoas: 2022-09-01 # release date of 1.14
     eol: false # release date of 1.18
     latest: "1.13.4"
     latestReleaseDate: 2022-04-07
 
 -   releaseCycle: "1.12"
     releaseDate: 2021-05-19
-    support: 2021-12-03 # release date of 1.13
+    eoas: 2021-12-03 # release date of 1.13
     eol: false # release date of 1.17
     latest: "1.12.3"
     latestReleaseDate: 2021-09-05
 
 -   releaseCycle: "1.11"
     releaseDate: 2020-10-06
-    support: 2021-05-19 # release date of 1.12
+    eoas: 2021-05-19 # release date of 1.12
     eol: 2023-12-22 # release date of 1.16
     latest: "1.11.4"
     latestReleaseDate: 2021-03-16
 
 -   releaseCycle: "1.10"
     releaseDate: 2020-01-27
-    support: 2020-10-06 # release date of 1.11
+    eoas: 2020-10-06 # release date of 1.11
     eol: 2023-06-19 # release date of 1.15
     latest: "1.10.4"
     latestReleaseDate: 2020-07-04
 
 -   releaseCycle: "1.9"
     releaseDate: 2019-06-24
-    support: 2020-01-27 # release date of 1.10
+    eoas: 2020-01-27 # release date of 1.10
     eol: 2022-09-01 # release date of 1.14
     latest: "1.9.4"
     latestReleaseDate: 2019-11-05
 
 -   releaseCycle: "1.8"
     releaseDate: 2019-01-14
-    support: 2019-06-24 # release date of 1.9
+    eoas: 2019-06-24 # release date of 1.9
     eol: 2021-12-03 # release date of 1.13
     latest: "1.8.2"
     latestReleaseDate: 2019-05-11
 
 -   releaseCycle: "1.7"
     releaseDate: 2018-07-25
-    support: 2019-01-14 # release date of 1.8
+    eoas: 2019-01-14 # release date of 1.8
     eol: 2021-05-19 # release date of 1.12
     latest: "1.7.4"
     latestReleaseDate: 2018-10-24
 
 -   releaseCycle: "1.6"
     releaseDate: 2018-01-17
-    support: 2018-07-25 # release date of 1.7
+    eoas: 2018-07-25 # release date of 1.7
     eol: 2020-10-06 # release date of 1.11
     latest: "1.6.6"
     latestReleaseDate: 2018-06-20
 
 -   releaseCycle: "1.5"
     releaseDate: 2017-07-25
-    support: 2018-01-17 # release date of 1.6
+    eoas: 2018-01-17 # release date of 1.6
     eol: 2020-01-27 # release date of 1.10
     latest: "1.5.3"
     latestReleaseDate: 2017-12-19
 
 -   releaseCycle: "1.4"
     releaseDate: 2017-01-05
-    support: 2017-07-25 # release date of 1.5
+    eoas: 2017-07-25 # release date of 1.5
     eol: 2019-06-24 # release date of 1.9
     latest: "1.4.5"
     latestReleaseDate: 2017-06-22

--- a/products/emberjs.md
+++ b/products/emberjs.md
@@ -9,7 +9,7 @@ alternate_urls:
 releasePolicyLink: https://emberjs.com/releases/
 changelogTemplate: https://github.com/emberjs/ember.js/releases/tag/v__LATEST__
 releaseDateColumn: true
-activeSupportColumn: true
+eoasColumn: true
 
 identifiers:
 -   purl: pkg:github/emberjs/ember.js
@@ -24,44 +24,44 @@ auto:
       fields:
         releaseCycle: "LTS version"
         lts: "Promotion date"
-        support: "Bugfixes until"
+        eoas: "Bugfixes until"
         eol: "Security patches until"
   -   release_table: https://emberjs.com/releases/lts/
       selector: "table"
       fields:
         releaseCycle: "LTS version"
         lts: "LTS promotion"
-        support: "Bugfixes until"
+        eoas: "Bugfixes until"
         eol: "Security patches until"
 
 # For LTS :
 # every 4 minor versions excluding the x.0 minor version, e.g. x.4, x.8, etc.
 # see https://emberjs.com/releases/lts/
 # - lts(x) = release(x) + 6 weeks
-# - support(x) = lts(x) + 36 weeks
+# - eoas(x) = lts(x) + 36 weeks
 # - eol(x) = lts(x) + 54 months
 #
 # For non-LTS :
-# - support(x) = release(x+1)
+# - eoas(x) = release(x+1)
 # - eol(x) = release(x+1)
 releases:
 -   releaseCycle: "5.7"
     releaseDate: 2024-03-04
-    support: true
+    eoas: false
     eol: false
     latest: "5.7.0"
     latestReleaseDate: 2024-03-04
 
 -   releaseCycle: "5.6"
     releaseDate: 2024-01-22
-    support: 2024-03-04
+    eoas: 2024-03-04
     eol: 2024-03-04
     latest: "5.6.0"
     latestReleaseDate: 2024-01-22
 
 -   releaseCycle: "5.5"
     releaseDate: 2023-12-11
-    support: 2024-01-22
+    eoas: 2024-01-22
     eol: 2024-01-22
     latest: "5.5.0"
     latestReleaseDate: 2023-12-11
@@ -69,35 +69,35 @@ releases:
 -   releaseCycle: "5.4"
     releaseDate: 2023-10-30
     lts: 2023-12-11
-    support: 2024-08-19
+    eoas: 2024-08-19
     eol: 2024-12-23
     latest: "5.4.1"
     latestReleaseDate: 2024-01-22
 
 -   releaseCycle: "5.3"
     releaseDate: 2023-09-18
-    support: 2023-11-03
+    eoas: 2023-11-03
     eol: 2023-11-03
     latest: "5.3.0"
     latestReleaseDate: 2023-09-18
 
 -   releaseCycle: "5.2"
     releaseDate: 2023-08-07
-    support: 2023-09-21
+    eoas: 2023-09-21
     eol: 2023-09-21
     latest: "5.2.0"
     latestReleaseDate: 2023-08-07
 
 -   releaseCycle: "5.1"
     releaseDate: 2023-06-26
-    support: 2023-08-07
+    eoas: 2023-08-07
     eol: 2023-08-07
     latest: "5.1.2"
     latestReleaseDate: 2023-06-30
 
 -   releaseCycle: "5.0"
     releaseDate: 2023-05-15
-    support: 2023-07-08
+    eoas: 2023-07-08
     eol: 2023-07-08
     latest: "5.0.0"
     latestReleaseDate: 2023-05-15
@@ -105,7 +105,7 @@ releases:
 -   releaseCycle: "4.12"
     releaseDate: 2023-04-03
     lts: 2023-05-15
-    support: 2024-01-22
+    eoas: 2024-01-22
     eol: 2024-05-27
     latest: "4.12.4"
     latestReleaseDate: 2024-01-22
@@ -113,7 +113,7 @@ releases:
 -   releaseCycle: "4.8"
     lts: 2022-12-08
     releaseDate: 2022-10-17
-    support: 2023-07-06
+    eoas: 2023-07-06
     eol: 2023-12-21
     latest: "4.8.6"
     latestReleaseDate: 2023-06-12
@@ -121,7 +121,7 @@ releases:
 -   releaseCycle: "4.4"
     lts: 2022-07-13
     releaseDate: 2022-05-03
-    support: 2023-02-08
+    eoas: 2023-02-08
     eol: 2023-07-26
     latest: "4.4.5"
     latestReleaseDate: 2023-05-04
@@ -129,7 +129,7 @@ releases:
 -   releaseCycle: "3.28"
     lts: 2021-12-20
     releaseDate: 2021-08-10
-    support: 2022-07-18
+    eoas: 2022-07-18
     eol: 2023-01-02
     latest: "3.28.12"
     latestReleaseDate: 2023-05-04
@@ -137,7 +137,7 @@ releases:
 -   releaseCycle: "3.24"
     lts: 2021-02-25
     releaseDate: 2020-12-28
-    support: 2021-09-23
+    eoas: 2021-09-23
     eol: 2022-03-10
     latest: "3.24.7"
     latestReleaseDate: 2022-11-02

--- a/products/erlang.md
+++ b/products/erlang.md
@@ -7,7 +7,7 @@ alternate_urls:
 -   /erlang-otp
 releasePolicyLink: https://www.erlang.org/doc/system_principles/misc.html
 changelogTemplate: https://github.com/erlang/otp/releases/tag/OTP-__LATEST__
-activeSupportColumn: true
+eoasColumn: true
 releaseDateColumn: true
 
 auto:
@@ -20,70 +20,70 @@ auto:
 releases:
 -   releaseCycle: "26"
     releaseDate: 2023-05-15
-    support: true
+    eoas: false
     eol: 2026-05-15 # projected
     latest: '26.2.3'
     latestReleaseDate: 2024-03-06
 
 -   releaseCycle: "25"
     releaseDate: 2022-05-17
-    support: 2023-05-15
+    eoas: 2023-05-15
     eol: 2025-05-17 # projected
     latest: '25.3.2.10'
     latestReleaseDate: 2024-03-11
 
 -   releaseCycle: "24"
     releaseDate: 2021-05-10
-    support: 2022-05-17
+    eoas: 2022-05-17
     eol: 2024-05-10 # projected
     latest: '24.3.4.16'
     latestReleaseDate: 2024-02-08
 
 -   releaseCycle: "23"
     releaseDate: 2020-05-11
-    support: 2021-05-10
+    eoas: 2021-05-10
     eol: 2023-06-05
     latest: '23.3.4.20'
     latestReleaseDate: 2024-03-14
 
 -   releaseCycle: "22"
     releaseDate: 2019-05-10
-    support: 2020-05-11
+    eoas: 2020-05-11
     eol: 2022-05-10
     latest: '22.3.4.27'
     latestReleaseDate: 2024-03-18
 
 -   releaseCycle: "21"
     releaseDate: 2018-06-19
-    support: 2019-05-10
+    eoas: 2019-05-10
     eol: 2021-06-19
     latest: '21.3.8.24'
     latestReleaseDate: 2021-05-31
 
 -   releaseCycle: "20"
     releaseDate: 2017-06-21
-    support: 2018-06-19
+    eoas: 2018-06-19
     eol: 2020-06-21
     latest: '20.3.8.26'
     latestReleaseDate: 2020-02-27
 
 -   releaseCycle: "19"
     releaseDate: 2016-06-21
-    support: 2017-06-21
+    eoas: 2017-06-21
     eol: 2019-06-21
     latest: '19.3.6.13'
     latestReleaseDate: 2019-01-08
 
 -   releaseCycle: "18"
     releaseDate: 2015-06-23
-    support: 2016-06-21
+    eoas: 2016-06-21
     eol: 2018-11-09
     latest: '18.3.4.11'
     latestReleaseDate: 2018-11-09
 
 -   releaseCycle: "17"
     releaseDate: 2014-04-07
-    support: 2015-06-23
+    eoas: 2015-06-23
     eol: 2018-10-11
     latest: '17.5.6.10'
     latestReleaseDate: 2018-10-11

--- a/products/eurolinux.md
+++ b/products/eurolinux.md
@@ -7,7 +7,7 @@ versionCommand: lsb_release --release
 releasePolicyLink: https://euro-linux.com/eurolinux/technical-specifications/
 changelogTemplate: https://euro-linux.com/eurolinux/technical-specifications/
 releaseDateColumn: true
-activeSupportColumn: true
+eoasColumn: true
 
 auto:
   methods:
@@ -17,28 +17,28 @@ auto:
 releases:
 -   releaseCycle: "9"
     releaseDate: 2022-06-14
-    support: 2032-05-31
+    eoas: 2032-05-31
     eol: 2032-06-30
     latest: "9.3"
     latestReleaseDate: 2023-11-16
 
 -   releaseCycle: "8"
     releaseDate: 2021-07-12
-    support: 2029-03-01
+    eoas: 2029-03-01
     eol: 2029-06-30
     latest: "8.8"
     latestReleaseDate: 2023-05-17
 
 -   releaseCycle: "7"
     releaseDate: 2020-11-25
-    support: 2024-07-31
+    eoas: 2024-07-31
     eol: 2024-07-31
     latest: "7.9"
     latestReleaseDate: 2020-11-25
 
 -   releaseCycle: "6"
     releaseDate: 2015-02-16
-    support: 2020-12-31
+    eoas: 2020-12-31
     eol: 2020-12-31
     latest: "6.10"
     latestReleaseDate: 2018-07-25

--- a/products/fairphone.md
+++ b/products/fairphone.md
@@ -6,7 +6,7 @@ permalink: /fairphone
 releasePolicyLink: https://forum.fairphone.com/t/fairphone-product-release-cycle/52652
 releaseColumn: false
 releaseDateColumn: true
-activeSupportColumn: Active Major Updates
+eoasColumn: Active Major Updates
 discontinuedColumn: true
 eolColumn: Security Updates
 customColumns:
@@ -23,7 +23,7 @@ releases:
     supportedAndroidVersions: "13"
     releaseDate: 2023-09-14
     discontinued: false
-    support: true
+    eoas: false
     eol: 2031-09-14 # according to https://www.gsmarena.com/fairphone_5_goes_official_with_5_years_warranty_up_to_10_years_of_software_support-news-59724.php
     link: https://support.fairphone.com/hc/articles/18020671537041-Fairphone-5-FAQ
 
@@ -32,7 +32,7 @@ releases:
     supportedAndroidVersions: 11 - 13
     releaseDate: 2021-09-30
     discontinued: false
-    support: false
+    eoas: true
     eol: 2026-09-30
     link: https://support.fairphone.com/hc/articles/4405858220945
 
@@ -41,7 +41,7 @@ releases:
     supportedAndroidVersions: 10 - 13
     releaseDate: 2020-09-30
     discontinued: 2022-11-01
-    support: false
+    eoas: true
     eol: 2025-09-30
     link: https://support.fairphone.com/hc/articles/360048139032
 
@@ -50,7 +50,7 @@ releases:
     supportedAndroidVersions: 10 - 13
     releaseDate: 2019-09-30
     discontinued: 2021-09-01
-    support: false
+    eoas: true
     eol: 2024-09-30
     link: https://support.fairphone.com/hc/articles/360048139032
 
@@ -60,7 +60,7 @@ releases:
     releaseDate: 2015-12-21
     # https://github.com/endoflife-date/endoflife.date/pull/2656#discussion_r1131930081
     discontinued: 2019-03-31
-    support: false
+    eoas: true
     # https://www.linkedin.com/posts/fairphone_fairphone2forever-unlaunching-changeisinyourhands-activity-7038910425882615808-DS7c
     eol: 2023-03-07
     link: https://support.fairphone.com/hc/articles/360019515018
@@ -70,7 +70,7 @@ releases:
     supportedAndroidVersions: "4.2" # https://support.fairphone.com/hc/articles/6217522827281-Fairphone-1-FAQ
     releaseDate: 2013-12-01
     discontinued: 2017-07-13
-    support: false
+    eoas: true
     eol: 2017-07-13
     link: https://support.fairphone.com/hc/articles/6217522827281
 

--- a/products/fortios.md
+++ b/products/fortios.md
@@ -11,37 +11,37 @@ changelogTemplate: https://docs.fortinet.com/product/fortigate/__RELEASE_CYCLE__
 releaseColumn: false
 releaseDateColumn: true
 eolColumn: End of Support
-activeSupportColumn: End of Engineering Support
+eoasColumn: End of Engineering Support
 
 releases:
 -   releaseCycle: "7.4"
     releaseDate: 2023-05-11
-    support: 2026-05-11
+    eoas: 2026-05-11
     eol: 2027-11-11
 
 -   releaseCycle: "7.2"
     releaseDate: 2022-03-31
-    support: 2025-03-31
+    eoas: 2025-03-31
     eol: 2026-09-30
 
 -   releaseCycle: "7.0"
     releaseDate: 2021-03-30
-    support: 2024-03-30
+    eoas: 2024-03-30
     eol: 2025-09-30
 
 -   releaseCycle: "6.4"
     releaseDate: 2020-03-31
-    support: 2023-03-31
+    eoas: 2023-03-31
     eol: 2024-09-30
 
 -   releaseCycle: "6.2"
     releaseDate: 2019-03-28
-    support: 2022-03-28
+    eoas: 2022-03-28
     eol: 2023-09-28
 
 -   releaseCycle: "6.0"
     releaseDate: 2018-03-29
-    support: 2021-03-29
+    eoas: 2021-03-29
     eol: 2022-09-29
 
 ---

--- a/products/gitlab.md
+++ b/products/gitlab.md
@@ -8,8 +8,8 @@ versionCommand: gitlab-rake gitlab:env:info
 releasePolicyLink: https://docs.gitlab.com/ee/policy/maintenance.html
 changelogTemplate: https://gitlab.com/gitlab-org/gitlab/-/releases/v__RELEASE_CYCLE__.0-ee
 releaseDateColumn: true
-activeSupportColumn: true
-activeSupportWarnThreshold: 20
+eoasColumn: true
+eoasWarnThreshold: 20
 eolColumn: Maintenance Support
 eolWarnThreshold: 60
 
@@ -19,265 +19,265 @@ auto:
       regex: '^v?(?P<major>[1-9]\d*)\.(?P<minor>\d+)\.(?P<patch>\d+)-ee?$'
 
 
-# support(x) = releaseDate(x+1)
+# eoas(x) = releaseDate(x+1)
 # eol(x) = releaseDate(x+3)
 # Upcoming release dates are available on https://about.gitlab.com/releases/.
 releases:
 -   releaseCycle: "16.10"
     releaseDate: 2024-03-20
-    support: 2024-04-18
+    eoas: 2024-04-18
     eol: 2024-06-20
     latest: "16.10.1"
     latestReleaseDate: 2024-03-27
 
 -   releaseCycle: "16.9"
     releaseDate: 2024-02-14
-    support: 2024-03-21
+    eoas: 2024-03-21
     eol: 2024-05-16
     latest: "16.9.3"
     latestReleaseDate: 2024-03-27
 
 -   releaseCycle: "16.8"
     releaseDate: 2024-01-17
-    support: 2024-02-15
+    eoas: 2024-02-15
     eol: 2024-04-18
     latest: "16.8.5"
     latestReleaseDate: 2024-03-27
 
 -   releaseCycle: "16.7"
     releaseDate: 2023-12-20
-    support: 2024-01-18
+    eoas: 2024-01-18
     eol: 2024-03-21
     latest: "16.7.7"
     latestReleaseDate: 2024-03-06
 
 -   releaseCycle: "16.6"
     releaseDate: 2023-11-15
-    support: 2023-12-21
+    eoas: 2023-12-21
     eol: 2024-02-15
     latest: "16.6.7"
     latestReleaseDate: 2024-02-07
 
 -   releaseCycle: "16.5"
     releaseDate: 2023-10-20
-    support: 2023-11-16
+    eoas: 2023-11-16
     eol: 2024-01-18
     latest: "16.5.8"
     latestReleaseDate: 2024-01-24
 
 -   releaseCycle: "16.4"
     releaseDate: 2023-09-21
-    support: 2023-10-22
+    eoas: 2023-10-22
     eol: 2023-12-21
     latest: "16.4.5"
     latestReleaseDate: 2024-01-11
 
 -   releaseCycle: "16.3"
     releaseDate: 2023-08-21
-    support: 2023-09-22
+    eoas: 2023-09-22
     eol: 2023-11-16
     latest: "16.3.7"
     latestReleaseDate: 2024-01-11
 
 -   releaseCycle: "16.2"
     releaseDate: 2023-07-21
-    support: 2023-08-22
+    eoas: 2023-08-22
     eol: 2023-10-22
     latest: "16.2.9"
     latestReleaseDate: 2024-01-11
 
 -   releaseCycle: "16.1"
     releaseDate: 2023-06-21
-    support: 2023-07-22
+    eoas: 2023-07-22
     eol: 2023-09-22
     latest: "16.1.6"
     latestReleaseDate: 2024-01-11
 
 -   releaseCycle: "16.0"
     releaseDate: 2023-05-18
-    support: 2023-06-22
+    eoas: 2023-06-22
     eol: 2023-08-22
     latest: "16.0.8"
     latestReleaseDate: 2023-08-01
 
 -   releaseCycle: "15.11"
     releaseDate: 2023-04-21
-    support: 2023-05-22
+    eoas: 2023-05-22
     eol: 2023-07-22
     latest: "15.11.13"
     latestReleaseDate: 2023-07-27
 
 -   releaseCycle: "15.10"
     releaseDate: 2023-03-21
-    support: 2023-04-22
+    eoas: 2023-04-22
     eol: 2023-06-22
     latest: "15.10.8"
     latestReleaseDate: 2023-06-05
 
 -   releaseCycle: "15.9"
     releaseDate: 2023-02-21
-    support: 2023-03-22
+    eoas: 2023-03-22
     eol: 2023-05-22
     latest: "15.9.8"
     latestReleaseDate: 2023-05-10
 
 -   releaseCycle: "15.8"
     releaseDate: 2023-01-20
-    support: 2023-02-22
+    eoas: 2023-02-22
     eol: 2023-04-22
     latest: "15.8.6"
     latestReleaseDate: 2023-04-18
 
 -   releaseCycle: "15.7"
     releaseDate: 2022-12-21
-    support: 2023-01-22
+    eoas: 2023-01-22
     eol: 2023-03-22
     latest: "15.7.9"
     latestReleaseDate: 2023-04-20
 
 -   releaseCycle: "15.6"
     releaseDate: 2022-11-21
-    support: 2022-12-22
+    eoas: 2022-12-22
     eol: 2023-02-22
     latest: "15.6.8"
     latestReleaseDate: 2023-02-10
 
 -   releaseCycle: "15.5"
     releaseDate: 2022-10-21
-    support: 2022-11-22
+    eoas: 2022-11-22
     eol: 2023-01-22
     latest: "15.5.9"
     latestReleaseDate: 2023-01-12
 
 -   releaseCycle: "15.4"
     releaseDate: 2022-09-21
-    support: 2022-10-22
+    eoas: 2022-10-22
     eol: 2022-12-22
     latest: "15.4.6"
     latestReleaseDate: 2022-11-30
 
 -   releaseCycle: "15.3"
     releaseDate: 2022-08-19
-    support: 2022-09-22
+    eoas: 2022-09-22
     eol: 2022-11-22
     latest: "15.3.5"
     latestReleaseDate: 2022-11-02
 
 -   releaseCycle: "15.2"
     releaseDate: 2022-07-21
-    support: 2022-08-22
+    eoas: 2022-08-22
     eol: 2022-10-22
     latest: "15.2.5"
     latestReleaseDate: 2022-09-29
 
 -   releaseCycle: "15.1"
     releaseDate: 2022-06-21
-    support: 2022-07-22
+    eoas: 2022-07-22
     eol: 2022-09-22
     latest: "15.1.6"
     latestReleaseDate: 2022-08-30
 
 -   releaseCycle: "15.0"
     releaseDate: 2022-05-20
-    support: 2022-06-22
+    eoas: 2022-06-22
     eol: 2022-08-22
     latest: "15.0.5"
     latestReleaseDate: 2022-07-28
 
 -   releaseCycle: "14.10"
     releaseDate: 2022-04-21
-    support: 2022-05-22
+    eoas: 2022-05-22
     eol: 2022-07-22
     latest: "14.10.5"
     latestReleaseDate: 2022-06-30
 
 -   releaseCycle: "14.9"
     releaseDate: 2022-03-21
-    support: 2022-04-22
+    eoas: 2022-04-22
     eol: 2022-06-22
     latest: "14.9.5"
     latestReleaseDate: 2022-06-01
 
 -   releaseCycle: "14.8"
     releaseDate: 2022-02-21
-    support: 2022-03-22
+    eoas: 2022-03-22
     eol: 2022-05-22
     latest: "14.8.6"
     latestReleaseDate: 2022-04-29
 
 -   releaseCycle: "14.7"
     releaseDate: 2022-01-21
-    support: 2022-02-22
+    eoas: 2022-02-22
     eol: 2022-04-22
     latest: "14.7.7"
     latestReleaseDate: 2022-03-31
 
 -   releaseCycle: "14.6"
     releaseDate: 2021-12-21
-    support: 2022-01-22
+    eoas: 2022-01-22
     eol: 2022-03-22
     latest: "14.6.7"
     latestReleaseDate: 2022-03-31
 
 -   releaseCycle: "14.5"
     releaseDate: 2021-11-19
-    support: 2021-12-22
+    eoas: 2021-12-22
     eol: 2022-02-22
     latest: "14.5.4"
     latestReleaseDate: 2022-02-03
 
 -   releaseCycle: "14.4"
     releaseDate: 2021-10-21
-    support: 2021-11-22
+    eoas: 2021-11-22
     eol: 2022-01-22
     latest: "14.4.5"
     latestReleaseDate: 2022-01-11
 
 -   releaseCycle: "14.3"
     releaseDate: 2021-09-21
-    support: 2021-10-22
+    eoas: 2021-10-22
     eol: 2021-12-22
     latest: "14.3.6"
     latestReleaseDate: 2021-12-03
 
 -   releaseCycle: "14.2"
     releaseDate: 2021-08-20
-    support: 2021-09-22
+    eoas: 2021-09-22
     eol: 2021-11-22
     latest: "14.2.7"
     latestReleaseDate: 2021-11-26
 
 -   releaseCycle: "14.1"
     releaseDate: 2021-07-21
-    support: 2021-08-22
+    eoas: 2021-08-22
     eol: 2021-10-22
     latest: "14.1.8"
     latestReleaseDate: 2021-11-15
 
 -   releaseCycle: "14.0"
     releaseDate: 2021-06-21
-    support: 2021-07-22
+    eoas: 2021-07-22
     eol: 2021-09-22
     latest: "14.0.12"
     latestReleaseDate: 2021-11-05
 
 -   releaseCycle: "13.12"
     releaseDate: 2021-05-21
-    support: 2021-06-22
+    eoas: 2021-06-22
     eol: 2021-08-22
     latest: "13.12.15"
     latestReleaseDate: 2021-11-03
 
 -   releaseCycle: "13.11"
     releaseDate: 2021-04-21
-    support: 2021-05-22
+    eoas: 2021-05-22
     eol: 2021-07-22
     latest: "13.11.7"
     latestReleaseDate: 2021-07-07
 
 -   releaseCycle: "13.10"
     releaseDate: 2021-03-18
-    support: 2021-04-22
+    eoas: 2021-04-22
     eol: 2021-06-22
     latest: "13.10.5"
     latestReleaseDate: 2021-06-01

--- a/products/gke.md
+++ b/products/gke.md
@@ -9,7 +9,7 @@ alternate_urls:
 versionCommand: kubectl version
 releasePolicyLink: https://cloud.google.com/kubernetes-engine/docs/release-schedule
 changelogTemplate: https://cloud.google.com/kubernetes-engine/docs/release-notes-nochannel
-activeSupportColumn: true
+eoasColumn: true
 releaseDateColumn: true
 eolColumn: Maintenance Support
 
@@ -18,25 +18,25 @@ auto:
   -   custom: gke
 
 # eol: As per https://cloud.google.com/kubernetes-engine/docs/release-schedule
-# support: last-date-in-month(eol - 2months)
+# eoas:last-date-in-month(eol - 2months)
 releases:
 -   releaseCycle: "1.29"
     releaseDate: 2024-01-26
-    support: 2025-01-31
+    eoas: 2025-01-31
     eol: 2025-03-21
     latest: '1.29.2-gke.1521000'
     latestReleaseDate: 2024-03-20
 
 -   releaseCycle: "1.28"
     releaseDate: 2023-12-04
-    support: 2024-09-30
+    eoas: 2024-09-30
     eol: 2024-11-12
     latest: '1.28.7-gke.1226000'
     latestReleaseDate: 2024-03-20
 
 -   releaseCycle: "1.27"
     releaseDate: 2023-06-15
-    support: 2024-06-30
+    eoas: 2024-06-30
     eol: 2024-08-31
     latest: '1.27.11-gke.1202000'
     latestReleaseDate: 2024-03-20
@@ -44,69 +44,69 @@ releases:
 -   releaseCycle: "1.26"
     releaseDate: 2023-03-31
     eol: 2024-05-31
-    support: 2024-03-31
+    eoas: 2024-03-31
     latest: '1.26.14-gke.1133000'
     latestReleaseDate: 2024-03-20
 
 -   releaseCycle: "1.25"
     releaseDate: 2022-12-14
     eol: 2024-02-29
-    support: 2023-12-31
+    eoas: 2023-12-31
     latest: '1.25.16-gke.1648000'
     latestReleaseDate: 2024-03-20
 
 -   releaseCycle: "1.24"
     releaseDate: 2022-06-23
     eol: 2023-10-31
-    support: 2023-08-31
+    eoas: 2023-08-31
     latest: '1.24.17-gke.2472000'
     latestReleaseDate: 2024-01-11
 
 -   releaseCycle: "1.23"
     releaseDate: 2022-05-03
     eol: 2023-07-31
-    support: 2023-05-31
+    eoas: 2023-05-31
     latest: '1.23.17-gke.10700'
     latestReleaseDate: 2023-08-08
 
 -   releaseCycle: "1.22"
     releaseDate: 2022-03-07
-    support: 2023-02-28
+    eoas: 2023-02-28
     eol: 2023-04-30
     latest: '1.22.17-gke.14100'
     latestReleaseDate: 2023-07-07
 
 -   releaseCycle: "1.21"
     releaseDate: 2021-10-01
-    support: 2022-11-01
+    eoas: 2022-11-01
     eol: 2023-01-31
     latest: '1.21.14-gke.18800'
     latestReleaseDate: 2023-03-22
 
 -   releaseCycle: "1.20"
     releaseDate: 2021-06-09
-    support: 2021-12-01
+    eoas: 2021-12-01
     eol: 2022-08-01
     latest: '1.20.15-gke.13700'
     latestReleaseDate: 2022-08-18
 
 -   releaseCycle: "1.19"
     releaseDate: 2021-04-14
-    support: 2021-10-01
+    eoas: 2021-10-01
     eol: 2022-06-01
     latest: '1.19.16-gke.15700'
     latestReleaseDate: 2022-06-23
 
 -   releaseCycle: "1.18"
     releaseDate: 2021-03-29
-    support: 2021-08-01
+    eoas: 2021-08-01
     eol: 2022-03-01
     latest: '1.18.20-gke.6000'
     latestReleaseDate: 2021-09-17
 
 -   releaseCycle: "1.17"
     releaseDate: 2021-03-29
-    support: 2021-07-01
+    eoas: 2021-07-01
     eol: 2021-11-01
     latest: '1.17.17-gke.9100'
     latestReleaseDate: 2021-06-09

--- a/products/godot.md
+++ b/products/godot.md
@@ -10,7 +10,7 @@ releasePolicyLink: https://docs.godotengine.org/en/latest/about/release_policy.h
 changelogTemplate: |
   https://godotengine.org/article/maintenance-release-godot-{{"__LATEST__" | replace:'.','-'}}
 eolColumn: Critical, Security and Platform support
-activeSupportColumn: true
+eoasColumn: true
 releaseDateColumn: true
 
 auto:
@@ -24,7 +24,7 @@ auto:
 releases:
 -   releaseCycle: "4.2"
     releaseDate: 2023-11-29
-    support: true
+    eoas: false
     eol: false
     latest: "4.2.1"
     latestReleaseDate: 2023-12-11
@@ -32,14 +32,14 @@ releases:
 
 -   releaseCycle: "4.1"
     releaseDate: 2023-07-05
-    support: true
+    eoas: false
     eol: false
     latest: "4.1.3"
     latestReleaseDate: 2023-11-01
 
 -   releaseCycle: "4.0"
     releaseDate: 2023-03-01
-    support: true
+    eoas: false
     eol: false
     latest: "4.0.4"
     latestReleaseDate: 2023-08-02
@@ -47,42 +47,42 @@ releases:
 -   releaseCycle: "3.5"
     releaseDate: 2022-08-05
     lts: true
-    support: true
+    eoas: false
     eol: false
     latest: "3.5.3"
     latestReleaseDate: 2023-09-24
 
 -   releaseCycle: "3.4"
     releaseDate: 2021-11-05
-    support: 2022-08-05
+    eoas: 2022-08-05
     eol: 2022-08-05
     latest: "3.4.5"
     latestReleaseDate: 2022-08-01
 
 -   releaseCycle: "3.3"
     releaseDate: 2021-04-21
-    support: 2021-11-05
+    eoas: 2021-11-05
     eol: 2021-11-05
     latest: "3.3.4"
     latestReleaseDate: 2021-10-01
 
 -   releaseCycle: "3.2"
     releaseDate: 2020-01-29
-    support: 2021-04-21
+    eoas: 2021-04-21
     eol: 2021-04-21
     latest: "3.2.3"
     latestReleaseDate: 2020-09-16
 
 -   releaseCycle: "3.1"
     releaseDate: 2019-03-13
-    support: 2020-01-29
+    eoas: 2020-01-29
     eol: 2020-01-29
     latest: "3.1.2"
     latestReleaseDate: 2019-12-03
 
 -   releaseCycle: "3.0"
     releaseDate: 2018-01-29
-    support: false
+    eoas: true
     eol: true
     latest: "3.0.6"
     latestReleaseDate: 2018-07-31
@@ -90,14 +90,14 @@ releases:
 -   releaseCycle: "2.1"
     releaseDate: 2016-08-09
     lts: true
-    support: false
+    eoas: true
     eol: true
     latest: "2.1.6"
     latestReleaseDate: 2019-07-08
 
 -   releaseCycle: "2.0"
     releaseDate: 2016-02-22
-    support: false
+    eoas: true
     eol: true
     latest: "2.0.4.1"
     latestReleaseDate: 2016-07-10
@@ -105,7 +105,7 @@ releases:
 
 -   releaseCycle: "1.0"
     releaseDate: 2014-12-15
-    support: false
+    eoas: true
     eol: true
     link: https://godotengine.org/article/godot-engine-reaches-1-0/
     latest: "1.0"

--- a/products/google-nexus.md
+++ b/products/google-nexus.md
@@ -9,7 +9,7 @@ releasePolicyLink: https://support.google.com/nexus/answer/11227897
 releaseColumn: false
 releaseDateColumn: true
 discontinuedColumn: true
-activeSupportColumn: Android updates
+eoasColumn: Android updates
 eolColumn: Security Updates
 customColumns:
 -   property: supportedAndroidVersions # data usually found on wikipedia
@@ -18,13 +18,13 @@ customColumns:
     description: Supported Android versions range
     link: https://endoflife.date/android
 
-# support and eol are based on https://support.google.com/nexus/answer/11227897
+# eoas and eol are based on https://support.google.com/nexus/answer/11227897
 releases:
 -   releaseCycle: "6p"
     releaseLabel: "Nexus 6P"
     releaseDate: 2015-09-29
     discontinued: 2016-10-04
-    support: 2017-09-01
+    eoas: 2017-09-01
     eol: 2018-11-01
     link: https://wikipedia.org/wiki/Nexus_6P
     supportedAndroidVersions: 6.0 - 8.1
@@ -33,7 +33,7 @@ releases:
     releaseLabel: "Nexus 5X"
     releaseDate: 2015-09-29
     discontinued: 2016-10-04
-    support: 2017-09-01
+    eoas: 2017-09-01
     eol: 2018-11-01
     link: https://wikipedia.org/wiki/Nexus_5X
     supportedAndroidVersions: 6.0 - 8.1
@@ -42,7 +42,7 @@ releases:
     releaseLabel: "Nexus Player"
     releaseDate: 2014-11-03
     discontinued: 2016-05-24
-    support: 2018-03-31
+    eoas: 2018-03-31
     eol: 2018-03-31 # as per https://wikipedia.org/wiki/Nexus_Player
     link: https://wikipedia.org/wiki/Nexus_Player
     supportedAndroidVersions: 5.0 - 8.0
@@ -51,7 +51,7 @@ releases:
     releaseLabel: "Nexus 9"
     releaseDate: 2014-11-03
     discontinued: 2016-05-26
-    support: 2016-10-01
+    eoas: 2016-10-01
     eol: 2017-10-01
     link: https://wikipedia.org/wiki/Nexus_9
     supportedAndroidVersions: 5.0 - 7.1
@@ -60,7 +60,7 @@ releases:
     releaseLabel: "Nexus 6"
     releaseDate: 2014-11-01 # approximate date
     discontinued: 2015-12-09
-    support: 2016-10-01
+    eoas: 2016-10-01
     eol: 2017-10-01
     link: https://wikipedia.org/wiki/Nexus_6
     supportedAndroidVersions: 5.0 - 7.1
@@ -69,7 +69,7 @@ releases:
     releaseLabel: "Nexus 7 (2013)"
     releaseDate: 2013-07-26
     discontinued: 2015-04-25
-    support: 2015-07-01
+    eoas: 2015-07-01
     eol: 2016-08-01
     link: https://wikipedia.org/wiki/Nexus_7_(2013)
     supportedAndroidVersions: 4.3 - 6.0
@@ -78,7 +78,7 @@ releases:
     releaseLabel: "Nexus 7 (2012)"
     releaseDate: 2012-07-13
     discontinued: 2013-07-24
-    support: 2014-07-01
+    eoas: 2014-07-01
     eol: 2015-07-01
     link: https://wikipedia.org/wiki/Nexus_7_(2012)
     supportedAndroidVersions: 4.1 - 5.1
@@ -87,7 +87,7 @@ releases:
     releaseLabel: "Nexus 10"
     releaseDate: 2012-11-13
     discontinued: true
-    support: 2014-11-01
+    eoas: 2014-11-01
     eol: 2015-11-01
     link: https://wikipedia.org/wiki/Nexus_10
     supportedAndroidVersions: 4.2 - 5.1
@@ -96,7 +96,7 @@ releases:
     releaseLabel: "Nexus 4"
     releaseDate: 2012-11-13
     discontinued: true
-    support: 2014-11-01
+    eoas: 2014-11-01
     eol: 2015-11-01
     link: https://wikipedia.org/wiki/Nexus_4
     supportedAndroidVersions: 4.2 - 5.1
@@ -105,7 +105,7 @@ releases:
     releaseLabel: "Nexus S"
     releaseDate: 2010-12-16
     discontinued: true
-    support: 2012-11-13 # as per https://wikipedia.org/wiki/Nexus_S#Software
+    eoas: 2012-11-13 # as per https://wikipedia.org/wiki/Nexus_S#Software
     eol: true # no information available
     link: https://wikipedia.org/wiki/Nexus_S
     supportedAndroidVersions: 2.3 - 4.1
@@ -114,7 +114,7 @@ releases:
     releaseLabel: "Nexus One"
     releaseDate: 2010-01-05 # https://wikipedia.org/wiki/Nexus_One#History
     discontinued: true
-    support: false
+    eoas: true
     eol: true
     link: https://wikipedia.org/wiki/Nexus_One
     supportedAndroidVersions: 2.1 - 2.3.6 # https://www.gsmarena.com/htc_google_nexus_one-3067.php

--- a/products/gradle.md
+++ b/products/gradle.md
@@ -7,7 +7,7 @@ permalink: /gradle
 versionCommand: gradle --version
 releasePolicyLink: https://docs.gradle.org/current/userguide/feature_lifecycle.html#eol_support
 changelogTemplate: https://github.com/gradle/gradle/releases/tag/v__LATEST__
-activeSupportColumn: true
+eoasColumn: true
 releaseDateColumn: true
 eolColumn: Critical Bug and Security Fixes
 
@@ -17,7 +17,7 @@ auto:
     # Exclude versions below 3.x because dates are wrong (https://github.com/endoflife-date/endoflife.date/pull/3619).
       regex_exclude: '^v?[0-2]\.'
 
-# support(x) = releaseDate(x+1)
+# eoas(x) = releaseDate(x+1)
 # eol(x) = releaseDate(x+2)
 releases:
 -   releaseCycle: "8"
@@ -28,7 +28,7 @@ releases:
     testedKotlinVersions: 1.6.10 - 1.9.20
     testedGroovyVersions: 1.5.8 - 4.0.0
     testedAndroidVersions: 7.3 - 8.2
-    support: true
+    eoas: false
     eol: false
     latest: "8.7.0"
     latestReleaseDate: 2024-03-21
@@ -41,7 +41,7 @@ releases:
     testedKotlinVersions: 1.3.72 - 1.7.10
     testedGroovyVersions: 1.5.8 - 4.0.0
     testedAndroidVersions: 4.1 - 4.2, 7.0 - 7.4
-    support: false
+    eoas: true
     eol: false
     latest: "7.6.4"
     latestReleaseDate: 2024-02-05
@@ -54,7 +54,7 @@ releases:
     testedKotlinVersions: 1.3.21 - 1.4.20
     testedGroovyVersions: 1.5.8 - 2.5.12
     testedAndroidVersions: 3.4 - 3.6, 4.0 - 4.2
-    support: 2021-04-09
+    eoas: 2021-04-09
     eol: 2023-02-10
     latest: "6.9.4"
     latestReleaseDate: 2023-02-21
@@ -66,7 +66,7 @@ releases:
     testedKotlinVersions: N/A
     testedGroovyVersions: N/A
     testedAndroidVersions: N/A
-    support: 2019-11-08
+    eoas: 2019-11-08
     eol: 2019-11-08
     latest: "5.6.4"
     latestReleaseDate: 2019-10-31
@@ -78,7 +78,7 @@ releases:
     testedKotlinVersions: N/A
     testedGroovyVersions: N/A
     testedAndroidVersions: N/A
-    support: 2018-11-26
+    eoas: 2018-11-26
     eol: 2018-11-26
     latest: "4.10.3"
     latestReleaseDate: 2018-12-04
@@ -90,7 +90,7 @@ releases:
     testedKotlinVersions: N/A
     testedGroovyVersions: N/A
     testedAndroidVersions: N/A
-    support: 2017-06-14
+    eoas: 2017-06-14
     eol: 2017-06-14
     latest: "3.5.1"
     latestReleaseDate: 2017-06-16
@@ -102,7 +102,7 @@ releases:
     testedKotlinVersions: N/A
     testedGroovyVersions: N/A
     testedAndroidVersions: N/A
-    support: 2016-08-15
+    eoas: 2016-08-15
     eol: 2016-08-15
     latest: "2.14.1"
     latestReleaseDate: 2016-07-18
@@ -114,7 +114,7 @@ releases:
     testedKotlinVersions: N/A
     testedGroovyVersions: N/A
     testedAndroidVersions: N/A
-    support: 2014-07-01
+    eoas: 2014-07-01
     eol: 2014-07-01
     latest: "1.12.0"
     latestReleaseDate: 2014-04-29

--- a/products/grafana.md
+++ b/products/grafana.md
@@ -6,7 +6,7 @@ permalink: /grafana
 versionCommand: grafana-server -v
 changelogTemplate: https://github.com/grafana/grafana/releases/tag/v__LATEST__
 releaseDateColumn: true
-activeSupportColumn: true
+eoasColumn: true
 
 identifiers:
 -   purl: pkg:github/grafana/grafana
@@ -19,103 +19,103 @@ auto:
 # The policy before 9.0 release was to support 2 major versions. After 9.0, 2 latest minors are
 # supported, along with the last minor of the previous major. Hence, we break the latest series into
 # minors but only keep the previous major.
-# - support(x) = releaseDate(x+1)
+# - eoas(x) = releaseDate(x+1)
 # - eol(x) = releaseDate(x+2)
 releases:
 -   releaseCycle: "10.4"
     releaseDate: 2024-03-05
-    support: true
+    eoas: false
     eol: false
     latest: "10.4.1"
     latestReleaseDate: 2024-03-20
 
 -   releaseCycle: "10.3"
     releaseDate: 2024-01-22
-    support: 2024-03-06
+    eoas: 2024-03-06
     eol: false
     latest: "10.3.5"
     latestReleaseDate: 2024-03-20
 
 -   releaseCycle: "10.2"
     releaseDate: 2023-10-24
-    support: 2024-01-23
+    eoas: 2024-01-23
     eol: 2024-03-06
     latest: "10.2.6"
     latestReleaseDate: 2024-03-25
 
 -   releaseCycle: "10.1"
     releaseDate: 2023-08-23
-    support: 2023-10-24
+    eoas: 2023-10-24
     eol: 2024-01-23
     latest: "10.1.9"
     latestReleaseDate: 2024-03-25
 
 -   releaseCycle: "10.0"
     releaseDate: 2023-06-09
-    support: 2023-08-23
+    eoas: 2023-08-23
     eol: 2023-10-24
     latest: "10.0.13"
     latestReleaseDate: 2024-03-25
 
 -   releaseCycle: "9.5"
     releaseDate: 2023-04-06
-    support: 2023-06-09
+    eoas: 2023-06-09
     eol: false # eol(x) = releaseDate(11.x)
     latest: "9.5.18"
     latestReleaseDate: 2024-03-25
 
 -   releaseCycle: "9.4"
     releaseDate: 2023-02-27
-    support: 2023-04-06
+    eoas: 2023-04-06
     eol: 2023-06-09
     latest: "9.4.17"
     latestReleaseDate: 2023-10-11
 
 -   releaseCycle: "9.3"
     releaseDate: 2022-11-29
-    support: 2023-02-27
+    eoas: 2023-02-27
     eol: 2023-04-06
     latest: "9.3.16"
     latestReleaseDate: 2023-06-07
 
 -   releaseCycle: "9.2"
     releaseDate: 2022-10-11
-    support: 2022-11-29
+    eoas: 2022-11-29
     eol: 2023-02-27
     latest: "9.2.20"
     latestReleaseDate: 2023-06-07
 
 -   releaseCycle: "9.1"
     releaseDate: 2022-08-16
-    support: 2022-10-11
+    eoas: 2022-10-11
     eol: 2022-11-29
     latest: "9.1.8"
     latestReleaseDate: 2022-10-11
 
 -   releaseCycle: "9.0"
     releaseDate: 2022-06-13
-    support: 2022-08-16
+    eoas: 2022-08-16
     eol: 2022-10-11
     latest: "9.0.9"
     latestReleaseDate: 2022-09-20
 
 -   releaseCycle: "8"
     releaseDate: 2021-06-08
-    support: 2022-06-13
+    eoas: 2022-06-13
     eol: false
     latest: "8.5.27"
     latestReleaseDate: 2023-06-07
 
 -   releaseCycle: "7"
     releaseDate: 2020-05-15
-    support: 2021-06-08
+    eoas: 2021-06-08
     eol: 2022-06-14
     latest: "7.5.17"
     latestReleaseDate: 2022-09-26
 
 -   releaseCycle: "6"
     releaseDate: 2019-02-25
-    support: 2020-05-15
+    eoas: 2020-05-15
     eol: 2021-06-08
     latest: "6.7.6"
     latestReleaseDate: 2021-03-18

--- a/products/grails.md
+++ b/products/grails.md
@@ -7,7 +7,7 @@ alternate_urls:
 -   /grails-framework
 releasePolicyLink: https://grails.org/support.html
 changelogTemplate: "https://github.com/grails/grails-core/releases/tag/v__LATEST__"
-activeSupportColumn: Active Development
+eoasColumn: Active Development
 eolColumn: Active Maintenance
 releaseDateColumn: true
 
@@ -18,42 +18,42 @@ auto:
 releases:
 -   releaseCycle: "6"
     releaseDate: 2023-07-24
-    support: true
+    eoas: false
     eol: false
     latest: "6.1.2"
     latestReleaseDate: 2024-01-31
 
 -   releaseCycle: "5"
     releaseDate: 2021-10-12
-    support: 2023-07-24
+    eoas: 2023-07-24
     eol: false
     latest: "5.3.6"
     latestReleaseDate: 2024-01-09
 
 -   releaseCycle: "4"
     releaseDate: 2019-07-11
-    support: false
+    eoas: true
     eol: 2023-03-31
     latest: "4.1.4"
     latestReleaseDate: 2024-03-08
 
 -   releaseCycle: "3"
     releaseDate: 2015-03-31
-    support: false
+    eoas: true
     eol: 2021-09-30
     latest: "3.3.18"
     latestReleaseDate: 2024-01-09
 
 -   releaseCycle: "2"
     releaseDate: 2011-12-15
-    support: false
+    eoas: true
     eol: 2021-06-30
     latest: "2.5.6"
     latestReleaseDate: 2017-03-23
 
 -   releaseCycle: "1"
     releaseDate: 2009-05-14
-    support: false
+    eoas: true
     eol: 2012-05-01
     latest: "1.3.9"
     latestReleaseDate: 2015-01-16

--- a/products/ibm-i.md
+++ b/products/ibm-i.md
@@ -16,7 +16,7 @@ versionCommand: DSPJOB OUTPUT(*PRINT)
 releasePolicyLink: https://www.ibm.com/support/pages/release-life-cycle # https://www.ibm.com/support/pages/ibm-i-release-support
 releaseDateColumn: true
 eolColumn: End of Service Pack Support (<abbr title="End of Service Pack Support">EoSPS</abbr>)
-extendedSupportColumn: Extended Life Cycle Support
+eoesColumn: Extended Life Cycle Support
 
 auto:
   methods:
@@ -29,13 +29,12 @@ auto:
           template: "{{major}}.{{minor}}"
         releaseDate: "GA date*"
         eol: "End of Program Support*"
-        extendedSupport: "Program Support Extension Available*"
+        eoes: "Program Support Extension Available*"
 
 releases:
 -   releaseCycle: "7.5"
     releaseDate: 2022-05-10
     eol: false
-    extendedSupport: false
     latest: "7.5"
     latestReleaseDate: 2022-05-10
     link: https://www.ibm.com/support/pages/customer-notices-and-information-ibm-i-75
@@ -43,7 +42,6 @@ releases:
 -   releaseCycle: "7.4"
     releaseDate: 2019-06-21
     eol: false
-    extendedSupport: false
     latest: "7.4"
     latestReleaseDate: 2019-06-21
     link: https://www.ibm.com/support/pages/customer-notices-and-information-ibm-i-74
@@ -51,7 +49,7 @@ releases:
 -   releaseCycle: "7.3"
     releaseDate: 2016-04-15
     eol: 2023-09-30
-    extendedSupport: 2026-09-30
+    eoes: 2026-09-30
     latest: "7.3"
     latestReleaseDate: 2016-04-15
     link: https://www.ibm.com/support/pages/customer-notices-and-information-ibm-i-73
@@ -59,7 +57,7 @@ releases:
 -   releaseCycle: "7.2"
     releaseDate: 2014-05-02
     eol: 2021-04-30
-    extendedSupport: 2026-04-30
+    eoes: 2026-04-30
     latest: "7.2"
     latestReleaseDate: 2014-05-02
     link: https://www.ibm.com/support/pages/customer-notices-and-information-ibm-i-72
@@ -67,7 +65,6 @@ releases:
 -   releaseCycle: "7.1"
     releaseDate: 2010-04-23
     eol: 2018-04-30
-    extendedSupport: false
     latest: "7.1"
     latestReleaseDate: 2010-04-23
     link: https://www.ibm.com/support/pages/customer-notices-and-information-ibm-i-71
@@ -75,7 +72,7 @@ releases:
 -   releaseCycle: "6.1"
     releaseDate: 2008-03-21
     eol: 2015-09-30
-    extendedSupport: 2019-09-30
+    eoes: 2019-09-30
     latest: "6.1"
     latestReleaseDate: 2008-04-23
     link: https://www.ibm.com/support/pages/customer-notices-and-information-ibm-i-61
@@ -83,119 +80,107 @@ releases:
 -   releaseCycle: "5.4"
     releaseDate: 2006-02-14
     eol: 2013-09-30
-    extendedSupport: 2017-09-30
+    eoes: 2017-09-30
     latest: "5.4"
     latestReleaseDate: 2006-02-14
 
 -   releaseCycle: "5.3"
     releaseDate: 2004-06-11
     eol: 2009-04-30
-    extendedSupport: 2013-04-30
+    eoes: 2013-04-30
     latest: "5.3"
     latestReleaseDate: 2004-06-11
 
 -   releaseCycle: "5.2"
     releaseDate: 2002-08-30
     eol: 2007-04-30
-    extendedSupport: false
     latest: "5.2"
     latestReleaseDate: 2002-08-30
 
 -   releaseCycle: "5.1"
     releaseDate: 2001-05-25
     eol: 2005-09-30
-    extendedSupport: false
     latest: "5.1"
     latestReleaseDate: 2001-05-25
 
 -   releaseCycle: "4.5"
     releaseDate: 2000-07-28
     eol: 2002-07-31
-    extendedSupport: 2002-12-31
+    eoes: 2002-12-31
     latest: "4.5"
     latestReleaseDate: 2000-07-28
 
 -   releaseCycle: "4.4"
     releaseDate: 1999-05-21
     eol: 2001-05-31
-    extendedSupport: 2001-11-30
+    eoes: 2001-11-30
     latest: "4.4"
     latestReleaseDate: 1999-05-21
 
 -   releaseCycle: "4.3"
     releaseDate: 1998-09-11
     eol: 2001-01-31
-    extendedSupport: false
     latest: "4.3"
     latestReleaseDate: 1998-09-11
 
 -   releaseCycle: "4.2"
     releaseDate: 1998-02-27
     eol: 2000-05-31
-    extendedSupport: 2001-01-31
+    eoes: 2001-01-31
     latest: "4.2"
     latestReleaseDate: 1998-02-27
 
 -   releaseCycle: "4.1"
     releaseDate: 1997-08-29
     eol: 2000-05-31
-    extendedSupport: false
     latest: "4.1"
     latestReleaseDate: 1997-08-29
 
 -   releaseCycle: "3.7"
     releaseDate: 1996-11-08
     eol: 1999-06-30
-    extendedSupport: false
     latest: "3.7"
     latestReleaseDate: 1996-11-08
 
 -   releaseCycle: "3.6"
     releaseDate: 1995-12-22
     eol: 1998-10-31
-    extendedSupport: false
     latest: "3.6"
     latestReleaseDate: 1995-12-22
 
 -   releaseCycle: "3.2"
     releaseDate: 1996-06-21
     eol: 2000-05-31
-    extendedSupport: false
     latest: "3.2"
     latestReleaseDate: 1996-06-21
 
 -   releaseCycle: "3.1"
     releaseDate: 1994-11-25
     eol: 1998-10-31
-    extendedSupport: false
     latest: "3.1"
     latestReleaseDate: 1994-11-25
 
 -   releaseCycle: "3.0"
     releaseDate: 1994-06-03
     eol: 1997-05-31
-    extendedSupport: false
     latest: "3.0.5"
     latestReleaseDate: 1994-06-03
 
 -   releaseCycle: "2.3"
     releaseDate: 1993-12-17
     eol: 1996-05-31
-    extendedSupport: false
     latest: "2.3"
     latestReleaseDate: 1993-12-17
 
 -   releaseCycle: "2.2"
     releaseDate: 1992-09-18
     eol: 1995-03-31
-    extendedSupport: false
     latest: "2.2"
     latestReleaseDate: 1992-09-18
 
 -   releaseCycle: "2.1"
     releaseDate: 1992-03-06
     eol: 1994-06-30
-    extendedSupport: false
     latest: "2.1.1"
     latestReleaseDate: 1992-03-06
 

--- a/products/icinga-web.md
+++ b/products/icinga-web.md
@@ -9,7 +9,7 @@ alternate_urls:
 versionCommand: icingacli version
 releasePolicyLink: https://icinga.com/subscriptions/support-matrix/
 changelogTemplate: https://github.com/Icinga/icingaweb2/releases/tag/v__LATEST__/
-activeSupportColumn: true
+eoasColumn: true
 releaseDateColumn: true
 
 identifiers:
@@ -22,102 +22,102 @@ auto:
   -   git: https://github.com/Icinga/icingaweb2
 
 # eol(x) = releaseDate(x+2)
-# support(x) = releaseDate(x+1)
+# eoas(x) = releaseDate(x+1)
 releases:
 -   releaseCycle: "2.12"
     releaseDate: 2023-09-21
-    support: true
+    eoas: false
     eol: false
     latest: "2.12.1"
     latestReleaseDate: 2023-11-15
 
 -   releaseCycle: "2.11"
     releaseDate: 2022-06-30
-    support: 2023-09-21
+    eoas: 2023-09-21
     eol: false
     latest: "2.11.4"
     latestReleaseDate: 2023-01-26
 
 -   releaseCycle: "2.10"
     releaseDate: 2022-03-23
-    support: 2022-06-30
+    eoas: 2022-06-30
     eol: 2023-09-21
     latest: "2.10.5"
     latestReleaseDate: 2023-01-26
 
 -   releaseCycle: "2.9"
     releaseDate: 2021-07-12
-    support: 2022-03-23
+    eoas: 2022-03-23
     eol: 2022-06-30
     latest: "2.9.9"
     latestReleaseDate: 2023-01-26
 
 -   releaseCycle: "2.8"
     releaseDate: 2020-06-08
-    support: 2021-07-12
+    eoas: 2021-07-12
     eol: 2022-03-23
     latest: "2.8.6"
     latestReleaseDate: 2022-03-08
 
 -   releaseCycle: "2.7"
     releaseDate: 2019-07-30
-    support: 2020-06-08
+    eoas: 2020-06-08
     eol: 2021-07-12
     latest: "2.7.6"
     latestReleaseDate: 2021-07-27
 
 -   releaseCycle: "2.6"
     releaseDate: 2018-07-19
-    support: 2019-07-30
+    eoas: 2019-07-30
     eol: 2020-06-08
     latest: "2.6.4"
     latestReleaseDate: 2020-08-18
 
 -   releaseCycle: "2.5"
     releaseDate: 2017-11-27
-    support: 2018-07-19
+    eoas: 2018-07-19
     eol: 2018-07-19
     latest: "2.5.3"
     latestReleaseDate: 2018-04-27
 
 -   releaseCycle: "2.4"
     releaseDate: 2016-12-13
-    support: 2017-11-27
+    eoas: 2017-11-27
     eol: 2017-11-27
     latest: "2.4.2"
     latestReleaseDate: 2017-09-28
 
 -   releaseCycle: "2.3"
     releaseDate: 2016-04-13
-    support: 2016-12-13
+    eoas: 2016-12-13
     eol: 2016-12-13
     latest: "2.3.4"
     latestReleaseDate: 2016-06-23
 
 -   releaseCycle: "2.2"
     releaseDate: 2016-02-29
-    support: 2016-04-13
+    eoas: 2016-04-13
     eol: 2016-04-13
     latest: "2.2.2"
     latestReleaseDate: 2016-06-09
 
 -   releaseCycle: "2.1"
     releaseDate: 2015-11-16
-    support: 2016-02-29
+    eoas: 2016-02-29
     eol: 2016-02-29
     latest: "2.1.4"
     latestReleaseDate: 2016-06-09
 
 -   releaseCycle: "2.0"
     releaseDate: 2015-10-02
-    support: 2015-11-16
+    eoas: 2015-11-16
     eol: 2015-11-16
     latest: "2.0.0"
     latestReleaseDate: 2015-10-02
 
 -   releaseCycle: "1"
     releaseDate: 2010-06-30
-    support: 2018-12-31
+    eoas: 2018-12-31
     eol: 2018-12-31
     latest: "1.14.1"
     latestReleaseDate: 2017-12-19

--- a/products/ionic.md
+++ b/products/ionic.md
@@ -8,10 +8,10 @@ alternate_urls:
 -   /ionic-framework
 releasePolicyLink: https://ionicframework.com/docs/reference/support
 changelogTemplate: https://github.com/ionic-team/ionic-framework/releases/tag/v__LATEST__
-activeSupportColumn: true
+eoasColumn: true
 eolColumn: Maintenance
 releaseDateColumn: true
-extendedSupportColumn: true
+eoesColumn: true
 
 identifiers:
 -   purl: pkg:github/ionic-team/ionic-framework
@@ -45,9 +45,9 @@ auto:
 releases:
 -   releaseCycle: "7"
     releaseDate: 2023-03-29
-    support: true
+    eoas: false
     eol: false
-    extendedSupport: true
+    eoes: false
     minAngularVersion: v14
     maxAngularVersion: v17.x
     supportedReactVersions: v17+
@@ -57,9 +57,9 @@ releases:
 
 -   releaseCycle: "6"
     releaseDate: 2021-12-08
-    support: 2023-03-29
+    eoas: 2023-03-29
     eol: 2023-09-29
-    extendedSupport: 2024-03-29
+    eoes: 2024-03-29
     minAngularVersion: v12
     maxAngularVersion: v15.x
     supportedReactVersions: v17+
@@ -69,9 +69,9 @@ releases:
 
 -   releaseCycle: "5"
     releaseDate: 2020-02-11
-    support: 2021-12-08
+    eoas: 2021-12-08
     eol: 2022-06-08
-    extendedSupport: 2022-12-08
+    eoes: 2022-12-08
     minAngularVersion: v8.2
     maxAngularVersion: v12.x
     supportedReactVersions: v16.8+
@@ -81,9 +81,9 @@ releases:
 
 -   releaseCycle: "4"
     releaseDate: 2019-01-23
-    support: 2020-02-11
+    eoas: 2020-02-11
     eol: 2020-08-11
-    extendedSupport: 2022-09-30
+    eoes: 2022-09-30
     minAngularVersion: v8.2
     maxAngularVersion: v11.x
     supportedReactVersions: v16.8+
@@ -93,9 +93,9 @@ releases:
 
 -   releaseCycle: "3"
     releaseDate: 2017-04-05
-    support: 2019-01-23
+    eoas: 2019-01-23
     eol: 2019-10-30
-    extendedSupport: 2020-08-11
+    eoes: 2020-08-11
     minAngularVersion: v5.2.11
     maxAngularVersion: v5.2.11
     supportedReactVersions: N/A
@@ -105,9 +105,9 @@ releases:
 
 -   releaseCycle: "2"
     releaseDate: 2017-01-24
-    support: 2017-04-05
+    eoas: 2017-04-05
     eol: 2017-04-05
-    extendedSupport: 2017-04-05
+    eoes: 2017-04-05
     minAngularVersion: v2.x
     maxAngularVersion: v2.x
     supportedReactVersions: N/A
@@ -117,9 +117,9 @@ releases:
 
 -   releaseCycle: "1"
     releaseDate: 2015-05-12
-    support: 2017-01-25
+    eoas: 2017-01-25
     eol: 2017-01-25
-    extendedSupport: 2017-01-25
+    eoes: 2017-01-25
     minAngularVersion: v1.x
     maxAngularVersion: v1.x
     supportedReactVersions: N/A

--- a/products/ios.md
+++ b/products/ios.md
@@ -5,7 +5,7 @@ tags: apple
 iconSlug: apple
 permalink: /ios
 releasePolicyLink: https://en.wikipedia.org/wiki/IOS_version_history#Overview
-activeSupportColumn: true
+eoasColumn: true
 releaseDateColumn: true
 
 auto:
@@ -21,7 +21,7 @@ auto:
 releases:
 -   releaseCycle: "17"
     releaseDate: 2023-09-18
-    support: true
+    eoas: false
     eol: false
     latest: "17.4.1"
     latestReleaseDate: 2024-03-21
@@ -29,7 +29,7 @@ releases:
 
 -   releaseCycle: "16"
     releaseDate: 2022-09-12
-    support: 2023-09-18
+    eoas: 2023-09-18
     eol: false
     latest: "16.7.7"
     latestReleaseDate: 2024-03-21
@@ -37,7 +37,7 @@ releases:
 
 -   releaseCycle: "15"
     releaseDate: 2021-09-20
-    support: 2022-09-12
+    eoas: 2022-09-12
     eol: false
     latest: "15.8.2"
     latestReleaseDate: 2024-03-05
@@ -45,7 +45,7 @@ releases:
 
 -   releaseCycle: "14"
     releaseDate: 2020-09-16
-    support: 2021-09-20
+    eoas: 2021-09-20
     eol: 2021-10-01
     latest: "14.8.1"
     latestReleaseDate: 2021-10-26
@@ -53,7 +53,7 @@ releases:
 
 -   releaseCycle: "13"
     releaseDate: 2019-09-19
-    support: 2020-09-16
+    eoas: 2020-09-16
     eol: 2020-09-16
     latest: "13.7"
     latestReleaseDate: 2020-09-01
@@ -61,7 +61,7 @@ releases:
 
 -   releaseCycle: "12"
     releaseDate: 2018-09-17
-    support: 2019-09-19
+    eoas: 2019-09-19
     eol: 2023-01-23
     latest: "12.5.7"
     latestReleaseDate: 2023-01-23
@@ -69,7 +69,7 @@ releases:
 
 -   releaseCycle: "11"
     releaseDate: 2017-09-19
-    support: 2018-09-17
+    eoas: 2018-09-17
     eol: 2018-10-08
     latest: "11.4.1"
     latestReleaseDate: 2018-07-09
@@ -77,7 +77,7 @@ releases:
 
 -   releaseCycle: "10"
     releaseDate: 2016-09-13
-    support: 2017-09-19
+    eoas: 2017-09-19
     eol: 2017-09-26
     latest: "10.3.4"
     latestReleaseDate: 2019-07-22
@@ -85,7 +85,7 @@ releases:
 
 -   releaseCycle: "9"
     releaseDate: 2015-09-16
-    support: 2016-09-13
+    eoas: 2016-09-13
     eol: 2016-09-13
     latest: "9.3.6"
     latestReleaseDate: 2019-07-22
@@ -93,7 +93,7 @@ releases:
 
 -   releaseCycle: "8"
     releaseDate: 2014-09-17
-    support: 2015-09-16
+    eoas: 2015-09-16
     eol: 2015-09-30
     latest: "8.4.1"
     latestReleaseDate: 2015-08-13
@@ -101,7 +101,7 @@ releases:
 
 -   releaseCycle: "7"
     releaseDate: 2013-09-18
-    support: 2014-09-17
+    eoas: 2014-09-17
     eol: 2014-10-20
     latest: "7.1.2"
     latestReleaseDate: 2014-06-30
@@ -109,7 +109,7 @@ releases:
 
 -   releaseCycle: "6"
     releaseDate: 2012-09-19
-    support: 2013-09-18
+    eoas: 2013-09-18
     eol: 2013-09-26
     latest: "6.1.6"
     latestReleaseDate: 2014-02-21
@@ -117,7 +117,7 @@ releases:
 
 -   releaseCycle: "5"
     releaseDate: 2011-10-12
-    support: 2012-09-19
+    eoas: 2012-09-19
     eol: 2012-11-01
     latest: "5.1.1"
     latestReleaseDate: 2012-05-07

--- a/products/ipados.md
+++ b/products/ipados.md
@@ -6,7 +6,7 @@ iconSlug: apple
 permalink: /ipados
 releasePolicyLink: https://en.wikipedia.org/wiki/IOS_version_history#Overview
 releaseDateColumn: true
-activeSupportColumn: true
+eoasColumn: true
 
 auto:
   methods:
@@ -20,7 +20,7 @@ auto:
 releases:
 -   releaseCycle: "17"
     releaseDate: 2023-09-18
-    support: true
+    eoas: false
     eol: false
     latest: '17.4.1'
     latestReleaseDate: 2024-03-21
@@ -28,7 +28,7 @@ releases:
 
 -   releaseCycle: "16"
     releaseDate: 2022-10-24
-    support: 2023-09-18
+    eoas: 2023-09-18
     eol: false
     latest: '16.7.7'
     latestReleaseDate: 2024-03-21
@@ -36,7 +36,7 @@ releases:
 
 -   releaseCycle: "15"
     releaseDate: 2021-09-20
-    support: 2022-10-24
+    eoas: 2022-10-24
     eol: false
     latest: '15.8.2'
     latestReleaseDate: 2024-03-05
@@ -44,7 +44,7 @@ releases:
 
 -   releaseCycle: "14"
     releaseDate: 2020-09-16
-    support: 2021-09-20
+    eoas: 2021-09-20
     eol: 2021-10-01
     latest: '14.8.1'
     latestReleaseDate: 2021-10-26
@@ -52,7 +52,7 @@ releases:
 
 -   releaseCycle: "13"
     releaseDate: 2019-09-24
-    support: 2020-09-16
+    eoas: 2020-09-16
     eol: 2020-09-16
     latest: '13.6'
     latestReleaseDate: 2020-07-15

--- a/products/jekyll.md
+++ b/products/jekyll.md
@@ -7,7 +7,7 @@ permalink: /jekyll
 releasePolicyLink: https://jekyllrb.com/docs/security/
 changelogTemplate: https://github.com/jekyll/jekyll/releases/tag/v__LATEST__
 releaseDateColumn: true
-activeSupportColumn: Active Development
+eoasColumn: Active Development
 eolColumn: Active Maintenance
 
 auto:
@@ -18,7 +18,7 @@ releases:
 -   releaseCycle: "4"
     minRubyVersion: "2.5+" # https://jekyllrb.com/docs/
     releaseDate: 2019-08-20
-    support: true
+    eoas: false
     eol: false
     latest: "4.3.3"
     latestReleaseDate: 2023-12-27
@@ -26,7 +26,7 @@ releases:
 -   releaseCycle: "3"
     minRubyVersion: "2.0+" # https://web.archive.org/web/20160103225823/https://jekyllrb.com/docs/installation/
     releaseDate: 2015-10-26
-    support: false
+    eoas: true
     eol: false
     latest: "3.9.5"
     latestReleaseDate: 2024-02-13
@@ -34,7 +34,7 @@ releases:
 -   releaseCycle: "2"
     minRubyVersion: "1.9.3+" # https://web.archive.org/web/20160103225823/https://jekyllrb.com/docs/installation/
     releaseDate: 2014-05-06
-    support: false
+    eoas: true
     eol: 2015-10-27
     latest: "2.5.3"
     latestReleaseDate: 2014-12-22
@@ -42,7 +42,7 @@ releases:
 -   releaseCycle: "1"
     minRubyVersion: "1.8+" # not sure, should be 1.8 according to https://github.com/jekyll/jekyll/releases/tag/v1.2.0
     releaseDate: 2013-05-06
-    support: false
+    eoas: true
     eol: 2014-05-07
     latest: "1.5.1"
     latestReleaseDate: 2014-03-28
@@ -51,7 +51,7 @@ releases:
     minRubyVersion: "1.8+" # not sure, should be 1.8 according to https://web.archive.org/web/20091202224411/http://wiki.github.com/mojombo/jekyll/install
     releaseDate: 2008-10-19 # See https://jekyllrb.com/docs/history/#v0-0-0
     eol: 2014-05-07
-    support: false
+    eoas: true
     latest: "0.9.0"
     latestReleaseDate: 2010-12-15
 

--- a/products/joomla.md
+++ b/products/joomla.md
@@ -7,7 +7,7 @@ permalink: /joomla
 releasePolicyLink: https://docs.joomla.org/Release_and_support_cycle
 changelogTemplate: "https://docs.joomla.org/Special:MyLanguage/Joomla_{{'__LATEST__'|split:'.'|slice:0,2|join:'.'}}_version_history#Joomla___LATEST__"
 releaseDateColumn: true
-activeSupportColumn: true
+eoasColumn: true
 
 auto:
   methods:
@@ -17,7 +17,7 @@ auto:
 releases:
 -   releaseCycle: "5"
     releaseDate: 2023-10-14
-    support: true
+    eoas: false
     eol: 2027-10-19
     latest: "5.0.3"
     latestReleaseDate: 2024-02-13
@@ -26,14 +26,14 @@ releases:
 
 -   releaseCycle: "4"
     releaseDate: 2021-08-17
-    support: 2024-10-17
+    eoas: 2024-10-17
     eol: 2025-10-17
     latest: "4.4.3"
     latestReleaseDate: 2024-02-19
 
 -   releaseCycle: "3"
     releaseDate: 2012-09-27
-    support: 2021-08-17
+    eoas: 2021-08-17
     eol: 2023-08-17
     latest: "3.10.12"
     latestReleaseDate: 2023-07-08

--- a/products/jreleaser.md
+++ b/products/jreleaser.md
@@ -7,7 +7,7 @@ versionCommand: jreleaser --version
 releasePolicyLink: https://jreleaser.org/guide/latest/release-history.html
 changelogTemplate: "https://github.com/jreleaser/jreleaser/releases/tag/v__LATEST__"
 releaseDateColumn: true
-activeSupportColumn: true
+eoasColumn: true
 eolColumn: Security Support
 
 auto:
@@ -18,14 +18,14 @@ releases:
 -   releaseCycle: "1"
     releaseDate: 2022-04-10
     eol: false
-    support: true
+    eoas: false
     latest: "1.11.0"
     latestReleaseDate: 2024-02-29
 
 -   releaseCycle: "0"
     releaseDate: 2021-04-10
     eol: 2022-04-10
-    support: 2022-04-10
+    eoas: 2022-04-10
     latest: "0.10.0"
     latestReleaseDate: 2021-12-28
 

--- a/products/kdeplasma.md
+++ b/products/kdeplasma.md
@@ -8,7 +8,7 @@ alternate_urls:
 versionCommand: plasmashell -v
 releasePolicyLink: https://community.kde.org/Schedules/Plasma_6
 changelogTemplate: https://kde.org/announcements/plasma/6/__LATEST__/
-activeSupportColumn: true
+eoasColumn: true
 releaseDateColumn: true
 eolColumn: Critical bug fixes
 
@@ -20,11 +20,11 @@ auto:
       -   '^v?(\d+)\.([8-9]\d+)(\.(\d+)(\.(\d+))?)?$' # double-digits minor >= 80
       -   '^v?(\d+)\.(\d+)(\.([8-9]\d+)(\.(\d+))?)?$' # double-digits patch >= 80
 
-# non-LTS: eol(x)/support(x) = releaseDate(x+1)
+# non-LTS: eol(x)/eoas(x) = releaseDate(x+1)
 releases:
 -   releaseCycle: "6.0"
     releaseDate: 2024-02-28
-    support: true
+    eoas: false
     eol: false # Will end when Plasma 6.1 comes out
     latest: "6.0.3"
     latestReleaseDate: 2024-03-26
@@ -32,7 +32,7 @@ releases:
 -   releaseCycle: "5.27"
     lts: true
     releaseDate: 2023-02-14
-    support: true
+    eoas: false
     eol: false # Not yet announced at https://community.kde.org/Schedules/Plasma_5
     latest: "5.27.11"
     latestReleaseDate: 2024-03-06
@@ -40,7 +40,7 @@ releases:
 
 -   releaseCycle: "5.26"
     releaseDate: 2022-10-11
-    support: 2023-02-14
+    eoas: 2023-02-14
     eol: 2023-02-14
     latest: "5.26.5"
     latestReleaseDate: 2023-01-03
@@ -48,7 +48,7 @@ releases:
 
 -   releaseCycle: "5.25"
     releaseDate: 2022-06-14
-    support: 2022-10-11
+    eoas: 2022-10-11
     eol: 2022-10-11
     latest: "5.25.5"
     latestReleaseDate: 2022-09-06
@@ -57,7 +57,7 @@ releases:
 -   releaseCycle: "5.24"
     lts: true
     releaseDate: 2022-02-08
-    support: 2022-06-14
+    eoas: 2022-06-14
     eol: 2022-10-14
     latest: "5.24.7"
     latestReleaseDate: 2022-10-14
@@ -65,7 +65,7 @@ releases:
 
 -   releaseCycle: "5.23"
     releaseDate: 2021-10-14
-    support: 2022-02-03
+    eoas: 2022-02-03
     eol: 2022-02-03
     latest: "5.23.5"
     latestReleaseDate: 2022-01-04
@@ -74,7 +74,7 @@ releases:
 -   releaseCycle: "5.18"
     lts: true
     releaseDate: 2020-02-11
-    support: 2020-06-04
+    eoas: 2020-06-04
     eol: 2022-02-11
     latest: "5.18.8"
     latestReleaseDate: 2021-10-19

--- a/products/kong-gateway.md
+++ b/products/kong-gateway.md
@@ -9,7 +9,7 @@ alternate_urls:
 changelogTemplate: https://github.com/Kong/kong/releases/tag/__LATEST__
 releaseDateColumn: true
 eolColumn: Support
-extendedSupportColumn: Enterprise Support
+eoesColumn: Enterprise Support
 
 auto:
   methods:
@@ -23,23 +23,23 @@ identifiers:
 #
 # For now, for non-LTS releases:
 # - eol(x) = MAX(latestReleaseDate, releaseDate(X+1))
-# - extendedSupport(x) = releaseDate(x) + 1 year
+# - eoes(x) = releaseDate(x) + 1 year
 #
 # For now, for LTS releases:
 # - eol(x) = true / false (the rule is still unclear)
-# - extendedSupport(x) = releaseDate(x) + 3 years
+# - eoes(x) = releaseDate(x) + 3 years
 releases:
 -   releaseCycle: "3.6"
     releaseDate: 2024-02-09
     eol: false
-    extendedSupport: 2025-02-15
+    eoes: 2025-02-15
     latest: "3.6.1"
     latestReleaseDate: 2024-03-04
 
 -   releaseCycle: "3.5"
     releaseDate: 2023-11-08
     eol: 2024-02-15
-    extendedSupport: 2024-11-08
+    eoes: 2024-11-08
     latest: "3.5.0"
     latestReleaseDate: 2023-11-08
 
@@ -47,35 +47,35 @@ releases:
     lts: true
     releaseDate: 2023-08-09
     eol: false
-    extendedSupport: 2026-08-09
+    eoes: 2026-08-09
     latest: "3.4.2"
     latestReleaseDate: 2023-10-12
 
 -   releaseCycle: "3.3"
     releaseDate: 2023-05-18
     eol: 2023-08-09
-    extendedSupport: 2024-05-18
+    eoes: 2024-05-18
     latest: "3.3.1"
     latestReleaseDate: 2023-07-11
 
 -   releaseCycle: "3.2"
     releaseDate: 2023-02-20
     eol: 2023-05-18
-    extendedSupport: 2024-02-21
+    eoes: 2024-02-21
     latest: "3.2.2"
     latestReleaseDate: 2023-03-16
 
 -   releaseCycle: "3.1"
     releaseDate: 2022-12-06
     eol: 2023-02-21
-    extendedSupport: 2023-12-06
+    eoes: 2023-12-06
     latest: "3.1.1"
     latestReleaseDate: 2022-12-09
 
 -   releaseCycle: "3.0"
     releaseDate: 2022-09-12
     eol: 2022-12-09
-    extendedSupport: 2023-09-12
+    eoes: 2023-09-12
     latest: "3.0.2"
     latestReleaseDate: 2022-12-09
 
@@ -83,7 +83,7 @@ releases:
     lts: true
     releaseDate: 2022-03-01
     eol: false
-    extendedSupport: 2025-03-01
+    eoes: 2025-03-01
     latest: "2.8.4"
     latestReleaseDate: 2023-09-20
 

--- a/products/kubernetes.md
+++ b/products/kubernetes.md
@@ -10,7 +10,7 @@ releasePolicyLink: https://kubernetes.io/releases/patch-releases/
 releaseImage: https://upload.wikimedia.org/wikipedia/en/timeline/cd6rbto8arbp7d9bq720l1r83634ihs.png
 changelogTemplate: https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-__RELEASE_CYCLE__.md
 releaseDateColumn: true
-activeSupportColumn: true
+eoasColumn: true
 eolColumn: Maintenance Support
 
 identifiers:
@@ -25,98 +25,98 @@ auto:
 releases:
 -   releaseCycle: "1.29"
     releaseDate: 2023-12-13
-    support: 2024-12-28
+    eoas: 2024-12-28
     eol: 2025-02-28
     latest: "1.29.3"
     latestReleaseDate: 2024-03-14
 
 -   releaseCycle: "1.28"
     releaseDate: 2023-08-15
-    support: 2024-08-28
+    eoas: 2024-08-28
     eol: 2024-10-28
     latest: "1.28.8"
     latestReleaseDate: 2024-03-15
 
 -   releaseCycle: "1.27"
     releaseDate: 2023-04-11
-    support: 2024-04-28
+    eoas: 2024-04-28
     eol: 2024-06-28
     latest: "1.27.12"
     latestReleaseDate: 2024-03-15
 
 -   releaseCycle: "1.26"
     releaseDate: 2022-12-08
-    support: 2023-12-28
+    eoas: 2023-12-28
     eol: 2024-02-28
     latest: "1.26.15"
     latestReleaseDate: 2024-03-14
 
 -   releaseCycle: "1.25"
     releaseDate: 2022-08-23
-    support: 2023-08-27
+    eoas: 2023-08-27
     eol: 2023-10-27
     latest: "1.25.16"
     latestReleaseDate: 2023-11-15
 
 -   releaseCycle: "1.24"
     releaseDate: 2022-05-03
-    support: 2023-05-28
+    eoas: 2023-05-28
     eol: 2023-07-28
     latest: "1.24.17"
     latestReleaseDate: 2023-08-23
 
 -   releaseCycle: "1.23"
     releaseDate: 2021-12-07
-    support: 2022-12-28
+    eoas: 2022-12-28
     eol: 2023-02-28
     latest: "1.23.17"
     latestReleaseDate: 2023-02-22
 
 -   releaseCycle: "1.22"
     releaseDate: 2021-08-04
-    support: 2022-08-28
+    eoas: 2022-08-28
     eol: 2022-10-28
     latest: "1.22.17"
     latestReleaseDate: 2022-12-08
 
 -   releaseCycle: "1.21"
     releaseDate: 2021-04-08
-    support: 2022-04-28
+    eoas: 2022-04-28
     eol: 2022-06-28
     latest: "1.21.14"
     latestReleaseDate: 2022-06-15
 
 -   releaseCycle: "1.20"
     releaseDate: 2020-12-08
-    support: 2021-12-28
+    eoas: 2021-12-28
     eol: 2022-02-28
     latest: "1.20.15"
     latestReleaseDate: 2022-01-19
 
 -   releaseCycle: "1.19"
     releaseDate: 2020-08-26
-    support: 2021-08-28
+    eoas: 2021-08-28
     eol: 2021-10-28
     latest: "1.19.16"
     latestReleaseDate: 2021-10-27
 
 -   releaseCycle: "1.18"
     releaseDate: 2020-03-25
-    support: 2021-04-28
+    eoas: 2021-04-28
     eol: 2021-06-18
     latest: "1.18.20"
     latestReleaseDate: 2021-06-16
 
 -   releaseCycle: "1.17"
     releaseDate: 2019-12-07
-    support: false
+    eoas: true
     eol: 2020-12-25
     latest: "1.17.17"
     latestReleaseDate: 2021-01-13
 
 -   releaseCycle: "1.16"
     releaseDate: 2019-09-18
-    support: false
+    eoas: true
     eol: 2020-08-04
     latest: "1.16.15"
     latestReleaseDate: 2020-09-02

--- a/products/laravel.md
+++ b/products/laravel.md
@@ -7,7 +7,7 @@ permalink: /laravel
 versionCommand: composer show laravel/framework|grep versions
 releasePolicyLink: https://laravel.com/docs/master/releases#support-policy
 changelogTemplate: https://laravel.com/docs/__RELEASE_CYCLE__.x/releases
-activeSupportColumn: true
+eoasColumn: true
 releaseDateColumn: true
 
 identifiers:
@@ -26,7 +26,7 @@ auto:
         releaseCycle:
           column: "Version"
           regex_exclude: "^1[2-9]$"
-        support:
+        eoas:
           column: "Bug Fixes Until"
           regex: '^(?P<month>\w+) (?P<day>\d+)\w+, (?P<year>\d+)$'
           template: "{{ month }} {{ day }}, {{ year }}"
@@ -40,7 +40,7 @@ auto:
 releases:
 -   releaseCycle: "11"
     releaseDate: 2024-03-12
-    support: 2025-09-03
+    eoas: 2025-09-03
     eol: 2026-03-12
     supportedPhpVersions: '8.2 - 8.3'
     latest: '11.1.1'
@@ -48,7 +48,7 @@ releases:
 
 -   releaseCycle: "10"
     releaseDate: 2023-02-14
-    support: 2024-08-06
+    eoas: 2024-08-06
     eol: 2025-02-04
     supportedPhpVersions: '8.1 - 8.3'
     latest: '10.48.4'
@@ -56,7 +56,7 @@ releases:
 
 -   releaseCycle: "9"
     releaseDate: 2022-02-08
-    support: 2023-08-08
+    eoas: 2023-08-08
     eol: 2024-02-06
     supportedPhpVersions: '8.0 - 8.2'
     latest: '9.52.16'
@@ -64,7 +64,7 @@ releases:
 
 -   releaseCycle: "8"
     releaseDate: 2020-09-08
-    support: 2022-07-26
+    eoas: 2022-07-26
     eol: 2023-01-24
     supportedPhpVersions: 7.3 - 8.1
     latest: '8.83.27'
@@ -72,7 +72,7 @@ releases:
 
 -   releaseCycle: "7"
     releaseDate: 2020-03-03
-    support: 2020-10-06
+    eoas: 2020-10-06
     eol: 2021-03-03
     supportedPhpVersions: 7.2 - 8.0
     latest: '7.30.6'
@@ -81,7 +81,7 @@ releases:
 -   releaseCycle: "6"
     lts: true
     releaseDate: 2019-09-03
-    support: 2022-01-25
+    eoas: 2022-01-25
     eol: 2022-09-06
     supportedPhpVersions: 7.2 - 8.0
     latest: '6.20.44'
@@ -89,7 +89,7 @@ releases:
 
 -   releaseCycle: "5.8"
     releaseDate: 2019-02-26
-    support: 2019-08-26
+    eoas: 2019-08-26
     eol: 2020-02-26
     supportedPhpVersions: 7.1 - 7.3
     link: https://laravel.com/docs/5.8/releases
@@ -99,7 +99,7 @@ releases:
 -   releaseCycle: "5.5"
     lts: true
     releaseDate: 2017-08-30
-    support: 2019-08-30
+    eoas: 2019-08-30
     eol: 2020-08-30
     supportedPhpVersions: 7.0 - 7.1
     link: https://laravel.com/docs/5.5/releases

--- a/products/linuxmint.md
+++ b/products/linuxmint.md
@@ -10,7 +10,7 @@ versionCommand: cat /etc/linuxmint/info
 releasePolicyLink: https://linuxmint.com/download_all.php
 releaseLabel: "__RELEASE_CYCLE__ '__CODENAME__'"
 releaseDateColumn: true
-activeSupportColumn: true
+eoasColumn: true
 
 auto:
   methods:
@@ -28,7 +28,7 @@ releases:
     codename: Virginia
     lts: true
     releaseDate: 2024-01-12
-    support: true
+    eoas: false
     eol: 2027-04-30
     latest: "21.3"
     link: https://blog.linuxmint.com/?p=4624
@@ -37,7 +37,7 @@ releases:
     releaseLabel: "LMDE 6"
     codename: Faye
     releaseDate: 2023-09-27
-    support: true
+    eoas: false
     eol: false
     latest: "6"
     link: https://blog.linuxmint.com/?p=4570
@@ -46,7 +46,7 @@ releases:
     codename: Victoria
     lts: true
     releaseDate: 2023-07-16
-    support: true
+    eoas: false
     eol: 2027-04-30
     latest: "21.2"
     link: https://blog.linuxmint.com/?p=4543
@@ -55,7 +55,7 @@ releases:
     codename: Vera
     lts: true
     releaseDate: 2022-12-20
-    support: true
+    eoas: false
     eol: 2027-04-30
     latest: "21.1"
     link: https://blog.linuxmint.com/?p=4454
@@ -64,7 +64,7 @@ releases:
     codename: Vanessa
     lts: true
     releaseDate: 2022-07-31
-    support: true
+    eoas: false
     eol: 2027-04-30
     latest: "21"
     link: https://blog.linuxmint.com/?p=4359
@@ -73,7 +73,7 @@ releases:
     releaseLabel: "LMDE 5"
     codename: Elsie
     releaseDate: 2022-03-20
-    support: true
+    eoas: false
     eol: 2024-07-01
     latest: "5"
     link: https://blog.linuxmint.com/?p=4287
@@ -82,7 +82,7 @@ releases:
     codename: Una
     lts: true
     releaseDate: 2022-01-07
-    support: true
+    eoas: false
     eol: 2025-04-30
     latest: "20.3"
     link: https://blog.linuxmint.com/?p=4220
@@ -91,7 +91,7 @@ releases:
     codename: Uma
     lts: true
     releaseDate: 2021-07-08
-    support: true
+    eoas: false
     eol: 2025-04-30
     latest: "20.2"
     link: https://blog.linuxmint.com/?p=4102
@@ -100,7 +100,7 @@ releases:
     codename: Ulyssa
     lts: true
     releaseDate: 2021-01-08
-    support: false
+    eoas: true
     eol: 2025-04-30
     latest: "20.1"
     link: https://blog.linuxmint.com/?p=4011
@@ -109,7 +109,7 @@ releases:
     codename: Ulyana
     lts: true
     releaseDate: 2020-06-27
-    support: false
+    eoas: true
     eol: 2025-04-30
     latest: "20"
     link: https://blog.linuxmint.com/?p=3928
@@ -117,7 +117,7 @@ releases:
 -   releaseCycle: "lmde4"
     releaseLabel: "LMDE 4"
     releaseDate: 2020-03-20
-    support: 2022-08-01
+    eoas: 2022-08-01
     eol: 2022-08-01
     latest: "4"
     link: https://blog.linuxmint.com/?p=3867
@@ -126,7 +126,7 @@ releases:
     codename: Tricia
     lts: true
     releaseDate: 2019-12-18
-    support: false
+    eoas: true
     eol: 2023-04-01
     latest: "19.3"
     link: https://blog.linuxmint.com/?p=3832
@@ -135,7 +135,7 @@ releases:
     codename: Tina
     lts: true
     releaseDate: 2019-08-02
-    support: false
+    eoas: true
     eol: 2023-04-01
     latest: "19.2"
     link: https://blog.linuxmint.com/?p=3786
@@ -144,7 +144,7 @@ releases:
     codename: Tessa
     lts: true
     releaseDate: 2018-12-19
-    support: false
+    eoas: true
     eol: 2023-04-01
     latest: "19.1"
     link: https://blog.linuxmint.com/?p=3669
@@ -153,7 +153,7 @@ releases:
     codename: Tara
     lts: true
     releaseDate: 2018-06-29
-    support: false
+    eoas: true
     eol: 2023-04-01
     latest: "19"
     link: https://blog.linuxmint.com/?p=3597
@@ -162,7 +162,7 @@ releases:
     codename: Sylvia
     lts: true
     releaseDate: 2017-11-27
-    support: false
+    eoas: true
     eol: 2021-05-03
     latest: "18.3"
     link: https://blog.linuxmint.com/?p=3457
@@ -170,7 +170,7 @@ releases:
 -   releaseCycle: "18.1"
     codename: Serena
     releaseDate: 2017-01-27
-    support: false
+    eoas: true
     eol: 2021-04-01
     latest: "18.1"
     link: https://blog.linuxmint.com/?p=3223

--- a/products/magento.md
+++ b/products/magento.md
@@ -11,9 +11,9 @@ releasePolicyLink:
   https://www.adobe.com/content/dam/cc/en/legal/terms/enterprise/pdfs/Magento-Open-Source-Software-Maintenance-Policy.pdf
 changelogTemplate: "https://experienceleague.adobe.com/docs/commerce-operations/release/notes/magento-open-source/{{'__LATEST__'|replace:'.','-'}}.html"
 releaseDateColumn: true
-activeSupportColumn: Bug fix maintenance
+eoasColumn: Bug fix maintenance
 eolColumn: Security maintenance
-extendedSupportColumn: Adobe Commerce end of software support
+eoesColumn: Adobe Commerce end of software support
 
 auto:
   methods:
@@ -24,63 +24,59 @@ auto:
 releases:
 -   releaseCycle: "2.4.6"
     releaseDate: 2023-02-28
-    support: true
+    eoas: false
     eol: false
-    extendedSupport: 2026-03-14
+    eoes: 2026-03-14
     supportedPhpVersions: 8.1, 8.2
     latest: "2.4.6"
     latestReleaseDate: 2023-02-28
 
 -   releaseCycle: "2.4.5"
     releaseDate: 2022-08-01
-    support: 2024-11-25
+    eoas: 2024-11-25
     eol: 2024-11-25
-    extendedSupport: 2025-08-09
+    eoes: 2025-08-09
     supportedPhpVersions: 8.1
     latest: "2.4.5"
     latestReleaseDate: 2022-08-01
 
 -   releaseCycle: "2.4.4"
     releaseDate: 2022-03-30
-    support: 2024-11-25
+    eoas: 2024-11-25
     eol: 2024-11-25
-    extendedSupport: 2025-04-24
+    eoes: 2025-04-24
     supportedPhpVersions: 8.1
     latest: "2.4.4"
     latestReleaseDate: 2022-03-30
 
 -   releaseCycle: "2.4.3"
     releaseDate: 2021-08-04
-    support: 2022-11-28
+    eoas: 2022-11-28
     eol: 2022-11-28
-    extendedSupport: false
     supportedPhpVersions: 7.4
     latest: "2.4.3"
     latestReleaseDate: 2021-08-04
 
 -   releaseCycle: "2.4.2"
     releaseDate: 2021-02-04
-    support: 2022-11-28
+    eoas: 2022-11-28
     eol: 2022-11-28
-    extendedSupport: false
     supportedPhpVersions: 7.4
     latest: "2.4.2"
     latestReleaseDate: 2021-02-04
 
 -   releaseCycle: "2.4.1"
     releaseDate: 2020-10-14
-    support: 2022-11-28
+    eoas: 2022-11-28
     eol: 2022-11-28
-    extendedSupport: false
     supportedPhpVersions: 7.4
     latest: "2.4.1"
     latestReleaseDate: 2020-10-14
 
 -   releaseCycle: "2.4.0"
     releaseDate: 2020-07-20
-    support: 2022-11-28
+    eoas: 2022-11-28
     eol: 2022-11-28
-    extendedSupport: false
     supportedPhpVersions: 7.3, 7.4
     latest: "2.4.0"
     latestReleaseDate: 2020-07-20
@@ -89,9 +85,8 @@ releases:
 
 -   releaseCycle: "2.3"
     releaseDate: 2018-11-23
-    support: 2022-07-31
+    eoas: 2022-07-31
     eol: 2022-09-30
-    extendedSupport: false
     # https://devdocs.magento.com/guides/v2.3/release-notes/release-notes-2-3-3-open-source.html#platform-upgrades
     supportedPhpVersions: 7.2, 7.3
     link: https://devdocs.magento.com/guides/v2.3/release-notes/open-source-2-3-7.html
@@ -100,9 +95,8 @@ releases:
 
 -   releaseCycle: "2.2"
     releaseDate: 2017-09-22
-    support: 2019-12-01
+    eoas: 2019-12-01
     eol: 2019-12-01
-    extendedSupport: false
     link:
       https://web.archive.org/web/20220729084223/https://devdocs.magento.com/guides/v2.2/release-notes/release-notes-2-2-11-open-source.html
     latest: "2.2.11"
@@ -110,9 +104,8 @@ releases:
 
 -   releaseCycle: "2.1"
     releaseDate: 2016-06-23
-    support: 2019-06-01
+    eoas: 2019-06-01
     eol: 2019-06-01
-    extendedSupport: false
     link:
       https://commerce-docs.github.io/devdocs-archive/2.1/guides/v2.1/release-notes/ReleaseNotes2.1.18CE.html
     latest: "2.1.18"
@@ -120,9 +113,8 @@ releases:
 
 -   releaseCycle: "2.0"
     releaseDate: 2015-11-16
-    support: 2018-03-01
+    eoas: 2018-03-01
     eol: 2018-03-01
-    extendedSupport: false
     link:
       https://commerce-docs.github.io/devdocs-archive/2.0/guides/v2.0/release-notes/ReleaseNotes2.0.18CE.html
     latest: "2.0.18"
@@ -130,81 +122,71 @@ releases:
 
 -   releaseCycle: "1.9"
     releaseDate: 2014-05-01
-    support: 2020-06-01
+    eoas: 2020-06-01
     eol: 2020-06-01
-    extendedSupport: false
     link: null
     latest: "1.9.4.3"
 
 -   releaseCycle: "1.8"
     releaseDate: 2013-09-01
-    support: 2014-09-01
+    eoas: 2014-09-01
     eol: 2020-06-01
-    extendedSupport: false
     link: null
     latest: "1.8.1.0"
 
 -   releaseCycle: "1.7"
     releaseDate: 2012-04-01
-    support: 2013-04-01
+    eoas: 2013-04-01
     eol: 2020-06-01
-    extendedSupport: false
     link: null
     latest: "1.7.0.2"
 
 -   releaseCycle: "1.6"
     releaseDate: 2011-08-01
-    support: 2012-08-01
+    eoas: 2012-08-01
     eol: 2020-06-01
-    extendedSupport: false
     link: null
     latest: "1.6.2.0"
 
 -   releaseCycle: "1.5"
     releaseDate: 2011-02-01
-    support: 2012-02-01
+    eoas: 2012-02-01
     eol: 2020-06-01
-    extendedSupport: false
     link: null
     latest: "1.5.1.0"
 
 -   releaseCycle: "1.4"
     releaseDate: 2010-02-01
-    support: 2011-02-01
+    eoas: 2011-02-01
     eol: 2012-02-01
-    extendedSupport: false
     link: null
     latest: "1.4.2.0"
 
 -   releaseCycle: "1.3"
     releaseDate: 2009-03-01
-    support: 2010-03-01
+    eoas: 2010-03-01
     eol: 2011-03-01
-    extendedSupport: false
     link: null
     latest: "1.3.3.0"
 
 -   releaseCycle: "1.2"
     releaseDate: 2008-12-01
-    support: 2009-12-01
+    eoas: 2009-12-01
     eol: 2010-12-01
-    extendedSupport: false
     link: null
     latest: "1.2.1.2"
 
 -   releaseCycle: "1.1"
     releaseDate: 2008-07-01
-    support: 2009-07-01
+    eoas: 2009-07-01
     eol: 2010-07-01
-    extendedSupport: false
     link: null
     latest: "1.1.8"
 
 -   releaseCycle: "1.0"
     releaseDate: 2008-03-01
-    support: 2009-03-01
+    eoas: 2009-03-01
     eol: 2010-03-01
-    extendedSupport: false
     link: null
     latest: "1.0.0"
 

--- a/products/matomo.md
+++ b/products/matomo.md
@@ -10,7 +10,7 @@ versionCommand: console core:version
 releasePolicyLink: https://matomo.org/faq/new-to-piwik/faq_18925/
 changelogTemplate: https://github.com/matomo-org/matomo/releases/tag/__LATEST__
 releaseDateColumn: true
-activeSupportColumn: true
+eoasColumn: true
 eolColumn: Long Term Support
 
 auto:
@@ -23,41 +23,41 @@ identifiers:
 -   purl: pkg:docker/bitnami/matomo
 -   purl: pkg:github/matomo-org/matomo
 
-# support(x) = releaseDate(x+1)
+# eoas(x) = releaseDate(x+1)
 # eol(x) documented on https://matomo.org/blog/2016/01/announcing-long-term-support-in-matomo-the-analytics-platform-for-your-mission-critical-projects/
 # No release is marked LTS, as this phase is true for all release and is considered here as the security support phase.
 releases:
 -   releaseCycle: "5"
     releaseDate: 2023-12-18
-    support: true
+    eoas: false
     eol: false
     latest: "5.0.3"
     latestReleaseDate: 2024-03-07
 
 -   releaseCycle: "4"
     releaseDate: 2020-11-24
-    support: 2023-12-18
+    eoas: 2023-12-18
     eol: 2024-12-19 # https://matomo.org/blog/2016/01/announcing-long-term-support-in-matomo-the-analytics-platform-for-your-mission-critical-projects/
     latest: "4.16.1"
     latestReleaseDate: 2024-02-05
 
 -   releaseCycle: "3"
     releaseDate: 2016-12-19
-    support: 2020-11-24
+    eoas: 2020-11-24
     eol: 2021-12-01 # https://web.archive.org/web/20231111145144/https://matomo.org/blog/2016/01/announcing-long-term-support-in-matomo-the-analytics-platform-for-your-mission-critical-projects/
     latest: "3.14.1"
     latestReleaseDate: 2020-09-11
 
 -   releaseCycle: "2"
     releaseDate: 2013-12-17
-    support: 2016-12-19
+    eoas: 2016-12-19
     eol: 2017-12-18 # https://matomo.org/blog/2017/12/piwik-2-reaches-end-life-soon-december-2017-update-now/
     latest: "2.18.1" # released to help upgrading to Matomo 4.x
     latestReleaseDate: 2020-07-01
 
 -   releaseCycle: "1"
     releaseDate: 2010-08-28
-    support: 2013-12-17
+    eoas: 2013-12-17
     eol: 2013-12-17
     latest: "1.12"
     latestReleaseDate: 2013-05-30

--- a/products/micronaut.md
+++ b/products/micronaut.md
@@ -8,7 +8,7 @@ alternate_urls:
 -   /mn
 releasePolicyLink: https://micronaut.io/support-schedule/
 changelogTemplate: "https://github.com/micronaut-projects/micronaut-core/releases/tag/v__LATEST__"
-activeSupportColumn: Active Development
+eoasColumn: Active Development
 eolColumn: Active Maintenance
 releaseDateColumn: true
 
@@ -20,28 +20,28 @@ releases:
 -   releaseCycle: "4"
     releaseDate: 2023-07-11
     eol: false
-    support: true
+    eoas: false
     latest: "4.4.0"
     latestReleaseDate: 2024-03-30
 
 -   releaseCycle: "3"
     releaseDate: 2021-08-18
     eol: false
-    support: 2023-07-11
+    eoas: 2023-07-11
     latest: "3.10.4"
     latestReleaseDate: 2024-03-23
 
 -   releaseCycle: "2"
     releaseDate: 2020-06-26
     eol: 2023-03-01
-    support: 2021-08-18
+    eoas: 2021-08-18
     latest: "2.5.13"
     latestReleaseDate: 2021-09-03
 
 -   releaseCycle: "1"
     releaseDate: 2018-10-23
     eol: 2021-12-31
-    support: false
+    eoas: true
     latest: "1.3.7"
     latestReleaseDate: 2020-07-10
 

--- a/products/moodle.md
+++ b/products/moodle.md
@@ -5,7 +5,7 @@ tags: php-runtime
 permalink: /moodle
 releasePolicyLink: https://moodledev.io/general/releases
 changelogTemplate: "https://moodledev.io/general/releases/__RELEASE_CYCLE__{% if '__RELEASE_CYCLE__.0'!='__LATEST__' %}/__LATEST__{% endif %}"
-activeSupportColumn: true
+eoasColumn: true
 releaseDateColumn: true
 
 auto:
@@ -18,14 +18,14 @@ auto:
           column: "Version"
           regex: '^(?P<value>\d+\.\d+).*$'
         releaseDate: "Initial release date"
-        support: "General support ends"
+        eoas: "General support ends"
         eol: "Security support ends"
 
 # supportedPhpVersions can be found in the release notes.
 releases:
 -   releaseCycle: "4.3"
     releaseDate: 2023-10-07
-    support: 2024-10-07
+    eoas: 2024-10-07
     eol: 2025-04-21
     supportedPhpVersions: 8.0 - 8.2
     latest: "4.3.3"
@@ -33,7 +33,7 @@ releases:
 
 -   releaseCycle: "4.2"
     releaseDate: 2023-04-22
-    support: 2024-04-22
+    eoas: 2024-04-22
     eol: 2024-10-07
     supportedPhpVersions: 8.0 - 8.2
     latest: "4.2.6"
@@ -42,7 +42,7 @@ releases:
 -   releaseCycle: "4.1"
     lts: true
     releaseDate: 2022-11-26
-    support: 2023-12-11
+    eoas: 2023-12-11
     eol: 2025-12-08
     supportedPhpVersions: 7.4 - 8.1
     latest: "4.1.9"
@@ -50,7 +50,7 @@ releases:
 
 -   releaseCycle: "4.0"
     releaseDate: 2022-04-17
-    support: 2023-05-08
+    eoas: 2023-05-08
     eol: 2023-11-13
     supportedPhpVersions: 7.3 - 8.0
     latest: "4.0.12"
@@ -58,7 +58,7 @@ releases:
 
 -   releaseCycle: "3.11"
     releaseDate: 2021-05-15
-    support: 2022-11-14
+    eoas: 2022-11-14
     eol: 2023-11-13
     supportedPhpVersions: 7.3 - 8.0
     latest: "3.11.18"
@@ -66,7 +66,7 @@ releases:
 
 -   releaseCycle: "3.10"
     releaseDate: 2020-11-07
-    support: 2021-11-08
+    eoas: 2021-11-08
     eol: 2022-05-09
     supportedPhpVersions: 7.2 - 7.4
     latest: "3.10.11"
@@ -75,7 +75,7 @@ releases:
 -   releaseCycle: "3.9"
     lts: true
     releaseDate: 2020-06-13
-    support: 2021-05-10
+    eoas: 2021-05-10
     eol: 2023-11-13
     supportedPhpVersions: 7.2 - 7.4
     latest: "3.9.25"
@@ -83,7 +83,7 @@ releases:
 
 -   releaseCycle: "3.8"
     releaseDate: 2019-11-16
-    support: 2020-11-09
+    eoas: 2020-11-09
     eol: 2021-05-10
     supportedPhpVersions: 7.1 - 7.4
     latest: "3.8.9"

--- a/products/msexchange.md
+++ b/products/msexchange.md
@@ -6,13 +6,13 @@ permalink: /msexchange
 versionCommand: Get-ExchangeServer | Format-List Name,Edition,AdminDisplayVersion
 releasePolicyLink: https://learn.microsoft.com/lifecycle/products/?terms=Exchange%20Server
 releaseDateColumn: true
-activeSupportColumn: true
+eoasColumn: true
 
 releases:
 -   releaseCycle: "2019"
     releaseLabel: "2019 CU14 SU1"
     releaseDate: 2018-10-22
-    support: 2024-01-09
+    eoas: 2024-01-09
     eol: 2025-10-14
     latest: "15.2.1544.9"
     latestReleaseDate: 2024-03-12
@@ -21,7 +21,7 @@ releases:
 -   releaseCycle: "2016"
     releaseLabel: "2016 CU23 SU12"
     releaseDate: 2015-10-01
-    support: 2020-10-13
+    eoas: 2020-10-13
     eol: 2025-10-14
     latest: "15.1.2507.37"
     latestReleaseDate: 2024-03-12
@@ -30,7 +30,7 @@ releases:
 -   releaseCycle: "2013"
     releaseLabel: "2013 CU23 SU21"
     releaseDate: 2013-01-09
-    support: 2018-04-10
+    eoas: 2018-04-10
     eol: 2023-04-11
     latest: "15.0.1497.48"
     latestReleaseDate: 2023-03-14
@@ -39,7 +39,7 @@ releases:
 -   releaseCycle: "2010"
     releaseLabel: "2010 SP3 UR32"
     releaseDate: 2009-11-09
-    support: 2015-01-13
+    eoas: 2015-01-13
     eol: 2020-10-13
     latest: "14.3.513.0"
     latestReleaseDate: 2021-03-02
@@ -47,7 +47,7 @@ releases:
 -   releaseCycle: "2007"
     releaseLabel: "2007 SP3 UR23"
     releaseDate: 2007-03-08
-    support: 2012-04-10
+    eoas: 2012-04-10
     eol: 2017-04-11
     latest: "8.3.517.0"
     latestReleaseDate: 2017-03-21
@@ -55,7 +55,7 @@ releases:
 -   releaseCycle: "2003"
     releaseLabel: "2003 SP2"
     releaseDate: 2003-09-28
-    support: 2009-04-14
+    eoas: 2009-04-14
     eol: 2014-04-08
     latest: "6.5.7654.4"
     latestReleaseDate: 2008-08-01
@@ -63,7 +63,7 @@ releases:
 -   releaseCycle: "2000"
     releaseLabel: "2000 SP3"
     releaseDate: 2000-11-29
-    support: 2005-12-31
+    eoas: 2005-12-31
     eol: 2011-01-11
     latest: "6.0.6620.7"
     latestReleaseDate: 2008-08-01
@@ -71,7 +71,7 @@ releases:
 -   releaseCycle: "5.5"
     releaseLabel: "5.5 SP4"
     releaseDate: 1998-02-03
-    support: 2003-12-31
+    eoas: 2003-12-31
     eol: 2006-01-10
     latest: "5.5.2653"
     latestReleaseDate: 2000-11-01
@@ -79,7 +79,7 @@ releases:
 -   releaseCycle: "5.0"
     releaseLabel: "5.0 SP2"
     releaseDate: 1997-05-23
-    support: 2003-12-31
+    eoas: 2003-12-31
     eol: 2006-01-10
     latest: "5.0.1460"
     latestReleaseDate: 1998-02-19
@@ -87,7 +87,7 @@ releases:
 -   releaseCycle: "4.0"
     releaseLabel: "4.0 SP5"
     releaseDate: 1996-06-11
-    support: false
+    eoas: true
     eol: true
     latest: "4.0.996"
     latestReleaseDate: 1998-05-05

--- a/products/mssharepoint.md
+++ b/products/mssharepoint.md
@@ -6,14 +6,14 @@ permalink: /sharepoint
 alternate_urls:
 -   /mssharepoint
 releasePolicyLink: https://learn.microsoft.com/lifecycle/products/?terms=SharePoint%20Server
-activeSupportColumn: true
+eoasColumn: true
 releaseDateColumn: true
 
 releases:
 -   releaseCycle: "subscription"
     releaseLabel: "Subscription Edition"
     releaseDate: 2021-11-02
-    support: true
+    eoas: false
     eol: false
     latest: "16.0.17328.20136"
     latestReleaseDate: 2024-03-12
@@ -21,7 +21,7 @@ releases:
 
 -   releaseCycle: "2019"
     releaseDate: 2018-10-22
-    support: 2024-01-09
+    eoas: 2024-01-09
     eol: 2026-07-14
     latest: "16.0.10408.20000"
     latestReleaseDate: 2024-03-12
@@ -29,7 +29,7 @@ releases:
 
 -   releaseCycle: "2016"
     releaseDate: 2016-05-01
-    support: 2021-07-13
+    eoas: 2021-07-13
     eol: 2026-07-14
     latest: "16.0.5439.1000"
     latestReleaseDate: 2024-03-12
@@ -38,7 +38,7 @@ releases:
 -   releaseCycle: "2013"
     releaseLabel: "2013 SP1"
     releaseDate: 2013-01-09
-    support: 2018-04-10
+    eoas: 2018-04-10
     eol: 2023-04-11
     latest: "15.0.5545.1000"
     latestReleaseDate: 2023-04-11
@@ -47,7 +47,7 @@ releases:
 -   releaseCycle: "2010"
     releaseLabel: "2010 SP2"
     releaseDate: 2010-07-05
-    support: 2015-10-13
+    eoas: 2015-10-13
     eol: 2021-04-13
     latest: "14.0.7268.5000"
     latestReleaseDate: 2021-04-13
@@ -56,7 +56,7 @@ releases:
 -   releaseCycle: "2007"
     releaseLabel: "2007 SP3"
     releaseDate: 2007-01-27
-    support: 2012-10-09
+    eoas: 2012-10-09
     eol: 2017-10-10
     latest: "12.0.6690.5000"
     latestReleaseDate: 2014-05-13

--- a/products/mssqlserver.md
+++ b/products/mssqlserver.md
@@ -9,18 +9,17 @@ alternate_urls:
 versionCommand: select @@version
 releasePolicyLink: https://learn.microsoft.com/lifecycle/products/?terms=SQL%20Server
 
-activeSupportColumn: true
+eoasColumn: true
 releaseDateColumn: true
-extendedSupportColumn: Extended Security Updates
+eoesColumn: Extended Security Updates
 
 releases:
 -   releaseCycle: "16.0"
     codename: Dallas
     releaseLabel: "2022 CU12"
     releaseDate: 2022-11-16
-    support: 2028-01-11
+    eoas: 2028-01-11
     eol: 2033-01-11
-    extendedSupport: false
     latest: "16.0.4115.5"
     latestReleaseDate: 2024-03-14
     link: https://learn.microsoft.com/troubleshoot/sql/releases/sqlserver-2022/cumulativeupdate12
@@ -29,9 +28,8 @@ releases:
     codename: Seattle
     releaseLabel: "2019 CU25"
     releaseDate: 2019-11-04
-    support: 2025-01-07
+    eoas: 2025-01-07
     eol: 2030-01-08
-    extendedSupport: false
     latest: "15.0.4355.3"
     latestReleaseDate: 2024-02-15
     link: https://learn.microsoft.com/troubleshoot/sql/releases/sqlserver-2019/cumulativeupdate25
@@ -40,9 +38,8 @@ releases:
     codename: Helsinki
     releaseLabel: "2017 CU31"
     releaseDate: 2017-09-29
-    support: 2022-10-11
+    eoas: 2022-10-11
     eol: 2027-10-12
-    extendedSupport: false
     latest: "14.0.3465.1"
     latestReleaseDate: 2023-10-10
     link: https://support.microsoft.com/help/5029376
@@ -51,9 +48,8 @@ releases:
     codename: SQL16
     releaseLabel: "2016 SP3"
     releaseDate: 2018-04-24
-    support: 2021-07-13
+    eoas: 2021-07-13
     eol: 2026-07-14
-    extendedSupport: false
     latest: "13.0.6435.1"
     latestReleaseDate: 2023-10-10
     link: https://support.microsoft.com/help/5029186
@@ -62,9 +58,8 @@ releases:
     codename: Hekaton
     releaseLabel: "2014 SP3 CU4"
     releaseDate: 2018-10-30
-    support: 2019-07-09
+    eoas: 2019-07-09
     eol: 2024-07-09
-    extendedSupport: false
     latest: "12.0.6449.1"
     latestReleaseDate: 2023-10-10
     link: https://support.microsoft.com/help/5029185
@@ -73,9 +68,9 @@ releases:
     codename: Denali
     releaseLabel: "2012 SP4"
     releaseDate: 2012-05-20
-    support: 2017-07-11
+    eoas: 2017-07-11
     eol: 2022-07-12
-    extendedSupport: 2025-07-08
+    eoes: 2025-07-08
     latest: "11.0.7512.11"
     latestReleaseDate: 2023-02-14
     link: https://support.microsoft.com/help/5021123
@@ -84,9 +79,9 @@ releases:
     codename: Kilimanjaro
     releaseLabel: "2008 R2 SP3"
     releaseDate: 2010-07-20
-    support: 2014-07-08
+    eoas: 2014-07-08
     eol: 2019-07-09
-    extendedSupport: 2022-07-12
+    eoes: 2022-07-12
     latest: "10.50.6785.2"
     latestReleaseDate: 2023-02-14
     link: https://support.microsoft.com/help/5021112
@@ -95,9 +90,9 @@ releases:
     codename: Katmai
     releaseLabel: "2008 SP4"
     releaseDate: 2008-11-06
-    support: 2014-07-08
+    eoas: 2014-07-08
     eol: 2019-07-09
-    extendedSupport: 2022-07-12
+    eoes: 2022-07-12
     latest: "10.0.6814.4"
     latestReleaseDate: 2023-02-14
     link: https://support.microsoft.com/help/5020863
@@ -106,9 +101,8 @@ releases:
     codename: Yukon
     releaseLabel: "2005 SP4"
     releaseDate: 2006-01-14
-    support: 2011-04-12
+    eoas: 2011-04-12
     eol: 2016-04-12
-    extendedSupport: false
     latest: "9.0.5324.0"
     latestReleaseDate: 2012-10-09
     link: https://support.microsoft.com/help/2716427
@@ -117,9 +111,8 @@ releases:
     codename: Shiloh
     releaseLabel: "2000 SP4"
     releaseDate: 2000-11-30
-    support: 2008-04-08
+    eoas: 2008-04-08
     eol: 2013-04-09
-    extendedSupport: false
     latest: "8.0.2305"
     latestReleaseDate: 2012-08-14
     link: https://support.microsoft.com/help/983811
@@ -128,9 +121,8 @@ releases:
     codename: Sphinx
     releaseLabel: "7.0 SP4"
     releaseDate: 1998-11-27
-    support: 2005-12-31
+    eoas: 2005-12-31
     eol: 2011-01-11
-    extendedSupport: false
     latest: "7.0.1152"
     latestReleaseDate: 2012-05-09
     link: https://support.microsoft.com/help/941203
@@ -139,9 +131,8 @@ releases:
     codename: Hydra
     releaseLabel: "6.5 SP5a"
     releaseDate: 1996-06-30
-    support: 2002-01-01
+    eoas: 2002-01-01
     eol: 2002-01-01
-    extendedSupport: false
     latest: "6.50.480"
     latestReleaseDate: 2005-10-07
     # Original KB238621 but 404 in the meantime: https://support.microsoft.com/help/238621
@@ -151,9 +142,8 @@ releases:
     codename: SQL95
     releaseLabel: "6.0 SP3"
     releaseDate: 1995-06-13
-    support: 1999-03-31
+    eoas: 1999-03-31
     eol: 1999-03-31
-    extendedSupport: false
     latest: "6.0.151"
     latestReleaseDate: 2005-10-07
     # Original KB152616 but 404 in the meantime: https://support.microsoft.com/help/152616

--- a/products/muleruntime.md
+++ b/products/muleruntime.md
@@ -10,7 +10,7 @@ alternate_urls:
 -   /mule-runtimes
 releasePolicyLink: https://www.mulesoft.com/legal/versioning-back-support-policy#mule-runtimes
 changelogTemplate: "https://docs.mulesoft.com/release-notes/mule-runtime/mule-{{'__LATEST__'|split:'-'|first}}-release-notes"
-activeSupportColumn: Standard Support
+eoasColumn: Standard Support
 releaseDateColumn: true
 eolColumn: Extended Support
 
@@ -20,7 +20,7 @@ releases:
 -   releaseCycle: "4.6"
     lts: true
     releaseDate: 2024-02-06
-    support: 2025-02-06
+    eoas: 2025-02-06
     eol: 2026-02-06
     latest: "4.6.0"
     latestReleaseDate: 2024-02-06
@@ -28,7 +28,7 @@ releases:
 
 -   releaseCycle: "4.5"
     releaseDate: 2023-10-03
-    support: 2024-02-06
+    eoas: 2024-02-06
     eol: 2024-06-04
     latest: "4.5.3"
     latestReleaseDate: 2024-01-15 # guessing
@@ -36,28 +36,28 @@ releases:
 
 -   releaseCycle: "4.4"
     releaseDate: 2021-09-07
-    support: 2024-10-08
+    eoas: 2024-10-08
     eol: 2025-10-08
     latest: "4.4.0-20240215"
     latestReleaseDate: 2024-02-15
 
 -   releaseCycle: "4.3"
     releaseDate: 2020-04-30
-    support: 2023-03-07
+    eoas: 2023-03-07
     eol: 2025-03-07
     latest: "4.3.0-20231026"
     latestReleaseDate: 2023-10-26
 
 -   releaseCycle: "4.2"
     releaseDate: 2019-05-02
-    support: 2021-05-02
+    eoas: 2021-05-02
     eol: 2023-05-02
     latest: "4.2.2-20221027"
     latestReleaseDate: 2022-10-27
 
 -   releaseCycle: "4.1"
     releaseDate: 2018-03-20
-    support: 2020-11-02
+    eoas: 2020-11-02
     eol: 2022-11-02
     latest: "4.1.6-20210419"
     latestReleaseDate: 2021-04-19
@@ -66,7 +66,7 @@ releases:
 -   releaseCycle: "3.9"
     lts: true
     releaseDate: 2017-10-09
-    support: 2021-03-20
+    eoas: 2021-03-20
     eol: 2024-03-20
     latest: "3.9.5-20230823"
     latestReleaseDate: 2023-08-23
@@ -74,7 +74,7 @@ releases:
 -   releaseCycle: "3.8"
     lts: true
     releaseDate: 2016-05-16
-    support: 2018-11-16
+    eoas: 2018-11-16
     eol: 2021-11-16
     latest: "3.8.7"
     latestReleaseDate: 2018-05-28

--- a/products/mxlinux.md
+++ b/products/mxlinux.md
@@ -11,7 +11,7 @@ alternate_urls:
 versionCommand: cat /etc/lsb-release
 releasePolicyLink: https://mxlinux.org/release-cycle/
 releaseLabel: "__RELEASE_CYCLE__ (__CODENAME__)"
-activeSupportColumn: true
+eoasColumn: true
 releaseDateColumn: true
 
 identifiers:
@@ -23,12 +23,12 @@ auto:
       regex: '^Distribution Release: MX Linux (?P<major>\d+)(\.(?P<minor>\d+))?$'
 
 # EOL dates documented on https://mxlinux.org/previous-releases/.
-# If not documented yet, use Debian eol for support, and extendedSupport for eol.
+# If not documented yet, use Debian eol for support, and eoes for eol.
 releases:
 -   releaseCycle: "23"
     codename: "Libretto"
     releaseDate: 2023-07-31
-    support: 2026-06-10
+    eoas: 2026-06-10
     eol: 2028-06-10
     latest: "23.2"
     latestReleaseDate: 2024-01-22
@@ -37,7 +37,7 @@ releases:
 -   releaseCycle: "21"
     codename: "Wildflower"
     releaseDate: 2021-10-21
-    support: 2024-06-30
+    eoas: 2024-06-30
     eol: 2026-06-30
     latest: "21.3"
     latestReleaseDate: 2023-01-15
@@ -46,7 +46,7 @@ releases:
 -   releaseCycle: "19"
     codename: "Patito Feo"
     releaseDate: 2019-10-22
-    support: 2022-09-10
+    eoas: 2022-09-10
     eol: 2024-06-30
     latest: "19.4"
     latestReleaseDate: 2021-04-01
@@ -55,7 +55,7 @@ releases:
 -   releaseCycle: "18"
     codename: "Continuum"
     releaseDate: 2018-12-20
-    support: 2020-06-05
+    eoas: 2020-06-05
     eol: 2022-06-30
     latest: "18.3"
     latestReleaseDate: 2019-05-28
@@ -64,7 +64,7 @@ releases:
 -   releaseCycle: "17"
     codename: "Horizon"
     releaseDate: 2017-12-15
-    support: 2020-06-05
+    eoas: 2020-06-05
     eol: 2022-06-30
     latest: "17.1"
     latestReleaseDate: 2018-03-15
@@ -73,7 +73,7 @@ releases:
 -   releaseCycle: "16"
     codename: "Metamorphosis"
     releaseDate: 2016-12-14
-    support: 2018-06-23
+    eoas: 2018-06-23
     eol: 2020-06-30
     latest: "16.1"
     latestReleaseDate: 2017-06-08
@@ -82,21 +82,21 @@ releases:
 -   releaseCycle: "15"
     codename: "Fusion"
     releaseDate: 2015-12-24
-    support: 2018-06-23
+    eoas: 2018-06-23
     eol: 2020-06-30
     latest: "15"
     latestReleaseDate: 2015-12-24
-    link: 
+    link:
       https://web.archive.org/web/20160105095436/http://antix.mepis.org/index.php?title=Main_Page
 
 -   releaseCycle: "14"
     codename: "Symbiosis"
     releaseDate: 2014-03-25
-    support: 2016-06-04
+    eoas: 2016-06-04
     eol: 2018-05-31
     latest: "14.4"
     latestReleaseDate: 2015-03-24
-    link: 
+    link:
       https://web.archive.org/web/20150402080108/http://antix.mepis.org/index.php?title=Main_Page
 
 ---

--- a/products/mysql.md
+++ b/products/mysql.md
@@ -10,7 +10,7 @@ releaseImage:
   https://blogs.oracle.com/content/published/api/v1.1/assets/CONT32EABEA4FBCC4464BD35F58CEEA2EAFD/Medium?format=jpg&channelToken=32954b2a813146c9b9a4fa99364eba8e
 changelogTemplate: "https://dev.mysql.com/doc/relnotes/mysql/__RELEASE_CYCLE__/en/news-{{'__LATEST__'|replace:'.','-'}}.html"
 releaseDateColumn: true
-activeSupportColumn: Premier Support
+eoasColumn: Premier Support
 eolColumn: Extended Support
 
 # Regexes take into account the first GA release in each cycle.
@@ -41,21 +41,21 @@ identifiers:
 releases:
 -   releaseCycle: "8.3"
     releaseDate: 2023-12-14
-    support: true
+    eoas: false
     eol: false
     latest: '8.3.0'
     latestReleaseDate: 2023-12-14
 
 -   releaseCycle: "8.2"
     releaseDate: 2023-10-12
-    support: true
+    eoas: false
     eol: false
     latest: '8.2.0'
     latestReleaseDate: 2023-10-12
 
 -   releaseCycle: "8.1"
     releaseDate: 2023-06-21
-    support: 2023-10-25
+    eoas: 2023-10-25
     eol: 2023-10-25
     latest: '8.1.0'
     latestReleaseDate: 2023-06-21
@@ -63,28 +63,28 @@ releases:
 -   releaseCycle: "8.0"
     releaseDate: 2018-04-08
     lts: 2023-07-18
-    support: 2025-04-30
+    eoas: 2025-04-30
     eol: 2026-04-30
     latest: '8.0.36'
     latestReleaseDate: 2023-12-12
 
 -   releaseCycle: "5.7"
     releaseDate: 2015-10-09
-    support: 2020-10-31
+    eoas: 2020-10-31
     eol: 2023-10-31
     latest: '5.7.44'
     latestReleaseDate: 2023-09-20
 
 -   releaseCycle: "5.6"
     releaseDate: 2013-02-01
-    support: 2018-02-28
+    eoas: 2018-02-28
     eol: 2021-02-28
     latest: '5.6.51'
     latestReleaseDate: 2021-01-05
 
 -   releaseCycle: "5.5"
     releaseDate: 2010-12-03
-    support: 2015-12-31
+    eoas: 2015-12-31
     eol: 2018-12-31
     latest: '5.5.63'
     latestReleaseDate: 2018-12-21

--- a/products/netbsd.md
+++ b/products/netbsd.md
@@ -8,40 +8,40 @@ versionCommand: uname -r
 releasePolicyLink: https://www.netbsd.org/releases/
 changelogTemplate: https://www.netbsd.org/releases/formal-__RELEASE_CYCLE__/NetBSD-__LATEST__.html
 releaseDateColumn: true
-activeSupportColumn: true
+eoasColumn: true
 
 releases:
 -   releaseCycle: "9"
     releaseDate: 2022-02-14
-    support: true
+    eoas: false
     eol: false
     latest: "9.3"
     latestReleaseDate: 2022-08-04
 
 -   releaseCycle: "8"
     releaseDate: 2018-07-17
-    support: 2022-02-14
+    eoas: 2022-02-14
     eol: false
     latest: "8.2"
     latestReleaseDate: 2020-03-31
 
 -   releaseCycle: "7"
     releaseDate: 2015-09-25
-    support: 2018-07-17
+    eoas: 2018-07-17
     eol: 2020-06-30
     latest: "7.2"
     latestReleaseDate: 2018-08-29
 
 -   releaseCycle: "6"
     releaseDate: 2012-10-17
-    support: 2015-09-25
+    eoas: 2015-09-25
     eol: 2018-08-17
     latest: "6.1.5"
     latestReleaseDate: 2014-09-22
 
 -   releaseCycle: "5"
     releaseDate: 2009-04-29
-    support: 2012-10-17
+    eoas: 2012-10-17
     eol: 2015-10-25
     latest: "5.2.3"
     latestReleaseDate: 2014-11-15

--- a/products/nextjs.md
+++ b/products/nextjs.md
@@ -19,7 +19,7 @@ auto:
   methods:
   -   npm: next
 
-# EOL(x) = MAX(releaseDate(x+1), latestReleaseDate(x))
+# eol(x) = MAX(releaseDate(x+1), latestReleaseDate(x))
 releases:
 -   releaseCycle: "14"
     releaseDate: 2023-10-26
@@ -65,7 +65,7 @@ releases:
 > developer-friendly, with a focus on fast refresh and an optimized production build.
 
 Next.js follows [semantic versioning](https://semver.org/). Major versions are released on average twice per year,
-minor versions more frequently, and patch versions very frequently. Important security patches can be 
+minor versions more frequently, and patch versions very frequently. Important security patches can be
 backported to past major versions, but it's not clear which past versions are supported or not on https://nextjs.org/.
 
 Next.js has [two release channels](https://github.com/vercel/next.js/blob/canary/contributing/repository/release-channels-publishing.md):

--- a/products/nodejs.md
+++ b/products/nodejs.md
@@ -10,7 +10,7 @@ versionCommand: node --version
 releasePolicyLink: https://nodejs.org/en/about/previous-releases
 releaseImage: https://raw.githubusercontent.com/nodejs/Release/main/schedule.svg?sanitize=true
 changelogTemplate: https://github.com/nodejs/node/blob/main/doc/changelogs/CHANGELOG_V__RELEASE_CYCLE__.md#__LATEST__
-activeSupportColumn: true
+eoasColumn: true
 releaseDateColumn: true
 
 identifiers:
@@ -28,7 +28,7 @@ auto:
 releases:
 -   releaseCycle: "21"
     releaseDate: 2023-10-17
-    support: 2024-04-01
+    eoas: 2024-04-01
     eol: 2024-06-01
     latest: "21.7.1"
     latestReleaseDate: 2024-03-08
@@ -36,14 +36,14 @@ releases:
 -   releaseCycle: "20"
     releaseDate: 2023-04-18
     lts: 2023-10-24
-    support: 2024-10-22
+    eoas: 2024-10-22
     eol: 2026-04-30
     latest: "20.12.0"
     latestReleaseDate: 2024-03-26
 
 -   releaseCycle: "19"
     releaseDate: 2022-10-18
-    support: 2023-04-01
+    eoas: 2023-04-01
     eol: 2023-06-01
     latest: "19.9.0"
     latestReleaseDate: 2023-04-10
@@ -51,14 +51,14 @@ releases:
 -   releaseCycle: "18"
     releaseDate: 2022-04-19
     lts: 2022-10-25
-    support: 2023-10-18
+    eoas: 2023-10-18
     eol: 2025-04-30
     latest: "18.20.0"
     latestReleaseDate: 2024-03-26
 
 -   releaseCycle: "17"
     releaseDate: 2021-10-19
-    support: 2022-04-01
+    eoas: 2022-04-01
     eol: 2022-06-01
     latest: "17.9.1"
     latestReleaseDate: 2022-06-01
@@ -66,14 +66,14 @@ releases:
 -   releaseCycle: "16"
     releaseDate: 2021-04-20
     lts: 2021-10-26
-    support: 2022-10-18
+    eoas: 2022-10-18
     eol: 2023-09-11
     latest: "16.20.2"
     latestReleaseDate: 2023-08-09
 
 -   releaseCycle: "15"
     releaseDate: 2020-10-20
-    support: 2021-04-01
+    eoas: 2021-04-01
     eol: 2021-06-01
     latest: "15.14.0"
     latestReleaseDate: 2021-04-06
@@ -81,14 +81,14 @@ releases:
 -   releaseCycle: "14"
     releaseDate: 2020-04-21
     lts: 2020-10-27
-    support: 2021-10-19
+    eoas: 2021-10-19
     eol: 2023-04-30
     latest: "14.21.3"
     latestReleaseDate: 2023-02-16
 
 -   releaseCycle: "13"
     releaseDate: 2019-10-22
-    support: 2020-04-01
+    eoas: 2020-04-01
     eol: 2020-06-01
     latest: "13.14.0"
     latestReleaseDate: 2020-04-29
@@ -96,14 +96,14 @@ releases:
 -   releaseCycle: "12"
     releaseDate: 2019-04-23
     lts: 2019-10-21
-    support: 2020-10-20
+    eoas: 2020-10-20
     eol: 2022-04-30
     latest: "12.22.12"
     latestReleaseDate: 2022-04-05
 
 -   releaseCycle: "11"
     releaseDate: 2018-10-23
-    support: 2019-04-01
+    eoas: 2019-04-01
     eol: 2019-06-30
     latest: "11.15.0"
     latestReleaseDate: 2019-04-30
@@ -111,14 +111,14 @@ releases:
 -   releaseCycle: "10"
     releaseDate: 2018-04-24
     lts: 2018-10-30
-    support: 2020-05-19
+    eoas: 2020-05-19
     eol: 2021-04-30
     latest: "10.24.1"
     latestReleaseDate: 2021-04-06
 
 -   releaseCycle: "9"
     releaseDate: 2017-10-31
-    support: 2018-06-30
+    eoas: 2018-06-30
     eol: 2018-06-30
     latest: "9.11.2"
     latestReleaseDate: 2018-06-12
@@ -126,14 +126,14 @@ releases:
 -   releaseCycle: "8"
     releaseDate: 2017-05-30
     lts: 2017-10-31
-    support: 2019-01-01
+    eoas: 2019-01-01
     eol: 2019-12-31
     latest: "8.17.0"
     latestReleaseDate: 2019-12-17
 
 -   releaseCycle: "7"
     releaseDate: 2016-10-25
-    support: 2017-06-30
+    eoas: 2017-06-30
     eol: 2017-06-30
     latest: "7.10.1"
     latestReleaseDate: 2017-07-11
@@ -141,14 +141,14 @@ releases:
 -   releaseCycle: "6"
     releaseDate: 2016-04-26
     lts: 2016-10-18
-    support: 2018-04-30
+    eoas: 2018-04-30
     eol: 2019-04-30
     latest: "6.17.1"
     latestReleaseDate: 2019-04-03
 
 -   releaseCycle: "5"
     releaseDate: 2015-10-30
-    support: 2016-06-30
+    eoas: 2016-06-30
     eol: 2016-06-30
     latest: "5.12.0"
     latestReleaseDate: 2016-06-23
@@ -156,14 +156,14 @@ releases:
 -   releaseCycle: "4"
     releaseDate: 2015-09-09
     lts: 2015-10-01
-    support: 2017-04-01
+    eoas: 2017-04-01
     eol: 2018-04-30
     latest: "4.9.1"
     latestReleaseDate: 2018-03-29
 
 -   releaseCycle: "3"
     releaseDate: 2015-08-04
-    support: false
+    eoas: true
     eol: true
     link: https://github.com/nodejs/node/blob/main/doc/changelogs/CHANGELOG_IOJS.md#__LATEST__
     latest: "3.3.1"
@@ -171,7 +171,7 @@ releases:
 
 -   releaseCycle: "2"
     releaseDate: 2015-05-04
-    support: false
+    eoas: true
     eol: true
     link: https://github.com/nodejs/node/blob/main/doc/changelogs/CHANGELOG_IOJS.md#__LATEST__
     latest: "2.5.0"
@@ -179,7 +179,7 @@ releases:
 
 -   releaseCycle: "1"
     releaseDate: 2015-01-20
-    support: false
+    eoas: true
     eol: true
     link: https://github.com/nodejs/node/blob/main/doc/changelogs/CHANGELOG_IOJS.md#__LATEST__
     latest: "1.8.4"

--- a/products/nutanix-aos.md
+++ b/products/nutanix-aos.md
@@ -6,7 +6,7 @@ iconSlug: nutanix
 permalink: /nutanix-aos
 versionCommand: ncli cluster version
 releasePolicyLink: "https://www.nutanix.com/support-services/product-support/support-policies-and-faqs"
-activeSupportColumn: true
+eoasColumn: true
 releaseDateColumn: true
 
 auto:
@@ -17,21 +17,21 @@ auto:
 releases:
 -   releaseCycle: "6.7"
     releaseDate: 2023-08-28
-    support: true
+    eoas: false
     eol: false
     latest: "6.7.1.6"
     latestReleaseDate: 2024-02-20
 
 -   releaseCycle: "6.6"
     releaseDate: 2023-01-23
-    support: 2023-08-31
+    eoas: 2023-08-31
     eol: 2023-11-30
     latest: "6.6.2.8"
     latestReleaseDate: 2023-08-01
 
 -   releaseCycle: "6.5"
     releaseDate: 2022-07-25
-    support: true
+    eoas: false
     eol: false
     lts: true
     latest: "6.5.5.5"
@@ -39,21 +39,21 @@ releases:
 
 -   releaseCycle: "6.1"
     releaseDate: 2022-02-24
-    support: 2022-07-31
+    eoas: 2022-07-31
     eol: 2022-10-31
     latest: "6.1.1.5"
     latestReleaseDate: 2022-06-28
 
 -   releaseCycle: "6.0"
     releaseDate: 2021-06-14
-    support: 2022-02-28
+    eoas: 2022-02-28
     eol: 2022-05-31
     latest: "6.0.2.6"
     latestReleaseDate: 2022-04-19
 
 -   releaseCycle: "5.20"
     releaseDate: 2021-05-17
-    support: 2022-10-31
+    eoas: 2022-10-31
     eol: 2023-07-31
     lts: true
     latest: "5.20.5.1"
@@ -61,35 +61,35 @@ releases:
 
 -   releaseCycle: "5.19"
     releaseDate: 2020-12-16
-    support: 2021-05-31
+    eoas: 2021-05-31
     eol: 2021-08-31
     latest: "5.19.2"
     latestReleaseDate: 2021-04-27
 
 -   releaseCycle: "5.18"
     releaseDate: 2020-08-25
-    support: 2020-12-31
+    eoas: 2020-12-31
     eol: 2021-03-31
     latest: "5.18.1.2"
     latestReleaseDate: 2020-11-23
 
 -   releaseCycle: "5.17"
     releaseDate: 2020-05-01
-    support: 2020-08-31
+    eoas: 2020-08-31
     eol: 2020-11-30
     latest: "5.17.1.5"
     latestReleaseDate: 2020-08-10
 
 -   releaseCycle: "5.16"
     releaseDate: 2020-01-06
-    support: 2020-05-31
+    eoas: 2020-05-31
     eol: 2020-08-31
     latest: "5.16.1.3"
     latestReleaseDate: 2020-05-18
 
 -   releaseCycle: "5.15"
     releaseDate: 2020-03-31
-    support: 2021-08-31
+    eoas: 2021-08-31
     eol: 2022-05-31
     lts: true
     latest: "5.15.7"
@@ -97,14 +97,14 @@ releases:
 
 -   releaseCycle: "5.11"
     releaseDate: 2019-08-05
-    support: 2020-01-31
+    eoas: 2020-01-31
     eol: 2020-04-30
     latest: "5.11.2.3"
     latestReleaseDate: 2020-02-06
 
 -   releaseCycle: "5.10"
     releaseDate: 2018-11-26
-    support: 2020-06-30
+    eoas: 2020-06-30
     eol: 2021-04-30
     lts: true
     latest: "5.10.11.1"
@@ -112,28 +112,28 @@ releases:
 
 -   releaseCycle: "5.9"
     releaseDate: 2018-10-04
-    support: 2019-01-31
+    eoas: 2019-01-31
     eol: 2019-04-30
     latest: "5.9.2.4"
     latestReleaseDate: 2019-02-06
 
 -   releaseCycle: "5.8"
     releaseDate: 2018-07-03
-    support: 2018-10-31
+    eoas: 2018-10-31
     eol: 2019-01-31
     latest: "5.8.2"
     latestReleaseDate: 2018-09-05
 
 -   releaseCycle: "5.6"
     releaseDate: 2018-04-16
-    support: 2018-07-31
+    eoas: 2018-07-31
     eol: 2018-10-31
     latest: "5.6.2"
     latestReleaseDate: 2018-07-18
 
 -   releaseCycle: "5.5"
     releaseDate: 2017-12-06
-    support: 2019-10-31
+    eoas: 2019-10-31
     eol: 2020-09-30
     lts: true
     latest: "5.5.9.5"

--- a/products/nutanix-files.md
+++ b/products/nutanix-files.md
@@ -5,7 +5,7 @@ tags: nutanix
 iconSlug: nutanix
 permalink: /nutanix-files
 releasePolicyLink: "https://www.nutanix.com/support-services/product-support/support-policies-and-faqs"
-activeSupportColumn: true
+eoasColumn: true
 releaseDateColumn: true
 
 auto:
@@ -16,63 +16,63 @@ auto:
 releases:
 -   releaseCycle: "4.4"
     releaseDate: 2023-09-13
-    support: true
+    eoas: false
     eol: false
     latest: "4.4.0.3"
 
     latestReleaseDate: 2024-03-26
 -   releaseCycle: "4.3"
     releaseDate: 2023-04-24
-    support: 2023-12-31
+    eoas: 2023-12-31
     eol: 2024-09-30
     latest: "4.3.0.1"
 
     latestReleaseDate: 2023-07-18
 -   releaseCycle: "4.2"
     releaseDate: 2022-09-28
-    support: 2023-07-31
+    eoas: 2023-07-31
     eol: 2024-04-30
     latest: "4.2.1.1"
 
     latestReleaseDate: 2023-03-16
 -   releaseCycle: "4.1"
     releaseDate: 2022-04-13
-    support: 2022-12-31
+    eoas: 2022-12-31
     eol: 2023-09-30
     latest: "4.1.0.3"
     latestReleaseDate: 2022-08-29
 
 -   releaseCycle: "4.0"
     releaseDate: 2021-10-04
-    support: 2022-07-31
+    eoas: 2022-07-31
     eol: 2023-04-30
     latest: "4.0.4"
     latestReleaseDate: 2022-04-27
 
 -   releaseCycle: "3.8"
     releaseDate: 2021-01-25
-    support: 2022-01-31
+    eoas: 2022-01-31
     eol: 2022-10-31
     latest: "3.8.1.3"
     latestReleaseDate: 2021-10-11
 
 -   releaseCycle: "3.7"
     releaseDate: 2020-07-22
-    support: 2021-04-30
+    eoas: 2021-04-30
     eol: 2022-01-31
     latest: "3.7.3.1"
     latestReleaseDate: 2021-04-21
 
 -   releaseCycle: "3.6"
     releaseDate: 2019-10-17
-    support: 2020-10-31
+    eoas: 2020-10-31
     eol: 2021-07-31
     latest: "3.6.5"
     latestReleaseDate: 2020-07-08
 
 -   releaseCycle: "3.5"
     releaseDate: 2019-12-15 # https://next.nutanix.com/community-blog-154/nutanix-files-3-5-31952
-    support: 2020-01-31
+    eoas: 2020-01-31
     eol: 2020-10-31
     latest: "3.5.6"
     latestReleaseDate: 2019-12-15

--- a/products/nutanix-prism.md
+++ b/products/nutanix-prism.md
@@ -10,7 +10,7 @@ alternate_urls:
 -   /prismcentral
 versionCommand: ncli cluster version
 releasePolicyLink: "https://www.nutanix.com/support-services/product-support/support-policies-and-faqs"
-activeSupportColumn: true
+eoasColumn: true
 releaseDateColumn: true
 
 auto:
@@ -21,147 +21,147 @@ auto:
 releases:
 -   releaseCycle: "pc.2023.4"
     releaseDate: 2023-08-28
-    support: true
+    eoas: false
     eol: false
     latest: "pc.2023.4"
 
     latestReleaseDate: 2023-12-20
 -   releaseCycle: "pc.2023.3"
     releaseDate: 2023-08-28
-    support: true
+    eoas: false
     eol: false
     latest: "pc.2023.3.0.1"
     latestReleaseDate: 2023-11-28
 
 -   releaseCycle: "pc.2023.1"
     releaseDate: 2023-03-15
-    support: 2023-10-31
+    eoas: 2023-10-31
     eol: 2024-01-31
     latest: "pc.2023.1.0.2"
     latestReleaseDate: 2023-07-17
 
 -   releaseCycle: "pc.2022.9"
     releaseDate: 2023-01-23
-    support: 2023-06-30
+    eoas: 2023-06-30
     eol: 2023-09-30
     latest: "pc.2022.9"
     latestReleaseDate: 2023-01-23
 
 -   releaseCycle: "pc.2022.6"
     releaseDate: 2022-08-03
-    support: 2024-01-31
+    eoas: 2024-01-31
     eol: 2024-07-31
     latest: "pc.2022.6.0.10"
     latestReleaseDate: 2024-01-15
 
 -   releaseCycle: "pc.2022.4"
     releaseDate: 2022-05-16
-    support: 2022-10-31
+    eoas: 2022-10-31
     eol: 2023-01-31
     latest: "pc.2022.4.0.2"
     latestReleaseDate: 2022-07-25
 
 -   releaseCycle: "pc.2022.1"
     releaseDate: 2022-02-24
-    support: 2022-07-31
+    eoas: 2022-07-31
     eol: 2022-10-31
     latest: "pc.2022.1.0.2"
     latestReleaseDate: 2022-03-21
 
 -   releaseCycle: "pc.2021.9"
     releaseDate: 2021-10-06
-    support: 2022-04-30
+    eoas: 2022-04-30
     eol: 2022-10-31
     latest: "pc.2021.9.0.6"
     latestReleaseDate: 2022-07-29
 
 -   releaseCycle: "pc.2021.8"
     releaseDate: 2021-08-31
-    support: 2021-12-31
+    eoas: 2021-12-31
     eol: 2022-03-31
     latest: "pc.2021.8.0.1"
     latestReleaseDate: 2021-09-14
 
 -   releaseCycle: "pc.2021.7"
     releaseDate: 2021-08-04
-    support: 2021-11-30
+    eoas: 2021-11-30
     eol: 2022-02-28
     latest: "pc.2021.7"
     latestReleaseDate: 2021-08-04
 
 -   releaseCycle: "pc.2021.5"
     releaseDate: 2021-06-14
-    support: 2021-10-31
+    eoas: 2021-10-31
     eol: 2022-01-31
     latest: "pc.2021.5.0.1"
     latestReleaseDate: 2021-07-01
 
 -   releaseCycle: "pc.2021.3"
     releaseDate: 2021-04-13
-    support: 2021-08-31
+    eoas: 2021-08-31
     eol: 2021-11-30
     latest: "pc.2021.3.0.2"
     latestReleaseDate: 2021-05-19
 
 -   releaseCycle: "pc.2021.1"
     releaseDate: 2021-02-04
-    support: 2021-06-30
+    eoas: 2021-06-30
     eol: 2021-09-30
     latest: "pc.2021.1.0.1"
     latestReleaseDate: 2021-02-22
 
 -   releaseCycle: "pc.2020.11"
     releaseDate: 2020-12-16
-    support: 2021-04-30
+    eoas: 2021-04-30
     eol: 2021-07-31
     latest: "pc.2020.11.0.1"
     latestReleaseDate: 2020-12-31
 
 -   releaseCycle: "pc.2020.9"
     releaseDate: 2020-10-01
-    support: 2021-02-28
+    eoas: 2021-02-28
     eol: 2021-05-31
     latest: "pc.2020.9.0.1"
     latestReleaseDate: 2020-10-19
 
 -   releaseCycle: "pc.2020.8"
     releaseDate: 2020-08-25
-    support: 2020-12-31
+    eoas: 2020-12-31
     eol: 2021-03-31
     latest: "pc.2020.8.0.1"
     latestReleaseDate: 2020-09-09
 
 -   releaseCycle: "pc.2020.7"
     releaseDate: 2020-07-27
-    support: 2020-10-31
+    eoas: 2020-10-31
     eol: 2021-01-31
     latest: "pc.2020.7"
     latestReleaseDate: 2020-07-27
 
 -   releaseCycle: "5.17"
     releaseDate: 2020-05-31
-    support: 2020-08-31
+    eoas: 2020-08-31
     eol: 2020-11-30
     latest: "5.17.1.1"
     latestReleaseDate: 2020-05-31
 
 -   releaseCycle: "5.16"
     releaseDate: 2020-01-31
-    support: 2020-05-31
+    eoas: 2020-05-31
     eol: 2020-08-31
     latest: "5.16.2"
     latestReleaseDate: 2020-01-31
 
 -   releaseCycle: "5.11"
     releaseDate: 2019-08-31
-    support: 2020-01-31
+    eoas: 2020-01-31
     eol: 2020-04-30
     latest: "5.11.3"
     latestReleaseDate: 2019-08-31
 
 -   releaseCycle: "5.10"
     releaseDate: 2018-11-30
-    support: 2019-08-31
+    eoas: 2019-08-31
     eol: 2019-11-30
     latest: "5.10.6"
     latestReleaseDate: 2018-11-30

--- a/products/nuxt.md
+++ b/products/nuxt.md
@@ -6,7 +6,7 @@ permalink: /nuxt
 versionCommand: npm list nuxt
 releasePolicyLink: https://nuxt.com/docs/community/roadmap
 changelogTemplate: https://github.com/nuxt/nuxt/releases/tag/v__LATEST__
-activeSupportColumn: true
+eoasColumn: true
 releaseDateColumn: true
 
 auto:
@@ -24,14 +24,14 @@ auto:
 releases:
 -   releaseCycle: "3"
     releaseDate: 2022-11-16
-    support: true
+    eoas: false
     eol: false
     latest: "3.11.1"
     latestReleaseDate: 2024-03-18
 
 -   releaseCycle: "2"
     releaseDate: 2018-09-21
-    support: 2022-11-16
+    eoas: 2022-11-16
     eol: 2024-06-30
     latest: "2.17.3"
     latestReleaseDate: 2024-01-12

--- a/products/nvidiadriver.md
+++ b/products/nvidiadriver.md
@@ -8,10 +8,10 @@ versionCommand: nvidia-smi
 releaseImage: https://docs.nvidia.com/datacenter/tesla/drivers/graphics/driver-branches-overview.png
 releasePolicyLink: https://www.nvidia.com/Download/index.aspx
 LTSLabel: "<abbr title='Long Term Support Branch'>LTSB</abbr>"
-activeSupportColumn: true
+eoasColumn: true
 releaseDateColumn: true
 
-# support(x) is:
+# eoas(x) is:
 # - false for NFB releases
 # - releaseDate(x) + 1 year for PB and LTS releases
 #
@@ -22,7 +22,7 @@ releases:
 -   releaseCycle: "R535-Linux"
     lts: true
     releaseDate: 2023-06-14
-    support: 2024-06-01
+    eoas: 2024-06-01
     eol: 2026-06-01
     latest: "535.54.03"
     latestReleaseDate: 2023-06-26
@@ -31,7 +31,7 @@ releases:
 -   releaseCycle: "R535-Windows"
     lts: true
     releaseDate: 2023-05-30
-    support: 2024-06-01
+    eoas: 2024-06-01
     eol: 2026-06-01
     latest: "536.25"
     latestReleaseDate: 2023-06-26
@@ -39,7 +39,7 @@ releases:
 
 -   releaseCycle: "R530-Linux (NFB)"
     releaseDate: 2023-03-23
-    support: false
+    eoas: true
     eol: 2023-06-24
     latest: "530.41.03"
     latestReleaseDate: 2023-03-23
@@ -47,7 +47,7 @@ releases:
 
 -   releaseCycle: "R530-Windows (NFB)"
     releaseDate: 2023-02-28
-    support: false
+    eoas: true
     eol: 2023-06-24
     latest: "531.79"
     latestReleaseDate: 2023-05-02
@@ -55,7 +55,7 @@ releases:
 
 -   releaseCycle: "R525-Windows (PB)"
     releaseDate: 2022-11-10
-    support: 2023-12-01
+    eoas: 2023-12-01
     eol: 2023-12-01
     latest: "529.11"
     latestReleaseDate: 2023-06-26
@@ -63,7 +63,7 @@ releases:
 
 -   releaseCycle: "R525-Linux (PB)"
     releaseDate: 2022-11-10
-    support: 2023-12-01
+    eoas: 2023-12-01
     eol: 2023-12-01
     latest: "525.125.06"
     latestReleaseDate: 2023-06-26
@@ -71,7 +71,7 @@ releases:
 
 -   releaseCycle: "R515-Windows (PB)"
     releaseDate: 2022-05-11
-    support: 2023-05-01
+    eoas: 2023-05-01
     eol: 2023-05-01
     latest: "518.03"
     latestReleaseDate: 2023-03-30
@@ -79,7 +79,7 @@ releases:
 
 -   releaseCycle: "R515-Linux (PB)"
     releaseDate: 2022-05-11
-    support: 2023-05-01
+    eoas: 2023-05-01
     eol: 2023-05-01
     latest: "515.105.01"
     latestReleaseDate: 2023-03-30
@@ -87,7 +87,7 @@ releases:
 
 -   releaseCycle: "R510-Windows (PB)"
     releaseDate: 2022-01-14
-    support: 2023-01-01
+    eoas: 2023-01-01
     eol: 2023-01-01
     latest: "513.91"
     latestReleaseDate: 2022-11-22
@@ -95,7 +95,7 @@ releases:
 
 -   releaseCycle: "R510-Linux (PB)"
     releaseDate: 2022-01-14
-    support: 2023-01-01
+    eoas: 2023-01-01
     eol: 2023-01-01
     latest: "510.108.03"
     latestReleaseDate: 2022-11-22
@@ -103,7 +103,7 @@ releases:
 
 -   releaseCycle: "R495-Linux (NFB)"
     releaseDate: 2021-10-26
-    support: false
+    eoas: true
     eol: 2022-10-12
     latest: "495.46"
     latestReleaseDate: 2021-12-13
@@ -111,7 +111,7 @@ releases:
 
 -   releaseCycle: "R495-Windows (NFB)"
     releaseDate: 2021-10-12
-    support: false
+    eoas: true
     eol: 2022-01-14
     latest: "497.29"
     latestReleaseDate: 2021-12-20
@@ -120,7 +120,7 @@ releases:
 -   releaseCycle: "R470-Linux"
     lts: true
     releaseDate: 2021-07-19
-    support: 2021-10-26
+    eoas: 2021-10-26
     eol: 2024-07-20
     latest: "470.199.02"
     latestReleaseDate: 2023-06-23
@@ -129,7 +129,7 @@ releases:
 -   releaseCycle: "R470-Windows"
     lts: true
     releaseDate: 2021-06-22
-    support: 2021-09-20
+    eoas: 2021-09-20
     eol: 2024-07-01
     latest: "474.44"
     latestReleaseDate: 2023-06-23
@@ -137,7 +137,7 @@ releases:
 
 -   releaseCycle: "R460-Linux (PB)"
     releaseDate: 2021-01-07
-    support: 2021-07-19
+    eoas: 2021-07-19
     eol: 2022-01-01
     latest: "460.91.03"
     latestReleaseDate: 2021-07-20
@@ -145,7 +145,7 @@ releases:
 
 -   releaseCycle: "R460-Windows (PB)"
     releaseDate: 2020-12-15
-    support: 2021-06-23
+    eoas: 2021-06-23
     eol: 2022-01-01
     latest: "462.96"
     latestReleaseDate: 2021-07-20
@@ -154,7 +154,7 @@ releases:
 -   releaseCycle: "R450-Windows"
     lts: true
     releaseDate: 2020-06-24
-    support: 2020-12-15
+    eoas: 2020-12-15
     eol: 2023-07-01
     latest: "453.94"
     latestReleaseDate: 2022-11-22
@@ -163,7 +163,7 @@ releases:
 -   releaseCycle: "R450-Linux"
     lts: true
     releaseDate: 2020-06-24
-    support: 2020-10-07
+    eoas: 2020-10-07
     eol: 2023-07-01
     latest: "450.216.04"
     latestReleaseDate: 2022-11-22
@@ -172,7 +172,7 @@ releases:
 -   releaseCycle: "R418-Windows"
     lts: true
     releaseDate: 2019-02-04
-    support: 2019-04-23
+    eoas: 2019-04-23
     eol: 2022-03-01
     latest: "427.45"
     latestReleaseDate: 2021-04-20
@@ -181,7 +181,7 @@ releases:
 -   releaseCycle: "R418-Linux"
     lts: true
     releaseDate: 2019-01-30
-    support: 2019-03-20
+    eoas: 2019-03-20
     eol: 2022-03-01
     latest: "418.197.02"
     latestReleaseDate: 2021-04-19
@@ -190,7 +190,7 @@ releases:
 -   releaseCycle: "R390-Windows"
     lts: true
     releaseDate: 2018-01-08
-    support: 2018-07-31
+    eoas: 2018-07-31
     eol: 2021-10-26
     latest: "392.68"
     latestReleaseDate: 2021-10-26
@@ -199,7 +199,7 @@ releases:
 -   releaseCycle: "R390-Linux"
     lts: true
     releaseDate: 2018-01-04
-    support: 2018-03-10
+    eoas: 2018-03-10
     eol: 2022-11-22
     latest: "390.157"
     latestReleaseDate: 2022-11-22

--- a/products/nvidiaproducts.md
+++ b/products/nvidiaproducts.md
@@ -11,192 +11,192 @@ releasePolicyLink: https://www.nvidia.com/en-us/geforce/graphics-cards/
 releaseDateColumn: true
 releaseColumn: false
 discontinuedColumn: true
-activeSupportColumn: true
+eoasColumn: true
 
 releases:
 -   releaseCycle: "Professional Ada Lovelace (AD1xx)"
     releaseDate: 2022-10-13
-    support: true
+    eoas: false
     eol: false
     discontinued: false
 
 -   releaseCycle: "Consumer Ada Lovelace (AD1xx)"
     releaseDate: 2022-09-20
-    support: true
+    eoas: false
     eol: false
     discontinued: false
 
 -   releaseCycle: "Mobile Professional Ampere (GA10x)"
     releaseDate: 2021-04-12
-    support: true
+    eoas: false
     eol: false
     discontinued: false
 
 -   releaseCycle: "Mobile Consumer Ampere (GA10x)"
     releaseDate: 2021-01-12
-    support: true
+    eoas: false
     eol: false
     discontinued: false
 
 -   releaseCycle: "Professional Ampere (GA10x)"
     releaseDate: 2020-10-05
-    support: true
+    eoas: false
     eol: false
     discontinued: false
 
 -   releaseCycle: "Consumer Ampere (GA10x)"
     releaseDate: 2020-09-01
-    support: true
+    eoas: false
     eol: false
     discontinued: false
 
 -   releaseCycle: "Mobile Professional Turing (TU1xX)"
     releaseDate: 2019-05-27
-    support: true
+    eoas: false
     eol: false
     discontinued: false
 
 -   releaseCycle: "Mobile Consumer Turing (TU1xX)"
     releaseDate: 2019-01-29
-    support: true
+    eoas: false
     eol: false
     discontinued: false
 
 -   releaseCycle: "Consumer Turing (TU1xX)"
     releaseDate: 2018-09-20
-    support: true
+    eoas: false
     eol: false
     discontinued: false
 
 -   releaseCycle: "Professional Turing (TU1xX)"
     releaseDate: 2018-08-13
-    support: true
+    eoas: false
     eol: false
     discontinued: false
 
 -   releaseCycle: "Professional Volta (GV100)"
     releaseDate: 2017-12-07
-    support: true
+    eoas: false
     eol: false
     discontinued: true
 
 -   releaseCycle: "Mobile Professional Pascal (GP10x)"
     releaseDate: 2017-02-06
-    support: true
+    eoas: false
     eol: false
     discontinued: true
 
 -   releaseCycle: "Mobile Consumer Pascal (GP10x)"
-    support: true
+    eoas: false
     eol: false
     discontinued: true
     releaseDate: 2016-08-15
 
 -   releaseCycle: "Consumer Pascal (GP10x)"
     releaseDate: 2016-05-27
-    support: true
+    eoas: false
     eol: false
     discontinued: true
 
 -   releaseCycle: "Professional Pascal (GP10x)"
     releaseDate: 2016-04-05
-    support: true
+    eoas: false
     eol: false
     discontinued: true
 
 -   releaseCycle: "Mobile Professional Maxwell (GMxxx)"
     releaseDate: 2015-08-18
-    support: true
+    eoas: false
     eol: false
     discontinued: true
 
 -   releaseCycle: "Professional Maxwell (GMxxx)"
     releaseDate: 2015-06-29
-    support: true
+    eoas: false
     eol: false
     discontinued: true
 
 -   releaseCycle: "Mobile Consumer Maxwell (GMxxx)"
     releaseDate: 2014-10-07
-    support: true
+    eoas: false
     eol: false
     discontinued: true
 
 -   releaseCycle: "Consumer Maxwell (GMxxx)"
     releaseDate: 2014-09-19
-    support: true
+    eoas: false
     eol: false
     discontinued: true
 
 -   releaseCycle: "Professional Kepler (GKxxx)"
     releaseDate: 2013-03-01
-    support: 2021-09-20
+    eoas: 2021-09-20
     eol: 2024-09-01
     discontinued: true
 
 -   releaseCycle: "Consumer Kepler (GKxxx)"
     releaseDate: 2012-03-22
-    support: 2021-09-20
+    eoas: 2021-09-20
     eol: 2024-09-01
     discontinued: true
 
 -   releaseCycle: "Mobile Professional Kepler (GKxxx)"
     releaseDate: 2012-03-22
-    support: 2019-04-23
+    eoas: 2019-04-23
     eol: 2022-03-01
     discontinued: true
 
 -   releaseCycle: "Mobile Consumer Kepler (GKxxx)"
     releaseDate: 2012-03-22
-    support: 2019-03-11
+    eoas: 2019-03-11
     eol: 2019-04-11
     discontinued: true
 
 -   releaseCycle: "Professional Fermi (GF1xx)**"
     releaseDate: 2010-07-23
-    support: 2018-07-31
+    eoas: 2018-07-31
     eol: 2022-12-31
     discontinued: true
 
 -   releaseCycle: "Consumer Fermi (GF1xx)*"
     releaseDate: 2010-03-26
-    support: 2018-03-10
+    eoas: 2018-03-10
     eol: 2018-03-10
     discontinued: true
 
 -   releaseCycle: "Consumer Tesla (Cxx, G8x, G9x, GT2xx, ION)"
     releaseDate: 2006-11-08
-    support: 2016-04-01
+    eoas: 2016-04-01
     eol: 2016-12-14
     discontinued: true
 
 -   releaseCycle: "Consumer Curie (NV4x, G7x)"
     releaseDate: 2004-04-14
-    support: 2013-02-25
+    eoas: 2013-02-25
     eol: 2015-02-24
     discontinued: true
 
 -   releaseCycle: "Consumer Rankine (NV3x)"
     releaseDate: 2003-01-27
-    support: 2008-06-23 # Verify support date.
+    eoas: 2008-06-23 # Verify support date.
     eol: 2008-06-23
     discontinued: true
 
 -   releaseCycle: "Consumer Kelvin (NV1x, NV2x)"
     releaseDate: 2001-02-27
-    support: 2006-11-02 # Verify support date.
+    eoas: 2006-11-02 # Verify support date.
     eol: 2006-11-02
     discontinued: true
 
 -   releaseCycle: "Consumer Celsius (NV1x)"
     releaseDate: 1999-10-11
-    support: 2005-04-14 # Verify support date.
+    eoas: 2005-04-14 # Verify support date.
     eol: 2005-04-14
     discontinued: true
 
 -   releaseCycle: "Consumer Fahrenheit (NVx)"
     releaseDate: 1998-06-15
-    support: 2005-03-11 # Verify support date.
+    eoas: 2005-03-11 # Verify support date.
     eol: 2005-03-11
     discontinued: true
 

--- a/products/office.md
+++ b/products/office.md
@@ -8,65 +8,65 @@ alternate_urls:
 releasePolicyLink: https://learn.microsoft.com/lifecycle/products/?terms=Office
 releaseColumn: false
 releaseDateColumn: true
-activeSupportColumn: true
+eoasColumn: true
 
 releases:
 -   releaseCycle: "365"
     releaseDate: 2015-09-22
-    support: true
+    eoas: false
     eol: false
     link: https://learn.microsoft.com/lifecycle/faq/office
 
 -   releaseCycle: "2021"
     releaseDate: 2021-10-05
-    support: 2026-10-13
+    eoas: 2026-10-13
     eol: 2026-10-13
     link: https://learn.microsoft.com/lifecycle/products/office-2021
 
 -   releaseCycle: "2019"
     releaseDate: 2018-09-24
-    support: 2023-10-10
+    eoas: 2023-10-10
     eol: 2025-10-14
     link: https://learn.microsoft.com/lifecycle/products/microsoft-office-2019
 
 -   releaseCycle: "2016"
     releaseDate: 2015-09-22
-    support: 2020-10-13
+    eoas: 2020-10-13
     eol: 2025-10-14
     link: https://learn.microsoft.com/lifecycle/products/microsoft-office-2016
 
 -   releaseCycle: "2013"
     releaseLabel: "2013 SP1"
     releaseDate: 2014-02-25
-    support: 2018-04-10
+    eoas: 2018-04-10
     eol: 2023-04-11
     link: https://learn.microsoft.com/lifecycle/products/microsoft-office-2013
 
 -   releaseCycle: "2011-for-mac"
     releaseLabel: "2011 for Mac SP3"
     releaseDate: 2013-01-29
-    support: 2017-10-10
+    eoas: 2017-10-10
     eol: 2017-10-10
     link: https://learn.microsoft.com/lifecycle/products/microsoft-office-for-mac-2011
 
 -   releaseCycle: "2010"
     releaseLabel: "2010 SP2"
     releaseDate: 2013-07-23
-    support: 2015-10-13
+    eoas: 2015-10-13
     eol: 2020-10-13
     link: https://learn.microsoft.com/lifecycle/products/microsoft-office-2010
 
 -   releaseCycle: "2008-for-mac"
     releaseLabel: "2008 for Mac SP2"
     releaseDate: 2009-10-18
-    support: 2013-04-09
+    eoas: 2013-04-09
     eol: 2013-04-09
     link: https://learn.microsoft.com/lifecycle/products/microsoft-office-2008-for-mac
 
 -   releaseCycle: "2007"
     releaseLabel: "2007 SP3"
     releaseDate: 2011-10-25
-    support: 2012-10-09
+    eoas: 2012-10-09
     eol: 2017-10-10
     link: https://learn.microsoft.com/lifecycle/products/microsoft-office-2007
 

--- a/products/opensearch.md
+++ b/products/opensearch.md
@@ -7,7 +7,7 @@ permalink: /opensearch
 releasePolicyLink: https://www.opensearch.org/releases.html
 changelogTemplate: "https://github.com/opensearch-project/opensearch-build/blob/main/release-notes/opensearch-release-notes-__LATEST__.md"
 releaseDateColumn: true
-activeSupportColumn: Active Development
+eoasColumn: Active Development
 eolColumn: Maintenance Support
 
 auto:
@@ -18,20 +18,20 @@ auto:
       fields:
         releaseCycle: "Major Version"
         releaseDate: "Initial Release"
-        support: "Maintenance Window Start"
+        eoas: "Maintenance Window Start"
         eol: "Maintenance Window End"
 
 releases:
 -   releaseCycle: "2"
     releaseDate: 2022-05-18
-    support: true
+    eoas: false
     eol: false
     latest: "2.12.0"
     latestReleaseDate: 2024-02-19
 
 -   releaseCycle: "1"
     releaseDate: 2021-07-02
-    support: 2022-05-26
+    eoas: 2022-05-26
     eol: false # upcoming support(2) at least 1 year
     latest: "1.3.15"
     latestReleaseDate: 2024-03-01

--- a/products/openssl.md
+++ b/products/openssl.md
@@ -8,7 +8,7 @@ releasePolicyLink: https://www.openssl.org/policies/releasestrat.html
 changelogTemplate: "https://www.openssl.org/news/cl{{'__RELEASE_CYCLE__'|replace:'.',''}}.txt"
 releaseDateColumn: true
 eolColumn: Supported
-extendedSupportColumn: Premium support
+eoesColumn: Premium support
 
 auto:
   methods:
@@ -20,14 +20,12 @@ releases:
 -   releaseCycle: "3.2"
     releaseDate: 2023-11-23
     eol: 2025-11-23
-    extendedSupport: false
     latest: "3.2.1"
     latestReleaseDate: 2024-01-30
 
 -   releaseCycle: "3.1"
     releaseDate: 2023-03-14
     eol: 2025-03-14
-    extendedSupport: false
     latest: "3.1.5"
     latestReleaseDate: 2024-01-30
 
@@ -35,7 +33,7 @@ releases:
     lts: true
     releaseDate: 2021-09-07
     eol: 2026-09-07
-    extendedSupport: true
+    eoes: false
     latest: "3.0.13"
     latestReleaseDate: 2024-01-30
 
@@ -43,7 +41,7 @@ releases:
     lts: true
     releaseDate: 2018-09-11
     eol: 2023-09-11
-    extendedSupport: true
+    eoes: false
     latest: "1.1.1w"
     latestReleaseDate: 2023-09-12
     link: https://www.openssl.org/news/changelog.txt
@@ -51,7 +49,6 @@ releases:
 -   releaseCycle: "1.1.0"
     releaseDate: 2016-08-25
     eol: 2019-09-11
-    extendedSupport: false
     latest: "1.1.0l"
     latestReleaseDate: 2019-09-10
     link: https://www.openssl.org/news/changelog.txt
@@ -60,7 +57,7 @@ releases:
     lts: true
     releaseDate: 2015-01-22
     eol: 2019-12-31
-    extendedSupport: true
+    eoes: false
     latest: "1.0.2u"
     latestReleaseDate: 2019-12-20
     link: https://www.openssl.org/news/changelog.txt

--- a/products/opentofu.md
+++ b/products/opentofu.md
@@ -15,7 +15,7 @@ auto:
   methods:
   -   git: https://github.com/opentofu/opentofu.git
 
-# EOL(x) = releaseDate(x+2)
+# eol(x) = releaseDate(x+2)
 releases:
 -   releaseCycle: "1.6"
     releaseDate: 2024-01-09

--- a/products/openwrt.md
+++ b/products/openwrt.md
@@ -10,7 +10,7 @@ versionCommand: cat /etc/os-release
 releasePolicyLink: https://openwrt.org/docs/guide-developer/security#support_status
 changelogTemplate: "https://openwrt.org/releases/{{'__LATEST__'|split:'.'|pop|join:'.'}}/start"
 releaseDateColumn: true
-activeSupportColumn: true
+eoasColumn: true
 
 auto:
   methods:
@@ -21,42 +21,42 @@ auto:
 releases:
 -   releaseCycle: "23.05"
     releaseDate: 2023-10-11
-    support: true
+    eoas: false
     eol: false
     latest: "23.05.3"
     latestReleaseDate: 2024-03-22
 
 -   releaseCycle: "22.03"
     releaseDate: 2022-09-03
-    support: 2023-10-11
+    eoas: 2023-10-11
     eol: 2024-04-11
     latest: "22.03.6"
     latestReleaseDate: 2023-12-03
 
 -   releaseCycle: "21.02"
     eol: 2023-04-30
-    support: 2022-09-03
+    eoas: 2022-09-03
     releaseDate: 2021-09-01
     latestReleaseDate: 2023-04-27
     latest: "21.02.7"
 
 -   releaseCycle: "19.07"
     eol: 2022-04-30
-    support: 2021-09-01
+    eoas: 2021-09-01
     releaseDate: 2020-01-06
     latestReleaseDate: 2022-04-17
     latest: "19.07.10"
 
 -   releaseCycle: "18.06"
     eol: 2021-07-01
-    support: 2020-01-06
+    eoas: 2020-01-06
     releaseDate: 2018-07-30
     latestReleaseDate: 2020-11-17
     latest: "18.06.9"
 
 -   releaseCycle: "17.01"
     eol: 2019-02-01
-    support: 2018-07-30
+    eoas: 2018-07-30
     releaseDate: 2017-02-20
     latestReleaseDate: 2019-06-21
     latest: "17.01.7"

--- a/products/oracle-database.md
+++ b/products/oracle-database.md
@@ -10,7 +10,7 @@ LTSLabel: <abbr title="Long Term Release">LTR</abbr>
 releaseColumn: false
 releaseDateColumn: true
 eolColumn: Premier Support
-extendedSupportColumn: Extended Support
+eoesColumn: Extended Support
 
 auto:
   methods:
@@ -31,14 +31,13 @@ releases:
     releaseDate: 2023-09-19
     lts: true
     eol: 2032-04-30
-    extendedSupport: yes
+    eoes: false
     link: https://docs.oracle.com/en/database/oracle/oracle-database/23/whats-new.html
 
 -   releaseCycle: "21"
     releaseLabel: "21c"
     releaseDate: 2021-08-13
     eol: 2025-04-30
-    extendedSupport: false
     link: https://docs.oracle.com/en/database/oracle/oracle-database/21/whats-new.html
 
 -   releaseCycle: "19"
@@ -47,21 +46,19 @@ releases:
     lts: true
     eol: 2026-04-30
     # The first year of extended support is free.
-    extendedSupport: 2027-04-30
+    eoes: 2027-04-30
     link: https://docs.oracle.com/en/database/oracle/oracle-database/19/whats-new.html
 
 -   releaseCycle: "18"
     releaseLabel: "18c"
     releaseDate: 2018-07-23
     eol: 2021-06-30
-    extendedSupport: false
     link: https://docs.oracle.com/en/database/oracle/oracle-database/18/whats-new.html
 
 -   releaseCycle: "12.2"
     releaseLabel: "12c Release 2"
     releaseDate: 2017-03-01
     eol: 2022-03-31
-    extendedSupport: false
     link: https://docs.oracle.com/en/database/oracle/oracle-database/12.2/whats-new.html
 
 -   releaseCycle: "12.1"
@@ -69,7 +66,7 @@ releases:
     lts: true
     releaseDate: 2013-06-25
     eol: 2018-07-31
-    extendedSupport: 2022-07-31
+    eoes: 2022-07-31
     link: https://docs.oracle.com/database/121/index.htm
 
 -   releaseCycle: "11.2"
@@ -78,7 +75,7 @@ releases:
     # https://www.orafaq.com/wiki/Oracle_11gR2
     releaseDate: 2009-09-01
     eol: 2015-01-31
-    extendedSupport: 2020-12-31
+    eoes: 2020-12-31
     link: https://docs.oracle.com/cd/E11882_01/index.htm
 
 -   releaseCycle: "11.1"
@@ -88,7 +85,7 @@ releases:
     releaseDate: 2007-08-09
     # https://web.archive.org/web/20190516170139/https://support.oracle.com/knowledge/Oracle%20Database%20Products/742060_1.html#foot1
     eol: 2012-08-31
-    extendedSupport: 2015-08-31
+    eoes: 2015-08-31
     link: https://docs.oracle.com/cd/B28359_01/index.htm
 
 -   releaseCycle: "10.2"
@@ -98,7 +95,7 @@ releases:
     releaseDate: 2005-07-11
     # https://web.archive.org/web/20190516170139/https://support.oracle.com/knowledge/Oracle%20Database%20Products/742060_1.html
     eol: 2010-07-31
-    extendedSupport: 2015-07-31
+    eoes: 2015-07-31
     link: https://docs.oracle.com/cd/B19306_01/nav/portal_1.htm
 
 -   releaseCycle: "10.1"
@@ -108,7 +105,7 @@ releases:
     releaseDate: 2003-09-08
     # https://www.orafaq.com/wiki/Oracle_10g
     eol: 2009-01-31
-    extendedSupport: 2012-01-01
+    eoes: 2012-01-01
     link: https://www.oracle.com/database/technologies/database10g-doc.html
 
 -   releaseCycle: "9.2"
@@ -117,7 +114,7 @@ releases:
     # https://www.orafaq.com/wiki/Oracle_9i
     releaseDate: 2002-05-01
     eol: 2007-07-31
-    extendedSupport: 2010-07-31
+    eoes: 2010-07-31
     link: https://www.oracle.com/database/technologies/oracle9i.html
 
 -   releaseCycle: "9.0"
@@ -125,7 +122,6 @@ releases:
     # https://www.orafaq.com/wiki/Oracle_9i
     releaseDate: 2001-06-01
     eol: 2003-12-31
-    extendedSupport: false
     link: https://www.oracle.com/database/technologies/database10g-doc.html
 
 ---

--- a/products/oracle-jdk.md
+++ b/products/oracle-jdk.md
@@ -12,7 +12,7 @@ versionCommand: java -version
 releasePolicyLink: https://www.oracle.com/java/technologies/java-se-support-roadmap.html
 changelogTemplate: "https://www.oracle.com/java/technologies/javase/{{'__LATEST__'|replace:'.','-'}}-{% if '__RELEASE_CYCLE__'=='__LATEST__' %}relnote-issues{% else %}relnotes{% endif %}.html"
 eolColumn: Premier Support
-extendedSupportColumn: Extended Support
+eoesColumn: Extended Support
 releaseDateColumn: true
 
 auto:
@@ -29,7 +29,7 @@ auto:
         eol:
           column: "Premier Support Until"
           regex: '^(?P<value>\w+ \d+).*'
-        extendedSupport:
+        eoes:
           column: "Extended Support Until"
           regex: '^(?P<value>\w+ \d+).*'
   # Fix the release date, as only month-year dates are provided in the previous table.
@@ -51,7 +51,6 @@ releases:
 -   releaseCycle: "22"
     releaseDate: 2024-03-19
     eol: 2024-09-17
-    extendedSupport: false
     latest: "22"
     latestReleaseDate: 2024-03-19
 
@@ -59,28 +58,25 @@ releases:
     lts: true
     releaseDate: 2023-09-19
     eol: 2028-09-30
-    extendedSupport: 2031-09-30
+    eoes: 2031-09-30
     latest: "21.0.2"
     latestReleaseDate: 2024-01-16
 
 -   releaseCycle: "20"
     releaseDate: 2023-03-21
     eol: 2023-09-19
-    extendedSupport: false
     latest: "20.0.2"
     latestReleaseDate: 2023-07-18
 
 -   releaseCycle: "19"
     releaseDate: 2022-09-20
     eol: 2023-03-21
-    extendedSupport: false
     latest: "19.0.2"
     latestReleaseDate: 2023-01-17
 
 -   releaseCycle: "18"
     releaseDate: 2022-03-22
     eol: 2022-09-20
-    extendedSupport: false
     latest: "18.0.2.1"
     latestReleaseDate: 2022-08-18
 
@@ -88,42 +84,37 @@ releases:
     lts: true
     releaseDate: 2021-09-14
     eol: 2026-09-30
-    extendedSupport: 2029-09-30
+    eoes: 2029-09-30
     latest: "17.0.10"
     latestReleaseDate: 2024-01-16
 
 -   releaseCycle: "16"
     releaseDate: 2021-03-16
     eol: 2021-09-14
-    extendedSupport: false
     latest: "16.0.2"
     latestReleaseDate: 2021-07-20
 
 -   releaseCycle: "15"
     releaseDate: 2020-09-15
     eol: 2021-03-16
-    extendedSupport: false
     latest: "15.0.2"
     latestReleaseDate: 2021-01-19
 
 -   releaseCycle: "14"
     releaseDate: 2020-03-17
     eol: 2020-09-16
-    extendedSupport: false
     latest: "14.0.2"
     latestReleaseDate: 2020-07-14
 
 -   releaseCycle: "13"
     releaseDate: 2019-09-17
     eol: 2020-03-17
-    extendedSupport: false
     latest: "13.0.2"
     latestReleaseDate: 2020-01-14
 
 -   releaseCycle: "12"
     releaseDate: 2019-03-19
     eol: 2019-09-17
-    extendedSupport: false
     latest: "12.0.2"
     latestReleaseDate: 2019-07-16
 
@@ -131,21 +122,19 @@ releases:
     lts: true
     releaseDate: 2018-09-25
     eol: 2023-09-30
-    extendedSupport: 2032-01-31
+    eoes: 2032-01-31
     latest: "11.0.22"
     latestReleaseDate: 2024-01-16
 
 -   releaseCycle: "10"
     releaseDate: 2018-03-20
     eol: 2018-09-25
-    extendedSupport: false
     latest: "10.0.2"
     latestReleaseDate: 2018-07-17
 
 -   releaseCycle: "9"
     releaseDate: 2017-09-21
     eol: 2018-03-20
-    extendedSupport: false
     latest: "9.0.4"
     latestReleaseDate: 2018-01-16
 
@@ -153,7 +142,7 @@ releases:
     lts: true
     releaseDate: 2014-03-18
     eol: 2022-03-31
-    extendedSupport: 2030-12-31
+    eoes: 2030-12-31
     latest: "8u401"
     latestReleaseDate: 2024-01-16
 
@@ -161,7 +150,7 @@ releases:
     lts: true
     releaseDate: 2011-07-11
     eol: 2019-07-31
-    extendedSupport: 2022-07-19
+    eoes: 2022-07-19
     link: https://www.oracle.com/java/technologies/javase/7-support-relnotes.html#R170_361
     latest: "7u351"
     latestReleaseDate: 2022-07-19
@@ -169,7 +158,6 @@ releases:
 -   releaseCycle: "6"
     releaseDate: 2006-12-12
     eol: 2018-12-31
-    extendedSupport: false
     link: https://www.oracle.com/java/technologies/javase/6u211-relnotes.html
     latest: "6u211"
     latestReleaseDate: 2018-10-16
@@ -178,7 +166,6 @@ releases:
     releaseDate: 2004-09-30
     # https://web.archive.org/web/20081217100039/http://java.sun.com/products/archive/eol.policy.html
     eol: 2009-10-30
-    extendedSupport: false
     link: https://www.oracle.com/java/technologies/javase/advancedv5-support-relnotes.html
     latest: "5.0u85"
     latestReleaseDate: 2015-04-14
@@ -187,7 +174,6 @@ releases:
     releaseDate: 2002-02-13
     # https://web.archive.org/web/20081217100039/http://java.sun.com/products/archive/eol.policy.html
     eol: 2008-10-30
-    extendedSupport: false
     link:
       https://www.oracle.com/java/technologies/javase/advanced-v142-support-relnotes.html
     latest: "1.4.2_42"
@@ -197,7 +183,6 @@ releases:
     releaseDate: 2000-05-08
     # https://web.archive.org/web/20080410071627/http://java.sun.com/products/archive/eol.policy.html
     eol: 2006-03-31
-    extendedSupport: false
     link: https://www.oracle.com/java/technologies/javase/releasenote-v131.html
     latest: "1.3.1_32"
     latestReleaseDate: 2011-10-18
@@ -206,7 +191,6 @@ releases:
     releaseDate: 1998-12-04
     # https://web.archive.org/web/20080410071627/http://java.sun.com/products/archive/eol.policy.html
     eol: 2003-11-30
-    extendedSupport: false
     link:
       https://web.archive.org/web/20080410071627/http://java.sun.com/products/archive/eol.policy.html
     latest: "1.2.2_18"
@@ -215,7 +199,6 @@ releases:
 -   releaseCycle: "1.1"
     releaseDate: 1997-02-18
     eol: 2002-10-09
-    extendedSupport: false
     link: null
     latest: "1.1.8_010"
     latestReleaseDate: 2002-10-09
@@ -223,7 +206,6 @@ releases:
 -   releaseCycle: "1.0"
     releaseDate: 1996-01-23
     eol: 1996-05-07
-    extendedSupport: false
     link: null
     latest: "1.0.2"
     latestReleaseDate: 1996-05-07

--- a/products/oracle-linux.md
+++ b/products/oracle-linux.md
@@ -8,11 +8,11 @@ alternate_urls:
 -   /oraclelinux
 versionCommand: lsb_release --release
 releasePolicyLink: https://www.oracle.com/a/ocom/docs/elsp-lifetime-069338.pdf
-changelogTemplate: 
+changelogTemplate:
   https://docs.oracle.com/en/operating-systems/oracle-linux/__RELEASE_CYCLE__/relnotes__LATEST__/
 releaseDateColumn: true
 eolColumn: Basic/Premier Support
-extendedSupportColumn: Extended Support
+eoesColumn: Extended Support
 
 # https://regex101.com/r/fRdw9L/1
 auto:
@@ -29,28 +29,28 @@ releases:
 -   releaseCycle: "9"
     releaseDate: 2022-07-06
     eol: 2032-06-30
-    extendedSupport: 2034-06-30
+    eoes: 2034-06-30
     latest: "9.3"
     latestReleaseDate: 2023-11-17
 
 -   releaseCycle: "8"
     releaseDate: 2019-07-19
     eol: 2029-07-01
-    extendedSupport: 2031-07-01
+    eoes: 2031-07-01
     latest: "8.9"
     latestReleaseDate: 2023-11-21
 
 -   releaseCycle: "7"
     releaseDate: 2014-07-23
     eol: 2024-12-01
-    extendedSupport: 2026-06-01
+    eoes: 2026-06-01
     latest: "7.9"
     latestReleaseDate: 2020-10-08
 
 -   releaseCycle: "6"
     releaseDate: 2011-02-12
     eol: 2021-03-01
-    extendedSupport: 2024-12-01
+    eoes: 2024-12-01
     latest: "6.10"
     latestReleaseDate: 2018-07-02
 

--- a/products/oracle-solaris.md
+++ b/products/oracle-solaris.md
@@ -11,7 +11,7 @@ releasePolicyLink: https://www.oracle.com/support/lifetime-support/
 releaseColumn: false
 releaseDateColumn: true
 eolColumn: Premier Support
-extendedSupportColumn: Extended Support
+eoesColumn: Extended Support
 
 # No auto update, https://distrowatch.com/?newsid=02397 is outdated.
 
@@ -24,49 +24,46 @@ releases:
 -   releaseCycle: "11.4"
     releaseDate: 2018-08-28
     eol: 2031-11-01
-    extendedSupport: 2034-11-01
+    eoes: 2034-11-01
     link: https://docs.oracle.com/cd/E37838_01/index.html
 
 -   releaseCycle: "11.3"
     releaseDate: 2015-10-26
     eol: 2021-01-01
-    extendedSupport: 2027-01-01
+    eoes: 2027-01-01
     link: https://docs.oracle.com/cd/E53394_01/index.html
 
 -   releaseCycle: "11.2"
     releaseDate: 2014-04-29
     eol: true
-    extendedSupport: false
     link: https://docs.oracle.com/cd/E36784_01/index.html
 
 -   releaseCycle: "11.1"
     releaseDate: 2012-10-03
     eol: true
-    extendedSupport: false
     link: https://docs.oracle.com/cd/E26502_01/index.html
 
 -   releaseCycle: "11"
     releaseDate: 2011-11-09
     eol: true
-    extendedSupport: false
     link: https://docs.oracle.com/cd/E23824_01/index.html
 
 -   releaseCycle: "10"
     releaseDate: 2005-01-31
     eol: 2018-01-01
-    extendedSupport: 2027-01-01
+    eoes: 2027-01-01
     link: https://docs.oracle.com/cd/F24622_01/index.html
 
 -   releaseCycle: "9"
     releaseDate: 2002-05-28
     eol: 2011-10-01
-    extendedSupport: 2014-10-01
+    eoes: 2014-10-01
     link: https://docs.oracle.com/cd/E19683-01/index.html
 
 -   releaseCycle: "8"
     releaseDate: 2000-02-01
     eol: 2009-03-01
-    extendedSupport: 2012-03-01
+    eoes: 2012-03-01
     link: https://docs.oracle.com/cd/E19455-01/index.html
 
 ---

--- a/products/pan-gp.md
+++ b/products/pan-gp.md
@@ -6,7 +6,7 @@ iconSlug: paloaltonetworks
 permalink: /pangp
 releasePolicyLink: https://www.paloaltonetworks.com/services/support/end-of-life-announcements/end-of-life-summary
 releaseDateColumn: true
-activeSupportColumn: true
+eoasColumn: true
 eolColumn: End-of-life Date
 
 auto:
@@ -18,14 +18,14 @@ auto:
       fields:
         releaseCycle: "GlobalProtect App version"
         releaseDate: "Release Date"
-        support: "End-of-Engineering Date"
+        eoas: "End-of-Engineering Date"
         eol: "End-of-Life Date"
 
 releases:
 -   releaseCycle: "6.2"
     releaseDate: 2023-05-23
     eol: 2025-05-23
-    support: 2025-05-23
+    eoas: 2025-05-23
     latest: "6.2.2"
     latestReleaseDate: 2023-11-22
     link: https://docs.paloaltonetworks.com/globalprotect/6-2/globalprotect-app-release-notes/globalprotect-addressed-issues
@@ -33,7 +33,7 @@ releases:
 -   releaseCycle: "6.1"
     releaseDate: 2022-09-01
     eol: 2025-03-01
-    support: 2024-09-01
+    eoas: 2024-09-01
     latest: "6.1.4"
     latestReleaseDate: 2024-01-29
     link: https://docs.paloaltonetworks.com/globalprotect/6-1/globalprotect-app-release-notes//globalprotect-addressed-issues
@@ -41,7 +41,7 @@ releases:
 -   releaseCycle: "6.0"
     releaseDate: 2022-02-22
     eol: 2025-02-22
-    support: 2025-02-22
+    eoas: 2025-02-22
     latest: "6.0.8"
     latestReleaseDate: 2023-10-18
     link: https://docs.paloaltonetworks.com/globalprotect/6-0/globalprotect-app-release-notes
@@ -49,7 +49,7 @@ releases:
 -   releaseCycle: "5.3"
     releaseDate: 2021-06-01
     eol: 2023-06-01
-    support: 2022-12-01
+    eoas: 2022-12-01
     latest: "5.3.4"
     latestReleaseDate: 2022-05-31
     link: https://web.archive.org/web/20221203201532/https://docs.paloaltonetworks.com/globalprotect/5-3/globalprotect-app-release-notes/gp-app-release-information
@@ -57,7 +57,7 @@ releases:
 -   releaseCycle: "5.2"
     releaseDate: 2020-07-30
     eol: 2024-02-28
-    support: 2023-08-31
+    eoas: 2023-08-31
     latest: "5.2.13-c418"
     latestReleaseDate: 2023-07-11
     link: https://docs.paloaltonetworks.com/globalprotect/5-2/globalprotect-app-release-notes/globalprotect-known-and-addressed-issues/globalprotect-addressed-issues
@@ -65,7 +65,7 @@ releases:
 -   releaseCycle: "5.1"
     releaseDate: 2019-12-12
     eol: 2024-12-31
-    support: 2021-03-12
+    eoas: 2021-03-12
     latest: "5.1.12"
     latestReleaseDate: 2024-02-12
     link: https://docs.paloaltonetworks.com/globalprotect/5-1/globalprotect-app-release-notes
@@ -73,35 +73,35 @@ releases:
 -   releaseCycle: "5.0"
     releaseDate: 2019-02-12
     eol: 2021-02-12
-    support: 2020-05-12
+    eoas: 2020-05-12
     latest: "5.0.10"
     link: https://web.archive.org/web/20220815074700/https://docs.paloaltonetworks.com/globalprotect/5-0/globalprotect-app-release-notes/gp-app-release-information/globalprotect-50-addressed-issues
 
 -   releaseCycle: "4.1"
     releaseDate: 2018-03-01
     eol: 2020-03-01
-    support: 2019-06-01
+    eoas: 2019-06-01
     latest: "4.1.13"
     link: https://web.archive.org/web/20220813143321/https://docs.paloaltonetworks.com/globalprotect/4-1/globalprotect-app-release-notes/gp-app-release-information/globalprotect-app-4113-addressed-issues
 
 -   releaseCycle: "4.0"
     releaseDate: 2017-01-30
     eol: 2019-01-30
-    support: 2018-05-02
+    eoas: 2018-05-02
     latest: "4.0"
     latestReleaseDate: 2017-01-30
 
 -   releaseCycle: "3.1"
     releaseDate: 2016-06-23
     eol: 2018-06-23
-    support: 2017-09-23
+    eoas: 2017-09-23
     latest: "3.1"
     latestReleaseDate: 2016-06-23
 
 -   releaseCycle: "3.0"
     releaseDate: 2016-02-16
     eol: 2018-02-15
-    support: 2017-05-18
+    eoas: 2017-05-18
     latest: "3.0"
     latestReleaseDate: 2016-02-16
 

--- a/products/perl.md
+++ b/products/perl.md
@@ -4,11 +4,11 @@ category: lang
 iconSlug: perl
 permalink: /perl
 versionCommand: perl -v
-releaseImage: 
+releaseImage:
   https://www.versio.io/img/product-release-version-end-of-life/Perl_Foundation-Perl.jpg
 releasePolicyLink: https://perldoc.perl.org/perlpolicy#MAINTENANCE-AND-SUPPORT
 changelogTemplate: "https://perldoc.perl.org/__LATEST__/perldelta"
-activeSupportColumn: true
+eoasColumn: true
 releaseDateColumn: true
 eolColumn: Critical security patches
 
@@ -38,49 +38,49 @@ auto:
 releases:
 -   releaseCycle: "5.38"
     releaseDate: 2023-07-02
-    support: true
+    eoas: false
     eol: 2026-07-02
     latest: "5.38.2"
     latestReleaseDate: 2023-11-29
 
 -   releaseCycle: "5.36"
     releaseDate: 2022-05-27
-    support: true
+    eoas: false
     eol: 2025-05-27
     latest: "5.36.3"
     latestReleaseDate: 2023-11-29
 
 -   releaseCycle: "5.34"
     releaseDate: 2021-05-20
-    support: 2022-05-27
+    eoas: 2022-05-27
     eol: 2024-05-20
     latest: "5.34.3"
     latestReleaseDate: 2023-11-29
 
 -   releaseCycle: "5.32"
     releaseDate: 2020-06-20
-    support: 2022-05-27
+    eoas: 2022-05-27
     eol: 2023-06-20
     latest: "5.32.1"
     latestReleaseDate: 2021-01-23
 
 -   releaseCycle: "5.30"
     releaseDate: 2019-05-22
-    support: 2021-05-20
+    eoas: 2021-05-20
     eol: 2022-05-22
     latest: "5.30.3"
     latestReleaseDate: 2020-05-29
 
 -   releaseCycle: "5.28"
     releaseDate: 2018-06-22
-    support: 2020-06-20
+    eoas: 2020-06-20
     eol: 2021-06-23
     latest: "5.28.3"
     latestReleaseDate: 2020-05-29
 
 -   releaseCycle: "5.26"
     releaseDate: 2017-05-30
-    support: 2019-05-22
+    eoas: 2019-05-22
     eol: 2020-05-30
     latest: "5.26.3"
     latestReleaseDate: 2018-11-28

--- a/products/php.md
+++ b/products/php.md
@@ -7,7 +7,7 @@ versionCommand: php --version
 releasePolicyLink: https://www.php.net/supported-versions.php
 changelogTemplate: "https://www.php.net/ChangeLog-{{'__LATEST__'|split:'.'|first}}.php#__LATEST__"
 releaseDateColumn: true
-activeSupportColumn: true
+eoasColumn: true
 
 identifiers:
 -   purl: pkg:deb/ubuntu/php
@@ -20,112 +20,112 @@ auto:
 releases:
 -   releaseCycle: "8.3"
     releaseDate: 2023-11-23
-    support: 2025-11-23
+    eoas: 2025-11-23
     eol: 2026-11-23
     latest: "8.3.4"
     latestReleaseDate: 2024-03-14
 
 -   releaseCycle: "8.2"
     releaseDate: 2022-12-08
-    support: 2024-12-08
+    eoas: 2024-12-08
     eol: 2025-12-08
     latest: "8.2.17"
     latestReleaseDate: 2024-03-14
 
 -   releaseCycle: "8.1"
     releaseDate: 2021-11-25
-    support: 2023-11-25
+    eoas: 2023-11-25
     eol: 2024-11-25
     latest: "8.1.27"
     latestReleaseDate: 2023-12-21
 
 -   releaseCycle: "8.0"
     releaseDate: 2020-11-26
-    support: 2022-11-26
+    eoas: 2022-11-26
     eol: 2023-11-26
     latest: "8.0.30"
     latestReleaseDate: 2023-08-03
 
 -   releaseCycle: "7.4"
     releaseDate: 2019-11-28
-    support: 2021-11-28
+    eoas: 2021-11-28
     eol: 2022-11-28
     latest: "7.4.33"
     latestReleaseDate: 2022-11-03
 
 -   releaseCycle: "7.3"
     releaseDate: 2018-12-06
-    support: 2020-12-06
+    eoas: 2020-12-06
     eol: 2021-12-06
     latest: "7.3.33"
     latestReleaseDate: 2021-11-18
 
 -   releaseCycle: "7.2"
     releaseDate: 2017-11-30
-    support: 2019-11-30
+    eoas: 2019-11-30
     eol: 2020-11-30
     latest: "7.2.34"
     latestReleaseDate: 2020-10-01
 
 -   releaseCycle: "7.1"
     releaseDate: 2016-12-01
-    support: 2018-12-01
+    eoas: 2018-12-01
     eol: 2019-12-01
     latest: "7.1.33"
     latestReleaseDate: 2019-10-24
 
 -   releaseCycle: "7.0"
     releaseDate: 2015-12-03
-    support: 2018-01-04
+    eoas: 2018-01-04
     eol: 2019-01-10
     latest: "7.0.33"
     latestReleaseDate: 2019-01-10
 
 -   releaseCycle: "5.6"
     releaseDate: 2014-08-28
-    support: 2017-01-19
+    eoas: 2017-01-19
     eol: 2018-12-31
     latest: "5.6.40"
     latestReleaseDate: 2019-01-10
 
 -   releaseCycle: "5.5"
     releaseDate: 2013-06-20
-    support: 2015-07-10
+    eoas: 2015-07-10
     eol: 2016-07-21
     latest: "5.5.38"
     latestReleaseDate: 2016-07-21
 
 -   releaseCycle: "5.4"
     releaseDate: 2012-03-01
-    support: 2014-09-14
+    eoas: 2014-09-14
     eol: 2015-09-14
     latest: "5.4.45"
     latestReleaseDate: 2015-09-03
 
 -   releaseCycle: "5.3"
     releaseDate: 2009-06-30
-    support: 2011-06-30
+    eoas: 2011-06-30
     eol: 2014-08-14
     latest: "5.3.29"
     latestReleaseDate: 2014-08-14
 
 -   releaseCycle: "5.2"
     releaseDate: 2006-11-02
-    support: 2008-11-02
+    eoas: 2008-11-02
     eol: 2011-01-06
     latest: "5.2.17"
     latestReleaseDate: 2011-01-06
 
 -   releaseCycle: "5.1"
     releaseDate: 2005-11-24
-    support: 2006-08-24
+    eoas: 2006-08-24
     eol: 2006-08-24
     latest: "5.1.6"
     latestReleaseDate: 2006-08-24
 
 -   releaseCycle: "5.0"
     releaseDate: 2004-07-13
-    support: 2005-09-05
+    eoas: 2005-09-05
     eol: 2005-09-05
     latest: "5.0.5"
     latestReleaseDate: 2005-09-05

--- a/products/phpbb.md
+++ b/products/phpbb.md
@@ -4,7 +4,7 @@ category: server-app
 tags: php-runtime
 permalink: /phpbb
 releaseDateColumn: true
-activeSupportColumn: true
+eoasColumn: true
 
 auto:
   methods:
@@ -14,7 +14,7 @@ auto:
 releases:
 -   releaseCycle: "3.3"
     releaseDate: 2020-01-06
-    support: true
+    eoas: false
     eol: false
     latest: "3.3.11"
     latestReleaseDate: 2023-10-21
@@ -22,21 +22,21 @@ releases:
 
 -   releaseCycle: "3.2"
     releaseDate: 2017-01-07
-    support: 2019-05-01
+    eoas: 2019-05-01
     eol: 2019-11-01
     latest: "3.2.11"
     latestReleaseDate: 2020-11-04
 
 -   releaseCycle: "3.1"
     releaseDate: 2014-10-28
-    support: 2017-06-01
+    eoas: 2017-06-01
     eol: 2018-11-01
     latest: "3.1.12"
     latestReleaseDate: 2018-01-07
 
 -   releaseCycle: "3.0"
     releaseDate: 2007-12-12
-    support: 2015-05-01
+    eoas: 2015-05-01
     eol: 2015-11-01
     latest: "3.0.14"
     latestReleaseDate: 2015-05-03

--- a/products/phpmyadmin.md
+++ b/products/phpmyadmin.md
@@ -6,7 +6,7 @@ iconSlug: phpmyadmin
 permalink: /phpmyadmin
 releasePolicyLink: https://www.phpmyadmin.net/downloads/#support
 changelogTemplate: "https://github.com/phpmyadmin/phpmyadmin/blob/QA_{{'__RELEASE_CYCLE__'|replace:'.','_'}}/ChangeLog"
-activeSupportColumn: true
+eoasColumn: true
 releaseDateColumn: true
 
 auto:
@@ -28,21 +28,21 @@ identifiers:
 releases:
 -   releaseCycle: "5.2"
     releaseDate: 2022-05-11
-    support: true
+    eoas: false
     eol: false
     latest: "5.2.1"
     latestReleaseDate: 2023-02-07
 
 -   releaseCycle: "5.1"
     releaseDate: 2021-02-24
-    support: 2022-05-11
+    eoas: 2022-05-11
     eol: 2022-05-11
     latest: "5.1.4"
     latestReleaseDate: 2022-05-11
 
 -   releaseCycle: "5.0"
     releaseDate: 2019-12-26
-    support: 2021-02-24
+    eoas: 2021-02-24
     eol: 2021-02-24
     latest: "5.0.4"
     latestReleaseDate: 2020-10-15
@@ -50,35 +50,35 @@ releases:
 -   releaseCycle: "4.9"
     lts: true
     releaseDate: 2019-06-04
-    support: 2019-12-31
+    eoas: 2019-12-31
     eol: false
     latest: "4.9.11"
     latestReleaseDate: 2023-02-07
 
 -   releaseCycle: "4.8"
     releaseDate: 2018-04-07
-    support: 2019-06-04
+    eoas: 2019-06-04
     eol: 2019-06-04
     latest: "4.8.5"
     latestReleaseDate: 2019-01-25
 
 -   releaseCycle: "4.7"
     releaseDate: 2017-03-29
-    support: 2018-04-07
+    eoas: 2018-04-07
     eol: 2018-04-07
     latest: "4.7.9"
     latestReleaseDate: 2018-03-05
 
 -   releaseCycle: "4.6"
     releaseDate: 2016-03-17
-    support: 2017-04-01
+    eoas: 2017-04-01
     eol: 2017-04-01
     latest: "4.6.6"
     latestReleaseDate: 2017-01-23
 
 -   releaseCycle: "4.5"
     releaseDate: 2015-09-23
-    support: 2016-04-01
+    eoas: 2016-04-01
     eol: 2016-04-01
     link: https://www.phpmyadmin.net/files/__LATEST__/
     latest: "4.5.5.1"
@@ -86,7 +86,7 @@ releases:
 
 -   releaseCycle: "4.4"
     releaseDate: 2015-04-01
-    support: 2016-10-01
+    eoas: 2016-10-01
     eol: 2016-10-01
     link: https://www.phpmyadmin.net/files/__LATEST__/
     latest: "4.4.15.10"
@@ -94,7 +94,7 @@ releases:
 
 -   releaseCycle: "4.3"
     releaseDate: 2014-12-05
-    support: 2015-10-01
+    eoas: 2015-10-01
     eol: 2015-10-01
     link: https://www.phpmyadmin.net/files/__LATEST__/
     latest: "4.3.13.3"
@@ -102,7 +102,7 @@ releases:
 
 -   releaseCycle: "4.2"
     releaseDate: 2014-05-08
-    support: 2015-07-01
+    eoas: 2015-07-01
     eol: 2015-07-01
     link: https://www.phpmyadmin.net/files/__LATEST__/
     latest: "4.2.13.3"
@@ -110,7 +110,7 @@ releases:
 
 -   releaseCycle: "4.1"
     releaseDate: 2013-12-11
-    support: 2015-01-01
+    eoas: 2015-01-01
     eol: 2015-01-01
     link: https://www.phpmyadmin.net/files/__LATEST__/
     latest: "4.1.14.8"
@@ -119,7 +119,7 @@ releases:
 -   releaseCycle: "4.0"
     lts: true
     releaseDate: 2013-05-03
-    support: 2013-12-31
+    eoas: 2013-12-31
     eol: 2017-04-01
     link: https://www.phpmyadmin.net/files/__LATEST__/
     latest: "4.0.10.20"

--- a/products/pixel.md
+++ b/products/pixel.md
@@ -9,7 +9,7 @@ releasePolicyLink: https://support.google.com/nexus/answer/4457705
 releaseColumn: false
 releaseDateColumn: true
 discontinuedColumn: true
-activeSupportColumn: Android Updates
+eoasColumn: Android Updates
 eolColumn: Security Updates
 customColumns:
 -   property: supportedAndroidVersions
@@ -26,7 +26,7 @@ releases:
 -   releaseCycle: "8"
     releaseLabel: "Pixel 8 / Pro"
     releaseDate: 2023-10-04
-    support: 2030-10-01 # at least
+    eoas: 2030-10-01 # at least
     eol: 2030-10-01 # at least
     discontinued: false
     link: https://en.wikipedia.org/wiki/Pixel_8
@@ -35,7 +35,7 @@ releases:
 -   releaseCycle: "fold"
     releaseLabel: "Pixel Fold"
     releaseDate: 2023-06-28
-    support: 2026-06-01  # at least
+    eoas: 2026-06-01  # at least
     eol: 2028-06-01  # at least
     discontinued: false
     link: https://en.wikipedia.org/wiki/Pixel_Fold
@@ -44,7 +44,7 @@ releases:
 -   releaseCycle: "tablet"
     releaseLabel: "Pixel Tablet"
     releaseDate: 2023-06-20
-    support: 2026-06-01 # at least
+    eoas: 2026-06-01 # at least
     eol: 2028-06-01 # at least
     discontinued: false
     link: https://en.wikipedia.org/wiki/Pixel_Tablet
@@ -53,7 +53,7 @@ releases:
 -   releaseCycle: "7a"
     releaseLabel: "Pixel 7a"
     releaseDate: 2023-05-10
-    support: 2026-05-01 # at least
+    eoas: 2026-05-01 # at least
     eol: 2028-05-01 # at least
     discontinued: false
     link: https://en.wikipedia.org/wiki/Pixel_7a
@@ -62,7 +62,7 @@ releases:
 -   releaseCycle: "7"
     releaseLabel: "Pixel 7 / Pro"
     releaseDate: 2022-10-13
-    support: 2025-10-01 # at least
+    eoas: 2025-10-01 # at least
     eol: 2027-10-01 # at least
     discontinued: false
     link: https://en.wikipedia.org/wiki/Pixel_7
@@ -71,7 +71,7 @@ releases:
 -   releaseCycle: "6a"
     releaseLabel: "Pixel 6a"
     releaseDate: 2022-07-28
-    support: 2025-07-01 # at least
+    eoas: 2025-07-01 # at least
     eol: 2027-07-01 # at least
     discontinued: false
     link: https://en.wikipedia.org/wiki/Pixel_6a
@@ -80,7 +80,7 @@ releases:
 -   releaseCycle: "6"
     releaseLabel: "Pixel 6 / Pro"
     releaseDate: 2021-10-28
-    support: 2024-10-01 # at least
+    eoas: 2024-10-01 # at least
     eol: 2026-10-01 # at least
     discontinued: 2022-10-06
     link: https://en.wikipedia.org/wiki/Pixel_6
@@ -89,7 +89,7 @@ releases:
 -   releaseCycle: "5a"
     releaseLabel: "Pixel 5a"
     releaseDate: 2021-08-26
-    support: 2024-08-01 # at least
+    eoas: 2024-08-01 # at least
     eol: 2024-08-01 # at least
     discontinued: 2022-07-21
     link: https://en.wikipedia.org/wiki/Pixel_5a
@@ -98,7 +98,7 @@ releases:
 -   releaseCycle: "4a-5g"
     releaseLabel: "Pixel 4a (5G)"
     releaseDate: 2020-11-05
-    support: 2023-11-05
+    eoas: 2023-11-05
     eol: 2023-11-05 # UP1A.231105.001
     discontinued: 2021-08-20
     link: https://en.wikipedia.org/wiki/Pixel_4a
@@ -107,7 +107,7 @@ releases:
 -   releaseCycle: "5"
     releaseLabel: "Pixel 5"
     releaseDate: 2020-10-15
-    support: 2023-11-05
+    eoas: 2023-11-05
     eol: 2023-11-05 # UP1A.231105.001
     discontinued: 2021-08-20
     link: https://en.wikipedia.org/wiki/Pixel_5
@@ -116,7 +116,7 @@ releases:
 -   releaseCycle: "4a"
     releaseLabel: "Pixel 4a"
     releaseDate: 2020-08-20
-    support: 2023-08-05
+    eoas: 2023-08-05
     eol: 2023-08-05 # TQ3A.230805.001.S1
     discontinued: 2022-01-31
     link: https://en.wikipedia.org/wiki/Pixel_4a
@@ -125,7 +125,7 @@ releases:
 -   releaseCycle: "4"
     releaseLabel: "Pixel 4 / XL"
     releaseDate: 2019-10-24
-    support: 2022-10-05
+    eoas: 2022-10-05
     eol: 2022-10-05 # TP1A.221005.002.B2
     discontinued: 2020-08-06
     link: https://en.wikipedia.org/wiki/Pixel_4
@@ -134,7 +134,7 @@ releases:
 -   releaseCycle: "3a"
     releaseLabel: "Pixel 3a / XL"
     releaseDate: 2019-05-07
-    support: 2022-05-05
+    eoas: 2022-05-05
     eol: 2022-05-05 # SP2A.220505.008
     discontinued: 2020-07-01
     link: https://en.wikipedia.org/wiki/Pixel_3a
@@ -143,7 +143,7 @@ releases:
 -   releaseCycle: "3"
     releaseLabel: "Pixel 3 / XL"
     releaseDate: 2018-10-09
-    support: 2021-10-05
+    eoas: 2021-10-05
     eol: 2021-10-05 # SP1A.210812.016.C2
     discontinued: 2020-03-31
     link: https://en.wikipedia.org/wiki/Pixel_3
@@ -152,7 +152,7 @@ releases:
 -   releaseCycle: "2"
     releaseLabel: "Pixel 2 / XL"
     releaseDate: 2017-10-19
-    support: 2020-10-05
+    eoas: 2020-10-05
     eol: 2020-10-05 # RP1A.201005.004.A1
     discontinued: 2019-04-01
     link: https://en.wikipedia.org/wiki/Pixel_2
@@ -161,7 +161,7 @@ releases:
 -   releaseCycle: "1"
     releaseLabel: "Pixel / Pixel XL"
     releaseDate: 2016-10-20
-    support: 2019-10-06
+    eoas: 2019-10-06
     eol: 2019-10-06 # QP1A.191005.007.A3
     discontinued: 2018-04-11
     link: https://en.wikipedia.org/wiki/Pixel_(1st_generation)

--- a/products/protractor.md
+++ b/products/protractor.md
@@ -7,7 +7,7 @@ permalink: /protractor
 versionCommand: npm list protractor
 releaseDateColumn: true
 eolColumn: Community Support
-extendedSupportColumn: Commercial Support
+eoesColumn: Commercial Support
 
 auto:
   methods:
@@ -19,63 +19,57 @@ identifiers:
 releases:
 -   releaseCycle: "7.0"
     releaseDate: 2020-05-13
-    support: 2023-08-31
+    eoas: 2023-08-31
     eol: 2023-08-31
-    extendedSupport: true
+    eoes: false
     latest: "7.0.0"
     latestReleaseDate: 2020-05-13
     link: https://github.com/angular/protractor/blob/release-7.0/CHANGELOG.md#700
 
 -   releaseCycle: "6.0"
     releaseDate: 2019-03-23
-    support: 2023-08-31
+    eoas: 2023-08-31
     eol: 2023-08-31
-    extendedSupport: false
     latest: "6.0.0"
     latestReleaseDate: 2019-03-23
     link: https://github.com/angular/protractor/blob/master/CHANGELOG.md#600
 
 -   releaseCycle: "5.0"
     releaseDate: 2017-01-10
-    support: 2023-08-31
+    eoas: 2023-08-31
     eol: 2023-08-31
-    extendedSupport: false
     latest: "5.4.4"
     latestReleaseDate: 2020-04-16
     link: https://github.com/angular/protractor/blob/release-5.4/CHANGELOG.md#544
 
 -   releaseCycle: "4.0"
     releaseDate: 2016-07-12
-    support: 2023-08-31
+    eoas: 2023-08-31
     eol: 2023-08-31
-    extendedSupport: false
     latest: "4.0.14"
     latestReleaseDate: 2016-12-21
     link: https://github.com/angular/protractor/blob/master/CHANGELOG.md#4014
 
 -   releaseCycle: "3.0"
     releaseDate: 2015-11-18
-    support: 2023-08-31
+    eoas: 2023-08-31
     eol: 2023-08-31
-    extendedSupport: false
     latest: "3.3.0"
     latestReleaseDate: 2016-04-25
     link: https://github.com/angular/protractor/blob/master/CHANGELOG.md#330
 
 -   releaseCycle: "2.0"
     releaseDate: 2015-03-18
-    support: 2023-08-31
+    eoas: 2023-08-31
     eol: 2023-08-31
-    extendedSupport: false
     latest: "2.5.1"
     latestReleaseDate: 2015-10-08
     link: https://github.com/angular/protractor/blob/master/CHANGELOG.md#251
 
 -   releaseCycle: "1.0"
     releaseDate: 2014-07-21
-    support: 2023-08-31
+    eoas: 2023-08-31
     eol: 2023-08-31
-    extendedSupport: false
     latest: "1.8.0"
     latestReleaseDate: 2015-03-02
     link: https://github.com/angular/protractor/blob/master/CHANGELOG.md#180

--- a/products/python.md
+++ b/products/python.md
@@ -11,7 +11,7 @@ versionCommand: |-
 releasePolicyLink: https://devguide.python.org/versions/
 changelogTemplate: |
   https://www.python.org/downloads/release/python-{{"__LATEST__" | replace:'.',''}}/
-activeSupportColumn: true
+eoasColumn: true
 releaseDateColumn: true
 
 identifiers:
@@ -132,105 +132,105 @@ auto:
 releases:
 -   releaseCycle: "3.12"
     releaseDate: 2023-10-02
-    support: 2025-04-02
+    eoas: 2025-04-02
     eol: 2028-10-31
     latest: "3.12.2"
     latestReleaseDate: 2024-02-06
 
 -   releaseCycle: "3.11"
     releaseDate: 2022-10-24
-    support: 2024-04-01
+    eoas: 2024-04-01
     eol: 2027-10-31
     latest: "3.11.8"
     latestReleaseDate: 2024-02-06
 
 -   releaseCycle: "3.10"
     releaseDate: 2021-10-04
-    support: 2023-04-05
+    eoas: 2023-04-05
     eol: 2026-10-31
     latest: "3.10.14"
     latestReleaseDate: 2024-03-19
 
 -   releaseCycle: "3.9"
     releaseDate: 2020-10-05
-    support: 2022-05-17
+    eoas: 2022-05-17
     eol: 2025-10-31
     latest: "3.9.19"
     latestReleaseDate: 2024-03-19
 
 -   releaseCycle: "3.8"
     releaseDate: 2019-10-14
-    support: 2021-05-03
+    eoas: 2021-05-03
     eol: 2024-10-31
     latest: "3.8.19"
     latestReleaseDate: 2024-03-19
 
 -   releaseCycle: "3.7"
     releaseDate: 2018-06-26
-    support: 2020-06-27
+    eoas: 2020-06-27
     eol: 2023-06-27
     latest: "3.7.17"
     latestReleaseDate: 2023-06-05
 
 -   releaseCycle: "3.6"
     releaseDate: 2016-12-22
-    support: 2018-12-24
+    eoas: 2018-12-24
     eol: 2021-12-23
     latest: "3.6.15"
     latestReleaseDate: 2021-09-03
 
 -   releaseCycle: "3.5"
     releaseDate: 2015-09-12
-    support: false
+    eoas: true
     eol: 2020-09-30
     latest: "3.5.10"
     latestReleaseDate: 2020-09-05
 
 -   releaseCycle: "3.4"
     releaseDate: 2014-03-15
-    support: false
+    eoas: true
     eol: 2019-03-18
     latest: "3.4.10"
     latestReleaseDate: 2019-03-18
 
 -   releaseCycle: "3.3"
     releaseDate: 2012-09-29
-    support: false
+    eoas: true
     eol: 2017-09-29
     latest: "3.3.7"
     latestReleaseDate: 2017-09-19
 
 -   releaseCycle: "3.2"
     releaseDate: 2011-02-20
-    support: false
+    eoas: true
     eol: 2016-02-20
     latest: "3.2.6"
     latestReleaseDate: 2014-10-12
 
 -   releaseCycle: "3.1"
     releaseDate: 2009-06-26
-    support: false
+    eoas: true
     eol: 2012-04-09
     latest: "3.1.5"
     latestReleaseDate: 2012-04-06
 
 -   releaseCycle: "3.0"
     releaseDate: 2008-12-03
-    support: false
+    eoas: true
     eol: 2009-06-27
     latest: "3.0.1"
     latestReleaseDate: 2009-02-12
 
 -   releaseCycle: "2.7"
     releaseDate: 2010-07-03
-    support: false
+    eoas: true
     eol: 2020-01-01
     latest: "2.7.18"
     latestReleaseDate: 2020-04-19
 
 -   releaseCycle: "2.6"
     releaseDate: 2008-10-01
-    support: false
+    eoas: true
     eol: 2013-10-29
     latest: "2.6.9"
     latestReleaseDate: 2013-10-29

--- a/products/qt.md
+++ b/products/qt.md
@@ -9,7 +9,7 @@ releasePolicyLink: https://cdn2.hubspot.net/hubfs/149513/_Website_Blog/Qt%20offe
 changelogTemplate: "https://www.qt.io/blog/qt-{{'__LATEST__' | drop_zero_patch}}-released"
 releaseDateColumn: true
 eolColumn: OSS support
-extendedSupportColumn: Commercial support
+eoesColumn: Commercial support
 
 # Upstream does not support filtering https://code.qt.io/qt/qt5.git
 auto:
@@ -17,7 +17,7 @@ auto:
   -   git: https://github.com/qt/qt5.git
 
 # eol(x) ~= releaseDate(x+1) (estimation = releaseDate(x) + 6 months)
-# extendedSupport(x) =
+# eoes(x) =
 # - releaseDate(x) + 1 year for non-LTS
 # - releaseDate(x) + 3 years for LTS
 # See also https://wiki.qt.io/QtReleasing.
@@ -25,7 +25,7 @@ releases:
 -   releaseCycle: "6.6"
     releaseDate: 2023-10-09
     eol: 2024-04-09 # estimated, 2023-10-09 + 6 months
-    extendedSupport: 2024-10-09
+    eoes: 2024-10-09
     latest: "6.6.3"
     latestReleaseDate: 2024-03-26
 
@@ -33,21 +33,21 @@ releases:
     lts: true
     releaseDate: 2023-03-31
     eol: 2023-10-09
-    extendedSupport: 2026-03-31
+    eoes: 2026-03-31
     latest: "6.5.3"
     latestReleaseDate: 2023-09-28
 
 -   releaseCycle: "6.4"
     releaseDate: 2022-09-28
     eol: 2023-03-31
-    extendedSupport: 2023-09-28
+    eoes: 2023-09-28
     latest: "6.4.3"
     latestReleaseDate: 2023-03-16
 
 -   releaseCycle: "6.3"
     releaseDate: 2022-04-11
     eol: 2022-09-28
-    extendedSupport: 2023-04-11
+    eoes: 2023-04-11
     latest: "6.3.2"
     latestReleaseDate: 2022-09-08
 
@@ -55,21 +55,21 @@ releases:
     lts: true
     releaseDate: 2021-09-30
     eol: 2022-04-11
-    extendedSupport: 2024-09-30
+    eoes: 2024-09-30
     latest: "6.2.4"
     latestReleaseDate: 2022-03-16
 
 -   releaseCycle: "6.1"
     releaseDate: 2021-05-05
     eol: 2021-09-30
-    extendedSupport: 2022-05-05
+    eoes: 2022-05-05
     latest: "6.1.3"
     latestReleaseDate: 2021-08-31
 
 -   releaseCycle: "6.0"
     releaseDate: 2020-12-08
     eol: 2021-05-05
-    extendedSupport: 2021-12-08
+    eoes: 2021-12-08
     latest: "6.0.4"
     latestReleaseDate: 2021-05-03
 
@@ -77,14 +77,13 @@ releases:
     lts: true
     releaseDate: 2020-05-25
     eol: 2020-12-08
-    extendedSupport: 2025-05-25
+    eoes: 2025-05-25
     latest: "5.15.2"
     latestReleaseDate: 2020-11-13
 
 -   releaseCycle: "5.14"
     releaseDate: 2019-12-11
     eol: 2020-12-12
-    extendedSupport: false
     latest: "5.14.2"
     latestReleaseDate: 2020-03-30
     link: https://www.qt.io/blog/qt-5.14-has-released
@@ -92,7 +91,6 @@ releases:
 -   releaseCycle: "5.13"
     releaseDate: 2019-06-18
     eol: 2020-06-19
-    extendedSupport: false
     latest: "5.13.2"
     latestReleaseDate: 2019-10-28
 
@@ -100,14 +98,12 @@ releases:
     lts: true
     releaseDate: 2018-12-04
     eol: 2021-12-05
-    extendedSupport: false
     latest: "5.12.12"
     latestReleaseDate: 2021-11-25
 
 -   releaseCycle: "5.9"
     releaseDate: 2017-05-29
     eol: 2020-05-31
-    extendedSupport: false
     latest: "5.9.9"
     latestReleaseDate: 2019-12-16
 
@@ -115,7 +111,6 @@ releases:
     lts: true
     releaseDate: 2016-03-15
     eol: 2019-03-16
-    extendedSupport: false
     latest: "5.6.3"
     latestReleaseDate: 2017-09-20
     link: https://www.qt.io/blog/2017/09/21/qt-5-6-3-released
@@ -124,7 +119,6 @@ releases:
     lts: true
     releaseDate: 2011-12-15
     eol: 2015-12-31
-    extendedSupport: false
     latest: "4.8.7"
     link: https://www.qt.io/blog/2015/05/26/qt-4-8-7-released
 

--- a/products/quarkus.md
+++ b/products/quarkus.md
@@ -11,8 +11,7 @@ releasePolicyLink: https://quarkus.io/security/
 changelogTemplate: https://github.com/quarkusio/quarkus/releases/tag/__LATEST__
 releaseDateColumn: true
 eolColumn: Support
-extendedSupport: Support
-extendedSupportColumn: <abbr title="Red Hat build of Quarkus">RHBQ</abbr>
+eoesColumn: <abbr title="Red Hat build of Quarkus">RHBQ</abbr>
 
 # The Quarkus team forgot to declare a GitHub release for 2.11.0.
 # Tag and Maven release of new minor versions are usually created
@@ -31,7 +30,6 @@ releases:
 -   releaseCycle: "3.9"
     releaseDate: 2024-03-27
     eol: false
-    extendedSupport: false
     latest: "3.9.1"
     latestReleaseDate: 2024-03-27
 
@@ -39,42 +37,36 @@ releases:
     releaseDate: 2024-02-28
     eol: 2025-02-28
     lts: true
-    extendedSupport: false
     latest: "3.8.3"
     latestReleaseDate: 2024-03-19
 
 -   releaseCycle: "3.7"
     releaseDate: 2024-01-31
     eol: 2024-02-28
-    extendedSupport: false
     latest: "3.7.4"
     latestReleaseDate: 2024-02-21
 
 -   releaseCycle: "3.6"
     releaseDate: 2023-11-29
     eol: 2024-01-31
-    extendedSupport: false
     latest: "3.6.9"
     latestReleaseDate: 2024-01-31
 
 -   releaseCycle: "3.5"
     releaseDate: 2023-10-25
     eol: 2023-11-29
-    extendedSupport: false
     latest: "3.5.3"
     latestReleaseDate: 2023-11-21
 
 -   releaseCycle: "3.4"
     releaseDate: 2023-09-20
     eol: 2023-10-25
-    extendedSupport: false
     latest: "3.4.3"
     latestReleaseDate: 2023-10-13
 
 -   releaseCycle: "3.3"
     releaseDate: 2023-08-23
     eol: 2023-09-20
-    extendedSupport: false
     latest: "3.3.3"
     latestReleaseDate: 2023-09-14
 
@@ -82,7 +74,7 @@ releases:
     releaseDate: 2023-07-05
     eol: 2024-07-05
     lts: true
-    extendedSupport: true
+    eoes: false
     latest: "3.2.11"
     latestReleaseDate: 2024-03-14
     link: https://github.com/quarkusio/quarkus/releases/tag/__LATEST__.Final
@@ -90,7 +82,6 @@ releases:
 -   releaseCycle: "3.1"
     releaseDate: 2023-05-31
     eol: 2023-07-05
-    extendedSupport: false
     latest: "3.1.3"
     latestReleaseDate: 2023-06-29
     link: https://github.com/quarkusio/quarkus/releases/tag/__LATEST__.Final
@@ -98,7 +89,6 @@ releases:
 -   releaseCycle: "3.0"
     releaseDate: 2023-04-26
     eol: 2023-05-31
-    extendedSupport: false
     latest: "3.0.4"
     latestReleaseDate: 2023-05-25
     link: https://github.com/quarkusio/quarkus/releases/tag/__LATEST__.Final
@@ -106,7 +96,6 @@ releases:
 -   releaseCycle: "2.16"
     releaseDate: 2023-01-25
     eol: 2023-10-31
-    extendedSupport: false
     latest: "2.16.12"
     latestReleaseDate: 2023-10-17
     link: https://github.com/quarkusio/quarkus/releases/tag/__LATEST__.Final
@@ -114,7 +103,6 @@ releases:
 -   releaseCycle: "2.15"
     releaseDate: 2022-12-14
     eol: 2023-01-25
-    extendedSupport: false
     latest: "2.15.3"
     latestReleaseDate: 2023-01-10
     link: https://github.com/quarkusio/quarkus/releases/tag/__LATEST__.Final
@@ -122,7 +110,6 @@ releases:
 -   releaseCycle: "2.14"
     releaseDate: 2022-11-09
     eol: 2022-12-14
-    extendedSupport: false
     latest: "2.14.3"
     latestReleaseDate: 2022-12-06
     link: https://github.com/quarkusio/quarkus/releases/tag/__LATEST__.Final
@@ -130,7 +117,7 @@ releases:
 -   releaseCycle: "2.13"
     releaseDate: 2022-09-28
     eol: 2022-11-07
-    extendedSupport: true
+    eoes: false
     latest: "2.13.9"
     latestReleaseDate: 2023-11-22
     link: https://github.com/quarkusio/quarkus/releases/tag/__LATEST__.Final
@@ -138,7 +125,6 @@ releases:
 -   releaseCycle: "2.12"
     releaseDate: 2022-08-31
     eol: 2022-09-21
-    extendedSupport: false
     latest: "2.12.3"
     latestReleaseDate: 2022-09-20
     link: https://github.com/quarkusio/quarkus/releases/tag/__LATEST__.Final
@@ -146,7 +132,6 @@ releases:
 -   releaseCycle: "2.11"
     releaseDate: 2022-07-27
     eol: 2022-08-24
-    extendedSupport: false
     latest: "2.11.3"
     latestReleaseDate: 2022-08-24
     link: https://github.com/quarkusio/quarkus/releases/tag/__LATEST__.Final
@@ -154,7 +139,6 @@ releases:
 -   releaseCycle: "2.10"
     releaseDate: 2022-06-22
     eol: 2022-07-26
-    extendedSupport: false
     latest: "2.10.4"
     latestReleaseDate: 2022-07-27
     link: https://github.com/quarkusio/quarkus/releases/tag/__LATEST__.Final
@@ -162,7 +146,6 @@ releases:
 -   releaseCycle: "2.9"
     releaseDate: 2022-05-11
     eol: 2022-06-15
-    extendedSupport: false
     latest: "2.9.2"
     latestReleaseDate: 2022-05-25
     link: https://github.com/quarkusio/quarkus/releases/tag/__LATEST__.Final
@@ -170,7 +153,6 @@ releases:
 -   releaseCycle: "2.8"
     releaseDate: 2022-04-12
     eol: 2022-05-06
-    extendedSupport: false
     latest: "2.8.3"
     latestReleaseDate: 2022-05-06
     link: https://github.com/quarkusio/quarkus/releases/tag/__LATEST__.Final
@@ -178,7 +160,7 @@ releases:
 -   releaseCycle: "2.7"
     releaseDate: 2022-02-02
     eol: 2022-05-30
-    extendedSupport: 2023-06-14
+    eoes: 2023-06-14
     latest: "2.7.7"
     latestReleaseDate: 2023-01-26
     link: https://github.com/quarkusio/quarkus/releases/tag/__LATEST__.Final
@@ -186,7 +168,6 @@ releases:
 -   releaseCycle: "2.6"
     releaseDate: 2021-12-22
     eol: 2022-01-26
-    extendedSupport: false
     latest: "2.6.3"
     latestReleaseDate: 2022-01-20
     link: https://github.com/quarkusio/quarkus/releases/tag/__LATEST__.Final
@@ -194,7 +175,6 @@ releases:
 -   releaseCycle: "2.5"
     releaseDate: 2021-11-24
     eol: 2021-12-17
-    extendedSupport: false
     latest: "2.5.4"
     latestReleaseDate: 2021-12-20
     link: https://github.com/quarkusio/quarkus/releases/tag/__LATEST__.Final
@@ -202,7 +182,6 @@ releases:
 -   releaseCycle: "2.4"
     releaseDate: 2021-10-27
     eol: 2021-11-17
-    extendedSupport: false
     latest: "2.4.2"
     latestReleaseDate: 2021-11-12
     link: https://github.com/quarkusio/quarkus/releases/tag/__LATEST__.Final
@@ -210,7 +189,6 @@ releases:
 -   releaseCycle: "2.3"
     releaseDate: 2021-10-06
     eol: 2021-10-20
-    extendedSupport: false
     latest: "2.3.1"
     latestReleaseDate: 2021-10-20
     link: https://github.com/quarkusio/quarkus/releases/tag/__LATEST__.Final
@@ -218,7 +196,7 @@ releases:
 -   releaseCycle: "2.2"
     releaseDate: 2021-08-31
     eol: 2021-12-21
-    extendedSupport: 2022-07-18
+    eoes: 2022-07-18
     latest: "2.2.5"
     latestReleaseDate: 2021-12-21
     link: https://github.com/quarkusio/quarkus/releases/tag/__LATEST__.Final
@@ -226,7 +204,6 @@ releases:
 -   releaseCycle: "2.1"
     releaseDate: 2021-07-29
     eol: 2021-08-26
-    extendedSupport: false
     latest: "2.1.4"
     latestReleaseDate: 2021-08-26
     link: https://github.com/quarkusio/quarkus/releases/tag/__LATEST__.Final
@@ -234,7 +211,6 @@ releases:
 -   releaseCycle: "2.0"
     releaseDate: 2021-06-30
     eol: 2021-07-22
-    extendedSupport: false
     latest: "2.0.3"
     latestReleaseDate: 2021-07-22
     link: https://github.com/quarkusio/quarkus/releases/tag/__LATEST__.Final
@@ -242,7 +218,7 @@ releases:
 -   releaseCycle: "1"
     releaseDate: 2019-11-25
     eol: 2021-06-23
-    extendedSupport: 2021-11-20
+    eoes: 2021-11-20
     latest: "1.13.7"
     latestReleaseDate: 2021-06-09
     link: https://github.com/quarkusio/quarkus/releases/tag/__LATEST__.Final
@@ -250,7 +226,6 @@ releases:
 -   releaseCycle: "0"
     releaseDate: 2018-12-12
     eol: 2019-11-25
-    extendedSupport: false
     latest: "0.28.1"
     latestReleaseDate: 2019-11-04
     link: https://github.com/quarkusio/quarkus/releases/tag/__LATEST__

--- a/products/quasar.md
+++ b/products/quasar.md
@@ -8,7 +8,7 @@ versionCommand: quasar -v
 releasePolicyLink: https://github.com/quasarframework/quasar/blob/dev/ROADMAP.md#support-policy-and-schedule
 changelogTemplate: https://github.com/quasarframework/quasar/releases/tag/quasar-v__LATEST__
 releaseDateColumn: true
-activeSupportColumn: true
+eoasColumn: true
 eolColumn: LTS support
 
 identifiers:
@@ -25,20 +25,20 @@ auto:
           column: "Version"
           regex: '^(?P<value>\d+)\.x$'
         releaseDate: "Released"
-        support: "Active support ends"
+        eoas: "Active support ends"
         eol: "LTS support ends"
 
 releases:
 -   releaseCycle: "2"
     releaseDate: 2021-06-21
-    support: true
+    eoas: false
     eol: false
     latest: "2.15.2"
     latestReleaseDate: 2024-03-29
 
 -   releaseCycle: "1"
     releaseDate: 2019-03-07
-    support: 2021-04-01
+    eoas: 2021-04-01
     eol: 2023-06-30
     latest: "1.22.10"
     latestReleaseDate: 2023-05-05

--- a/products/rabbitmq.md
+++ b/products/rabbitmq.md
@@ -9,7 +9,7 @@ releasePolicyLink: https://www.rabbitmq.com/versions.html
 changelogTemplate: https://github.com/rabbitmq/rabbitmq-server/releases/tag/v__LATEST__
 releaseDateColumn: true
 eolColumn: Community Support
-extendedSupportColumn: Extended Commercial Support
+eoesColumn: Extended Commercial Support
 
 auto:
   methods:
@@ -30,7 +30,7 @@ auto:
           column: 5 # the page has multi-line header preventing us from using the column name
           regex: '^(?P<day>\d+) (?P<month>\w{3}).* (?P<year>\d+)$' # 'Sept' is not valid
           template: "{{day}} {{month}} {{year}}"
-        extendedSupport:
+        eoes:
           column: 6 # the page has multi-line header preventing us from using the column name
           regex: '^(?P<day>\d+) (?P<month>\w{3}).* (?P<year>\d+)$' # 'Sept' is not valid
           template: "{{day}} {{month}} {{year}}"
@@ -39,56 +39,56 @@ releases:
 -   releaseCycle: "3.13"
     releaseDate: 2024-02-22
     eol: 2025-02-28
-    extendedSupport: 2025-08-31
+    eoes: 2025-08-31
     latest: "3.13.1"
     latestReleaseDate: 2024-03-29
 
 -   releaseCycle: "3.12"
     releaseDate: 2023-06-01
     eol: 2024-06-30
-    extendedSupport: 2024-12-31
+    eoes: 2024-12-31
     latest: "3.12.13"
     latestReleaseDate: 2024-02-16
 
 -   releaseCycle: "3.11"
     releaseDate: 2022-09-26
     eol: 2023-12-31
-    extendedSupport: 2024-07-31
+    eoes: 2024-07-31
     latest: "3.11.28"
     latestReleaseDate: 2023-12-21
 
 -   releaseCycle: "3.10"
     releaseDate: 2022-05-03
     eol: 2022-05-03
-    extendedSupport: 2023-12-31
+    eoes: 2023-12-31
     latest: "3.10.25"
     latestReleaseDate: 2023-07-18
 
 -   releaseCycle: "3.9"
     releaseDate: 2021-07-23
     eol: 2023-01-31
-    extendedSupport: 2023-07-31
+    eoes: 2023-07-31
     latest: "3.9.29"
     latestReleaseDate: 2023-03-09
 
 -   releaseCycle: "3.8"
     releaseDate: 2019-10-01
     eol: 2022-07-31
-    extendedSupport: 2022-07-31
+    eoes: 2022-07-31
     latest: "3.8.35"
     latestReleaseDate: 2022-07-09
 
 -   releaseCycle: "3.7"
     releaseDate: 2017-11-28
     eol: 2020-09-30
-    extendedSupport: 2020-09-30
+    eoes: 2020-09-30
     latest: "3.7.28"
     latestReleaseDate: 2020-08-17
 
 -   releaseCycle: "3.6"
     releaseDate: 2015-12-22
     eol: 2018-05-31
-    extendedSupport: 2018-05-31
+    eoes: 2018-05-31
     latest: "3.6.16"
     latestReleaseDate: 2018-06-13
     link: "https://github.com/rabbitmq/rabbitmq-server/releases/tag/rabbitmq_v{{'__LATEST__'|replace:'.','_'}}"
@@ -96,7 +96,7 @@ releases:
 -   releaseCycle: "3.5"
     releaseDate: 2015-03-11
     eol: 2016-10-31
-    extendedSupport: 2016-10-31
+    eoes: 2016-10-31
     latest: "3.5.8"
     latestReleaseDate: 2016-11-03
     link: "https://github.com/rabbitmq/rabbitmq-server/releases/tag/rabbitmq_v{{'__LATEST__'|replace:'.','_'}}"
@@ -104,7 +104,7 @@ releases:
 -   releaseCycle: "3.4"
     releaseDate: 2014-10-21
     eol: 2015-10-31
-    extendedSupport: 2015-10-31
+    eoes: 2015-10-31
     latest: "3.4.4"
     latestReleaseDate: 2015-02-11
     link: "https://github.com/rabbitmq/rabbitmq-server/releases/tag/rabbitmq_v{{'__LATEST__'|replace:'.','_'}}"
@@ -112,7 +112,7 @@ releases:
 -   releaseCycle: "3.3"
     releaseDate: 2014-04-02
     eol: 2015-03-31
-    extendedSupport: 2015-03-31
+    eoes: 2015-03-31
     latest: "3.3.5"
     latestReleaseDate: 2014-08-11
     link: "https://github.com/rabbitmq/rabbitmq-server/releases/tag/rabbitmq_v{{'__LATEST__'|replace:'.','_'}}"
@@ -120,7 +120,7 @@ releases:
 -   releaseCycle: "3.2"
     releaseDate: 2013-10-23
     eol: 2014-10-31
-    extendedSupport: 2014-10-31
+    eoes: 2014-10-31
     latest: "3.2.4"
     latestReleaseDate: 2014-03-04
     link: "https://github.com/rabbitmq/rabbitmq-server/releases/tag/rabbitmq_v{{'__LATEST__'|replace:'.','_'}}"
@@ -128,7 +128,7 @@ releases:
 -   releaseCycle: "3.1"
     releaseDate: 2013-05-01
     eol: 2014-04-30
-    extendedSupport: 2014-04-30
+    eoes: 2014-04-30
     latest: "3.1.5"
     latestReleaseDate: 2013-08-15
     link: "https://github.com/rabbitmq/rabbitmq-server/releases/tag/rabbitmq_v{{'__LATEST__'|replace:'.','_'}}"
@@ -136,7 +136,7 @@ releases:
 -   releaseCycle: "3.0"
     releaseDate: 2012-11-19
     eol: 2013-11-30
-    extendedSupport: 2013-11-30
+    eoes: 2013-11-30
     latest: "3.0.4"
     latestReleaseDate: 2013-03-06
     link: "https://github.com/rabbitmq/rabbitmq-server/releases/tag/rabbitmq_v{{'__LATEST__'|replace:'.','_'}}"

--- a/products/rancher.md
+++ b/products/rancher.md
@@ -9,7 +9,7 @@ alternate_urls:
 releasePolicyLink: https://www.suse.com/support/kb/doc/?id=000020432
 changelogTemplate: https://github.com/rancher/rancher/releases/tag/v__LATEST__
 releaseDateColumn: General Availability
-activeSupportColumn: Full Support
+eoasColumn: Full Support
 eolColumn: Limited Support
 eolWarnThreshold: 121
 
@@ -24,70 +24,70 @@ auto:
 releases:
 -   releaseCycle: "2.8"
     releaseDate: 2023-12-05
-    support: true # to update once defined on https://www.suse.com/lifecycle#rancher
+    eoas: false # to update once defined on https://www.suse.com/lifecycle#rancher
     eol: false # to update once defined on https://www.suse.com/lifecycle#rancher
     latest: "2.8.3"
     latestReleaseDate: 2024-03-28
 
 -   releaseCycle: "2.7"
     releaseDate: 2022-11-16
-    support: 2024-05-15
+    eoas: 2024-05-15
     eol: 2024-11-18
     latest: "2.7.12"
     latestReleaseDate: 2024-03-27
 
 -   releaseCycle: "2.6"
     releaseDate: 2021-08-30
-    support: 2023-03-01
+    eoas: 2023-03-01
     eol: 2024-04-30
     latest: "2.6.14"
     latestReleaseDate: 2024-02-06
 
 -   releaseCycle: "2.5"
     releaseDate: 2020-10-05
-    support: 2022-01-05
+    eoas: 2022-01-05
     eol: 2023-01-31
     latest: "2.5.17"
     latestReleaseDate: 2023-01-23
 
 -   releaseCycle: "2.4"
     releaseDate: 2020-03-30
-    support: 2021-07-30
+    eoas: 2021-07-30
     eol: 2022-03-31
     latest: "2.4.18"
     latestReleaseDate: 2022-03-31
 
 -   releaseCycle: "2.3"
     releaseDate: 2019-10-07
-    support: 2020-10-07
+    eoas: 2020-10-07
     eol: 2021-04-07
     latest: "2.3.11"
     latestReleaseDate: 2021-03-02
 
 -   releaseCycle: "2.2"
     releaseDate: 2019-03-25
-    support: 2020-04-15
+    eoas: 2020-04-15
     eol: 2020-10-15
     latest: "2.2.13"
     latestReleaseDate: 2020-06-01
 
 -   releaseCycle: "2.1"
     releaseDate: 2018-10-05
-    support: 2019-10-19
+    eoas: 2019-10-19
     eol: 2020-04-19
     latest: "2.1.14"
     latestReleaseDate: 2020-01-03
 
 -   releaseCycle: "2.0"
     releaseDate: 2018-04-30
-    support: 2019-05-01
+    eoas: 2019-05-01
     eol: 2019-11-01
     latest: "2.0.16"
     latestReleaseDate: 2019-07-03
 
 -   releaseCycle: "1.6"
     releaseDate: 2017-05-04
-    support: 2019-12-31
+    eoas: 2019-12-31
     eol: 2020-06-30
     latest: "1.6.30"
     latestReleaseDate: 2020-05-04

--- a/products/react.md
+++ b/products/react.md
@@ -7,7 +7,7 @@ permalink: /react
 releasePolicyLink: https://react.dev/community/versioning-policy
 changelogTemplate: https://github.com/facebook/react/releases/tag/v__LATEST__
 releaseDateColumn: true
-activeSupportColumn: true
+eoasColumn: true
 
 identifiers:
 -   purl: pkg:github/facebook/react
@@ -21,42 +21,42 @@ auto:
 releases:
 -   releaseCycle: "18.2"
     releaseDate: 2022-06-14
-    support: true
+    eoas: false
     eol: false
     latest: "18.2.0"
     latestReleaseDate: 2022-06-14
 
 -   releaseCycle: "18.1"
     releaseDate: 2022-04-26
-    support: 2022-06-14
+    eoas: 2022-06-14
     eol: false
     latest: "18.1.0"
     latestReleaseDate: 2022-04-26
 
 -   releaseCycle: "18.0"
     releaseDate: 2022-03-29
-    support: 2022-04-26
+    eoas: 2022-04-26
     eol: false
     latest: "18.0.0"
     latestReleaseDate: 2022-03-29
 
 -   releaseCycle: "17"
     releaseDate: 2020-10-20
-    support: 2022-03-29
+    eoas: 2022-03-29
     eol: false
     latest: "17.0.2"
     latestReleaseDate: 2021-03-22
 
 -   releaseCycle: "16"
     releaseDate: 2017-09-26
-    support: 2020-10-20
+    eoas: 2020-10-20
     eol: false
     latest: "16.14.0"
     latestReleaseDate: 2020-10-14
 
 -   releaseCycle: "15"
     releaseDate: 2016-04-07
-    support: 2017-09-26
+    eoas: 2017-09-26
     eol: false
     latest: "15.7.0"
     latestReleaseDate: 2020-10-14

--- a/products/red-hat-jboss-eap.md
+++ b/products/red-hat-jboss-eap.md
@@ -11,9 +11,9 @@ versionCommand: $JBOSS_HOME/bin/version.sh
 releasePolicyLink: https://access.redhat.com/support/policy/updates/jboss_notes
 changelogTemplate: "https://access.redhat.com/documentation/en-us/red_hat_jboss_enterprise_application_platform/{{'__LATEST__'|split:'.'|pop|join:'.'}}"
 releaseDateColumn: true
-activeSupportColumn: Full Support
+eoasColumn: Full Support
 eolColumn: Maintenance Support
-extendedSupportColumn: Extended Life Support 1
+eoesColumn: Extended Life Support 1
 
 # Latest releases with their date can be found in each cycles release notes.date.
 # Other dates can be found on https://access.redhat.com/support/policy/updates/jboss_notes#p_eap.
@@ -21,43 +21,43 @@ extendedSupportColumn: Extended Life Support 1
 releases:
 -   releaseCycle: "7"
     releaseDate: 2016-05-01
-    support: 2023-12-31
+    eoas: 2023-12-31
     eol: 2025-06-30
-    extendedSupport: 2026-11-30
+    eoes: 2026-11-30
     latest: "7.4.14"
     latestReleaseDate: 2023-12-12
 
 -   releaseCycle: "6"
     releaseDate: 2012-06-01
-    support: 2016-06-30
+    eoas: 2016-06-30
     eol: 2019-06-30
-    extendedSupport: 2022-06-30
+    eoes: 2022-06-30
     latest: "6.4.24"
     latestReleaseDate: 2022-06-30
 
 -   releaseCycle: "5"
     releaseDate: 2009-11-01
-    support: 2013-11-30
+    eoas: 2013-11-30
     eol: 2016-11-30
-    extendedSupport: 2019-11-30
+    eoes: 2019-11-30
     latest: "5.2.0"
     latestReleaseDate: 2013-01-23 # unknown, date from https://access.redhat.com/documentation/en-us/jboss_enterprise_application_platform/5/html/release_notes_5.2.0/appe-release_notes_5.2-revision_history
     link: https://access.redhat.com/documentation/en-us/jboss_enterprise_application_platform/5/html/release_notes_5.2.0
 
 -   releaseCycle: "4.3"
     releaseDate: 2008-01-01
-    support: 2011-01-31
+    eoas: 2011-01-31
     eol: 2013-01-31
-    extendedSupport: 2016-11-30
+    eoes: 2016-11-30
     latest: '4.3.0 CP10'
     latestReleaseDate: 2013-02-11
     link: https://access.redhat.com/errata/RHSA-2013:0249
 
 -   releaseCycle: "4.2"
     releaseDate: 2007-06-01
-    support: 2010-06-30
+    eoas: 2010-06-30
     eol: 2012-06-30
-    extendedSupport: 2015-06-30
+    eoes: 2015-06-30
     latest: '4.2.0.CP09'
     latestReleaseDate: 2010-04-26
     link: https://listman.redhat.com/archives/rhsa-announce/2010-April/000713.html

--- a/products/red-hat-openshift.md
+++ b/products/red-hat-openshift.md
@@ -12,9 +12,9 @@ releasePolicyLink: https://access.redhat.com/support/policy/updates/openshift
 releaseImage: https://access.redhat.com/sites/default/files/styles/XL%20-%20Extra%20Large/public/images/ocp_lifecycle_eus_v5.png
 changelogTemplate: https://docs.openshift.com/container-platform/__RELEASE_CYCLE__/release_notes/ocp-{{"__RELEASE_CYCLE__"| replace:'.','-'}}-release-notes.html
 releaseDateColumn: true
-activeSupportColumn: Full Support
+eoasColumn: Full Support
 eolColumn: Maintenance Support
-extendedSupportColumn: Extended Update Support
+eoesColumn: Extended Update Support
 
 auto:
   methods:
@@ -24,121 +24,110 @@ auto:
 releases:
 -   releaseCycle: "4.15"
     releaseDate: 2024-02-27
-    support: true # 4.16 GA + 3 months
+    eoas: false # 4.16 GA + 3 months
     eol: 2025-08-27
-    extendedSupport: true # not yet announced
+    eoes: false # not yet announced
     latest: "4.15.5"
     latestReleaseDate: 2024-03-27
 
 -   releaseCycle: "4.14"
     releaseDate: 2023-11-01
-    support: 2024-05-27
+    eoas: 2024-05-27
     eol: 2025-05-01
-    extendedSupport: 2025-10-31
+    eoes: 2025-10-31
     latest: "4.14.18"
     latestReleaseDate: 2024-03-27
 
 -   releaseCycle: "4.13"
     releaseDate: 2023-05-17
-    support: 2024-01-31
+    eoas: 2024-01-31
     eol: 2024-11-17
-    extendedSupport: false
     latest: "4.13.38"
     latestReleaseDate: 2024-03-27
 
 -   releaseCycle: "4.12"
     releaseDate: 2023-01-17
-    support: 2023-08-17
+    eoas: 2023-08-17
     eol: 2024-07-17
-    extendedSupport: 2025-01-17
+    eoes: 2025-01-17
     latest: "4.12.53"
     latestReleaseDate: 2024-03-20
 
 -   releaseCycle: "4.11"
     releaseDate: 2022-08-10
-    support: 2023-04-17
+    eoas: 2023-04-17
     eol: 2024-02-10
-    extendedSupport: false
     latest: "4.11.59"
     latestReleaseDate: 2024-03-27
 
 -   releaseCycle: "4.10"
     releaseDate: 2022-03-10
-    support: 2022-11-10
+    eoas: 2022-11-10
     eol: 2023-09-10
-    extendedSupport: false
     latest: "4.10.67"
     latestReleaseDate: 2023-09-06
 
 -   releaseCycle: "4.9"
     releaseDate: 2021-10-18
-    support: 2022-06-10
+    eoas: 2022-06-10
     eol: 2023-04-18
-    extendedSupport: false
     latest: "4.9.59"
     latestReleaseDate: 2023-04-05
 
 -   releaseCycle: "4.8"
     releaseDate: 2021-07-27
-    support: 2022-01-27
+    eoas: 2022-01-27
     eol: 2023-01-27
-    extendedSupport: 2023-04-27
+    eoes: 2023-04-27
     latest: "4.8.57"
     latestReleaseDate: 2023-01-25
 
 -   releaseCycle: "4.7"
     releaseDate: 2021-02-24
-    support: 2021-10-27
+    eoas: 2021-10-27
     eol: 2022-08-24
-    extendedSupport: false
     latest: "4.7.60"
     latestReleaseDate: 2022-11-10
 
 -   releaseCycle: "4.6"
     releaseDate: 2020-11-09
-    support: 2021-03-24
+    eoas: 2021-03-24
     eol: 2022-10-27
-    extendedSupport: false
     latest: "4.6.62"
     latestReleaseDate: 2022-11-10
 
 -   releaseCycle: "4.5"
     releaseDate: 2020-07-16
-    support: 2020-11-27
+    eoas: 2020-11-27
     eol: 2021-07-27
-    extendedSupport: false
     latest: "4.5.41"
     latestReleaseDate: 2021-06-30
 
 -   releaseCycle: "4.4"
     releaseDate: 2020-05-18
-    support: 2020-08-13
+    eoas: 2020-08-13
     eol: 2021-02-24
-    extendedSupport: false
     latest: "4.4.33"
     latestReleaseDate: 2021-02-02
 
 -   releaseCycle: "4.3"
     releaseDate: 2020-02-12
-    support: 2020-06-05
+    eoas: 2020-06-05
     eol: 2020-10-27
-    extendedSupport: false
     latest: "4.3.40"
     latestReleaseDate: 2020-10-20
 
 -   releaseCycle: "4.2"
     releaseDate: 2019-10-29
-    support: 2020-02-23
+    eoas: 2020-02-23
     eol: 2020-07-13
-    extendedSupport: false
     latest: "4.2.36"
     latestReleaseDate: 2020-07-01
 
 -   releaseCycle: "4.1"
     releaseDate: 2019-06-18
-    support: 2019-11-16
+    eoas: 2019-11-16
     eol: 2020-05-05
-    extendedSupport: false
     latest: "4.1.41"
     latestReleaseDate: 2020-04-22
 

--- a/products/redhat-satellite.md
+++ b/products/redhat-satellite.md
@@ -15,8 +15,8 @@ releaseImage: https://access.redhat.com/sites/default/files/styles/XL%20-%20Extr
 releasePolicyLink: https://access.redhat.com/support/policy/updates/satellite
 changelogTemplate: "https://access.redhat.com/documentation/en-us/red_hat_satellite/__RELEASE_CYCLE__/html/release_notes/index"
 releaseDateColumn: General availability
-activeSupportColumn: Full support
-activeSupportWarnThreshold: 30
+eoasColumn: Full support
+eoasWarnThreshold: 30
 eolColumn: Maintenance support
 
 auto:
@@ -26,42 +26,42 @@ auto:
 releases:
 -   releaseCycle: "6.14"
     releaseDate: 2023-02-13
-    support: 2024-05-31
+    eoas: 2024-05-31
     eol: 2025-05-31
     latest: "6.14.3"
     latestReleaseDate: 2024-03-27
 
 -   releaseCycle: "6.13"
     releaseDate: 2023-05-03
-    support: 2023-11-30
+    eoas: 2023-11-30
     eol: 2024-11-30
     latest: "6.13.7"
     latestReleaseDate: 2024-02-29
 
 -   releaseCycle: "6.12"
     releaseDate: 2022-11-16
-    support: 2023-05-31
+    eoas: 2023-05-31
     eol: 2024-05-31
     latest: "6.12.5.2"
     latestReleaseDate: 2023-10-20
 
 -   releaseCycle: "6.11"
     releaseDate: 2022-07-05
-    support: 2022-11-30
+    eoas: 2022-11-30
     eol: 2024-01-31
     latest: "6.11.5.6"
     latestReleaseDate: 2023-10-20
 
 -   releaseCycle: "6.10"
     releaseDate: 2021-11-16
-    support: 2022-06-30
+    eoas: 2022-06-30
     eol: 2023-05-31
     latest: "6.10.7.2"
     latestReleaseDate: 2023-03-01
 
 -   releaseCycle: "6.9"
     releaseDate: 2021-04-21
-    support: 2021-11-30
+    eoas: 2021-11-30
     eol: 2022-11-30
     latest: "6.9.10"
     latestReleaseDate: 2022-11-17

--- a/products/redhat.md
+++ b/products/redhat.md
@@ -8,14 +8,14 @@ alternate_urls:
 -   /redhat
 -   /redhatlinux
 versionCommand: cat /etc/redhat-release
-changelogTemplate: 
+changelogTemplate:
   https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/__RELEASE_CYCLE__/html/__LATEST___release_notes/index
 releasePolicyLink: https://access.redhat.com/support/policy/updates/errata
 LTSLabel: "<abbr title='Extended Life Cycle Support'>ELS</abbr>"
-activeSupportColumn: Full Support
+eoasColumn: Full Support
 eolColumn: Maintenance Support
 releaseDateColumn: true
-extendedSupportColumn: Extended Life Cycle Support
+eoesColumn: Extended Life Cycle Support
 
 identifiers:
 -   cpe: cpe:/o:redhat:enterprise_linux
@@ -24,54 +24,54 @@ identifiers:
 releases:
 -   releaseCycle: "9"
     releaseDate: 2022-05-17
-    support: 2027-05-31
+    eoas: 2027-05-31
     eol: 2032-05-31
     lts: 2032-05-31
-    extendedSupport: 2035-05-31
+    eoes: 2035-05-31
     latest: "9.3"
     latestReleaseDate: 2023-11-07
 
 -   releaseCycle: "8"
     releaseDate: 2019-05-07
-    support: 2024-05-31
+    eoas: 2024-05-31
     eol: 2029-05-31
     lts: 2029-05-31
-    extendedSupport: 2032-05-31
+    eoes: 2032-05-31
     latest: "8.9"
     latestReleaseDate: 2023-11-14
 
 -   releaseCycle: "7"
     releaseDate: 2013-12-11
-    support: 2019-08-06
+    eoas: 2019-08-06
     eol: 2024-06-30
     lts: 2024-06-30
-    extendedSupport: 2028-06-30
+    eoes: 2028-06-30
     latest: "7.9"
     latestReleaseDate: 2020-09-29
 
 -   releaseCycle: "6"
     releaseDate: 2010-11-09
-    support: 2016-05-10
+    eoas: 2016-05-10
     eol: 2020-11-30
     lts: 2020-11-30
-    extendedSupport: 2024-06-30
+    eoes: 2024-06-30
     latest: '6.10'
     latestReleaseDate: 2018-06-19
 
 -   releaseCycle: "5"
     releaseDate: 2007-03-15
-    support: 2013-01-08
+    eoas: 2013-01-08
     eol: 2017-03-31
     lts: 2017-03-31
-    extendedSupport: 2020-11-30
+    eoes: 2020-11-30
     latest: '5.11'
     latestReleaseDate: 2014-09-16
 
 -   releaseCycle: "4"
     releaseDate: 2005-02-15
-    support: 2009-03-31
+    eoas: 2009-03-31
     eol: 2012-02-29
-    extendedSupport: 2017-03-31
+    eoes: 2017-03-31
     latest: '4.9'
     latestReleaseDate: 2011-02-16
 

--- a/products/redis.md
+++ b/products/redis.md
@@ -6,7 +6,7 @@ permalink: /redis
 versionCommand: redis-server --version
 releasePolicyLink: https://redis.io/docs/about/releases/
 changelogTemplate: https://raw.githubusercontent.com/redis/redis/__RELEASE_CYCLE__/00-RELEASENOTES
-activeSupportColumn: true
+eoasColumn: true
 releaseDateColumn: true
 
 identifiers:
@@ -28,40 +28,40 @@ auto:
   methods:
   -   git: https://github.com/redis/redis.git
 
-# - support(x) = release(x+1)
+# - eoas(x) = release(x+1)
 # - eol(x) = release(x+3)
 releases:
 -   releaseCycle: "7.2"
     releaseDate: 2023-08-15
-    support: true
+    eoas: false
     eol: false
     latest: '7.2.4'
     latestReleaseDate: 2024-01-09
 
 -   releaseCycle: "7.0"
     releaseDate: 2022-04-27
-    support: 2023-08-15
+    eoas: 2023-08-15
     eol: false
     latest: '7.0.15'
     latestReleaseDate: 2024-01-09
 
 -   releaseCycle: "6.2"
     releaseDate: 2021-02-22
-    support: 2022-04-27
+    eoas: 2022-04-27
     eol: false
     latest: '6.2.14'
     latestReleaseDate: 2023-10-18
 
 -   releaseCycle: "6.0"
     releaseDate: 2020-04-30
-    support: 2021-02-22
+    eoas: 2021-02-22
     eol: 2023-08-15
     latest: '6.0.20'
     latestReleaseDate: 2023-07-10
 
 -   releaseCycle: "5.0"
     releaseDate: 2018-10-17
-    support: 2020-04-30
+    eoas: 2020-04-30
     eol: 2022-04-27
     latest: '5.0.14'
     latestReleaseDate: 2021-10-04

--- a/products/robo.md
+++ b/products/robo.md
@@ -4,7 +4,7 @@ category: framework
 tags: php-runtime
 permalink: /robo
 versionCommand: robo --version
-activeSupportColumn: true
+eoasColumn: true
 customColumns:
   -   property: supportedPHPVersions
       position: after-release-column
@@ -25,33 +25,33 @@ auto:
         supportedPHPVersions: "PHP Versions"
 
 # Based on https://github.com/consolidation/robo#branches:
-# support(x) = true if "Stable", false otherwise
+# eoas(x) = true if "Stable", false otherwise
 # eol(x) = false if "Stable" or "Important fixes only", false otherwise
 releases:
 -   releaseCycle: "4"
     supportedPHPVersions: "8.0 - 8.1"
-    support: true
+    eoas: false
     eol: false
     latest: "4.0.6"
     latestReleaseDate: 2023-04-30
 
 -   releaseCycle: "3"
     supportedPHPVersions: "7.1 - 8.1"
-    support: false
+    eoas: true
     eol: true # https://github.com/consolidation/robo/pull/1154#issuecomment-1989610031
     latest: "3.0.12"
     latestReleaseDate: 2023-04-30
 
 -   releaseCycle: "2"
     supportedPHPVersions: "7.1 - 7.4"
-    support: false
+    eoas: true
     eol: true # https://github.com/consolidation/robo/pull/1154#issuecomment-1989610031
     latest: "2.2.2"
     latestReleaseDate: 2020-12-18
 
 -   releaseCycle: "1"
     supportedPHPVersions: "5.5 - 7.4"
-    support: false
+    eoas: true
     eol: true # https://github.com/consolidation/robo/pull/1154#issuecomment-1989610031
     latest: "1.5.0"
     latestReleaseDate: 2021-10-07

--- a/products/rocket-chat.md
+++ b/products/rocket-chat.md
@@ -9,7 +9,7 @@ alternate_urls:
 releasePolicyLink: https://docs.rocket.chat/resources/rocket.chats-support-structure/enterprise-support-and-version-durability
 changelogTemplate: "https://github.com/RocketChat/Rocket.Chat/releases/tag/__LATEST__"
 releaseDateColumn: true
-activeSupportColumn: true
+eoasColumn: true
 eolColumn: Support
 
 auto:
@@ -23,53 +23,53 @@ auto:
           regex: '^(?P<value>\d+\.\d+).*$'
         eol: "End of Life"
 
-# support(x) = releaseDate(x+1)
+# eoas(x) = releaseDate(x+1)
 releases:
 -   releaseCycle: "6.6"
     releaseDate: 2024-02-07
-    support: true
+    eoas: false
     eol: 2024-08-31
     latest: '6.6.6'
     latestReleaseDate: 2024-03-25
 
 -   releaseCycle: "6.5"
     releaseDate: 2023-12-01
-    support: 2024-02-07
+    eoas: 2024-02-07
     eol: 2024-06-30
     latest: '6.5.5'
     latestReleaseDate: 2024-03-25
 
 -   releaseCycle: "6.4"
     releaseDate: 2023-09-27
-    support: 2023-12-01
+    eoas: 2023-12-01
     eol: 2024-03-31
     latest: '6.4.9'
     latestReleaseDate: 2024-01-03
 
 -   releaseCycle: "6.3"
     releaseDate: 2023-08-02
-    support: 2023-09-27
+    eoas: 2023-09-27
     eol: 2024-02-29
     latest: '6.3.12'
     latestReleaseDate: 2023-11-17
 
 -   releaseCycle: "6.2"
     releaseDate: 2023-05-15
-    support: 2023-08-02
+    eoas: 2023-08-02
     eol: 2023-11-30
     latest: '6.2.12'
     latestReleaseDate: 2023-08-11
 
 -   releaseCycle: "6.1"
     releaseDate: 2023-03-29
-    support: 2023-05-15
+    eoas: 2023-05-15
     eol: 2023-09-30
     latest: '6.1.8'
     latestReleaseDate: 2023-05-17
 
 -   releaseCycle: "6.0"
     releaseDate: 2023-03-09
-    support: 2023-03-29
+    eoas: 2023-03-29
     eol: 2023-09-30
     latest: '6.0.8'
     latestReleaseDate: 2023-05-17
@@ -77,35 +77,35 @@ releases:
 -   releaseCycle: "5.4"
     lts: true
     releaseDate: 2022-12-05
-    support: 2023-03-09
+    eoas: 2023-03-09
     eol: 2023-06-30
     latest: '5.4.10'
     latestReleaseDate: 2023-05-17
 
 -   releaseCycle: "5.3"
     releaseDate: 2022-11-01
-    support: 2022-12-05
+    eoas: 2022-12-05
     eol: 2023-05-31
     latest: '5.3.7'
     latestReleaseDate: 2023-04-17
 
 -   releaseCycle: "5.2"
     releaseDate: 2022-10-13
-    support: 2022-11-01
+    eoas: 2022-11-01
     eol: 2023-04-30
     latest: '5.2.2'
     latestReleaseDate: 2023-01-24
 
 -   releaseCycle: "5.1"
     releaseDate: 2022-09-02
-    support: 2022-10-13
+    eoas: 2022-10-13
     eol: 2023-03-31
     latest: '5.1.5'
     latestReleaseDate: 2022-11-24
 
 -   releaseCycle: "5.0"
     releaseDate: 2022-07-21
-    support: 2022-09-02
+    eoas: 2022-09-02
     eol: 2023-01-31
     latest: '5.0.8'
     latestReleaseDate: 2022-11-24
@@ -113,63 +113,63 @@ releases:
 -   releaseCycle: "4.8"
     lts: true
     releaseDate: 2022-05-31
-    support: 2022-07-21
+    eoas: 2022-07-21
     eol: 2022-12-31
     latest: '4.8.7'
     latestReleaseDate: 2022-11-24
 
 -   releaseCycle: "4.7"
     releaseDate: 2022-05-04
-    support: 2022-05-31
+    eoas: 2022-05-31
     eol: 2022-11-30
     latest: '4.7.5'
     latestReleaseDate: 2022-07-20
 
 -   releaseCycle: "4.6"
     releaseDate: 2022-04-01
-    support: 2022-05-04
+    eoas: 2022-05-04
     eol: 2022-10-31
     latest: '4.6.4'
     latestReleaseDate: 2022-06-02
 
 -   releaseCycle: "4.5"
     releaseDate: 2022-02-28
-    support: 2022-04-01
+    eoas: 2022-04-01
     eol: 2022-09-30
     latest: '4.5.7'
     latestReleaseDate: 2022-06-02
 
 -   releaseCycle: "4.4"
     releaseDate: 2022-01-28
-    support: 2022-02-28
+    eoas: 2022-02-28
     eol: 2022-07-31
     latest: '4.4.5'
     latestReleaseDate: 2022-05-30
 
 -   releaseCycle: "4.3"
     releaseDate: 2021-12-28
-    support: 2022-01-28
+    eoas: 2022-01-28
     eol: 2022-06-30
     latest: '4.3.3'
     latestReleaseDate: 2022-01-28
 
 -   releaseCycle: "4.2"
     releaseDate: 2021-11-30
-    support: 2021-12-28
+    eoas: 2021-12-28
     eol: 2022-05-31
     latest: '4.2.4'
     latestReleaseDate: 2022-01-28
 
 -   releaseCycle: "4.1"
     releaseDate: 2021-10-28
-    support: 2021-11-30
+    eoas: 2021-11-30
     eol: 2022-04-30
     latest: '4.1.6'
     latestReleaseDate: 2022-06-02
 
 -   releaseCycle: "4.0"
     releaseDate: 2021-10-01
-    support: 2021-10-28
+    eoas: 2021-10-28
     eol: 2022-04-30
     latest: '4.0.6'
     latestReleaseDate: 2021-11-05
@@ -177,133 +177,133 @@ releases:
 -   releaseCycle: "3.18"
     lts: true
     releaseDate: 2021-08-31
-    support: 2021-10-01
+    eoas: 2021-10-01
     eol: 2022-02-28
     latest: '3.18.7'
     latestReleaseDate: 2022-05-30
 
 -   releaseCycle: "3.17"
     releaseDate: 2021-07-30
-    support: 2021-08-31
+    eoas: 2021-08-31
     eol: 2022-01-31
     latest: '3.17.3'
     latestReleaseDate: 2021-10-01
 
 -   releaseCycle: "3.16"
     releaseDate: 2021-06-28
-    support: 2021-07-30
+    eoas: 2021-07-30
     eol: 2021-12-31
     latest: '3.16.5'
     latestReleaseDate: 2021-10-01
 
 -   releaseCycle: "3.15"
     releaseDate: 2021-05-28
-    support: 2021-06-28
+    eoas: 2021-06-28
     eol: 2021-11-30
     latest: '3.15.4'
     latestReleaseDate: 2021-07-13
 
 -   releaseCycle: "3.14"
     releaseDate: 2021-04-28
-    support: 2021-05-28
+    eoas: 2021-05-28
     eol: 2021-10-31
     latest: '3.14.6'
     latestReleaseDate: 2021-07-13
 
 -   releaseCycle: "3.13"
     releaseDate: 2021-04-04
-    support: 2021-04-28
+    eoas: 2021-04-28
     eol: 2021-10-31
     latest: '3.13.5'
     latestReleaseDate: 2021-05-27
 
 -   releaseCycle: "3.12"
     releaseDate: 2021-02-28
-    support: 2021-04-04
+    eoas: 2021-04-04
     eol: 2021-08-31
     latest: '3.12.7'
     latestReleaseDate: 2021-05-27
 
 -   releaseCycle: "3.11"
     releaseDate: 2021-01-31
-    support: 2021-02-28
+    eoas: 2021-02-28
     eol: 2021-08-31
     latest: '3.11.6'
     latestReleaseDate: 2022-08-22
 
 -   releaseCycle: "3.10"
     releaseDate: 2020-12-29
-    support: 2021-01-31
+    eoas: 2021-01-31
     eol: 2021-06-30
     latest: '3.10.7'
     latestReleaseDate: 2021-03-26
 
 -   releaseCycle: "3.9"
     releaseDate: 2020-11-28
-    support: 2020-12-29
+    eoas: 2020-12-29
     eol: 2021-05-31
     latest: '3.9.7'
     latestReleaseDate: 2021-01-27
 
 -   releaseCycle: "3.8"
     releaseDate: 2020-11-14
-    support: 2020-11-28
+    eoas: 2020-11-28
     eol: 2021-05-31
     latest: '3.8.9'
     latestReleaseDate: 2021-03-26
 
 -   releaseCycle: "3.7"
     releaseDate: 2020-09-28
-    support: 2020-11-14
+    eoas: 2020-11-14
     eol: 2021-03-31
     latest: '3.7.4'
     latestReleaseDate: 2020-12-18
 
 -   releaseCycle: "3.6"
     releaseDate: 2020-08-29
-    support: 2020-09-28
+    eoas: 2020-09-28
     eol: 2021-02-28
     latest: '3.6.3'
     latestReleaseDate: 2020-09-25
 
 -   releaseCycle: "3.5"
     releaseDate: 2020-07-27
-    support: 2020-08-29
+    eoas: 2020-08-29
     eol: 2021-01-31
     latest: '3.5.4'
     latestReleaseDate: 2020-08-24
 
 -   releaseCycle: "3.4"
     releaseDate: 2020-06-30
-    support: 2020-07-27
+    eoas: 2020-07-27
     eol: 2020-12-31
     latest: '3.4.3'
     latestReleaseDate: 2020-07-31
 
 -   releaseCycle: "3.3"
     releaseDate: 2020-05-27
-    support: 2020-06-30
+    eoas: 2020-06-30
     eol: 2020-11-30
     latest: '3.3.3'
     latestReleaseDate: 2020-06-11
 
 -   releaseCycle: "3.2"
     releaseDate: 2020-04-27
-    support: 2020-05-27
+    eoas: 2020-05-27
     eol: 2020-10-31
     latest: '3.2.2'
     latestReleaseDate: 2020-05-11
 
 -   releaseCycle: "3.1"
     releaseDate: 2020-04-09
-    support: 2020-04-27
+    eoas: 2020-04-27
     eol: 2020-10-31
     latest: '3.1.3'
     latestReleaseDate: 2020-05-11
 
 -   releaseCycle: "3.0"
     releaseDate: 2020-02-14
-    support: 2020-04-09
+    eoas: 2020-04-09
     eol: 2020-08-31
     latest: '3.0.13'
     latestReleaseDate: 2020-05-11
@@ -311,35 +311,35 @@ releases:
 -   releaseCycle: "2.4"
     lts: true
     releaseDate: 2019-12-27
-    support: 2020-02-14
+    eoas: 2020-02-14
     eol: 2020-06-30
     latest: '2.4.14'
     latestReleaseDate: 2020-12-18
 
 -   releaseCycle: "2.3"
     releaseDate: 2019-11-27
-    support: 2019-12-27
+    eoas: 2019-12-27
     eol: 2020-05-31
     latest: '2.3.3'
     latestReleaseDate: 2020-01-10
 
 -   releaseCycle: "2.2"
     releaseDate: 2019-10-27
-    support: 2019-11-27
+    eoas: 2019-11-27
     eol: 2020-04-30
     latest: '2.2.1'
     latestReleaseDate: 2019-11-19
 
 -   releaseCycle: "2.1"
     releaseDate: 2019-09-27
-    support: 2019-10-27
+    eoas: 2019-10-27
     eol: 2020-03-31
     latest: '2.1.3'
     latestReleaseDate: 2019-11-19
 
 -   releaseCycle: "2.0"
     releaseDate: 2019-09-12
-    support: 2019-09-27
+    eoas: 2019-09-27
     eol: 2020-03-31
     latest: '2.0.1'
     latestReleaseDate: 2019-11-19
@@ -347,28 +347,28 @@ releases:
 -   releaseCycle: "1.3"
     lts: true
     releaseDate: 2019-08-02
-    support: 2019-09-12
+    eoas: 2019-09-12
     eol: 2020-02-29
     latest: '1.3.5'
     latestReleaseDate: 2020-12-18
 
 -   releaseCycle: "1.2"
     releaseDate: 2019-06-27
-    support: 2019-08-02
+    eoas: 2019-08-02
     eol: 2019-12-31
     latest: '1.2.4'
     latestReleaseDate: 2019-08-08
 
 -   releaseCycle: "1.1"
     releaseDate: 2019-05-27
-    support: 2019-06-27
+    eoas: 2019-06-27
     eol: 2019-11-30
     latest: '1.1.5'
     latestReleaseDate: 2019-08-08
 
 -   releaseCycle: "1.0"
     releaseDate: 2019-04-28
-    support: 2019-05-27
+    eoas: 2019-05-27
     eol: 2019-10-31
     latest: '1.0.5'
     latestReleaseDate: 2019-08-08

--- a/products/rockylinux.md
+++ b/products/rockylinux.md
@@ -10,7 +10,7 @@ alternate_urls:
 versionCommand: cat /etc/os-release
 releasePolicyLink: https://wiki.rockylinux.org/rocky/version/
 changelogTemplate: "https://rockylinux.org/news/rocky-linux-{{'__LATEST__'|replace:'.','-'}}-ga-release/"
-activeSupportColumn: true
+eoasColumn: true
 releaseDateColumn: true
 
 identifiers:
@@ -29,20 +29,20 @@ auto:
           column: "Major Version"
           regex: '^Rocky Linux (?P<value>\d+)$'
         releaseDate: "Release Date"
-        support: "Active Support"
+        eoas: "Active Support"
         eol: "End of Life"
 
 releases:
 -   releaseCycle: "9"
     releaseDate: 2022-07-14
-    support: 2027-05-31
+    eoas: 2027-05-31
     eol: 2032-05-31
     latest: "9.3"
     latestReleaseDate: 2023-11-20
 
 -   releaseCycle: "8"
     releaseDate: 2021-05-01
-    support: 2024-05-31
+    eoas: 2024-05-31
     eol: 2029-05-31
     latest: "8.9"
     latestReleaseDate: 2023-11-22

--- a/products/roundcube.md
+++ b/products/roundcube.md
@@ -6,7 +6,7 @@ iconSlug: roundcube
 permalink: /roundcube
 releasePolicyLink: https://roundcube.net/news/2021/10/18/roundcube-1.5.0-released
 changelogTemplate: https://github.com/roundcube/roundcubemail/releases/tag/__LATEST__
-activeSupportColumn: true
+eoasColumn: true
 releaseDateColumn: true
 eolColumn: Security Support
 
@@ -17,49 +17,49 @@ auto:
 releases:
 -   releaseCycle: "1.6"
     releaseDate: 2022-07-25
-    support: true
+    eoas: false
     eol: false
     latest: "1.6.6"
     latestReleaseDate: 2024-01-20
 
 -   releaseCycle: "1.5"
     releaseDate: 2021-10-18
-    support: true
+    eoas: false
     eol: false
     latest: "1.5.6"
     latestReleaseDate: 2023-11-05
 
 -   releaseCycle: "1.4"
     releaseDate: 2019-11-09
-    support: false
+    eoas: true
     eol: false
     latest: "1.4.16"
     latestReleaseDate: 2023-12-10
 
 -   releaseCycle: "1.3"
     releaseDate: 2017-06-26
-    support: false
+    eoas: true
     eol: 2022-07-28
     latest: "1.3.17"
     latestReleaseDate: 2021-11-12
 
 -   releaseCycle: "1.2"
     releaseDate: 2016-05-21
-    support: false
+    eoas: true
     eol: 2021-10-18
     latest: "1.2.13"
     latestReleaseDate: 2020-12-27
 
 -   releaseCycle: "1.1"
     releaseDate: 2015-02-07
-    support: false
+    eoas: true
     eol: true
     latest: "1.1.12"
     latestReleaseDate: 2018-04-29
 
 -   releaseCycle: "1.0"
     releaseDate: 2014-04-05
-    support: false
+    eoas: true
     eol: true
     latest: "1.0.12"
     latestReleaseDate: 2017-11-08

--- a/products/ruby-on-rails.md
+++ b/products/ruby-on-rails.md
@@ -38,35 +38,35 @@ releases:
 
 -   releaseCycle: "6.0"
     releaseDate: 2019-08-16
-    support: 2021-12-15
+    eoas: 2021-12-15
     eol: 2023-06-01
     latest: "6.0.6.1"
     latestReleaseDate: 2023-01-17
 
 -   releaseCycle: "5.2"
     releaseDate: 2018-04-09
-    support: 2021-12-15
+    eoas: 2021-12-15
     eol: 2022-06-01
     latest: "5.2.8.1"
     latestReleaseDate: 2022-07-12
 
 -   releaseCycle: "5.1"
     releaseDate: 2017-04-27
-    support: 2018-04-09
+    eoas: 2018-04-09
     eol: 2019-08-25
     latest: "5.1.7"
     latestReleaseDate: 2019-03-27
 
 -   releaseCycle: "5.0"
     releaseDate: 2016-06-30
-    support: 2018-04-09
+    eoas: 2018-04-09
     eol: 2018-04-09
     latest: "5.0.7.2"
     latestReleaseDate: 2019-03-13
 
 -   releaseCycle: "4.2"
     releaseDate: 2014-12-19
-    support: 2016-06-30
+    eoas: 2016-06-30
     eol: 2017-04-27
     latest: "4.2.11.3"
     latestReleaseDate: 2020-05-15

--- a/products/salt.md
+++ b/products/salt.md
@@ -11,7 +11,7 @@ releasePolicyLink: https://docs.saltproject.io/salt/install-guide/en/latest/topi
 releaseImage: https://docs.saltproject.io/salt/install-guide/en/latest/_images/salt-release-timeline.png
 changelogTemplate: https://docs.saltproject.io/en/__RELEASE_CYCLE__/topics/releases/__LATEST__.html
 eolColumn: CVE & Critical Support
-activeSupportColumn: true
+eoasColumn: true
 releaseDateColumn: true
 
 auto:
@@ -32,7 +32,7 @@ releases:
 -   releaseCycle: "3007"
     lts: false # not yet on https://docs.saltproject.io/salt/install-guide/en/latest/topics/salt-version-support-lifecycle.html
     releaseDate: 2024-03-06
-    support: true # not yet on https://docs.saltproject.io/salt/install-guide/en/latest/topics/salt-version-support-lifecycle.html
+    eoas: false # not yet on https://docs.saltproject.io/salt/install-guide/en/latest/topics/salt-version-support-lifecycle.html
     eol: false # not yet on https://docs.saltproject.io/salt/install-guide/en/latest/topics/salt-version-support-lifecycle.html
     latest: "3007.0"
     latestReleaseDate: 2024-03-06
@@ -41,7 +41,7 @@ releases:
 -   releaseCycle: "3006"
     lts: true
     releaseDate: 2023-04-18
-    support: 2024-04-18
+    eoas: 2024-04-18
     eol: 2025-04-18
     latest: "3006.7"
     latestReleaseDate: 2024-02-21
@@ -49,14 +49,14 @@ releases:
 
 -   releaseCycle: "3005"
     releaseDate: 2022-08-22
-    support: 2023-08-25
+    eoas: 2023-08-25
     eol: 2024-02-25
     latest: "3005.5"
     latestReleaseDate: 2024-01-24
 
 -   releaseCycle: "3004"
     releaseDate: 2021-10-12
-    support: 2022-10-18
+    eoas: 2022-10-18
     eol: 2023-04-18
     latest: "3004.2"
     latestReleaseDate: 2022-05-13

--- a/products/samsungmobile.md
+++ b/products/samsungmobile.md
@@ -9,7 +9,7 @@ alternate_urls:
 releasePolicyLink: https://security.samsungmobile.com/workScope.smsb
 releaseColumn: false
 releaseDateColumn: true
-activeSupportColumn: true
+eoasColumn: true
 eolColumn: Security Updates
 
 # Models compatible with Android 12+ are considered fully supported.
@@ -21,2539 +21,2539 @@ eolColumn: Security Updates
 releases:
 -   releaseCycle: "Galaxy S24 Ultra"
     releaseDate: 2024-01-24
-    support: 2031-01-24 # "seven generations of OS upgrades" (https://news.samsung.com/global/enter-the-new-era-of-mobile-ai-with-samsung-galaxy-s24-series)
+    eoas: 2031-01-24 # "seven generations of OS upgrades" (https://news.samsung.com/global/enter-the-new-era-of-mobile-ai-with-samsung-galaxy-s24-series)
     eol: 2031-01-24 # "seven years of security updates"
     link: https://doc.samsungmobile.com/SM-S928U1/XAA/doc.html
 
 -   releaseCycle: "Galaxy S24+"
     releaseDate: 2024-01-24
-    support: 2031-01-24 # "seven generations of OS upgrades" (https://news.samsung.com/global/enter-the-new-era-of-mobile-ai-with-samsung-galaxy-s24-series)
+    eoas: 2031-01-24 # "seven generations of OS upgrades" (https://news.samsung.com/global/enter-the-new-era-of-mobile-ai-with-samsung-galaxy-s24-series)
     eol: 2031-01-24 # "seven years of security updates"
     link: https://doc.samsungmobile.com/SM-S926U1/XAA/doc.html
 
 -   releaseCycle: "Galaxy S24"
     releaseDate: 2024-01-24
-    support: 2031-01-24 # "seven generations of OS upgrades" (https://news.samsung.com/global/enter-the-new-era-of-mobile-ai-with-samsung-galaxy-s24-series)
+    eoas: 2031-01-24 # "seven generations of OS upgrades" (https://news.samsung.com/global/enter-the-new-era-of-mobile-ai-with-samsung-galaxy-s24-series)
     eol: 2031-01-24 # "seven years of security updates"
     link: https://doc.samsungmobile.com/SM-S921U1/XAA/doc.html
 
 -   releaseCycle: "Galaxy S23 FE"
     releaseDate: 2023-10-05
-    support: true
+    eoas: false
     eol: 2028-10-05 # "five years of security updates" (https://security.samsungmobile.com/securityPost.smsb)
     link: https://doc.samsungmobile.com/SM-S711B/INS/doc.html
 
 -   releaseCycle: "Galaxy A54 5G"
     releaseDate: 2023-03-24
-    support: true # "four generations of OS upgrades"
+    eoas: false # "four generations of OS upgrades"
     eol: 2028-03-24 # "five years of security updates" (https://news.samsung.com/global/the-samsung-galaxy-a54-5g-and-galaxy-a34-5g-awesome-experiences-for-all)
     link: https://doc.samsungmobile.com/SM-A546U/TMB/doc.html
 
 -   releaseCycle: "Galaxy A34 5G"
     releaseDate: 2023-03-24
-    support: true # "four generations of OS upgrades"
+    eoas: false # "four generations of OS upgrades"
     eol: 2028-03-24 # "five years of security updates" (https://news.samsung.com/global/the-samsung-galaxy-a54-5g-and-galaxy-a34-5g-awesome-experiences-for-all)
     link: https://doc.samsungmobile.com/SM-A346E/INS/doc.html
 
 -   releaseCycle: "Galaxy S23 Ultra"
     releaseDate: 2023-02-17
-    support: true
+    eoas: false
     eol: 2028-02-17 # "five years of security updates" (https://security.samsungmobile.com/securityPost.smsb)
     link: https://doc.samsungmobile.com/SM-S918B/EUX/doc.html
 
 -   releaseCycle: "Galaxy S23+"
     releaseDate: 2023-02-17
-    support: true
+    eoas: false
     eol: 2028-02-17 # "five years of security updates" (https://security.samsungmobile.com/securityPost.smsb)
     link: https://doc.samsungmobile.com/SM-S916B/EUX/doc.html
 
 -   releaseCycle: "Galaxy S23"
     releaseDate: 2023-02-17
-    support: true
+    eoas: false
     eol: 2028-02-17 # "five years of security updates" (https://security.samsungmobile.com/securityPost.smsb)
     link: https://doc.samsungmobile.com/SM-S911B/EUX/doc.html
 
 -   releaseCycle: "Galaxy A14 5G"
     releaseDate: 2023-01-12
-    support: true
+    eoas: false
     eol: false
     link: https://doc.samsungmobile.com/SM-A146B/INS/doc.html
 
 -   releaseCycle: "Galaxy F04"
     releaseDate: 2023-01-12
-    support: true
+    eoas: false
     eol: false
     link: null
 
 -   releaseCycle: "Galaxy M04"
     releaseDate: 2022-12-16
-    support: true
+    eoas: false
     eol: false
     link: https://doc.samsungmobile.com/SM-M045F/INS/doc.html
 
 -   releaseCycle: "Galaxy Tab A7 10.4 (2022)"
     releaseDate: 2022-11-21
-    support: true
+    eoas: false
     eol: false
     link: https://doc.samsungmobile.com/SM-T509/ITV/doc.html
 
 -   releaseCycle: "Galaxy A04e"
     releaseDate: 2022-11-07
-    support: true
+    eoas: false
     eol: false
     link: https://doc.samsungmobile.com/SM-A042F/XXV/doc.html
 
 -   releaseCycle: "Galaxy A04"
     releaseDate: 2022-10-10
-    support: true
+    eoas: false
     eol: false
     link: https://doc.samsungmobile.com/SM-A045F/XXV/doc.html
 
 -   releaseCycle: "Galaxy A04s"
     releaseDate: 2022-09-22
-    support: true
+    eoas: false
     eol: false
     link: https://doc.samsungmobile.com/SM-A047F/XXV/doc.html
 
 -   releaseCycle: "Galaxy Tab Active4 Pro"
     releaseDate: 2022-09-13
-    support: true
+    eoas: false
     eol: false
     link: https://doc.samsungmobile.com/SM-T636B/XSA/doc.html
 
 -   releaseCycle: "Galaxy A23 5G"
     releaseDate: 2022-09-02
-    support: true
+    eoas: false
     eol: false
     link: https://doc.samsungmobile.com/SM-A236U/DSA/doc.html
 
 -   releaseCycle: "Galaxy Watch5 Pro"
     releaseDate: 2022-08-26
-    support: true
+    eoas: false
     eol: false
     link: https://doc.samsungmobile.com/SM-R925F/ITV/doc.html
 
 -   releaseCycle: "Galaxy Watch5"
     releaseDate: 2022-08-26
-    support: true
+    eoas: false
     eol: false
     link: https://doc.samsungmobile.com/SM-R905F/BTU/doc.html
 
 -   releaseCycle: "Galaxy Z Fold4"
     releaseDate: 2022-08-25
-    support: true
+    eoas: false
     eol: false
     link: https://doc.samsungmobile.com/SM-F936U1/TMB/doc.html
 
 -   releaseCycle: "Galaxy Z Flip4"
     releaseDate: 2022-08-25
-    support: true
+    eoas: false
     eol: false
     link: https://doc.samsungmobile.com/SM-F721U1/XAR/doc.html
 
 -   releaseCycle: "Galaxy M13 5G"
     releaseDate: 2022-07-23
-    support: true
+    eoas: false
     eol: false
     link: https://doc.samsungmobile.com/SM-M136B/INS/doc.html
 
 -   releaseCycle: "Galaxy M13 (India)"
     releaseDate: 2022-07-23
-    support: true
+    eoas: false
     eol: false
     link: https://doc.samsungmobile.com/SM-M135FU/INS/doc.html
 
 -   releaseCycle: "Galaxy Xcover6 Pro"
     releaseDate: 2022-07-13
-    support: true
+    eoas: false
     eol: false
     link: https://doc.samsungmobile.com/SM-G736B/XSA/doc.html
 
 -   releaseCycle: "Galaxy A13 (SM-A137)"
     releaseDate: 2022-07-01 # Approximate to the month and year.
-    support: true
+    eoas: false
     eol: false
     link: https://doc.samsungmobile.com/SM-A137F/SFR/doc.html
 
 -   releaseCycle: "Galaxy M13"
     releaseDate: 2022-07-01
-    support: true
+    eoas: false
     eol: false
     link: https://doc.samsungmobile.com/SM-M135F/EUX/doc.html
 
 -   releaseCycle: "Galaxy F13"
     releaseDate: 2022-06-29
-    support: true
+    eoas: false
     eol: false
     link: https://doc.samsungmobile.com/SM-E135F/INS/doc.html
 
 -   releaseCycle: "Galaxy Tab S6 Lite (2022)"
     releaseDate: 2022-05-23
-    support: true
+    eoas: false
     eol: false
     link: https://doc.samsungmobile.com/SM-P619/ATO/doc.html
 
 -   releaseCycle: "Galaxy Tab S8 Ultra"
     releaseDate: 2022-04-30
-    support: true
+    eoas: false
     eol: false
     link: https://doc.samsungmobile.com/SM-X906B/XXV/doc.html
 
 -   releaseCycle: "Galaxy M53"
     releaseDate: 2022-04-22
-    support: true
+    eoas: false
     eol: false
     link: https://doc.samsungmobile.com/SM-M536B/SER/doc.html
 
 -   releaseCycle: "Galaxy A73 5G"
     releaseDate: 2022-04-22
-    support: true
+    eoas: false
     eol: false
     link: https://doc.samsungmobile.com/SM-A736B/XSA/doc.html
 
 -   releaseCycle: "Galaxy Tab S8+"
     releaseDate: 2022-04-14
-    support: true
+    eoas: false
     eol: false
     link: https://doc.samsungmobile.com/SM-X806B/XXV/doc.html
 
 -   releaseCycle: "Galaxy M33"
     releaseDate: 2022-04-08
-    support: true
+    eoas: false
     eol: false
     link: https://doc.samsungmobile.com/SM-M336BU/INS/doc.html
 
 -   releaseCycle: "Galaxy M23"
     releaseDate: 2022-04-08
-    support: true
+    eoas: false
     eol: false
     link: https://doc.samsungmobile.com/SM-M236B/XXV/doc.html
 
 -   releaseCycle: "Galaxy S20 FE 2022" # South Korea only
     releaseDate: 2022-04-01
-    support: true
+    eoas: false
     eol: false
     link: https://doc.samsungmobile.com/sm-g781b/xeo/doc.html
 
 -   releaseCycle: "Galaxy A53 5G"
     releaseDate: 2022-04-01
-    support: true
+    eoas: false
     eol: false
     link: https://doc.samsungmobile.com/SM-A536B/EUX/doc.html
 
 -   releaseCycle: "Galaxy A33 5G"
     releaseDate: 2022-04-01
-    support: true
+    eoas: false
     eol: false
     link: https://doc.samsungmobile.com/sm-a336e/ins/doc.html
 
 -   releaseCycle: "Galaxy A23"
     releaseDate: 2022-03-25
-    support: true
+    eoas: false
     eol: false
     link: https://doc.samsungmobile.com/SM-A235M/PET/doc.html
 
 -   releaseCycle: "Galaxy A13"
     releaseDate: 2022-03-23
-    support: true
+    eoas: false
     eol: false
     link: https://doc.samsungmobile.com/SM-A135M/PET/doc.html
 
 -   releaseCycle: "Galaxy Tab S8"
     releaseDate: 2022-03-22
-    support: true
+    eoas: false
     eol: false
     link: https://doc.samsungmobile.com/SM-X706B/SER/doc.html
 
 -   releaseCycle: "Galaxy F23"
     releaseDate: 2022-03-16
-    support: true
+    eoas: false
     eol: false
     link: https://doc.samsungmobile.com/SM-E236B/INS/doc.html
 
 -   releaseCycle: "Galaxy S22 Ultra 5G"
     releaseDate: 2022-02-25
-    support: true
+    eoas: false
     eol: 2027-02-25 # "five years of security updates" (https://security.samsungmobile.com/securityPost.smsb)
     link: https://doc.samsungmobile.com/SM-S908E/VAU/doc.html
 
 -   releaseCycle: "Galaxy S22+ 5G"
     releaseDate: 2022-02-25
-    support: true
+    eoas: false
     eol: 2027-02-25 # "five years of security updates" (https://security.samsungmobile.com/securityPost.smsb)
     link: https://doc.samsungmobile.com/SM-S906E/XXV/doc.html
 
 -   releaseCycle: "Galaxy S22 5G"
     releaseDate: 2022-02-25
-    support: true
+    eoas: false
     eol: 2027-02-25 # "five years of security updates" (https://security.samsungmobile.com/securityPost.smsb)
     link: https://doc.samsungmobile.com/SM-S901E/XXV/doc.html
 
 -   releaseCycle: "Galaxy A03"
     releaseDate: 2022-01-21
-    support: true
+    eoas: false
     eol: false
     link: https://doc.samsungmobile.com/SM-A035G/BTU/doc.html
 
 -   releaseCycle: "Galaxy Tab A8 10.5 (2021)"
     releaseDate: 2022-01-17
-    support: true
+    eoas: false
     eol: false
     link: https://doc.samsungmobile.com/SM-X205/INS/doc.html
 
 -   releaseCycle: "Galaxy S21 FE 5G"
     releaseDate: 2022-01-07
-    support: true
+    eoas: false
     eol: 2027-01-07 # "five years of security updates" (https://security.samsungmobile.com/securityPost.smsb)
     link: https://doc.samsungmobile.com/SM-G990B2/SER/doc.html
 
 -   releaseCycle: "Galaxy A03 Core"
     releaseDate: 2021-12-06
-    support: true
+    eoas: false
     eol: false
     link: https://doc.samsungmobile.com/SM-A032M/PET/doc.html
 
 -   releaseCycle: "Galaxy A13 5G"
     releaseDate: 2021-12-03
-    support: true
+    eoas: false
     eol: false
     link: https://doc.samsungmobile.com/SM-A136U/USC/doc.html
 
 -   releaseCycle: "Galaxy F42 5G"
     releaseDate: 2021-10-03
-    support: true
+    eoas: false
     eol: false
     link: https://doc.samsungmobile.com/sm-e426b/ins/doc.html
 
 -   releaseCycle: "Galaxy M52 5G"
     releaseDate: 2021-10-03
-    support: true
+    eoas: false
     eol: false
     link: https://doc.samsungmobile.com/SM-M526BR/ITV/doc.html
 
 -   releaseCycle: "Galaxy M22"
     releaseDate: 2021-09-14 # Unclear date, defaulting to announcement date
-    support: true
+    eoas: false
     eol: false
     link: https://doc.samsungmobile.com/sm-m225fv/zto/doc.html
 
 -   releaseCycle: "Galaxy M32 5G"
     releaseDate: 2021-09-02
-    support: true
+    eoas: false
     eol: false
     link: https://doc.samsungmobile.com/SM-M326B/INS/doc.html
 
 -   releaseCycle: "Galaxy A52s 5G"
     releaseDate: 2021-09-01
-    support: true
+    eoas: false
     eol: false
     link: https://doc.samsungmobile.com/SM-A528B/BTU/doc.html
 
 -   releaseCycle: "Galaxy Z Fold3 5G"
     releaseDate: 2021-08-27
-    support: true
+    eoas: false
     eol: false
     link: https://doc.samsungmobile.com/SM-F926B/SER/doc.html
 
 -   releaseCycle: "Galaxy Z Flip3 5G"
     releaseDate: 2021-08-27
-    support: true
+    eoas: false
     eol: false
     link: https://doc.samsungmobile.com/SM-F711B/SER/doc.html
 
 -   releaseCycle: "Galaxy Watch4 Classic"
     releaseDate: 2021-08-27
-    support: true
+    eoas: false
     eol: false
     link: https://doc.samsungmobile.com/SM-R890/XAA/doc.html
 
 -   releaseCycle: "Galaxy Watch4"
     releaseDate: 2021-08-27
-    support: true
+    eoas: false
     eol: false
     link: https://doc.samsungmobile.com/SM-R870/XAA/doc.html
 
 -   releaseCycle: "Galaxy A03s"
     releaseDate: 2021-08-18
-    support: true
+    eoas: false
     eol: false
     link: https://doc.samsungmobile.com/SM-A037F/INS/doc.html
 
 -   releaseCycle: "Galaxy A12 (India)"
     releaseDate: 2021-08-12
-    support: true
+    eoas: false
     eol: false
     link: https://doc.samsungmobile.com/SM-A127F/INS/doc.html
 
 -   releaseCycle: "Galaxy A12 Nacho"
     releaseDate: 2021-08-09
-    support: true
+    eoas: false
     eol: false
     link: https://doc.samsungmobile.com/SM-A127F/ITV/doc.html
 
 -   releaseCycle: "Galaxy M21 2021"
     releaseDate: 2021-07-26
-    support: true
+    eoas: false
     eol: false
     link: https://doc.samsungmobile.com/sm-m215f/ins/doc.html
 
 -   releaseCycle: "Galaxy F22"
     releaseDate: 2021-07-13
-    support: true
+    eoas: false
     eol: false
     link: https://doc.samsungmobile.com/SM-E225F/INS/doc.html
 
 -   releaseCycle: "Galaxy M32"
     releaseDate: 2021-06-28
-    support: true
+    eoas: false
     eol: false
     link: https://doc.samsungmobile.com/sm-m325f/ins/doc.html
 
 -   releaseCycle: "Galaxy A22 5G"
     releaseDate: 2021-06-24
-    support: true
+    eoas: false
     eol: false
     link: https://doc.samsungmobile.com/SM-A226B/XEH/doc.html
 
 -   releaseCycle: "Galaxy A22"
     releaseDate: 2021-06-03
-    support: true
+    eoas: false
     eol: false
     link: https://doc.samsungmobile.com/SM-A225F/TUR/doc.html
 
 -   releaseCycle: "Galaxy F52 5G"
     releaseDate: 2021-06-01
-    support: true
+    eoas: false
     eol: false
     link: https://doc.samsungmobile.com/SM-E5260/CHC/doc.html
 
 -   releaseCycle: "Galaxy Tab A7 Lite"
     releaseDate: 2021-05-27
-    support: true
+    eoas: false
     eol: false
     link: https://doc.samsungmobile.com/SM-T220/CHN/doc.html
 
 -   releaseCycle: "Galaxy Tab S7 FE"
     releaseDate: 2021-05-25
-    support: true
+    eoas: false
     eol: false
     link: https://doc.samsungmobile.com/SM-T730/KOO/doc.html
 
 -   releaseCycle: "Galaxy A82 5G"
     releaseDate: 2021-05-05
-    support: true
+    eoas: false
     eol: false
     link: https://doc.samsungmobile.com/sm-a528b/dbt/doc.html
 
 -   releaseCycle: "Galaxy M42 5G"
     releaseDate: 2021-04-30
-    support: true
+    eoas: false
     eol: false
     link: https://doc.samsungmobile.com/SM-M426B/INS/doc.html
 
 -   releaseCycle: "Galaxy A Quantum2"
     releaseDate: 2021-04-23
-    support: true
+    eoas: false
     eol: false
     link: https://doc.samsungmobile.com/sm-a826s/skc/doc.html
 
 -   releaseCycle: "Galaxy F12"
     releaseDate: 2021-04-12
-    support: true
+    eoas: false
     eol: false
     link: https://doc.samsungmobile.com/SM-F127G/INS/doc.html
 
 -   releaseCycle: "Galaxy F02s"
     releaseDate: 2021-04-09
-    support: true
+    eoas: false
     eol: false
     link: https://doc.samsungmobile.com/SM-E025F/INS/doc.html
 
 -   releaseCycle: "Galaxy A52"
     releaseDate: 2021-03-26
-    support: true
+    eoas: false
     eol: false
     link: https://doc.samsungmobile.com/SM-A525F/XID/doc.html
 
 -   releaseCycle: "Galaxy A72"
     releaseDate: 2021-03-26
-    support: true
+    eoas: false
     eol: false
     link: https://doc.samsungmobile.com/SM-A725F/XEO/doc.html
 
 -   releaseCycle: "Galaxy M12 (India)"
     releaseDate: 2021-03-18
-    support: true
+    eoas: false
     eol: false
     link: https://doc.samsungmobile.com/SM-M127G/INS/doc.html
 
 -   releaseCycle: "Galaxy A52 5G"
     releaseDate: 2021-03-17
-    support: true
+    eoas: false
     eol: false
     link: https://doc.samsungmobile.com/sm-a526b/dbt/doc.html
 
 -   releaseCycle: "Galaxy Xcover 5"
     releaseDate: 2021-03-12
-    support: true
+    eoas: false
     eol: false
     link: https://doc.samsungmobile.com/SM-G525N/KOO/doc.html
 
 -   releaseCycle: "Galaxy M62"
     releaseDate: 2021-03-03
-    support: true
+    eoas: false
     eol: false
     link: https://doc.samsungmobile.com/SM-M625F/NPL/doc.html
 
 -   releaseCycle: "Galaxy A32"
     releaseDate: 2021-02-25
-    support: true
+    eoas: false
     eol: false
     link: https://doc.samsungmobile.com/sm-a325f/ins/doc.html
 
 -   releaseCycle: "Galaxy F62"
     releaseDate: 2021-02-22
-    support: true
+    eoas: false
     eol: false
     link: https://doc.samsungmobile.com/SM-E625F/INS/doc.html
 
 -   releaseCycle: "Galaxy M02"
     releaseDate: 2021-02-09
-    support: true
+    eoas: false
     eol: false
     link: https://doc.samsungmobile.com/SM-M022F/XTC/doc.html
 
 -   releaseCycle: "Galaxy M31s"
     releaseDate: 2021-02-09
-    support: true
+    eoas: false
     eol: false
     link: https://doc.samsungmobile.com/sm-m317f/ins/doc.html
 
 -   releaseCycle: "Galaxy S21 Ultra 5G"
     releaseDate: 2021-01-29
-    support: true
+    eoas: false
     eol: 2026-01-29 # "five years of security updates" (https://security.samsungmobile.com/securityPost.smsb)
     link: https://doc.samsungmobile.com/sm-g998b/dbt/doc.html
 
 -   releaseCycle: "Galaxy S21+ 5G"
     releaseDate: 2021-01-29
-    support: true
+    eoas: false
     eol: 2026-01-29 # "five years of security updates" (https://security.samsungmobile.com/securityPost.smsb)
     link: https://doc.samsungmobile.com/SM-G996B/DBT/doc.html
 
 -   releaseCycle: "Galaxy S21 5G"
     releaseDate: 2021-01-29
-    support: true
+    eoas: false
     eol: 2026-01-29 # "five years of security updates" (https://security.samsungmobile.com/securityPost.smsb)
     link: https://doc.samsungmobile.com/SM-G991B/DBT/doc.html
 
 -   releaseCycle: "Galaxy A02"
     releaseDate: 2021-01-27
-    support: true
+    eoas: false
     eol: false
     link: https://doc.samsungmobile.com/SM-A022F/XID/doc.html
 
 -   releaseCycle: "Galaxy A32 5G"
     releaseDate: 2021-01-13
-    support: true
+    eoas: false
     eol: false
     link: https://doc.samsungmobile.com/sm-a326u/tmb/doc.html
 
 -   releaseCycle: "Galaxy M02s"
     releaseDate: 2021-01-07
-    support: true
+    eoas: false
     eol: false
     link: https://doc.samsungmobile.com/SM-M025F/SLK/doc.html
 
 -   releaseCycle: "Galaxy A02s"
     releaseDate: 2021-01-04
-    support: true
+    eoas: false
     eol: false
     link: https://doc.samsungmobile.com/SM-A025G/XEF/doc.html
 
 -   releaseCycle: "Galaxy A12"
     releaseDate: 2020-11-24
-    support: true
+    eoas: false
     eol: false
     link: https://doc.samsungmobile.com/SM-A125F/XEF/doc.html
 
 -   releaseCycle: "Galaxy M12"
     releaseDate: 2020-11-24
-    support: true
+    eoas: false
     eol: false
     link: https://doc.samsungmobile.com/SM-M127F/ARO/doc.html
 
 -   releaseCycle: "Galaxy A42 5G"
     releaseDate: 2020-11-11
-    support: true
+    eoas: false
     eol: false
     link: https://doc.samsungmobile.com/SM-A426B/XEF/doc.html
 
 -   releaseCycle: "Galaxy M21s"
     releaseDate: 2020-11-06
-    support: true
+    eoas: false
     eol: false
     link: https://doc.samsungmobile.com/SM-F415F/INS/doc.html
 
 -   releaseCycle: "Galaxy Z Fold2 5G"
     releaseDate: 2020-11-04
-    support: false
+    eoas: true
     eol: false
     link: https://doc.samsungmobile.com/SM-F916B/XEH/doc.html
 
 -   releaseCycle: "Galaxy M31 Prime"
     releaseDate: 2020-10-17
-    support: true
+    eoas: false
     eol: false
     link: https://doc.samsungmobile.com/sm-m315f/ins/doc.html
 
 -   releaseCycle: "Galaxy F41"
     releaseDate: 2020-10-16
-    support: true
+    eoas: false
     eol: false
     link: https://doc.samsungmobile.com/SM-F415F/INS/doc.html
 
 -   releaseCycle: "Galaxy S20 FE 5G"
     releaseDate: 2020-10-02
-    support: false # three generations of upgrades
+    eoas: true # three generations of upgrades
     eol: 2024-10-02 # "minimum of four (4) years following their global launch" (https://security.samsungmobile.com/workScope.smsb)
     link: https://doc.samsungmobile.com/SM-G781B/BTU/doc.html
 
 -   releaseCycle: "Galaxy S20 FE"
     releaseDate: 2020-10-02
-    support: false # three generations of upgrades
+    eoas: true # three generations of upgrades
     eol: 2024-10-02 # "minimum of four (4) years following their global launch" (https://security.samsungmobile.com/workScope.smsb)
     link: https://doc.samsungmobile.com/SM-G780G/BTU/doc.html
 
 -   releaseCycle: "Galaxy Tab Active3"
     releaseDate: 2020-09-28
-    support: true
+    eoas: false
     eol: false
     link: https://doc.samsungmobile.com/SM-T575/XEF/doc.html
 
 -   releaseCycle: "Galaxy Z Fold 2"
     releaseDate: 2020-09-18
-    support: true
+    eoas: false
     eol: false
     link: https://doc.samsungmobile.com/SM-F916B/XEH/doc.html
 
 -   releaseCycle: "Galaxy Tab A7 10.4 (2020)"
     releaseDate: 2020-09-11
-    support: true
+    eoas: false
     eol: false
     link: https://doc.samsungmobile.com/SM-T505/BTU/doc.html
 
 -   releaseCycle: "Galaxy Note 20 Ultra 5G"
     releaseDate: 2020-08-21
-    support: true
+    eoas: false
     eol: false
     link: https://doc.samsungmobile.com/SM-N986U1/VZW/doc.html
 
 -   releaseCycle: "Galaxy Note 20 5G"
     releaseDate: 2020-08-21
-    support: true
+    eoas: false
     eol: false
     link: https://doc.samsungmobile.com/SM-N981U1/VZW/doc.html
 
 -   releaseCycle: "Galaxy Note20 Ultra"
     releaseDate: 2020-08-21
-    support: true
+    eoas: false
     eol: false
     link: https://doc.samsungmobile.com/SM-N985F/XNZ/doc.html
 
 -   releaseCycle: "Galaxy Tab S7"
     releaseDate: 2020-08-21
-    support: true
+    eoas: false
     eol: false
     link: https://doc.samsungmobile.com/SM-T875/DBT/doc.html
 
 -   releaseCycle: "Galaxy Note20"
     releaseDate: 2020-08-21
-    support: true
+    eoas: false
     eol: false
     link: https://doc.samsungmobile.com/SM-N980F/XEO/doc.html
 
 -   releaseCycle: "Galaxy A51 5G UW"
     releaseDate: 2020-08-14
-    support: true
+    eoas: false
     eol: false
     link: https://doc.samsungmobile.com/SM-A516V/CHA/doc.html
 
 -   releaseCycle: "Galaxy Z Flip 5G"
     releaseDate: 2020-08-07
-    support: true
+    eoas: false
     eol: false
     link: https://doc.samsungmobile.com/SM-F707B/XEH/doc.html
 
 -   releaseCycle: "Galaxy A51 5G"
     releaseDate: 2020-08-07
-    support: true
+    eoas: false
     eol: false
     link: https://doc.samsungmobile.com/SM-A516B/012784200623/nld.html
 
 -   releaseCycle: "Galaxy M51"
     releaseDate: 2020-08-06
-    support: true
+    eoas: false
     eol: false
     link: https://doc.samsungmobile.com/SM-M515F/DBT/doc.html
 
 -   releaseCycle: "Galaxy Watch3"
     releaseDate: 2020-08-06
-    support: true
+    eoas: false
     eol: false
     link: https://doc.samsungmobile.com/sm-r850/btu/doc.html
 
 -   releaseCycle: "Galaxy A01 Core"
     releaseDate: 2020-08-06
-    support: false
+    eoas: true
     eol: false
     link: https://doc.samsungmobile.com/SM-A013F/SEK/doc.html
 
 -   releaseCycle: "Galaxy Tab S7+"
     releaseDate: 2020-08-05
-    support: true
+    eoas: false
     eol: false
     link: https://doc.samsungmobile.com/SM-T970/XAR/doc.html
 
 -   releaseCycle: "Galaxy M01 Core"
     releaseDate: 2020-07-29
-    support: true
+    eoas: false
     eol: false
     link: https://doc.samsungmobile.com/SM-M013F/INS/doc.html
 
 -   releaseCycle: "Galaxy M01s"
     releaseDate: 2020-07-16
-    support: true
+    eoas: false
     eol: false
     link: https://doc.samsungmobile.com/SM-M017F/INS/doc.html
 
 -   releaseCycle: "Galaxy A71 5G UW"
     releaseDate: 2020-07-16
-    support: true
+    eoas: false
     eol: false
     link: https://doc.samsungmobile.com/SM-A716V/CCT/doc.html
 
 -   releaseCycle: "Galaxy A21"
     releaseDate: 2020-06-26
-    support: true
+    eoas: false
     eol: false # Quarterly
     link: https://doc.samsungmobile.com/sm-a215u/usc/doc.html
 
 -   releaseCycle: "Galaxy A71 5G"
     releaseDate: 2020-06-15
-    support: true
+    eoas: false
     eol: false
     link: https://doc.samsungmobile.com/sm-a716u/spr/doc.html
 
 -   releaseCycle: "Galaxy S20 5G UW" # Verizon only
     releaseDate: 2020-06-04
-    support: false # three generations of upgrades
+    eoas: true # three generations of upgrades
     eol: 2024-06-04 # "minimum of four (4) years following their global launch" (https://security.samsungmobile.com/workScope.smsb)
     link: https://www.verizon.com/support/samsung-galaxy-s20-5g-uw-update/
 
 -   releaseCycle: "Galaxy A21s"
     releaseDate: 2020-06-02
-    support: true
+    eoas: false
     eol: false # Quarterly
     link: https://doc.samsungmobile.com/SM-A217F/XEF/doc.html
 
 -   releaseCycle: "Galaxy M01"
     releaseDate: 2020-06-02
-    support: true
+    eoas: false
     eol: false
     link: https://doc.samsungmobile.com/SM-M015G/INS/doc.html
 
 -   releaseCycle: "Galaxy A Quantum"
     releaseDate: 2020-05-22
-    support: true
+    eoas: false
     eol: false
     link: https://doc.samsungmobile.com/sm-a716s/skc/doc.html
 
 -   releaseCycle: "Galaxy Tab S6 Lite"
     releaseDate: 2020-05-16
-    support: true
+    eoas: false
     eol: false
     link: https://doc.samsungmobile.com/SM-P610/XEH/doc.html
 
 -   releaseCycle: "Galaxy A11"
     releaseDate: 2020-05-15
-    support: true
+    eoas: false
     eol: false # Quarterly
     link: https://doc.samsungmobile.com/SM-A115F/XSG/doc.html
 
 -   releaseCycle: "Galaxy M11"
     releaseDate: 2020-05-04
-    support: true
+    eoas: false
     eol: false
     link: https://doc.samsungmobile.com/SM-M115F/INS/doc.html
 
 -   releaseCycle: "Galaxy A31"
     releaseDate: 2020-04-27
-    support: true
+    eoas: false
     eol: false # Quarterly
     link: https://doc.samsungmobile.com/SM-A315F/MID/doc.html
 
 -   releaseCycle: "Galaxy J2 Core (2020)"
     releaseDate: 2020-04-27
-    support: false # Android 8.1 Oreo (Go edition) is not supported anymore
+    eoas: true # Android 8.1 Oreo (Go edition) is not supported anymore
     eol: false
     link: https://doc.samsungmobile.com/SM-J260FU/SER/doc.html
 
 -   releaseCycle: "Galaxy Xcover FieldPro"
     releaseDate: 2020-04-06
-    support: 2022-10-01 # Approximate from here: https://9to5google.com/2022/10/04/samsung-android-12-update-rollout/
+    eoas: 2022-10-01 # Approximate from here: https://9to5google.com/2022/10/04/samsung-android-12-update-rollout/
     eol: false
     link: https://doc.samsungmobile.com/SM-G889YB/DBT/doc.html
 
 -   releaseCycle: "Galaxy Tab A 8.4 (2020)" # Yeah we need to specify the year here, multiple models from different years with the same name.
     releaseDate: 2020-03-25
-    support: true
+    eoas: false
     eol: false
     link: https://doc.samsungmobile.com/sm-t307u/glw/doc.html
 
 -   releaseCycle: "Galaxy M21"
     releaseDate: 2020-03-23
-    support: true
+    eoas: false
     eol: false
     link: https://doc.samsungmobile.com/sm-m215f/ins/doc.html
 
 -   releaseCycle: "Galaxy A41"
     releaseDate: 2020-03-18
-    support: true
+    eoas: false
     eol: false # Quarterly
     link: https://doc.samsungmobile.com/SM-A415F/TMH/doc.html
 
 -   releaseCycle: "Galaxy S20 Ultra"
     releaseDate: 2020-03-15
-    support: false
+    eoas: true
     eol: 2024-03-15 # "minimum of four (4) years following their global launch" (https://security.samsungmobile.com/workScope.smsb)
     link: https://doc.samsungmobile.com/SM-G988B/DCO/doc.html
 
 -   releaseCycle: "Galaxy S20 Ultra 5G"
     releaseDate: 2020-03-06
-    support: false
+    eoas: true
     eol: 2024-03-06 # "minimum of four (4) years following their global launch" (https://security.samsungmobile.com/workScope.smsb)
     link: https://doc.samsungmobile.com/SM-G988B/ATO/doc.html
 
 -   releaseCycle: "Galaxy S20+ 5G"
     releaseDate: 2020-03-06
-    support: false
+    eoas: true
     eol: 2024-03-06 # "minimum of four (4) years following their global launch" (https://security.samsungmobile.com/workScope.smsb)
     link: https://doc.samsungmobile.com/SM-G986B/XEF/doc.html
 
 -   releaseCycle: "Galaxy S20+"
     releaseDate: 2020-03-06
-    support: false
+    eoas: true
     eol: 2024-03-06 # "minimum of four (4) years following their global launch" (https://security.samsungmobile.com/workScope.smsb)
     link: https://doc.samsungmobile.com/SM-G985F/XEH/doc.html
 
 -   releaseCycle: "Galaxy S20 5G"
     releaseDate: 2020-03-06
-    support: false
+    eoas: true
     eol: 2024-03-06 # "minimum of four (4) years following their global launch" (https://security.samsungmobile.com/workScope.smsb)
     link: https://doc.samsungmobile.com/SM-G981B/ITV/doc.html
 
 -   releaseCycle: "Galaxy S20"
     releaseDate: 2020-03-06
-    support: false
+    eoas: true
     eol: 2024-03-06 # "minimum of four (4) years following their global launch" (https://security.samsungmobile.com/workScope.smsb)
     link: https://doc.samsungmobile.com/SM-G980F/VDC/doc.html
 
 -   releaseCycle: "Galaxy M31"
     releaseDate: 2020-03-05
-    support: true
+    eoas: false
     eol: false
     link: https://doc.samsungmobile.com/sm-m315f/ins/doc.html
 
 -   releaseCycle: "Galaxy Z Flip"
     releaseDate: 2020-02-14
-    support: true
+    eoas: false
     eol: false
     link: https://doc.samsungmobile.com/SM-F700F/XEH/doc.html
 
 -   releaseCycle: "Galaxy Tab S6 5G"
     releaseDate: 2020-01-30
-    support: true
+    eoas: false
     eol: false
     link: https://doc.samsungmobile.com/sm-t866n/koo/doc.html
 
 -   releaseCycle: "Galaxy A71"
     releaseDate: 2020-01-17
-    support: true
+    eoas: false
     eol: false
     link: https://doc.samsungmobile.com/sm-a715f/ins/doc.html
 
 -   releaseCycle: "Galaxy S10 Lite"
     releaseDate: 2020-01-03
-    support: true
+    eoas: false
     eol: false
     link: https://doc.samsungmobile.com/sm-g770f/phe/doc.html
 
 -   releaseCycle: "Galaxy Note10 Lite"
     releaseDate: 2020-01-03
-    support: true
+    eoas: false
     eol: false
     link: https://doc.samsungmobile.com/sm-n770f/xef/doc.html
 
 -   releaseCycle: "Galaxy XCover Pro" # Unclear release date.
     releaseDate: 2020-01-01
-    support: true
+    eoas: false
     eol: false
     link: https://doc.samsungmobile.com/SM-G715FN/XEH/doc.html
 
 -   releaseCycle: "Galaxy A51"
     releaseDate: 2019-12-27
-    support: true
+    eoas: false
     eol: false
     link: https://doc.samsungmobile.com/SM-A515F/XEF/doc.html
 
 -   releaseCycle: "Galaxy A01"
     releaseDate: 2019-12-18
-    support: true
+    eoas: false
     eol: false # Quarterly
     link: https://doc.samsungmobile.com/SM-A015F/THL/doc.html
 
 -   releaseCycle: "Galaxy Fold 5G"
     releaseDate: 2019-11-20
-    support: false
+    eoas: true
     eol: true
     link: https://doc.samsungmobile.com/SM-F907B/AUT/doc.html
 
 -   releaseCycle: "Galaxy M30s"
     releaseDate: 2019-10-30
-    support: false
+    eoas: true
     eol: true
     link: https://doc.samsungmobile.com/sm-m307f/ins/doc.html
 
 -   releaseCycle: "Galaxy A20s"
     releaseDate: 2019-10-05
-    support: false
+    eoas: true
     eol: true
     link: https://doc.samsungmobile.com/SM-A207F/XEH/doc.html
 
 -   releaseCycle: "Galaxy Tab Active Pro"
     releaseDate: 2019-10-01
-    support: 2022-10-01 # Approximate from here: https://9to5google.com/2022/10/04/samsung-android-12-update-rollout/
+    eoas: 2022-10-01 # Approximate from here: https://9to5google.com/2022/10/04/samsung-android-12-update-rollout/
     eol: true
     link: https://doc.samsungmobile.com/SM-T540/XEH/doc.html
 
 -   releaseCycle: "Galaxy A30s"
     releaseDate: 2019-09-11
-    support: false
+    eoas: true
     eol: true
     link: https://doc.samsungmobile.com/SM-A307GN/XXV/doc.html
 
 -   releaseCycle: "Galaxy Fold"
     releaseDate: 2019-09-06
-    support: false
+    eoas: true
     eol: true
     link: https://doc.samsungmobile.com/SM-F900F/XEH/doc.html
 
 -   releaseCycle: "Galaxy A90 5G"
     releaseDate: 2019-09-03
-    support: false
+    eoas: true
     eol: true
     link: https://doc.samsungmobile.com/SM-A908B/009444191005/eng.html
 
 -   releaseCycle: "Galaxy A70s"
     releaseDate: 2019-09-01
-    support: false
+    eoas: true
     eol: true
     link: https://doc.samsungmobile.com/sm-a707f/ins/doc.html
 
 -   releaseCycle: "Galaxy A50s"
     releaseDate: 2019-09-01
-    support: false
+    eoas: true
     eol: true
     link: https://doc.samsungmobile.com/sm-a507fn/ins/doc.html
 
 -   releaseCycle: "Galaxy M10s"
     releaseDate: 2019-09-01
-    support: false
+    eoas: true
     eol: true
     link: https://doc.samsungmobile.com/SM-M107F/INS/doc.html
 
 -   releaseCycle: "Galaxy Watch Active2"
     releaseDate: 2019-09-01 # Approximate to the month and year.
-    support: false
+    eoas: true
     eol: true
     link: https://doc.samsungmobile.com/sm-r825f/dbt/doc.html
 
 -   releaseCycle: "Galaxy Watch Active2 Aluminum"
     releaseDate: 2019-09-01 # Approximate to the month and year.
-    support: false
+    eoas: true
     eol: true
     link: https://doc.samsungmobile.com/SM-R830/XAR/doc.html
 
 -   releaseCycle: "Galaxy A10s"
     releaseDate: 2019-08-27
-    support: false
+    eoas: true
     eol: true
     link: https://doc.samsungmobile.com/SM-A107F/SEK/doc.html
 
 -   releaseCycle: "Galaxy A10e"
     releaseDate: 2019-08-27
-    support: false
+    eoas: true
     eol: true
     link: https://doc.samsungmobile.com/SM-A102U/DSH/doc.html
 
 -   releaseCycle: "Galaxy Note10+"
     releaseDate: 2019-08-23
-    support: false
+    eoas: true
     eol: true
     link: https://doc.samsungmobile.com/SM-N975U/008579190821/fra.html
 
 -   releaseCycle: "Galaxy Note10"
     releaseDate: 2019-08-23
-    support: false
+    eoas: true
     eol: true
     link: https://doc.samsungmobile.com/SM-N970F/XEF/doc.html
 
 -   releaseCycle: "Galaxy Tab S6"
     releaseDate: 2019-08-01
-    support: false
+    eoas: true
     eol: true
     link: https://doc.samsungmobile.com/SM-T860/XAR/doc.html
 
 -   releaseCycle: "Galaxy Note10+ 5G"
     releaseDate: 2019-08-01 # Approximate to the month and year.
-    support: false
+    eoas: true
     eol: true
     link: https://doc.samsungmobile.com/SM-N976B/SFR/doc.html
 
 -   releaseCycle: "Galaxy Note10 5G"
     releaseDate: 2019-08-01 # Approximate to the month and year.
-    support: false
+    eoas: true
     eol: true
     link: https://doc.samsungmobile.com/sm-n971n/koo/doc.html
 
 -   releaseCycle: "Galaxy Tab A 8.0 (2019)"
     releaseDate: 2019-07-01
-    support: false
+    eoas: true
     eol: true
     link: https://doc.samsungmobile.com/SM-T290/008916190830/mlt.html
 
 -   releaseCycle: "Galaxy Xcover 4s"
     releaseDate: 2019-07-01 # Approximate to the month and year.
-    support: 2022-10-01 # Approximate from here: https://9to5google.com/2022/10/04/samsung-android-12-update-rollout/
+    eoas: 2022-10-01 # Approximate from here: https://9to5google.com/2022/10/04/samsung-android-12-update-rollout/
     eol: true
     link: https://doc.samsungmobile.com/SM-G398FN/ATO/doc.html
 
 -   releaseCycle: "Galaxy A60"
     releaseDate: 2019-06-01
-    support: false
+    eoas: true
     eol: true
     link: https://doc.samsungmobile.com/SM-A6060/TGY/doc.html
 
 -   releaseCycle: "Galaxy M40"
     releaseDate: 2019-06-01 # Approximate to the month and year.
-    support: false
+    eoas: true
     eol: true
     link: https://doc.samsungmobile.com/SM-M405F/INS/doc.html
 
 -   releaseCycle: "Galaxy A80"
     releaseDate: 2019-05-01
-    support: false
+    eoas: true
     eol: true
     link: https://doc.samsungmobile.com/SM-A805F/XEH/doc.html
 
 -   releaseCycle: "Galaxy A70"
     releaseDate: 2019-05-01
-    support: false
+    eoas: true
     eol: true
     link: https://doc.samsungmobile.com/SM-A705F/XID/doc.html
 
 -   releaseCycle: "Galaxy A20e"
     releaseDate: 2019-05-01
-    support: false
+    eoas: true
     eol: true
     link: https://doc.samsungmobile.com/SM-A202F/DBT/doc.html
 
 -   releaseCycle: "Galaxy A20"
     releaseDate: 2019-04-05
-    support: false
+    eoas: true
     eol: true
     link: https://doc.samsungmobile.com/SM-A205F/AFR/doc.html
 
 -   releaseCycle: "Galaxy A40"
     releaseDate: 2019-04-01
-    support: 2022-10-01 # Approximate from here: https://9to5google.com/2022/10/04/samsung-android-12-update-rollout/
+    eoas: 2022-10-01 # Approximate from here: https://9to5google.com/2022/10/04/samsung-android-12-update-rollout/
     eol: true
     link: https://doc.samsungmobile.com/SM-A405FN/XEH/doc.html
 
 -   releaseCycle: "Galaxy Watch Active"
     releaseDate: 2019-04-01 # Approximate to the month and year.
-    support: false
+    eoas: true
     eol: true
     link: https://doc.samsungmobile.com/sm-r500/xar/doc.html
 
 -   releaseCycle: "Galaxy View2"
     releaseDate: 2019-04-01
-    support: false
+    eoas: true
     eol: 2021-12-31
     link: null
 
 -   releaseCycle: "Galaxy Tab S5e"
     releaseDate: 2019-04-01
-    support: false
+    eoas: true
     eol: true
     link: https://doc.samsungmobile.com/SM-T725/XEO/doc.html
 
 -   releaseCycle: "Galaxy Tab A 8.0 with S Pen (2019)"
     releaseDate: 2019-04-01
-    support: false
+    eoas: true
     eol: 2021-11-17
     link: https://doc.samsungmobile.com/sm-p205/xtc/doc.html
 
 -   releaseCycle: "Galaxy Tab A 10.1 (2019)"
     releaseDate: 2019-04-01
-    support: false
+    eoas: true
     eol: true
     link: https://doc.samsungmobile.com/SM-T515/TMZ/doc.html
 
 -   releaseCycle: "Galaxy A2 Core"
     releaseDate: 2019-04-01
-    support: false
+    eoas: true
     eol: 2021-10-01
     link: https://doc.samsungmobile.com/SM-A260F/ECT/doc.html
 
 -   releaseCycle: "Galaxy A10"
     releaseDate: 2019-03-19
-    support: false
+    eoas: true
     eol: true
     link: https://doc.samsungmobile.com/SM-A105F/AFR/doc.html
 
 -   releaseCycle: "Galaxy A50"
     releaseDate: 2019-03-18
-    support: 2022-10-01 # Approximate from here: https://9to5google.com/2022/10/04/samsung-android-12-update-rollout/
+    eoas: 2022-10-01 # Approximate from here: https://9to5google.com/2022/10/04/samsung-android-12-update-rollout/
     eol: 2023-04-01 # https://www.sammobile.com/news/samsung-galaxy-s10-a50-software-update-support-discontinued/
     link: https://doc.samsungmobile.com/SM-A505G/CHL/doc.html
 
 -   releaseCycle: "Galaxy A30"
     releaseDate: 2019-03-01
-    support: false
+    eoas: true
     eol: true
     link: https://doc.samsungmobile.com/SM-A305F/AFR/doc.html
 
 -   releaseCycle: "Galaxy M30"
     releaseDate: 2019-03-01 # Approximate to the month and year.
-    support: false
+    eoas: true
     eol: true
     link: https://doc.samsungmobile.com/SM-M305M/XXV/doc.html
 
 -   releaseCycle: "Galaxy S10 5G"
     releaseDate: 2019-02-20
-    support: false
+    eoas: true
     eol: true
     link: https://doc.samsungmobile.com/SM-G977B/EVR/doc.html
 
 -   releaseCycle: "Galaxy S10"
     releaseDate: 2019-02-20
-    support: false
+    eoas: true
     eol: 2023-04-01 # https://www.sammobile.com/news/samsung-galaxy-s10-a50-software-update-support-discontinued/
     link: https://doc.samsungmobile.com/SM-G973F/XEF/doc.html
 
 -   releaseCycle: "Galaxy S10+"
     releaseDate: 2019-02-20
-    support: false
+    eoas: true
     eol: 2023-04-01 # https://www.sammobile.com/news/samsung-galaxy-s10-a50-software-update-support-discontinued/
     link: https://doc.samsungmobile.com/SM-G975F/XEF/doc.html
 
 -   releaseCycle: "Galaxy S10e"
     releaseDate: 2019-02-20
-    support: false
+    eoas: true
     eol: 2023-04-01 # https://www.sammobile.com/news/samsung-galaxy-s10-a50-software-update-support-discontinued/
     link: https://doc.samsungmobile.com/sm-g970f/dbt/doc.html
 
 -   releaseCycle: "Galaxy M20"
     releaseDate: 2019-02-01 # Approximate to the month and year.
-    support: false
+    eoas: true
     eol: true
     link: https://doc.samsungmobile.com/SM-M205F/INS/doc.html
 
 -   releaseCycle: "Galaxy M10"
     releaseDate: 2019-02-01 # Approximate to the month and year.
-    support: false
+    eoas: true
     eol: true
     link: https://doc.samsungmobile.com/SM-M105F/INS/doc.html
 
 -   releaseCycle: "Galaxy A8s"
     releaseDate: 2018-12-01
-    support: false
+    eoas: true
     eol: true
     link: https://doc.samsungmobile.com/SM-G8870/TGY/doc.html
 
 -   releaseCycle: "Galaxy Tab Advanced2"
     releaseDate: 2018-12-01 # Approximate to the month and year.
-    support: false
+    eoas: true
     eol: true
     link: https://doc.samsungmobile.com/SM-T583/KOO/doc.html
 
 -   releaseCycle: "Galaxy J4 Core"
     releaseDate: 2018-11-01
-    support: false
+    eoas: true
     eol: 2020-12-01
     link: https://doc.samsungmobile.com/SM-J410F/AFR/doc.html
 
 -   releaseCycle: "Galaxy A6s"
     releaseDate: 2018-11-01 # Approximate to the month and year.
-    support: false
+    eoas: true
     eol: true
     link: https://doc.samsungmobile.com/SM-A600FN/XEF/doc.html
 
 -   releaseCycle: "Galaxy A9 (2018)"
     releaseDate: 2018-11-01
-    support: false
+    eoas: true
     eol: 2022-06-01
     link: https://doc.samsungmobile.com/SM-A920F/XEO/doc.html
 
 -   releaseCycle: "Galaxy J6+"
     releaseDate: 2018-10-01
-    support: false
+    eoas: true
     eol: 2022-06-01
     link: https://doc.samsungmobile.com/SM-J610FN/XEF/doc.html
 
 -   releaseCycle: "Galaxy J4+"
     releaseDate: 2018-10-01
-    support: false
+    eoas: true
     eol: 2020-12-01
     link: https://doc.samsungmobile.com/SM-J415F/AFR/doc.html
 
 -   releaseCycle: "Galaxy A7 (2018)"
     releaseDate: 2018-10-01
-    support: false
+    eoas: true
     eol: 2022-07-01
     link: https://doc.samsungmobile.com/SM-A750GN/XXV/doc.html
 
 -   releaseCycle: "Galaxy Tab A 8.0 (2018)"
     releaseDate: 2018-09-01 # Approximate to the month and year.
-    support: false
+    eoas: true
     eol: true
     link: https://doc.samsungmobile.com/SM-A530F/FTM/doc.html
 
 -   releaseCycle: "Galaxy Note 9"
     releaseDate: 2018-08-24
-    support: false
+    eoas: true
     eol: 2022-07-01
     link: https://doc.samsungmobile.com/sm-n960f/dbt/doc.html
 
 -   releaseCycle: "Galaxy Tab S4 10.5"
     releaseDate: 2018-08-01
-    support: false
+    eoas: true
     eol: 2022-06-01
     link: https://doc.samsungmobile.com/SM-T830/XAR/doc.html
 
 -   releaseCycle: "Galaxy Tab A 10.5 (2018)"
     releaseDate: 2018-08-01 # Approximate to the month and year.
-    support: false
+    eoas: true
     eol: 2022-06-01
     link: https://doc.samsungmobile.com/SM-T595/SER/doc.html
 
 -   releaseCycle: "Galaxy Watch"
     releaseDate: 2018-08-01 # Approximate to the month and year.
-    support: false
+    eoas: true
     eol: true
     link: https://doc.samsungmobile.com/SM-R810/001398180827/fra.html
 
 -   releaseCycle: "Galaxy J2 Core"
     releaseDate: 2018-08-01
-    support: false
+    eoas: true
     eol: 2021-12-31
     link: https://doc.samsungmobile.com/SM-J260M/COM/doc.html
 
 -   releaseCycle: "Galaxy J8"
     releaseDate: 2018-07-01
-    support: false
+    eoas: true
     eol: 2021-09-01
     link: https://doc.samsungmobile.com/SM-J810G/INS/doc.html
 
 -   releaseCycle: "Galaxy On6"
     releaseDate: 2018-07-01 # Approximate to the month and year.
-    support: false
+    eoas: true
     eol: 2022-02-01
     link: https://doc.samsungmobile.com/SM-J600GF/INS/doc.html
 
 -   releaseCycle: "Galaxy J7 (2018)"
     releaseDate: 2018-07-01 # Approximate to the month and year.
-    support: false
+    eoas: true
     eol: 2021-12-01
     link: https://doc.samsungmobile.com/SM-J700F/023395220803/roh.html
 
 -   releaseCycle: "Galaxy J7 Top"
     releaseDate: 2018-07-01
-    support: false
+    eoas: true
     eol: 2021-12-31
     link: https://doc.samsungmobile.com/SM-J737U/XAR/doc.html
 
 -   releaseCycle: "Galaxy J3 (2018)"
     releaseDate: 2018-06-01 # Approximate to the month and year.
-    support: false
+    eoas: true
     eol: 2021-11-01
     link: https://doc.samsungmobile.com/SM-J3300/CHC/doc.html
 
 -   releaseCycle: "Galaxy A8 Star"
     releaseDate: 2018-06-01
-    support: false
+    eoas: true
     eol: 2022-06-01
     link: https://doc.samsungmobile.com/SM-G885F/XXV/doc.html
 
 -   releaseCycle: "Galaxy J6"
     releaseDate: 2018-05-01
-    support: false
+    eoas: true
     eol: 2022-02-01
     link: https://doc.samsungmobile.com/SM-J600G/INS/doc.html
 
 -   releaseCycle: "Galaxy J4"
     releaseDate: 2018-05-01
-    support: false
+    eoas: true
     eol: 2022-02-01
     link: https://doc.samsungmobile.com/SM-J400G/BRI/doc.html
 
 -   releaseCycle: "Galaxy S Light Luxury"
     releaseDate: 2018-05-01 # Approximate to the month and year.
-    support: false
+    eoas: true
     eol: true
     link: https://doc.samsungmobile.com/SM-G8750/000773180601/zho-cn.html
 
 -   releaseCycle: "Galaxy A6+ (2018)"
     releaseDate: 2018-05-01 # Approximate to the month and year.
-    support: false
+    eoas: true
     eol: 2021-12-01
     link: https://doc.samsungmobile.com/SM-A605G/XXV/doc.html
 
 -   releaseCycle: "Galaxy A6 (2018)"
     releaseDate: 2018-05-01 # Approximate to the month and year.
-    support: false
+    eoas: true
     eol: 2022-03-01
     link: https://doc.samsungmobile.com/SM-A600U/XAR/doc.html
 
 -   releaseCycle: "Galaxy J7 Prime 2"
     releaseDate: 2018-04-01
-    support: false
+    eoas: true
     eol: 2021-12-31
     link: null
 
 -   releaseCycle: "Galaxy J7 Duo"
     releaseDate: 2018-04-01
-    support: false
+    eoas: true
     eol: 2021-12-31
     link: null
 
 -   releaseCycle: "Galaxy S9+"
     releaseDate: 2018-03-09
-    support: false
+    eoas: true
     eol: 2022-04-05
     link: https://doc.samsungmobile.com/sm-g965f/dbt/doc.html
 
 -   releaseCycle: "Galaxy S9"
     releaseDate: 2018-03-09
-    support: false
+    eoas: true
     eol: 2022-04-05
     link: https://doc.samsungmobile.com/sm-g960f/dbt/doc.html
 
 -   releaseCycle: "Galaxy A8 (2018) Enterprise"
     releaseDate: 2018-01-01
-    support: false
+    eoas: true
     eol: 2021-12-31
     link: null
 
 -   releaseCycle: "Galaxy A8+ (2018)"
     releaseDate: 2018-01-01 # Approximate to the month and year.
-    support: false
+    eoas: true
     eol: 2021-09-01
     link: https://doc.samsungmobile.com/SM-A730F/INS/doc.html
 
 -   releaseCycle: "Galaxy A8 (2018)"
     releaseDate: 2018-01-01 # Approximate to the month and year.
-    support: false
+    eoas: true
     eol: 2022-01-01
     link: https://doc.samsungmobile.com/SM-A530F/CHL/doc.html
 
 -   releaseCycle: "Galaxy J2 Pro (2018)"
     releaseDate: 2018-01-01 # Approximate to the month and year.
-    support: false
+    eoas: true
     eol: 2019-10-01
     link: https://doc.samsungmobile.com/SM-J250Y/ITV/doc.html
 
 -   releaseCycle: "Galaxy Tab Active2"
     releaseDate: 2017-10-20
-    support: false
+    eoas: true
     eol: 2021-11-17
     link: https://doc.samsungmobile.com/SM-T395/DBT/doc.html
 
 -   releaseCycle: "Galaxy J2 (2017)"
     releaseDate: 2017-10-01 # Approximate to the month and year.
-    support: false
+    eoas: true
     eol: true
     link: null
 
 -   releaseCycle: "Galaxy C7 (2017)"
     releaseDate: 2017-10-01 # Approximate to the month and year.
-    support: false
+    eoas: true
     eol: true
     link: https://doc.samsungmobile.com/SM-C710F/XXV/doc.html
 
 -   releaseCycle: "Gear Sport"
     releaseDate: 2017-10-01 # Approximate to the month and year.
-    support: false
+    eoas: true
     eol: true
     link: https://doc.samsungmobile.com/SM-R600/CHC/doc.html
 
 -   releaseCycle: "Galaxy Note8"
     releaseDate: 2017-09-01
-    support: false
+    eoas: true
     eol: 2021-11-17
     link: https://doc.samsungmobile.com/sm-n950f/dbt/doc.html
 
 -   releaseCycle: "Galaxy Tab A 8.0 (2017)"
     releaseDate: 2017-09-01
-    support: false
+    eoas: true
     eol: 2021-11-17
     link: https://doc.samsungmobile.com/SM-T380/COO/doc.html
 
 -   releaseCycle: "Galaxy S8 Active"
     releaseDate: 2017-08-01
-    support: false
+    eoas: true
     eol: 2021-11-17
     link: null
 
 -   releaseCycle: "Galaxy Note FE"
     releaseDate: 2017-07-01 # Approximate to the month and year.
-    support: false
+    eoas: true
     eol: 2019-03-01
     link: https://doc.samsungmobile.com/SM-N935F/XXV/doc.html
 
 -   releaseCycle: "Galaxy J7 (2017)"
     releaseDate: 2017-07-01 # Approximate to the month and year.
-    support: false
+    eoas: true
     eol: 2019-05-01
     link: https://doc.samsungmobile.com/SM-J730F/XEF/doc.html
 
 -   releaseCycle: "Galaxy J7 Pro"
     releaseDate: 2017-07-01 # Approximate to the month and year.
-    support: false
+    eoas: true
     eol: 2019-04-01
     link: https://doc.samsungmobile.com/SM-J730G/TNZ/doc.html
 
 -   releaseCycle: "Galaxy J3 (2017)"
     releaseDate: 2017-07-01 # Approximate to the month and year.
-    support: false
+    eoas: true
     eol: 2019-07-01
     link: https://doc.samsungmobile.com/SM-J327U/XAR/doc.html
 
 -   releaseCycle: "Galaxy Folder2"
     releaseDate: 2017-07-01 # Approximate to the month and year.
-    support: false
+    eoas: true
     eol: true
     link: https://doc.samsungmobile.com/SM-G160N/KOO/doc.html
 
 -   releaseCycle: "Galaxy J7 Neo"
     releaseDate: 2017-07-01 # Approximate to the month and year.
-    support: false
+    eoas: true
     eol: 2019-05-01
     link: https://doc.samsungmobile.com/SM-J701M/PET/doc.html
 
 -   releaseCycle: "Galaxy J7 Max"
     releaseDate: 2017-06-01 # Approximate to the month and year.
-    support: false
+    eoas: true
     eol: 2019-03-01
     link: https://doc.samsungmobile.com/SM-G615FU/INS/doc.html
 
 -   releaseCycle: "Galaxy J5 (2017)"
     releaseDate: 2017-06-01 # Approximate to the month and year.
-    support: false
+    eoas: true
     eol: 2019-03-01
     link: https://doc.samsungmobile.com/SM-J530F/XEO/doc.html
 
 -   releaseCycle: "Z4"
     releaseDate: 2017-06-01 # Approximate to the month and year.
-    support: false
+    eoas: true
     eol: true
     link: null
 
 -   releaseCycle: "Gear S3 classic LTE"
     releaseDate: 2017-05-01 # Approximate to the month and year.
-    support: false
+    eoas: true
     eol: true
     link: https://doc.samsungmobile.com/SM-R770/BRI/doc.html
 
 -   releaseCycle: "Galaxy S8"
     releaseDate: 2017-04-24
-    support: false
+    eoas: true
     eol: 2021-04-01
     link: https://doc.samsungmobile.com/SM-G950F/ITV/doc.html
 
 -   releaseCycle: "Galaxy S8+"
     releaseDate: 2017-04-01 # Approximate to the month and year.
-    support: false
+    eoas: true
     eol: 2021-04-01
     link: https://doc.samsungmobile.com/SM-G955F/SER/doc.html
 
 -   releaseCycle: "Galaxy Xcover 4"
     releaseDate: 2017-04-01 # Approximate to the month and year.
-    support: false
+    eoas: true
     eol: 2019-06-01
     link: https://doc.samsungmobile.com/SM-G390F/ATO/doc.html
 
 -   releaseCycle: "Galaxy Tab S3 9.7"
     releaseDate: 2017-04-01 # Approximate to the month and year.
-    support: false
+    eoas: true
     eol: 2019-04-01
     link: https://doc.samsungmobile.com/SM-T825Y/XXV/doc.html
 
 -   releaseCycle: "Galaxy J7 V"
     releaseDate: 2017-03-01 # Approximate to the month and year.
-    support: false
+    eoas: true
     eol: 2019-03-01
     link: https://doc.samsungmobile.com/SM-J727U/XAA/doc.html
 
 -   releaseCycle: "Galaxy C5 Pro"
     releaseDate: 2017-03-01 # Approximate to the month and year.
-    support: false
+    eoas: true
     eol: 2018-10-01
     link: https://doc.samsungmobile.com/SM-C5010/TGY/doc.html
 
 -   releaseCycle: "Galaxy C7 Pro"
     releaseDate: 2017-02-01 # Approximate to the month and year.
-    support: false
+    eoas: true
     eol: 2019-05-01
     link: https://doc.samsungmobile.com/SM-C701F/INS/doc.html
 
 -   releaseCycle: "Galaxy J3 Emerge"
     releaseDate: 2017-01-01 # Approximate to the month and year.
-    support: false
+    eoas: true
     eol: 2019-08-01
     link: https://doc.samsungmobile.com/SM-J327T/TMB/doc.html
 
 -   releaseCycle: "Galaxy A7 (2017)"
     releaseDate: 2017-01-01 # Approximate to the month and year.
-    support: false
+    eoas: true
     eol: 2020-08-01
     link: https://doc.samsungmobile.com/SM-A720F/CHL/doc.html
 
 -   releaseCycle: "Galaxy A5 (2017)"
     releaseDate: 2017-01-01 # Approximate to the month and year.
-    support: false
+    eoas: true
     eol: 2019-04-01
     link: https://doc.samsungmobile.com/SM-A520F/XSA/doc.html
 
 -   releaseCycle: "Galaxy A3 (2017)"
     releaseDate: 2017-01-01 # Approximate to the month and year.
-    support: false
+    eoas: true
     eol: 2020-11-01
     link: https://doc.samsungmobile.com/SM-A320FL/ITV/doc.html
 
 -   releaseCycle: "Galaxy J1 mini prime"
     releaseDate: 2016-12-01 # Approximate to the month and year.
-    support: false
+    eoas: true
     eol: true
     link: null
 
 -   releaseCycle: "Galaxy J7 Prime"
     releaseDate: 2016-11-30
-    support: false
+    eoas: true
     eol: 2020-04-01
     link: https://doc.samsungmobile.com/SM-G610F/XXV/doc.html
 
 -   releaseCycle: "Galaxy Grand Prime Plus"
     releaseDate: 2016-11-01 # Approximate to the month and year.
-    support: false
+    eoas: true
     eol: true
     link: null
 
 -   releaseCycle: "Galaxy J2 Prime"
     releaseDate: 2016-11-01 # Approximate to the month and year.
-    support: false
+    eoas: true
     eol: true
     link: null
 
 -   releaseCycle: "Galaxy C9 Pro"
     releaseDate: 2016-11-01 # Approximate to the month and year.
-    support: false
+    eoas: true
     eol: 2019-07-01
     link: https://doc.samsungmobile.com/SM-C900F/INS/doc.html
 
 -   releaseCycle: "Gear S3 classic"
     releaseDate: 2016-11-01 # Approximate to the month and year.
-    support: false
+    eoas: true
     eol: true
     link: https://doc.samsungmobile.com/SM-R770/BRI/doc.html
 
 -   releaseCycle: "Gear S3 frontier"
     releaseDate: 2016-11-01 # Approximate to the month and year.
-    support: false
+    eoas: true
     eol: true
     link: https://doc.samsungmobile.com/SM-R770/BRI/doc.html
 
 -   releaseCycle: "Gear S3 frontier LTE"
     releaseDate: 2016-11-01 # Approximate to the month and year.
-    support: false
+    eoas: true
     eol: true
     link: https://doc.samsungmobile.com/SM-R770/BRI/doc.html
 
 -   releaseCycle: "Galaxy A8 (2016)"
     releaseDate: 2016-10-01 # Approximate to the month and year.
-    support: false
+    eoas: true
     eol: true
     link: https://doc.samsungmobile.com/SM-A800IZ/000065170406/zho-tw.html
 
 -   releaseCycle: "Galaxy On8"
     releaseDate: 2016-10-01 # Approximate to the month and year.
-    support: false
+    eoas: true
     eol: 2019-01-01
     link: https://doc.samsungmobile.com/SM-J710FN/INS/doc.html
 
 -   releaseCycle: "Galaxy On7 (2016)"
     releaseDate: 2016-10-01 # Approximate to the month and year.
-    support: false
+    eoas: true
     eol: 2020-07-01
     link: https://doc.samsungmobile.com/SM-G6100/TGY/doc.html
 
 -   releaseCycle: "Galaxy J5 Prime"
     releaseDate: 2016-10-01 # Approximate to the month and year.
-    support: false
+    eoas: true
     eol: 2020-10-01
     link: https://doc.samsungmobile.com/SM-G570F/SER/doc.html
 
 -   releaseCycle: "Galaxy Note7"
     releaseDate: 2016-09-01 # Approximate to the month and year.
-    support: false
+    eoas: true
     eol: true
     link: null
 
 -   releaseCycle: "Z2"
     releaseDate: 2016-08-01 # Approximate to the month and year.
-    support: false
+    eoas: true
     eol: true
     link: null
 
 -   releaseCycle: "Galaxy Note 7 (USA)"
     releaseDate: 2016-08-01 # Approximate to the month and year.
-    support: false
+    eoas: true
     eol: true
     link: null
 
 -   releaseCycle: "Galaxy Tab J"
     releaseDate: 2016-08-01 # Approximate to the month and year.
-    support: false
+    eoas: true
     eol: true
     link: null
 
 -   releaseCycle: "Galaxy J Max"
     releaseDate: 2016-08-01 # Approximate to the month and year.
-    support: false
+    eoas: true
     eol: true
     link: null
 
 -   releaseCycle: "Galaxy On7 Pro"
     releaseDate: 2016-07-01 # Approximate to the month and year.
-    support: false
+    eoas: true
     eol: true
     link: null
 
 -   releaseCycle: "Galaxy On5 Pro"
     releaseDate: 2016-07-01 # Approximate to the month and year.
-    support: false
+    eoas: true
     eol: true
     link: null
 
 -   releaseCycle: "Galaxy J2 Pro (2016)"
     releaseDate: 2016-07-01 # Approximate to the month and year.
-    support: false
+    eoas: true
     eol: 2019-10-01
     link: https://doc.samsungmobile.com/SM-J250F/TUR/doc.html
 
 -   releaseCycle: "Galaxy J2 (2016)"
     releaseDate: 2016-07-01 # Approximate to the month and year.
-    support: false
+    eoas: true
     eol: 2018-08-01
     link: https://doc.samsungmobile.com/SM-J210F/INS/doc.html
 
 -   releaseCycle: "Z3 Corporate"
     releaseDate: 2016-06-01 # Approximate to the month and year.
-    support: false
+    eoas: true
     eol: true
     link: null
 
 -   releaseCycle: "Galaxy S7 active"
     releaseDate: 2016-06-01 # Approximate to the month and year.
-    support: false
+    eoas: true
     eol: true
     link: null
 
 -   releaseCycle: "Galaxy J3 Pro"
     releaseDate: 2016-06-01 # Approximate to the month and year.
-    support: false
+    eoas: true
     eol: 2021-04-01
     link: https://doc.samsungmobile.com/SM-J330G/BRI/doc.html
 
 -   releaseCycle: "Galaxy C7"
     releaseDate: 2016-06-01 # Approximate to the month and year.
-    support: false
+    eoas: true
     eol: 2018-10-01
     link: https://doc.samsungmobile.com/SM-C7000/CHC/doc.html
 
 -   releaseCycle: "Galaxy C5"
     releaseDate: 2016-06-01 # Approximate to the month and year.
-    support: false
+    eoas: true
     eol: 2019-01-01
     link: https://doc.samsungmobile.com/sm-c5000/tgy/doc.html
 
 -   releaseCycle: "Galaxy J3 (2016)"
     releaseDate: 2016-05-06
-    support: false
+    eoas: true
     eol: 2019-04-02
     link: https://doc.samsungmobile.com/SM-J320H/AFR/doc.html
 
 -   releaseCycle: "Galaxy A9 Pro (2016)"
     releaseDate: 2016-05-01 # Approximate to the month and year.
-    support: false
+    eoas: true
     eol: 2019-02-01
     link: https://doc.samsungmobile.com/SM-A910F/INS/doc.html
 
 -   releaseCycle: "Galaxy Tab A 10.1 (2016)"
     releaseDate: 2016-05-01 # Approximate to the month and year.
-    support: false
+    eoas: true
     eol: 2020-04-01
     link: https://doc.samsungmobile.com/SM-T580/ATO/doc.html
 
 -   releaseCycle: "Galaxy Xcover3 G389F"
     releaseDate: 2016-04-01 # Approximate to the month and year.
-    support: false
+    eoas: true
     eol: 2018-06-01
     link: https://doc.samsungmobile.com/SM-G389F/ATO/doc.html
 
 -   releaseCycle: "Galaxy J7 (2016)"
     releaseDate: 2016-04-01 # Approximate to the month and year.
-    support: false
+    eoas: true
     eol: 2019-11-01
     link: https://doc.samsungmobile.com/SM-J710F/INS/doc.html
 
 -   releaseCycle: "Galaxy J5 (2016)"
     releaseDate: 2016-04-01 # Approximate to the month and year.
-    support: false
+    eoas: true
     eol: 2019-08-01
     link: https://doc.samsungmobile.com/SM-J510FN/ATO/doc.html
 
 -   releaseCycle: "Gear S2 classic 3G"
     releaseDate: 2016-04-01 # Approximate to the month and year.
-    support: false
+    eoas: true
     eol: true
     link: null
 
 -   releaseCycle: "Galaxy Express Prime"
     releaseDate: 2016-04-01 # Approximate to the month and year.
-    support: false
+    eoas: true
     eol: true
     link: null
 
 -   releaseCycle: "Galaxy S7 edge"
     releaseDate: 2016-03-11
-    support: false
+    eoas: true
     eol: 2019-03-01
     link: https://doc.samsungmobile.com/SM-G935F/AFR/doc.html
 
 -   releaseCycle: "Galaxy S7"
     releaseDate: 2016-03-11
-    support: false
+    eoas: true
     eol: 2019-06-01
     link: https://doc.samsungmobile.com/SM-G930F/CHL/doc.html
 
 -   releaseCycle: "Galaxy Tab A 7.0 (2016)"
     releaseDate: 2016-03-01 # Approximate to the month and year.
-    support: false
+    eoas: true
     eol: 2016-12-30
     link: https://doc.samsungmobile.com/SM-T280/KOO/doc.html
 
 -   releaseCycle: "Galaxy J1 Nxt"
     releaseDate: 2016-02-01 # Approximate to the month and year.
-    support: false
+    eoas: true
     eol: true
     link: null
 
 -   releaseCycle: "Galaxy J1 (2016)"
     releaseDate: 2016-01-01 # Approximate to the month and year.
-    support: false
+    eoas: true
     eol: true
     link: null
 
 -   releaseCycle: "Galaxy A9 (2016)"
     releaseDate: 2016-01-01 # Approximate to the month and year.
-    support: false
+    eoas: true
     eol: true
     link: null
 
 -   releaseCycle: "Galaxy Tab E 8.0"
     releaseDate: 2016-01-01
-    support: false
+    eoas: true
     eol: 2020-11-10
     link: https://doc.samsungmobile.com/SM-A710S/SKC/doc.html
 
 -   releaseCycle: "Galaxy A7 (2016)"
     releaseDate: 2015-12-01 # Approximate to the month and year.
-    support: false
+    eoas: true
     eol: 2018-11-01
     link: https://doc.samsungmobile.com/SM-A710F/INS/doc.html
 
 -   releaseCycle: "Galaxy A5 (2016)"
     releaseDate: 2015-12-01 # Approximate to the month and year.
-    support: false
+    eoas: true
     eol: 2019-06-01
     link: https://doc.samsungmobile.com/SM-A510F/INS/doc.html
 
 -   releaseCycle: "Galaxy A3 (2016)"
     releaseDate: 2015-12-01 # Approximate to the month and year.
-    support: false
+    eoas: true
     eol: 2018-06-01
     link: https://doc.samsungmobile.com/SM-A310F/BTU/doc.html
 
 -   releaseCycle: "Galaxy View"
     releaseDate: 2015-11-01 # Approximate to the month and year.
-    support: false
+    eoas: true
     eol: 2018-01-01
     link: https://doc.samsungmobile.com/SM-T810/XSA/doc.html
 
 -   releaseCycle: "Galaxy On7"
     releaseDate: 2015-11-01 # Approximate to the month and year.
-    support: false
+    eoas: true
     eol: 2018-01-01
     link: https://doc.samsungmobile.com/SM-G600S/SKC/doc.html
 
 -   releaseCycle: "Galaxy On5"
     releaseDate: 2015-11-01 # Approximate to the month and year.
-    support: false
+    eoas: true
     eol: true
     link: null
 
 -   releaseCycle: "Z3"
     releaseDate: 2015-10-01 # Approximate to the month and year.
-    support: false
+    eoas: true
     eol: true
     link: null
 
 -   releaseCycle: "Galaxy J1 Ace"
     releaseDate: 2015-10-01 # Approximate to the month and year.
-    support: false
+    eoas: true
     eol: true
     link: null
 
 -   releaseCycle: "Gear S2 classic"
     releaseDate: 2015-10-01 # Approximate to the month and year.
-    support: false
+    eoas: true
     eol: 2018-03-26
     link: https://doc.samsungmobile.com/SM-R720/CHC/doc.html
 
 -   releaseCycle: "Gear S2"
     releaseDate: 2015-10-01 # Approximate to the month and year.
-    support: false
+    eoas: true
     eol: 2018-03-26
     link: https://doc.samsungmobile.com/SM-R720/CHC/doc.html
 
 -   releaseCycle: "Gear S2 3G"
     releaseDate: 2015-10-01 # Approximate to the month and year.
-    support: false
+    eoas: true
     eol: 2018-03-26
     link: https://doc.samsungmobile.com/SM-R720/CHC/doc.html
 
 -   releaseCycle: "Galaxy Tab S2 9.7"
     releaseDate: 2015-09-01 # Approximate to the month and year.
-    support: false
+    eoas: true
     eol: 2019-07-01
     link: https://doc.samsungmobile.com/SM-T819Y/INS/doc.html
 
 -   releaseCycle: "Galaxy Tab S2 8.0"
     releaseDate: 2015-09-01 # Approximate to the month and year.
-    support: false
+    eoas: true
     eol: 2019-07-01
     link: https://doc.samsungmobile.com/SM-T713/BTU/doc.html
 
 -   releaseCycle: "Galaxy J2"
     releaseDate: 2015-09-01 # Approximate to the month and year.
-    support: false
+    eoas: true
     eol: true
     link: null
 
 -   releaseCycle: "Galaxy Note 5 (USA)"
     releaseDate: 2015-08-01 # Approximate to the month and year.
-    support: false
+    eoas: true
     eol: true
     link: null
 
 -   releaseCycle: "Galaxy Note 5"
     releaseDate: 2015-08-01 # Approximate to the month and year.
-    support: false
+    eoas: true
     eol: 2018-08-01
     link: https://doc.samsungmobile.com/SM-N920G/CHL/doc.html
 
 -   releaseCycle: "Galaxy Note 5 Duos"
     releaseDate: 2015-08-01 # Approximate to the month and year.
-    support: false
+    eoas: true
     eol: 2018-08-01
     link: https://doc.samsungmobile.com/SM-N920C/SER/doc.html
 
 -   releaseCycle: "Galaxy S6 edge+ (USA)"
     releaseDate: 2015-08-01 # Approximate to the month and year.
-    support: false
+    eoas: true
     eol: true
     link: null
 
 -   releaseCycle: "Galaxy S6 edge+"
     releaseDate: 2015-08-01 # Approximate to the month and year.
-    support: false
+    eoas: true
     eol: 2018-08-01
     link: https://doc.samsungmobile.com/SM-G928C/XXV/doc.html
 
 -   releaseCycle: "Galaxy S6 edge+ Duos"
     releaseDate: 2015-08-01 # Approximate to the month and year.
-    support: false
+    eoas: true
     eol: 2018-08-01
     link: https://doc.samsungmobile.com/SM-G928F/ITV/doc.html
 
 -   releaseCycle: "Galaxy S5 Neo"
     releaseDate: 2015-08-01 # Approximate to the month and year.
-    support: false
+    eoas: true
     eol: 2018-04-01
     link: https://doc.samsungmobile.com/SM-G903F/DBT/doc.html
 
 -   releaseCycle: "Galaxy A8 Duos"
     releaseDate: 2015-08-01 # Approximate to the month and year.
-    support: false
+    eoas: true
     eol: 2017-08-01
     link: https://doc.samsungmobile.com/SM-A800I/INS/doc.html
 
 -   releaseCycle: "Galaxy A8"
     releaseDate: 2015-08-01 # Approximate to the month and year.
-    support: false
+    eoas: true
     eol: 2017-08-01
     link: https://doc.samsungmobile.com/SM-A800F/INS/doc.html
 
 -   releaseCycle: "Galaxy J5"
     releaseDate: 2015-07-28
-    support: false
+    eoas: true
     eol: 2019-12-03
     link: https://doc.samsungmobile.com/SM-J500F/INS/doc.html
 
 -   releaseCycle: "Galaxy J7"
     releaseDate: 2015-07-16
-    support: false
+    eoas: true
     eol: 2018-04-01
     link: https://doc.samsungmobile.com/SM-J700F/INS/doc.html
 
 -   releaseCycle: "Galaxy Folder"
     releaseDate: 2015-07-01 # Approximate to the month and year.
-    support: false
+    eoas: true
     eol: true
     link: null
 
 -   releaseCycle: "Galaxy V Plus"
     releaseDate: 2015-07-01 # Approximate to the month and year.
-    support: false
+    eoas: true
     eol: true
     link: null
 
 -   releaseCycle: "Galaxy Tab E 9.6"
     releaseDate: 2015-07-01 # Approximate to the month and year.
-    support: false
+    eoas: true
     eol: true
     link: null
 
 -   releaseCycle: "Galaxy Tab A 9.7 & S Pen"
     releaseDate: 2015-07-01 # Approximate to the month and year.
-    support: false
+    eoas: true
     eol: 2017-08-01
     link: https://doc.samsungmobile.com/SM-P555/XXV/doc.html
 
 -   releaseCycle: "Galaxy S4 mini I9195I"
     releaseDate: 2015-06-01 # Approximate to the month and year.
-    support: false
+    eoas: true
     eol: true
     link: null
 
 -   releaseCycle: "Galaxy S6 active"
     releaseDate: 2015-06-01 # Approximate to the month and year.
-    support: false
+    eoas: true
     eol: true
     link: null
 
 -   releaseCycle: "Galaxy S6 Duos"
     releaseDate: 2015-06-01 # Approximate to the month and year.
-    support: false
+    eoas: true
     eol: true
     link: null
 
 -   releaseCycle: "Galaxy Tab A 9.7"
     releaseDate: 2015-05-01 # Approximate to the month and year.
-    support: false
+    eoas: true
     eol: 2017-08-01
     link: https://doc.samsungmobile.com/SM-P550/XSA/doc.html
 
 -   releaseCycle: "Galaxy Tab A 8.0 & S Pen (2015)"
     releaseDate: 2015-05-01 # Approximate to the month and year.
-    support: false
+    eoas: true
     eol: 2017-08-01
     link: https://doc.samsungmobile.com/SM-P355/XXV/doc.html
 
 -   releaseCycle: "Galaxy Tab A 8.0 (2015)"
     releaseDate: 2015-05-01 # Approximate to the month and year.
-    support: false
+    eoas: true
     eol: 2017-08-01
     link: https://doc.samsungmobile.com/SM-T355/SER/doc.html
 
 -   releaseCycle: "Galaxy Tab 3 V"
     releaseDate: 2015-04-01 # Approximate to the month and year.
-    support: false
+    eoas: true
     eol: true
     link: null
 
 -   releaseCycle: "Galaxy Xcover 3"
     releaseDate: 2015-04-01 # Approximate to the month and year.
-    support: false
+    eoas: true
     eol: true
     link: null
 
 -   releaseCycle: "Galaxy S6 edge (USA)"
     releaseDate: 2015-04-01 # Approximate to the month and year.
-    support: false
+    eoas: true
     eol: true
     link: null
 
 -   releaseCycle: "Galaxy S6 (USA)"
     releaseDate: 2015-04-01 # Approximate to the month and year.
-    support: false
+    eoas: true
     eol: 2018-03-01
     link: https://doc.samsungmobile.com/SM-G920T1/TMB/doc.html
 
 -   releaseCycle: "Galaxy S6 edge"
     releaseDate: 2015-04-01 # Approximate to the month and year.
-    support: false
+    eoas: true
     eol: 2018-06-01
     link: https://doc.samsungmobile.com/SM-G925I/PET/doc.html
 
 -   releaseCycle: "Galaxy S6"
     releaseDate: 2015-04-01 # Approximate to the month and year.
-    support: false
+    eoas: true
     eol: 2018-06-01
     link: https://doc.samsungmobile.com/SM-G920I/INS/doc.html
 
 -   releaseCycle: "Galaxy J1 4G"
     releaseDate: 2015-03-01 # Approximate to the month and year.
-    support: false
+    eoas: true
     eol: true
     link: null
 
 -   releaseCycle: "Galaxy Tab 3 Lite 7.0 VE"
     releaseDate: 2015-03-01 # Approximate to the month and year.
-    support: false
+    eoas: true
     eol: true
     link: null
 
 -   releaseCycle: "Galaxy J1"
     releaseDate: 2015-02-01 # Approximate to the month and year.
-    support: false
+    eoas: true
     eol: true
     link: null
 
 -   releaseCycle: "Galaxy A7 Duos"
     releaseDate: 2015-02-01 # Approximate to the month and year.
-    support: false
+    eoas: true
     eol: true
     link: null
 
 -   releaseCycle: "Galaxy E7"
     releaseDate: 2015-02-01 # Approximate to the month and year.
-    support: false
+    eoas: true
     eol: true
     link: null
 
 -   releaseCycle: "Galaxy E5"
     releaseDate: 2015-02-01 # Approximate to the month and year.
-    support: false
+    eoas: true
     eol: true
     link: null
 
 -   releaseCycle: "Z1"
     releaseDate: 2015-01-01 # Approximate to the month and year.
-    support: false
+    eoas: true
     eol: true
     link: null
 
 -   releaseCycle: "Galaxy Grand Max"
     releaseDate: 2015-01-01 # Approximate to the month and year.
-    support: false
+    eoas: true
     eol: true
     link: null
 
 -   releaseCycle: "Galaxy A5"
     releaseDate: 2014-12-01 # Approximate to the month and year.
-    support: false
+    eoas: true
     eol: true
     link: null
 
 -   releaseCycle: "Galaxy A3 Duos"
     releaseDate: 2014-12-01 # Approximate to the month and year.
-    support: false
+    eoas: true
     eol: true
     link: null
 
 -   releaseCycle: "Galaxy A3"
     releaseDate: 2014-12-01 # Approximate to the month and year.
-    support: false
+    eoas: true
     eol: true
     link: null
 
 -   releaseCycle: "Galaxy Tab Active LTE"
     releaseDate: 2014-12-01 # Approximate to the month and year.
-    support: false
+    eoas: true
     eol: true
     link: null
 
 -   releaseCycle: "Galaxy Tab Active"
     releaseDate: 2014-12-01 # Approximate to the month and year.
-    support: false
+    eoas: true
     eol: true
     link: null
 
 -   releaseCycle: "Galaxy Core Prime"
     releaseDate: 2014-11-01 # Approximate to the month and year.
-    support: false
+    eoas: true
     eol: true
     link: null
 
 -   releaseCycle: "Galaxy A5 Duos"
     releaseDate: 2014-11-01 # Approximate to the month and year.
-    support: false
+    eoas: true
     eol: true
     link: null
 
 -   releaseCycle: "Galaxy S5 Plus"
     releaseDate: 2014-11-01 # Approximate to the month and year.
-    support: false
+    eoas: true
     eol: true
     link: null
 
 -   releaseCycle: "Galaxy Note Edge"
     releaseDate: 2014-11-01 # Approximate to the month and year.
-    support: false
+    eoas: true
     eol: true
     link: null
 
 -   releaseCycle: "Galaxy Core LTE G386W"
     releaseDate: 2014-11-01 # Approximate to the month and year.
-    support: false
+    eoas: true
     eol: true
     link: null
 
 -   releaseCycle: "Galaxy Grand Prime Duos TV"
     releaseDate: 2014-10-01 # Approximate to the month and year.
-    support: false
+    eoas: true
     eol: true
     link: null
 
 -   releaseCycle: "Galaxy Grand Prime"
     releaseDate: 2014-10-01 # Approximate to the month and year.
-    support: false
+    eoas: true
     eol: true
     link: null
 
 -   releaseCycle: "Galaxy Note 4 Duos"
     releaseDate: 2014-10-01 # Approximate to the month and year.
-    support: false
+    eoas: true
     eol: true
     link: null
 
 -   releaseCycle: "Galaxy Note4"
     releaseDate: 2014-10-01 # Approximate to the month and year.
-    support: false
+    eoas: true
     eol: 2017-08-01
     link: https://doc.samsungmobile.com/SM-N910U/TNZ/doc.html
 
 -   releaseCycle: "Gear S"
     releaseDate: 2014-10-01 # Approximate to the month and year.
-    support: false
+    eoas: true
     eol: true
     link: null
 
 -   releaseCycle: "Galaxy Young 2"
     releaseDate: 2014-10-01 # Approximate to the month and year.
-    support: false
+    eoas: true
     eol: true
     link: null
 
 -   releaseCycle: "Galaxy Pocket 2"
     releaseDate: 2014-09-01 # Approximate to the month and year.
-    support: false
+    eoas: true
     eol: true
     link: null
 
 -   releaseCycle: "Galaxy V"
     releaseDate: 2014-09-01 # Approximate to the month and year.
-    support: false
+    eoas: true
     eol: true
     link: null
 
 -   releaseCycle: "Galaxy Ace Style LTE G357"
     releaseDate: 2014-09-01 # Approximate to the month and year.
-    support: false
+    eoas: true
     eol: true
     link: null
 
 -   releaseCycle: "Galaxy Mega 2"
     releaseDate: 2014-09-01 # Approximate to the month and year.
-    support: false
+    eoas: true
     eol: true
     link: null
 
 -   releaseCycle: "Galaxy Alpha (S801)"
     releaseDate: 2014-09-01 # Approximate to the month and year.
-    support: false
+    eoas: true
     eol: true
     link: null
 
 -   releaseCycle: "Galaxy Alpha"
     releaseDate: 2014-09-01 # Approximate to the month and year.
-    support: false
+    eoas: true
     eol: 2017-01-01
     link: https://doc.samsungmobile.com/SM-G850Y/XSA/doc.html
 
 -   releaseCycle: "Galaxy W"
     releaseDate: 2014-09-01 # Approximate to the month and year.
-    support: false
+    eoas: true
     eol: true
     link: null
 
 -   releaseCycle: "Galaxy S5 LTE-A G901F"
     releaseDate: 2014-08-01 # Approximate to the month and year.
-    support: false
+    eoas: true
     eol: true
     link: null
 
 -   releaseCycle: "Galaxy S5 mini Duos"
     releaseDate: 2014-08-01 # Approximate to the month and year.
-    support: false
+    eoas: true
     eol: true
     link: null
 
 -   releaseCycle: "Galaxy S Duos 3"
     releaseDate: 2014-08-01 # Approximate to the month and year.
-    support: false
+    eoas: true
     eol: true
     link: null
 
 -   releaseCycle: "Galaxy Ace NXT"
     releaseDate: 2014-08-01 # Approximate to the month and year.
-    support: false
+    eoas: true
     eol: true
     link: null
 
 -   releaseCycle: "Galaxy Star 2 Plus"
     releaseDate: 2014-08-01 # Approximate to the month and year.
-    support: false
+    eoas: true
     eol: true
     link: null
 
 -   releaseCycle: "Galaxy Ace 4 LTE G313"
     releaseDate: 2014-08-01 # Approximate to the month and year.
-    support: false
+    eoas: true
     eol: true
     link: null
 
 -   releaseCycle: "Galaxy Ace 4"
     releaseDate: 2014-08-01 # Approximate to the month and year.
-    support: false
+    eoas: true
     eol: true
     link: null
 
 -   releaseCycle: "Galaxy Star 2"
     releaseDate: 2014-08-01 # Approximate to the month and year.
-    support: false
+    eoas: true
     eol: true
     link: null
 
 -   releaseCycle: "Gear Live"
     releaseDate: 2014-07-01 # Approximate to the month and year.
-    support: false
+    eoas: true
     eol: true
     link: null
 
 -   releaseCycle: "Galaxy Avant"
     releaseDate: 2014-07-01 # Approximate to the month and year.
-    support: false
+    eoas: true
     eol: true
     link: null
 
 -   releaseCycle: "Galaxy S5 mini"
     releaseDate: 2014-07-01 # Approximate to the month and year.
-    support: false
+    eoas: true
     eol: 2017-08-01
     link: https://doc.samsungmobile.com/SM-G800F/DBT/doc.html
 
 -   releaseCycle: "Galaxy Core II"
     releaseDate: 2014-07-01 # Approximate to the month and year.
-    support: false
+    eoas: true
     eol: true
     link: null
 
 -   releaseCycle: "Galaxy S5 LTE-A G906S"
     releaseDate: 2014-07-01 # Approximate to the month and year.
-    support: false
+    eoas: true
     eol: 2017-01-04
     link: https://doc.samsungmobile.com/sm-g906s/skc/doc.html
 
 -   releaseCycle: "Galaxy Tab S 8.4 LTE"
     releaseDate: 2014-07-01 # Approximate to the month and year.
-    support: false
+    eoas: true
     eol: 2016-12-01
     link: https://doc.samsungmobile.com/SM-T705/INS/doc.html
 
 -   releaseCycle: "Galaxy Tab S 8.4"
     releaseDate: 2014-07-01 # Approximate to the month and year.
-    support: false
+    eoas: true
     eol: 2017-08-01
     link: https://doc.samsungmobile.com/SM-T700/BTU/doc.html
 
 -   releaseCycle: "Galaxy Tab S 10.5 LTE"
     releaseDate: 2014-07-01 # Approximate to the month and year.
-    support: false
+    eoas: true
     eol: 2016-12-01
     link: https://doc.samsungmobile.com/SM-T805/ATO/doc.html
 
 -   releaseCycle: "Galaxy Tab S 10.5"
     releaseDate: 2014-07-01 # Approximate to the month and year.
-    support: false
+    eoas: true
     eol: 2017-08-01
     link: https://doc.samsungmobile.com/SM-T800/ATO/doc.html
 
 -   releaseCycle: "Galaxy Beam2"
     releaseDate: 2014-07-01 # Approximate to the month and year.
-    support: false
+    eoas: true
     eol: true
     link: null
 
 -   releaseCycle: "Galaxy S5 Sport"
     releaseDate: 2014-06-01 # Approximate to the month and year.
-    support: false
+    eoas: true
     eol: true
     link: null
 
 -   releaseCycle: "Galaxy Core Lite LTE"
     releaseDate: 2014-06-01 # Approximate to the month and year.
-    support: false
+    eoas: true
     eol: true
     link: null
 
 -   releaseCycle: "I9301I Galaxy S3 Neo"
     releaseDate: 2014-06-01 # Approximate to the month and year.
-    support: false
+    eoas: true
     eol: true
     link: null
 
 -   releaseCycle: "Galaxy K zoom"
     releaseDate: 2014-06-01 # Approximate to the month and year.
-    support: false
+    eoas: true
     eol: true
     link: null
 
 -   releaseCycle: "Galaxy Tab 4 8.0"
     releaseDate: 2014-06-01 # Approximate to the month and year.
-    support: false
+    eoas: true
     eol: true
     link: https://doc.samsungmobile.com/SM-T330/KSA/doc.html
 
 -   releaseCycle: "Galaxy Tab 4 8.0 3G"
     releaseDate: 2014-06-01 # Approximate to the month and year.
-    support: false
+    eoas: true
     eol: true
     link: null
 
 -   releaseCycle: "Galaxy Tab 4 8.0 LTE"
     releaseDate: 2014-06-01 # Approximate to the month and year.
-    support: false
+    eoas: true
     eol: true
     link: null
 
 -   releaseCycle: "Galaxy Tab 4 10.1"
     releaseDate: 2014-06-01 # Approximate to the month and year.
-    support: false
+    eoas: true
     eol: true
     link: https://doc.samsungmobile.com/SM-T530/KOO/doc.html
 
 -   releaseCycle: "Galaxy Tab 4 10.1 3G"
     releaseDate: 2014-06-01 # Approximate to the month and year.
-    support: false
+    eoas: true
     eol: true
     link: null
 
 -   releaseCycle: "Galaxy Tab 4 10.1 LTE"
     releaseDate: 2014-06-01 # Approximate to the month and year.
-    support: false
+    eoas: true
     eol: true
     link: null
 
 -   releaseCycle: "Galaxy S5 Duos"
     releaseDate: 2014-06-01 # Approximate to the month and year.
-    support: false
+    eoas: true
     eol: true
     link: null
 
 -   releaseCycle: "Gear 2 Neo"
     releaseDate: 2014-05-01 # Approximate to the month and year.
-    support: false
+    eoas: true
     eol: true
     link: null
 
 -   releaseCycle: "Galaxy S5 Active"
     releaseDate: 2014-05-01 # Approximate to the month and year.
-    support: false
+    eoas: true
     eol: true
     link: null
 
 -   releaseCycle: "Galaxy Ace Style"
     releaseDate: 2014-05-01 # Approximate to the month and year.
-    support: false
+    eoas: true
     eol: true
     link: null
 
 -   releaseCycle: "Galaxy Tab 4 7.0"
     releaseDate: 2014-05-01 # Approximate to the month and year.
-    support: false
+    eoas: true
     eol: true
     link: null
 
 -   releaseCycle: "Galaxy Tab 4 7.0 3G"
     releaseDate: 2014-05-01 # Approximate to the month and year.
-    support: false
+    eoas: true
     eol: true
     link: null
 
 -   releaseCycle: "Galaxy Tab 4 7.0 LTE"
     releaseDate: 2014-05-01 # Approximate to the month and year.
-    support: false
+    eoas: true
     eol: true
     link: null
 
 -   releaseCycle: "Galaxy Core LTE"
     releaseDate: 2014-05-01 # Approximate to the month and year.
-    support: false
+    eoas: true
     eol: true
     link: null
 
 -   releaseCycle: "Galaxy Star Trios S5283"
     releaseDate: 2014-05-01 # Approximate to the month and year.
-    support: false
+    eoas: true
     eol: true
     link: null
 
 -   releaseCycle: "Galaxy Tab Pro 12.2 LTE"
     releaseDate: 2014-05-01 # Approximate to the month and year.
-    support: false
+    eoas: true
     eol: true
     link: null
 
 -   releaseCycle: "Gear 2"
     releaseDate: 2014-04-01 # Approximate to the month and year.
-    support: false
+    eoas: true
     eol: true
     link: null
 
 -   releaseCycle: "I9300I Galaxy S3 Neo"
     releaseDate: 2014-04-01 # Approximate to the month and year.
-    support: false
+    eoas: true
     eol: true
     link: null
 
 -   releaseCycle: "ATIV SE"
     releaseDate: 2014-04-01 # Approximate to the month and year.
-    support: false
+    eoas: true
     eol: true
     link: null
 
 -   releaseCycle: "Galaxy S5 (octa-core)"
     releaseDate: 2014-04-01 # Approximate to the month and year.
-    support: false
+    eoas: true
     eol: 2017-04-01
     link: https://doc.samsungmobile.com/SM-G900H/XXV/doc.html
 
 -   releaseCycle: "Galaxy S5"
     releaseDate: 2014-04-01 # Approximate to the month and year.
-    support: false
+    eoas: true
     eol: 2017-04-01
     link: https://doc.samsungmobile.com/SM-G900H/XXV/doc.html
 
 -   releaseCycle: "Galaxy Tab Pro 12.2 3G"
     releaseDate: 2014-04-01 # Approximate to the month and year.
-    support: false
+    eoas: true
     eol: true
     link: null
 
 -   releaseCycle: "G3812B Galaxy S3 Slim"
     releaseDate: 2014-03-01 # Approximate to the month and year.
-    support: false
+    eoas: true
     eol: true
     link: null
 
 -   releaseCycle: "I8200 Galaxy S III mini VE"
     releaseDate: 2014-03-01 # Approximate to the month and year.
-    support: false
+    eoas: true
     eol: true
     link: null
 
 -   releaseCycle: "Galaxy Note Pro 12.2 LTE"
     releaseDate: 2014-03-01 # Approximate to the month and year.
-    support: false
+    eoas: true
     eol: true
     link: null
 
 -   releaseCycle: "Galaxy Note Pro 12.2 3G"
     releaseDate: 2014-03-01 # Approximate to the month and year.
-    support: false
+    eoas: true
     eol: true
     link: null
 
 -   releaseCycle: "Galaxy Tab Pro 12.2"
     releaseDate: 2014-03-01 # Approximate to the month and year.
-    support: false
+    eoas: true
     eol: true
     link: null
 
 -   releaseCycle: "Galaxy Note 3 Neo Duos"
     releaseDate: 2014-02-01 # Approximate to the month and year.
-    support: false
+    eoas: true
     eol: true
     link: null
 
 -   releaseCycle: "Galaxy Note 3 Neo"
     releaseDate: 2014-02-01 # Approximate to the month and year.
-    support: false
+    eoas: true
     eol: true
     link: https://doc.samsungmobile.com/SM-N750K/KTC/doc.html
 
 -   releaseCycle: "Galaxy Tab 3 Lite 7.0 3G"
     releaseDate: 2014-02-01 # Approximate to the month and year.
-    support: false
+    eoas: true
     eol: true
     link: null
 
 -   releaseCycle: "Galaxy Tab 3 Lite 7.0"
     releaseDate: 2014-02-01 # Approximate to the month and year.
-    support: false
+    eoas: true
     eol: true
     link: null
 
 -   releaseCycle: "Galaxy Grand Neo"
     releaseDate: 2014-02-01 # Approximate to the month and year.
-    support: false
+    eoas: true
     eol: true
     link: null
 
 -   releaseCycle: "Galaxy Note Pro 12.2"
     releaseDate: 2014-02-01 # Approximate to the month and year.
-    support: false
+    eoas: true
     eol: true
     link: https://doc.samsungmobile.com/SM-P900/KOO/doc.html
 
 -   releaseCycle: "Galaxy Gear"
     releaseDate: 2013-09-01 # Approximate to the month and year.
-    support: false
+    eoas: true
     eol: true
     link: null
 

--- a/products/sapmachine.md
+++ b/products/sapmachine.md
@@ -15,7 +15,7 @@ auto:
       template: '{{version}}'
 
 # LTS : EOL dates can be found on https://github.com/SAP/SapMachine/wiki/Maintenance-and-Support
-# non-LTS : EOL(x) = releaseDate(x+1) (exact date for future releases can be found on https://www.java.com/releases/)
+# non-LTS : eol(x) = releaseDate(x+1) (exact date for future releases can be found on https://www.java.com/releases/)
 releases:
 -   releaseCycle: "22"
     releaseDate: 2024-03-18

--- a/products/scala.md
+++ b/products/scala.md
@@ -9,7 +9,7 @@ alternate_urls:
 versionCommand: scalac -version
 releasePolicyLink: https://www.scala-lang.org/download/all.html
 changelogTemplate: "https://github.com/lampepfl/dotty/releases/tag/__LATEST__"
-activeSupportColumn: Current Releases
+eoasColumn: Current Releases
 eolColumn: Maintenance Releases
 releaseDateColumn: true
 
@@ -18,11 +18,11 @@ auto:
   -   git: https://github.com/scala/scala.git # Scala < 3
   -   git: https://github.com/lampepfl/dotty.git # Scala >= 3
 
-# For 3.x : support(x) = eol(x) = releaseDate(x+1)
+# For 3.x : eoas(x) = eol(x) = releaseDate(x+1)
 releases:
 -   releaseCycle: "3.4"
     releaseDate: 2024-02-14
-    support: true
+    eoas: false
     eol: false
     latest: "3.4.1"
     latestReleaseDate: 2024-03-27
@@ -30,35 +30,35 @@ releases:
 -   releaseCycle: "3.3"
     lts: true
     releaseDate: 2023-05-23
-    support: true
+    eoas: false
     eol: false
     latest: "3.3.3"
     latestReleaseDate: 2024-02-29
 
 -   releaseCycle: "3.2"
     releaseDate: 2022-08-31
-    support: 2023-05-23
+    eoas: 2023-05-23
     eol: 2023-05-23
     latest: "3.2.2"
     latestReleaseDate: 2023-01-11
 
 -   releaseCycle: "3.1"
     releaseDate: 2021-10-18
-    support: 2022-09-01
+    eoas: 2022-09-01
     eol: 2022-09-01
     latest: "3.1.3"
     latestReleaseDate: 2022-06-14
 
 -   releaseCycle: "3.0"
     releaseDate: 2021-05-13
-    support: 2021-10-18
+    eoas: 2021-10-18
     eol: 2021-10-18
     latest: "3.0.2"
     latestReleaseDate: 2021-09-01
 
 -   releaseCycle: "2.13"
     releaseDate: 2019-06-07
-    support: true
+    eoas: false
     eol: false
     latest: "2.13.13"
     latestReleaseDate: 2024-02-21
@@ -66,7 +66,7 @@ releases:
 
 -   releaseCycle: "2.12"
     releaseDate: 2016-10-28
-    support: 2019-06-07
+    eoas: 2019-06-07
     eol: false
     latest: "2.12.19"
     latestReleaseDate: 2024-02-20
@@ -74,7 +74,7 @@ releases:
 
 -   releaseCycle: "2.11"
     releaseDate: 2014-04-16
-    support: 2016-11-03
+    eoas: 2016-11-03
     eol: false
     latest: "2.11.12"
     latestReleaseDate: 2017-11-06
@@ -82,7 +82,7 @@ releases:
 
 -   releaseCycle: "2.10"
     releaseDate: 2012-12-19
-    support: 2014-04-17
+    eoas: 2014-04-17
     eol: false
     latest: "2.10.7"
     latestReleaseDate: 2017-11-06

--- a/products/silverstripe.md
+++ b/products/silverstripe.md
@@ -10,7 +10,7 @@ versionCommand: composer info silverstripe/cms
 releaseImage: https://www.silverstripe.org/assets/Uploads/_resampled/ResizedImageWzYwMCw0ODdd/CMS-5.1-Support-Timeline-with-provisional-release-date.png
 releasePolicyLink: https://www.silverstripe.org/software/roadmap/
 changelogTemplate: "https://docs.silverstripe.org/en/{{'__RELEASE_CYCLE__'|split:'.'|first}}/changelogs/__RELEASE_CYCLE__.0/"
-activeSupportColumn: Active Development
+eoasColumn: Active Development
 eolColumn: Security Support
 releaseDateColumn: true
 eolWarnThreshold: 182
@@ -28,76 +28,76 @@ auto:
       fields:
         releaseCycle: "MINOR VERSION"
         releaseDate: "STABLERELEASE"
-        support: "FULL SUPPORT ENDS"
+        eoas: "FULL SUPPORT ENDS"
         eol: "END OF LIFE(EOL)"
 
 releases:
 -   releaseCycle: "5.1"
     releaseDate: 2023-10-16
-    support: 2024-04-17
+    eoas: 2024-04-17
     eol: 2024-10-17
     latest: "5.1.6"
     latestReleaseDate: 2024-02-10
 
 -   releaseCycle: "5.0"
     releaseDate: 2023-05-04
-    support: 2023-10-17
+    eoas: 2023-10-17
     eol: 2024-04-17
     latest: "5.0.7"
     latestReleaseDate: 2023-09-23
 
 -   releaseCycle: "4.13"
     releaseDate: 2023-04-26
-    support: 2024-04-30
+    eoas: 2024-04-30
     eol: 2025-04-30
     latest: "4.13.13"
     latestReleaseDate: 2024-02-08
 
 -   releaseCycle: "4.12"
     releaseDate: 2022-12-19
-    support: 2023-04-26
+    eoas: 2023-04-26
     eol: 2023-10-26
     latest: "4.12.7"
     latestReleaseDate: 2023-05-31
 
 -   releaseCycle: "4.11"
     releaseDate: 2022-05-11
-    support: 2022-12-19
+    eoas: 2022-12-19
     eol: 2023-05-19
     latest: "4.11.16"
     latestReleaseDate: 2023-05-31
 
 -   releaseCycle: "4.10"
     releaseDate: 2022-01-25
-    support: 2022-06-30
+    eoas: 2022-06-30
     eol: 2022-12-31
     latest: "4.10.11"
     latestReleaseDate: 2022-11-21
 
 -   releaseCycle: "3.7"
     releaseDate: 2018-06-08
-    support: false
+    eoas: true
     eol: 2021-09-30 # http://web.archive.org/web/20200930101626/https://www.silverstripe.org/software/roadmap/
     latest: "3.7.7"
     latestReleaseDate: 2021-06-02
 
 -   releaseCycle: "3.1"
     releaseDate: 2013-10-01
-    support: false
+    eoas: true
     eol: 2016-12-31 # https://www.silverstripe.org/blog/support-timeline-update-where-are-we-heading/
     latest: "3.1.21"
     latestReleaseDate: 2016-11-18
 
 -   releaseCycle: "3.0"
     releaseDate: 2012-06-28
-    support: false
+    eoas: true
     eol: 2015-10-12 # as stated in https://www.silverstripe.org/blog/silverstripe-2-4-end-of-life-announcement/, the release policy was at the time that support lasts for 2 minor versions
     latest: "3.0.14"
     latestReleaseDate: 2015-05-28
 
 -   releaseCycle: "2.4"
     releaseDate: 2011-02-02
-    support: false
+    eoas: true
     eol: 2015-03-31 # https://www.silverstripe.org/blog/silverstripe-2-4-end-of-life-announcement/
     latest: "2.4.13"
     latestReleaseDate: 2013-09-26
@@ -105,7 +105,7 @@ releases:
 
 -   releaseCycle: "2.3"
     releaseDate: 2011-02-02
-    support: false
+    eoas: true
     eol: true
     latest: "2.3.13"
     latestReleaseDate: 2011-09-15

--- a/products/sles.md
+++ b/products/sles.md
@@ -14,7 +14,7 @@ changelogTemplate: "https://www.suse.com/releasenotes/x86_64/SUSE-SLES/{{'__RELE
 releaseColumn: false
 releaseDateColumn: true
 eolColumn: General Support
-extendedSupportColumn: Long Term Service Pack Support
+eoesColumn: Long Term Service Pack Support
 
 identifiers:
 -   cpe: cpe:/o:suse:sles
@@ -24,154 +24,154 @@ releases:
 -   releaseCycle: "15.5"
     releaseDate: 2023-06-20
     eol: false
-    extendedSupport: true
+    eoes: false
     latest: '15.5'
     latestReleaseDate: 2023-06-20
 
 -   releaseCycle: "15.4"
     releaseDate: 2022-06-21
     eol: 2023-12-31
-    extendedSupport: 2026-12-31
+    eoes: 2026-12-31
     latest: '15.4'
     latestReleaseDate: 2022-06-21
 
 -   releaseCycle: "15.3"
     releaseDate: 2021-06-22
     eol: 2022-12-31
-    extendedSupport: 2025-12-31
+    eoes: 2025-12-31
     latest: '15.3'
     latestReleaseDate: 2021-06-22
 
 -   releaseCycle: "15.2"
     releaseDate: 2020-07-21
     eol: 2021-12-31
-    extendedSupport: 2024-12-31
+    eoes: 2024-12-31
     latest: '15.2'
     latestReleaseDate: 2020-07-21
 
 -   releaseCycle: "12.5"
     releaseDate: 2019-12-09
     eol: 2024-10-31
-    extendedSupport: 2027-10-31
+    eoes: 2027-10-31
     latest: '12.5'
     latestReleaseDate: 2019-12-09
 
 -   releaseCycle: "15.1"
     releaseDate: 2019-06-24
     eol: 2021-01-31
-    extendedSupport: 2024-01-31
+    eoes: 2024-01-31
     latest: '15.1'
     latestReleaseDate: 2019-06-24
 
 -   releaseCycle: "15"
     releaseDate: 2018-07-16
     eol: 2019-12-31
-    extendedSupport: 2022-12-31
+    eoes: 2022-12-31
     latest: '15.5'
     latestReleaseDate: 2023-06-20
 
 -   releaseCycle: "12.4"
     releaseDate: 2018-12-12
     eol: 2020-06-30
-    extendedSupport: 2023-06-30
+    eoes: 2023-06-30
     latest: '12.4'
     latestReleaseDate: 2018-12-12
 
 -   releaseCycle: "12.3"
     releaseDate: 2017-09-07
     eol: 2019-06-30
-    extendedSupport: 2022-06-30
+    eoes: 2022-06-30
     latest: '12.3'
     latestReleaseDate: 2017-09-07
 
 -   releaseCycle: "12.2"
     releaseDate: 2016-11-08
     eol: 2018-03-31
-    extendedSupport: 2021-03-31
+    eoes: 2021-03-31
     latest: '12.2'
     latestReleaseDate: 2016-11-08
 
 -   releaseCycle: "12.1"
     releaseDate: 2015-12-15
     eol: 2017-05-31
-    extendedSupport: 2020-05-31
+    eoes: 2020-05-31
     latest: '12.1'
     latestReleaseDate: 2015-12-15
 
 -   releaseCycle: "11.4"
     releaseDate: 2015-07-15
     eol: 2019-03-31
-    extendedSupport: 2022-03-31
+    eoes: 2022-03-31
     latest: '11.4'
     latestReleaseDate: 2015-07-15
 
 -   releaseCycle: "12"
     releaseDate: 2014-10-27
     eol: 2016-06-30
-    extendedSupport: 2019-07-01
+    eoes: 2019-07-01
     latest: '12.5'
     latestReleaseDate: 2019-12-09
 
 -   releaseCycle: "11.3"
     releaseDate: 2013-07-01
     eol: 2016-01-31
-    extendedSupport: 2019-01-30
+    eoes: 2019-01-30
     latest: '11.3'
     latestReleaseDate: 2013-07-01
 
 -   releaseCycle: "11.2"
     releaseDate: 2012-02-29
     eol: 2014-01-31
-    extendedSupport: 2017-01-30
+    eoes: 2017-01-30
     latest: '11.2'
     latestReleaseDate: 2012-02-29
 
 -   releaseCycle: "10.4"
     releaseDate: 2011-04-12
     eol: 2013-07-31
-    extendedSupport: 2016-07-30
+    eoes: 2016-07-30
     latest: '10.4'
     latestReleaseDate: 2011-04-12
 
 -   releaseCycle: "11.1"
     releaseDate: 2010-06-02
     eol: 2012-08-31
-    extendedSupport: 2015-08-30
+    eoes: 2015-08-30
     latest: '11.1'
     latestReleaseDate: 2010-06-02
 
 -   releaseCycle: "11"
     releaseDate: 2009-03-24
     eol: 2010-12-31
-    extendedSupport: 2010-12-31
+    eoes: 2010-12-31
     latest: '11.4'
     latestReleaseDate: 2015-07-15
 
 -   releaseCycle: "10.3"
     releaseDate: 2009-10-12
     eol: 2011-10-11
-    extendedSupport: 2014-10-31
+    eoes: 2014-10-31
     latest: '10.3'
     latestReleaseDate: 2009-10-12
 
 -   releaseCycle: "10.2"
     releaseDate: 2008-05-19
     eol: 2010-04-11
-    extendedSupport: 2013-04-10
+    eoes: 2013-04-10
     latest: '10.2'
     latestReleaseDate: 2008-05-19
 
 -   releaseCycle: "10.1"
     releaseDate: 2007-06-18
     eol: 2008-11-30
-    extendedSupport: 2010-12-31
+    eoes: 2010-12-31
     latest: '10.1'
     latestReleaseDate: 2007-06-18
 
 -   releaseCycle: "10"
     releaseDate: 2006-07-17
     eol: 2007-12-31
-    extendedSupport: 2007-12-31
+    eoes: 2007-12-31
     latest: '10.4'
     latestReleaseDate: 2011-04-12
     link:

--- a/products/sonarqube.md
+++ b/products/sonarqube.md
@@ -8,7 +8,7 @@ alternate_urls:
 -   /sonarqube
 releasePolicyLink: https://www.sonarsource.com/products/sonarqube/downloads/lts/
 changelogTemplate: "https://www.sonarsource.com/products/sonarqube/whats-new/sonarqube-{{'__LATEST__'|split:'.'|pop|join:'-'}}/"
-activeSupportColumn: true
+eoasColumn: true
 releaseDateColumn: true
 eolColumn: Bug and Security Fixes
 
@@ -20,7 +20,7 @@ auto:
 releases:
 -   releaseCycle: "10"
     releaseDate: 2023-03-30
-    support: true
+    eoas: false
     eol: false
     latest: "10.4.1"
     latestReleaseDate: 2024-02-23
@@ -28,7 +28,7 @@ releases:
 
 -   releaseCycle: "9"
     releaseDate: 2021-07-05
-    support: 2023-03-30
+    eoas: 2023-03-30
     eol: false
     lts: 2023-02-07
     latest: "9.9.4"
@@ -37,7 +37,7 @@ releases:
 
 -   releaseCycle: "8"
     releaseDate: 2019-10-15
-    support: 2021-07-05
+    eoas: 2021-07-05
     eol: 2023-02-07
     lts: 2021-05-04
     latest: "8.9.10"
@@ -47,7 +47,7 @@ releases:
 -   releaseCycle: "7"
     # https://groups.google.com/g/sonarqube/c/p3l3naFctpg/m/Sbk7fzX3AgAJ
     releaseDate: 2018-02-02
-    support: 2019-10-16
+    eoas: 2019-10-16
     eol: 2021-05-04
     lts: 2019-07-01
     latest: "7.9.6"

--- a/products/spring-boot.md
+++ b/products/spring-boot.md
@@ -10,7 +10,7 @@ releasePolicyLink: https://github.com/spring-projects/spring-boot/wiki/Supported
 changelogTemplate: "https://github.com/spring-projects/spring-boot/releases/tag/v__LATEST__"
 releaseDateColumn: true
 eolColumn: OSS support
-extendedSupportColumn: Commercial Support
+eoesColumn: Commercial Support
 
 identifiers:
 -   purl: pkg:maven/org.springframework.boot/spring-boot
@@ -29,14 +29,14 @@ auto:
           regex: '^(?P<value>\d+\.\d+)\.x$'
         releaseDate: "Initial Release"
         eol: "End of Support"
-        extendedSupport: "End Commercial Support *"
+        eoes: "End Commercial Support *"
 
 releases:
 -   releaseCycle: "3.2"
     supportedJavaVersions: "17 - 21" # https://docs.spring.io/spring-boot/docs/3.2.x/reference/html/getting-started.html#getting-started.system-requirements
     releaseDate: 2023-11-23
     eol: 2024-11-23
-    extendedSupport: 2026-02-23
+    eoes: 2026-02-23
     latest: "3.2.4"
     latestReleaseDate: 2024-03-21
 
@@ -44,7 +44,7 @@ releases:
     supportedJavaVersions: "17 - 21" # https://docs.spring.io/spring-boot/docs/3.1.x/reference/html/getting-started.html#getting-started.system-requirements
     releaseDate: 2023-05-18
     eol: 2024-05-18
-    extendedSupport: 2025-08-18
+    eoes: 2025-08-18
     latest: "3.1.10"
     latestReleaseDate: 2024-03-21
 
@@ -52,7 +52,7 @@ releases:
     supportedJavaVersions: "17 - 21" # https://docs.spring.io/spring-boot/docs/3.0.x/reference/html/getting-started.html#getting-started.system-requirements
     releaseDate: 2022-11-24
     eol: 2023-11-24
-    extendedSupport: 2025-02-24
+    eoes: 2025-02-24
     latest: "3.0.13"
     latestReleaseDate: 2023-11-23
 
@@ -60,7 +60,7 @@ releases:
     supportedJavaVersions: "8 - 21" # https://docs.spring.io/spring-boot/docs/2.7.x/reference/html/getting-started.html#getting-started.system-requirements
     releaseDate: 2022-05-19
     eol: 2023-11-24
-    extendedSupport: 2025-08-24
+    eoes: 2025-08-24
     latest: "2.7.18"
     latestReleaseDate: 2023-11-23
 
@@ -68,7 +68,7 @@ releases:
     supportedJavaVersions: "8 - 19" # https://docs.spring.io/spring-boot/docs/2.6.14/reference/html/getting-started.html#getting-started.system-requirements
     releaseDate: 2021-11-17
     eol: 2022-11-24
-    extendedSupport: 2024-02-24
+    eoes: 2024-02-24
     latest: "2.6.15"
     latestReleaseDate: 2023-05-18
 
@@ -76,7 +76,7 @@ releases:
     supportedJavaVersions: "8 - 18" # https://docs.spring.io/spring-boot/docs/2.5.14/reference/html/getting-started.html#getting-started.system-requirements
     releaseDate: 2021-05-20
     eol: 2022-05-19
-    extendedSupport: 2023-08-24
+    eoes: 2023-08-24
     latest: "2.5.15"
     latestReleaseDate: 2023-05-18
 
@@ -84,7 +84,7 @@ releases:
     supportedJavaVersions: "8 - 16" # https://docs.spring.io/spring-boot/docs/2.4.13/reference/html/getting-started.html#getting-started-system-requirements
     releaseDate: 2020-11-12
     eol: 2021-11-18
-    extendedSupport: 2023-02-23
+    eoes: 2023-02-23
     latest: "2.4.13"
     latestReleaseDate: 2021-11-18
 
@@ -92,7 +92,7 @@ releases:
     supportedJavaVersions: "8 - 15" # https://docs.spring.io/spring-boot/docs/2.3.12.RELEASE/reference/html/getting-started.html#getting-started-system-requirements
     releaseDate: 2020-05-15
     eol: 2021-05-20
-    extendedSupport: 2022-08-20
+    eoes: 2022-08-20
     link: https://github.com/spring-projects/spring-boot/releases/tag/v__LATEST__.RELEASE
     latest: "2.3.12"
     latestReleaseDate: 2021-06-10
@@ -101,7 +101,7 @@ releases:
     supportedJavaVersions: "8 - 15" # https://docs.spring.io/spring-boot/docs/2.2.13.RELEASE/reference/html/getting-started.html#getting-started-system-requirements
     releaseDate: 2019-10-16
     eol: 2020-10-16
-    extendedSupport: 2022-01-16
+    eoes: 2022-01-16
     link: https://github.com/spring-projects/spring-boot/releases/tag/v__LATEST__.RELEASE
     latest: "2.2.13"
     latestReleaseDate: 2021-01-14
@@ -110,7 +110,7 @@ releases:
     supportedJavaVersions: "8 - 12" # https://docs.spring.io/spring-boot/docs/2.1.18.RELEASE/reference/html/getting-started-system-requirements.html
     releaseDate: 2018-10-30
     eol: 2019-10-30
-    extendedSupport: 2021-01-30
+    eoes: 2021-01-30
     link: https://github.com/spring-projects/spring-boot/releases/tag/v__LATEST__.RELEASE
     latest: "2.1.18"
     latestReleaseDate: 2020-10-29
@@ -119,7 +119,7 @@ releases:
     supportedJavaVersions: "8 - 9" # https://docs.spring.io/spring-boot/docs/2.0.9.RELEASE/reference/html/getting-started-system-requirements.html
     releaseDate: 2018-03-01
     eol: 2019-03-01
-    extendedSupport: 2020-06-01
+    eoes: 2020-06-01
     link: https://github.com/spring-projects/spring-boot/releases/tag/v__LATEST__.RELEASE
     latest: "2.0.9"
     latestReleaseDate: 2019-04-03
@@ -128,7 +128,7 @@ releases:
     supportedJavaVersions: "6 - 8" # https://docs.spring.io/spring-boot/docs/1.5.22.RELEASE/reference/html/getting-started-system-requirements.html
     releaseDate: 2017-01-30
     eol: 2019-08-06
-    extendedSupport: 2020-11-06
+    eoes: 2020-11-06
     link: https://github.com/spring-projects/spring-boot/releases/tag/v__LATEST__.RELEASE
     latest: "1.5.22"
     latestReleaseDate: 2019-08-06

--- a/products/spring-framework.md
+++ b/products/spring-framework.md
@@ -10,7 +10,7 @@ releasePolicyLink: https://github.com/spring-projects/spring-framework/wiki/Spri
 changelogTemplate: https://github.com/spring-projects/spring-framework/releases/tag/v__LATEST__
 releaseDateColumn: true
 eolColumn: OSS support
-extendedSupportColumn: Commercial Support
+eoesColumn: Commercial Support
 
 auto:
   methods:
@@ -25,7 +25,7 @@ auto:
           regex: '^(?P<value>\d+\.\d+)\.x$'
         releaseDate: "Initial Release"
         eol: "End of Support"
-        extendedSupport: "End Commercial Support *"
+        eoes: "End Commercial Support *"
 
 # Supported Java/Jakarta EE versions available on https://github.com/spring-projects/spring-framework/wiki/Spring-Framework-Versions#jdk-version-range.
 releases:
@@ -34,7 +34,7 @@ releases:
     supportedJakartaEEVersions: "9 - 10"
     releaseDate: 2023-11-16
     eol: 2025-08-31
-    extendedSupport: 2026-12-31
+    eoes: 2026-12-31
     latest: "6.1.5"
     latestReleaseDate: 2024-03-14
 
@@ -43,7 +43,7 @@ releases:
     supportedJakartaEEVersions: "9 - 10"
     releaseDate: 2022-11-16
     eol: 2024-08-31
-    extendedSupport: 2025-12-31
+    eoes: 2025-12-31
     latest: "6.0.18"
     latestReleaseDate: 2024-03-14
 
@@ -52,7 +52,7 @@ releases:
     supportedJakartaEEVersions: "7 - 8"
     releaseDate: 2020-10-27
     eol: 2024-08-31
-    extendedSupport: 2026-12-31
+    eoes: 2026-12-31
     lts: true
     latest: "5.3.33"
     latestReleaseDate: 2024-03-14
@@ -62,7 +62,7 @@ releases:
     supportedJakartaEEVersions: "N/A"
     releaseDate: 2019-09-30
     eol: 2021-12-31
-    extendedSupport: 2023-12-31
+    eoes: 2023-12-31
     link: https://github.com/spring-projects/spring-framework/releases/tag/v__LATEST__.RELEASE
     latest: "5.2.25"
     latestReleaseDate: 2023-07-13
@@ -72,7 +72,7 @@ releases:
     supportedJakartaEEVersions: "N/A"
     releaseDate: 2018-09-21
     eol: 2020-12-31
-    extendedSupport: 2022-12-31
+    eoes: 2022-12-31
     link: https://github.com/spring-projects/spring-framework/releases/tag/v__LATEST__.RELEASE
     latest: "5.1.20"
     latestReleaseDate: 2020-12-09
@@ -82,7 +82,6 @@ releases:
     supportedJakartaEEVersions: "N/A"
     releaseDate: 2017-09-28
     eol: 2020-12-31
-    extendedSupport: false
     link: https://github.com/spring-projects/spring-framework/releases/tag/v__LATEST__.RELEASE
     latest: "5.0.20"
     latestReleaseDate: 2020-12-09
@@ -92,7 +91,6 @@ releases:
     supportedJakartaEEVersions: "N/A"
     releaseDate: 2016-06-10
     eol: 2020-12-31
-    extendedSupport: false
     link: https://github.com/spring-projects/spring-framework/releases/tag/v__LATEST__.RELEASE
     latest: "4.3.30"
     latestReleaseDate: 2020-12-09
@@ -102,7 +100,6 @@ releases:
     supportedJakartaEEVersions: "N/A"
     releaseDate: 2012-12-13
     eol: 2016-12-31
-    extendedSupport: false
     link: https://github.com/spring-projects/spring-framework/releases/tag/v__LATEST__.RELEASE
     latest: "3.2.18"
     latestReleaseDate: 2016-12-21

--- a/products/symfony.md
+++ b/products/symfony.md
@@ -7,7 +7,7 @@ permalink: /symfony
 versionCommand: composer show | grep "symfony/"
 releasePolicyLink: https://symfony.com/releases
 changelogTemplate: "https://symfony.com/blog/symfony-{{'__LATEST__'|replace:'.','-'}}-released"
-activeSupportColumn: true
+eoasColumn: true
 releaseDateColumn: true
 
 auto:
@@ -15,16 +15,16 @@ auto:
   -   git: https://github.com/symfony/symfony.git
 
 # For LTS:
-# - support(x) = releaseDate(x) + 36 months
+# - eoas(x) = releaseDate(x) + 36 months
 # - eol(x) = releaseDate(x) + 48 months
 #
 # For non-LTS:
-# - support(x) = releaseDate(x) + 8 months
+# - eoas(x) = releaseDate(x) + 8 months
 # - eol(x) = releaseDate(x) + 8 months
 releases:
 -   releaseCycle: "7.0"
     releaseDate: 2023-11-29
-    support: 2024-07-31
+    eoas: 2024-07-31
     eol: 2024-07-31
     latest: "7.0.5"
     latestReleaseDate: 2024-03-04
@@ -32,35 +32,35 @@ releases:
 -   releaseCycle: "6.4"
     lts: true
     releaseDate: 2023-11-29
-    support: 2026-11-30
+    eoas: 2026-11-30
     eol: 2027-11-30
     latest: "6.4.5"
     latestReleaseDate: 2024-03-04
 
 -   releaseCycle: "6.3"
     releaseDate: 2023-05-30
-    support: 2024-01-31
+    eoas: 2024-01-31
     eol: 2024-01-31
     latest: "6.3.12"
     latestReleaseDate: 2024-01-30
 
 -   releaseCycle: "6.2"
     releaseDate: 2022-11-30
-    support: 2023-07-31
+    eoas: 2023-07-31
     eol: 2023-07-31
     latest: "6.2.14"
     latestReleaseDate: 2023-07-31
 
 -   releaseCycle: "6.1"
     releaseDate: 2022-05-27
-    support: 2023-01-31
+    eoas: 2023-01-31
     eol: 2023-01-31
     latest: "6.1.12"
     latestReleaseDate: 2023-02-01
 
 -   releaseCycle: "6.0"
     releaseDate: 2021-11-29
-    support: 2023-01-31
+    eoas: 2023-01-31
     eol: 2023-01-31
     latest: "6.0.20"
     latestReleaseDate: 2023-02-01
@@ -68,35 +68,35 @@ releases:
 -   releaseCycle: "5.4"
     lts: true
     releaseDate: 2021-11-29
-    support: 2024-11-30
+    eoas: 2024-11-30
     eol: 2025-11-30
     latest: "5.4.37"
     latestReleaseDate: 2024-03-04
 
 -   releaseCycle: "5.3"
     releaseDate: 2021-05-31
-    support: 2022-01-01
+    eoas: 2022-01-01
     eol: 2022-01-01
     latest: "5.3.16"
     latestReleaseDate: 2022-03-01
 
 -   releaseCycle: "5.2"
     releaseDate: 2020-11-30
-    support: 2021-07-21
+    eoas: 2021-07-21
     eol: 2021-07-21
     latest: "5.2.14"
     latestReleaseDate: 2021-07-29
 
 -   releaseCycle: "5.1"
     releaseDate: 2020-05-31
-    support: 2021-01-21
+    eoas: 2021-01-21
     eol: 2021-01-21
     latest: "5.1.11"
     latestReleaseDate: 2021-01-27
 
 -   releaseCycle: "5.0"
     releaseDate: 2019-11-21
-    support: 2020-07-21
+    eoas: 2020-07-21
     eol: 2020-07-21
     latest: "5.0.11"
     latestReleaseDate: 2020-07-24
@@ -104,28 +104,28 @@ releases:
 -   releaseCycle: "4.4"
     lts: true
     releaseDate: 2019-11-21
-    support: 2022-11-21
+    eoas: 2022-11-21
     eol: 2023-11-21
     latest: "4.4.51"
     latestReleaseDate: 2023-11-10
 
 -   releaseCycle: "4.3"
     releaseDate: 2019-05-30
-    support: 2020-01-01
+    eoas: 2020-01-01
     eol: 2020-07-01
     latest: "4.3.11"
     latestReleaseDate: 2020-01-31
 
 -   releaseCycle: "4.2"
     releaseDate: 2018-11-30
-    support: 2019-07-01
+    eoas: 2019-07-01
     eol: 2020-01-01
     latest: "4.2.12"
     latestReleaseDate: 2019-11-13
 
 -   releaseCycle: "4.1"
     releaseDate: 2018-05-30
-    support: 2019-01-01
+    eoas: 2019-01-01
     eol: 2019-07-01
     # No announcement for 4.1.13, which was tagged the same day
     link: https://symfony.com/blog/symfony-4-1-12-released
@@ -134,7 +134,7 @@ releases:
 
 -   releaseCycle: "4.0"
     releaseDate: 2017-11-30
-    support: 2018-07-01
+    eoas: 2018-07-01
     eol: 2019-01-01
     latest: "4.0.15"
     latestReleaseDate: 2018-12-06
@@ -142,35 +142,35 @@ releases:
 -   releaseCycle: "3.4"
     lts: true
     releaseDate: 2017-11-30
-    support: 2020-11-01
+    eoas: 2020-11-01
     eol: 2021-11-01
     latest: "3.4.49"
     latestReleaseDate: 2021-05-19
 
 -   releaseCycle: "3.3"
     releaseDate: 2017-05-29
-    support: 2018-01-01
+    eoas: 2018-01-01
     eol: 2018-07-01
     latest: "3.3.18"
     latestReleaseDate: 2018-08-01
 
 -   releaseCycle: "3.2"
     releaseDate: 2016-11-30
-    support: 2017-07-01
+    eoas: 2017-07-01
     eol: 2018-01-01
     latest: "3.2.14"
     latestReleaseDate: 2017-11-16
 
 -   releaseCycle: "3.1"
     releaseDate: 2016-05-30
-    support: 2017-01-01
+    eoas: 2017-01-01
     eol: 2017-07-01
     latest: "3.1.10"
     latestReleaseDate: 2017-01-27
 
 -   releaseCycle: "3.0"
     releaseDate: 2015-11-30
-    support: 2016-07-01
+    eoas: 2016-07-01
     eol: 2017-01-01
     latest: "3.0.9"
     latestReleaseDate: 2016-07-30
@@ -178,7 +178,7 @@ releases:
 -   releaseCycle: "2.8"
     lts: true
     releaseDate: 2015-11-30
-    support: 2018-11-01
+    eoas: 2018-11-01
     eol: 2019-11-01
     latest: "2.8.52"
     latestReleaseDate: 2019-11-13
@@ -186,7 +186,7 @@ releases:
 -   releaseCycle: "2.7"
     lts: true
     releaseDate: 2015-05-30
-    support: 2018-05-01
+    eoas: 2018-05-01
     eol: 2019-05-01
     # no announcement for 2.7.52, which was tagged the same day
     link: https://symfony.com/blog/symfony-2-7-51-released
@@ -196,7 +196,7 @@ releases:
 -   releaseCycle: "2.3"
     lts: true
     releaseDate: 2013-06-03
-    support: 2016-05-01
+    eoas: 2016-05-01
     eol: 2017-05-01
     latest: "2.3.42"
     latestReleaseDate: 2016-05-30

--- a/products/terraform.md
+++ b/products/terraform.md
@@ -17,7 +17,7 @@ auto:
   methods:
   -   git: https://github.com/hashicorp/terraform.git
 
-# EOL(x) = releaseDate(x+2)
+# eol(x) = releaseDate(x+2)
 releases:
 -   releaseCycle: "1.7"
     releaseDate: 2024-01-17

--- a/products/traefik.md
+++ b/products/traefik.md
@@ -8,7 +8,7 @@ versionCommand: traefik version
 releasePolicyLink: https://doc.traefik.io/traefik/deprecation/releases
 changelogTemplate: https://github.com/traefik/traefik/releases/tag/v__LATEST__
 releaseDateColumn: true
-activeSupportColumn: true
+eoasColumn: true
 eolColumn: Security Support
 
 identifiers:
@@ -20,96 +20,96 @@ auto:
   methods:
   -   git: https://github.com/traefik/traefik.git
 
-# Table with releaseCycles/releaseDate/support: https://doc.traefik.io/traefik/deprecation/releases
-# Estimation: support(x) = releaseDate(x+1)
+# Table with releaseCycles/releaseDate/eoas:https://doc.traefik.io/traefik/deprecation/releases
+# Estimation: eoas(x) = releaseDate(x+1)
 releases:
 -   releaseCycle: "2.11"
     releaseDate: 2024-02-12
-    support: true
+    eoas: false
     eol: false
     latest: "2.11.0"
     latestReleaseDate: 2024-02-12
 
 -   releaseCycle: "2.10"
     releaseDate: 2023-04-24
-    support: 2024-02-12
+    eoas: 2024-02-12
     eol: 2024-02-12
     latest: "2.10.7"
     latestReleaseDate: 2023-12-06
 
 -   releaseCycle: "2.9"
     releaseDate: 2022-10-03
-    support: 2023-04-24
+    eoas: 2023-04-24
     eol: 2023-04-24
     latest: "2.9.10"
     latestReleaseDate: 2023-04-06
 
 -   releaseCycle: "2.8"
     releaseDate: 2022-06-29
-    support: 2022-10-03
+    eoas: 2022-10-03
     eol: 2022-10-03
     latest: "2.8.8"
     latestReleaseDate: 2022-09-30
 
 -   releaseCycle: "2.7"
     releaseDate: 2022-05-24
-    support: 2022-06-29
+    eoas: 2022-06-29
     eol: 2022-06-29
     latest: "2.7.3"
     latestReleaseDate: 2022-06-29
 
 -   releaseCycle: "2.6"
     releaseDate: 2022-01-24
-    support: 2022-05-24
+    eoas: 2022-05-24
     eol: 2022-05-24
     latest: "2.6.7"
     latestReleaseDate: 2022-05-24
 
 -   releaseCycle: "2.5"
     releaseDate: 2021-08-17
-    support: 2022-01-24
+    eoas: 2022-01-24
     eol: 2022-01-24
     latest: "2.5.7"
     latestReleaseDate: 2022-01-20
 
 -   releaseCycle: "2.4"
     releaseDate: 2021-01-19
-    support: 2021-08-17
+    eoas: 2021-08-17
     eol: 2021-08-17
     latest: "2.4.14"
     latestReleaseDate: 2021-08-16
 
 -   releaseCycle: "2.3"
     releaseDate: 2020-09-23
-    support: 2021-01-19
+    eoas: 2021-01-19
     eol: 2021-01-19
     latest: "2.3.7"
     latestReleaseDate: 2021-01-11
 
 -   releaseCycle: "2.2"
     releaseDate: 2020-03-25
-    support: 2020-09-23
+    eoas: 2020-09-23
     eol: 2020-09-23
     latest: "2.2.11"
     latestReleaseDate: 2020-09-07
 
 -   releaseCycle: "2.1"
     releaseDate: 2019-12-11
-    support: 2020-03-25
+    eoas: 2020-03-25
     eol: 2020-03-25
     latest: "2.1.9"
     latestReleaseDate: 2020-03-23
 
 -   releaseCycle: "2.0"
     releaseDate: 2019-09-16
-    support: 2019-12-11
+    eoas: 2019-12-11
     eol: 2019-12-11
     latest: "2.0.7"
     latestReleaseDate: 2019-12-09
 
 -   releaseCycle: "1.7"
     releaseDate: 2018-09-24
-    support: 2021-12-31
+    eoas: 2021-12-31
     eol: 2021-12-31
     latest: "1.7.34"
     latestReleaseDate: 2021-12-10

--- a/products/typo3.md
+++ b/products/typo3.md
@@ -7,8 +7,8 @@ permalink: /typo3
 releasePolicyLink: https://get.typo3.org/
 changelogTemplate: https://get.typo3.org/release-notes/__LATEST__
 releaseDateColumn: true
-activeSupportColumn: true
-extendedSupportColumn: Extended Long Term Support
+eoasColumn: true
+eoesColumn: Extended Long Term Support
 
 identifiers:
 -   repology: typo3
@@ -21,59 +21,59 @@ auto:
 releases:
 -   releaseCycle: "13"
     releaseDate: 2024-01-30
-    support: 2026-04-30
+    eoas: 2026-04-30
     eol: 2027-10-31
-    extendedSupport: 2030-10-31
+    eoes: 2030-10-31
     latest: '13.0.1'
     latestReleaseDate: 2024-02-13
 
 -   releaseCycle: "12"
     releaseDate: 2022-10-04
-    support: 2024-10-31
+    eoas: 2024-10-31
     eol: 2026-04-30
-    extendedSupport: 2029-04-30
+    eoes: 2029-04-30
     latest: '12.4.13'
     latestReleaseDate: 2024-03-19
 
 -   releaseCycle: "11"
     releaseDate: 2020-12-22
     lts: 2021-10-05
-    support: 2023-03-31
+    eoas: 2023-03-31
     eol: 2024-10-31
-    extendedSupport: 2027-10-31
+    eoes: 2027-10-31
     latest: "11.5.36"
     latestReleaseDate: 2024-02-20
 
 -   releaseCycle: "10"
     releaseDate: 2019-07-23
     lts: 2020-04-07
-    support: 2021-10-31
+    eoas: 2021-10-31
     eol: 2023-04-30
-    extendedSupport: 2026-04-30
+    eoes: 2026-04-30
     latest: "10.4.44"
     latestReleaseDate: 2024-02-14
 
 -   releaseCycle: "9"
     releaseDate: 2017-12-12
-    support: 2020-04-30
+    eoas: 2020-04-30
     eol: 2021-09-30
-    extendedSupport: 2024-09-30
+    eoes: 2024-09-30
     latest: "9.5.47"
     latestReleaseDate: 2024-02-14
 
 -   releaseCycle: "8"
     releaseDate: 2016-03-22
-    support: 2018-09-30
+    eoas: 2018-09-30
     eol: 2020-03-31
-    extendedSupport: 2024-03-31
+    eoes: 2024-03-31
     latest: "8.7.58"
     latestReleaseDate: 2024-02-14
 
 -   releaseCycle: "7"
     releaseDate: 2014-12-02
-    support: 2017-04-01
+    eoas: 2017-04-01
     eol: 2018-12-01
-    extendedSupport: 2022-11-30
+    eoes: 2022-11-30
     latest: "7.6.58"
     latestReleaseDate: 2022-09-12
 

--- a/products/ubuntu.md
+++ b/products/ubuntu.md
@@ -10,9 +10,9 @@ releaseImage: https://user-images.githubusercontent.com/3691490/235072519-20107b
 releaseLabel: "__RELEASE_CYCLE__ '__CODENAME__'"
 changelogTemplate: https://wiki.ubuntu.com/{{"__CODENAME__"|replace:' ',''}}/ReleaseNotes/
 releaseDateColumn: true
-activeSupportColumn: Hardware & Maintenance
+eoasColumn: Hardware & Maintenance
 eolColumn: Maintenance & Security Support
-extendedSupportColumn: Extended Security Maintenance
+eoesColumn: Extended Security Maintenance
 
 # https://regex101.com/r/Fzt9US/1
 # We return v1 and v2 separated by newline in case 2 releases were marked
@@ -32,27 +32,24 @@ releases:
 -   releaseCycle: "23.10"
     codename: "Mantic Minotaur"
     releaseDate: 2023-10-12
-    support: 2024-07-01
+    eoas: 2024-07-01
     eol: 2024-07-01
-    extendedSupport: false
     latest: "23.10"
     latestReleaseDate: 2023-10-12
 
 -   releaseCycle: "23.04"
     codename: "Lunar Lobster"
     releaseDate: 2023-04-20
-    support: 2024-01-20
+    eoas: 2024-01-20
     eol: 2024-01-20
-    extendedSupport: false
     latest: "23.04"
     latestReleaseDate: 2023-04-20
 
 -   releaseCycle: "22.10"
     codename: "Kinetic Kudu"
     releaseDate: 2022-10-20
-    support: 2023-07-20
+    eoas: 2023-07-20
     eol: 2023-07-20
-    extendedSupport: false
     latest: "22.10"
     latestReleaseDate: 2022-10-20
 
@@ -60,36 +57,33 @@ releases:
     codename: "Jammy Jellyfish"
     lts: true
     releaseDate: 2022-04-21
-    support: 2024-09-30
+    eoas: 2024-09-30
     eol: 2027-04-01
-    extendedSupport: 2032-04-09
+    eoes: 2032-04-09
     latest: "22.04.4"
     latestReleaseDate: 2024-02-22
 
 -   releaseCycle: "21.10"
     codename: "Impish Indri"
     releaseDate: 2021-10-14
-    support: 2022-07-14
+    eoas: 2022-07-14
     eol: 2022-07-14
-    extendedSupport: false
     latest: "21.10"
     latestReleaseDate: 2021-10-14
 
 -   releaseCycle: "21.04"
     codename: "Hirsute Hippo"
     releaseDate: 2021-04-22
-    support: 2022-01-20
+    eoas: 2022-01-20
     eol: 2022-01-20
-    extendedSupport: false
     latest: "21.04"
     latestReleaseDate: 2021-04-22
 
 -   releaseCycle: "20.10"
     codename: "Groovy Gorilla"
     releaseDate: 2020-10-22
-    support: 2021-07-22
+    eoas: 2021-07-22
     eol: 2021-07-22
-    extendedSupport: false
     latest: "20.10"
     latestReleaseDate: 2020-10-22
 
@@ -97,36 +91,33 @@ releases:
     codename: "Focal Fossa"
     lts: true
     releaseDate: 2020-04-23
-    support: 2022-10-01
+    eoas: 2022-10-01
     eol: 2025-04-02
-    extendedSupport: 2030-04-02
+    eoes: 2030-04-02
     latest: "20.04.6"
     latestReleaseDate: 2023-03-23
 
 -   releaseCycle: "19.10"
     codename: "Eoan Ermine"
     releaseDate: 2019-10-17
-    support: 2020-07-06
+    eoas: 2020-07-06
     eol: 2020-07-06
-    extendedSupport: false
     latest: "19.10"
     latestReleaseDate: 2019-10-17
 
 -   releaseCycle: "19.04"
     codename: "Disco Dingo"
     releaseDate: 2019-04-18
-    support: 2020-01-23
+    eoas: 2020-01-23
     eol: 2020-01-23
-    extendedSupport: false
     latest: "19.04"
     latestReleaseDate: 2019-04-18
 
 -   releaseCycle: "18.10"
     codename: "Cosmic Cuttlefish"
     releaseDate: 2018-10-18
-    support: 2019-07-18
+    eoas: 2019-07-18
     eol: 2019-07-18
-    extendedSupport: false
     latest: "18.10"
     latestReleaseDate: 2018-10-18
 
@@ -134,27 +125,25 @@ releases:
     codename: "Bionic Beaver"
     lts: true
     releaseDate: 2018-04-26
-    support: 2023-05-31
+    eoas: 2023-05-31
     eol: 2023-05-31
-    extendedSupport: 2028-04-01
+    eoes: 2028-04-01
     latest: "18.04.6"
     latestReleaseDate: 2021-09-17
 
 -   releaseCycle: "17.10"
     codename: "Artful Aardvark"
     releaseDate: 2017-10-19
-    support: 2018-07-19
+    eoas: 2018-07-19
     eol: 2018-07-19
-    extendedSupport: false
     latest: "17.10"
     latestReleaseDate: 2017-10-19
 
 -   releaseCycle: "17.04"
     codename: "Zesty Zapus"
     releaseDate: 2017-04-13
-    support: 2018-01-13
+    eoas: 2018-01-13
     eol: 2018-01-13
-    extendedSupport: false
     latest: "17.04"
     latestReleaseDate: 2017-04-13
 
@@ -162,36 +151,33 @@ releases:
     codename: "Xenial Xerus"
     lts: true
     releaseDate: 2016-04-21
-    support: 2021-04-02
+    eoas: 2021-04-02
     eol: 2021-04-02
-    extendedSupport: 2026-04-02
+    eoes: 2026-04-02
     latest: "16.04.7"
     latestReleaseDate: 2020-08-13
 
 -   releaseCycle: "15.10"
     codename: "Wily Werewolf"
     releaseDate: 2015-10-22
-    support: 2016-07-28
+    eoas: 2016-07-28
     eol: 2016-07-28
-    extendedSupport: false
     latest: "15.10"
     latestReleaseDate: 2015-10-22
 
 -   releaseCycle: "15.04"
     codename: "Vivid Vervet"
     releaseDate: 2015-04-23
-    support: 2016-02-04
+    eoas: 2016-02-04
     eol: 2016-02-04
-    extendedSupport: false
     latest: "15.04"
     latestReleaseDate: 2015-04-23
 
 -   releaseCycle: "14.10"
     codename: "Utopic Unicorn"
     releaseDate: 2014-10-23
-    support: 2015-07-23
+    eoas: 2015-07-23
     eol: 2015-07-23
-    extendedSupport: false
     latest: "14.10"
     latestReleaseDate: 2014-10-23
 
@@ -199,9 +185,9 @@ releases:
     codename: "Trusty Tahr"
     lts: true
     releaseDate: 2014-04-17
-    support: 2019-04-02
+    eoas: 2019-04-02
     eol: 2019-04-02
-    extendedSupport: 2024-04-02
+    eoes: 2024-04-02
     latest: "14.04.6"
     latestReleaseDate: 2019-03-07
 
@@ -209,9 +195,9 @@ releases:
     codename: "Precise Pangolin"
     lts: true
     releaseDate: 2012-04-26
-    support: 2017-04-28
+    eoas: 2017-04-28
     eol: 2017-04-28
-    extendedSupport: 2019-04-26
+    eoes: 2019-04-26
     latest: "12.04.5"
     latestReleaseDate: 2014-08-08
 
@@ -219,9 +205,8 @@ releases:
     codename: "Oneiric Ocelot"
     lts: false
     releaseDate: 2011-10-13
-    support: 2013-05-09
+    eoas: 2013-05-09
     eol: 2013-05-09
-    extendedSupport: false
     latest: "11.10"
     latestReleaseDate: 2011-10-13
 
@@ -229,9 +214,8 @@ releases:
     codename: "Natty Narwhal"
     lts: false
     releaseDate: 2011-04-28
-    support: 2012-10-28
+    eoas: 2012-10-28
     eol: 2012-10-28
-    extendedSupport: false
     latest: "11.04"
     latestReleaseDate: 2011-04-28
 
@@ -239,9 +223,8 @@ releases:
     codename: "Maverick Meerkat"
     lts: false
     releaseDate: 2010-10-10
-    support: 2012-04-10
+    eoas: 2012-04-10
     eol: 2012-04-10
-    extendedSupport: false
     latest: "10.10"
     latestReleaseDate: 2010-10-10
 
@@ -249,9 +232,8 @@ releases:
     codename: "Lucid Lynx"
     lts: true
     releaseDate: 2010-04-29
-    support: 2013-05-09
+    eoas: 2013-05-09
     eol: 2013-05-09
-    extendedSupport: false
     latest: "10.04.4"
     latestReleaseDate: 2012-02-16
 
@@ -259,9 +241,8 @@ releases:
     codename: "Karmic Koala"
     lts: false
     releaseDate: 2009-10-29
-    support: 2011-04-30
+    eoas: 2011-04-30
     eol: 2011-04-30
-    extendedSupport: false
     latest: "9.10"
     latestReleaseDate: 2009-10-29
 
@@ -269,9 +250,8 @@ releases:
     codename: "Jaunty Jackalope"
     lts: false
     releaseDate: 2009-04-23
-    support: 2010-10-23
+    eoas: 2010-10-23
     eol: 2010-10-23
-    extendedSupport: false
     latest: "9.04"
     latestReleaseDate: 2009-04-23
 
@@ -279,9 +259,8 @@ releases:
     codename: "Hardy Heron"
     lts: true
     releaseDate: 2008-04-24
-    support: 2013-05-09
+    eoas: 2013-05-09
     eol: 2013-05-09
-    extendedSupport: false
     latest: "8.04.4"
     latestReleaseDate: 2010-01-29
 
@@ -289,9 +268,8 @@ releases:
     codename: "Gutsy Gibbon"
     lts: false
     releaseDate: 2007-10-18
-    support: 2009-04-18
+    eoas: 2009-04-18
     eol: 2009-04-18
-    extendedSupport: false
     latest: "7.10"
     latestReleaseDate: 2007-10-18
 
@@ -299,9 +277,8 @@ releases:
     codename: "Feisty Fawn"
     lts: false
     releaseDate: 2007-04-19
-    support: 2008-10-19
+    eoas: 2008-10-19
     eol: 2008-10-19
-    extendedSupport: false
     latest: "7.04"
     latestReleaseDate: 2007-04-19
 
@@ -309,19 +286,17 @@ releases:
     codename: "Edgy Eft"
     lts: false
     releaseDate: 2006-10-26
-    support: 2006-10-26
+    eoas: 2006-10-26
     eol: 2008-04-26
-    extendedSupport: false
     latest: "6.10"
     latestReleaseDate: 2006-10-26
 
 -   releaseCycle: "6.06"
     codename: "Dapper Drake"
     lts: true
-    support: 2011-06-01
+    eoas: 2011-06-01
     releaseDate: 2006-08-10
     eol: 2011-06-01
-    extendedSupport: false
     latest: "6.06.2"
     latestReleaseDate: 2008-01-22
 
@@ -329,9 +304,8 @@ releases:
     codename: "Breezy Badger"
     lts: false
     releaseDate: 2005-10-13
-    support: 2007-04-13
+    eoas: 2007-04-13
     eol: 2007-04-13
-    extendedSupport: false
     latest: "5.10"
     latestReleaseDate: 2005-10-13
 
@@ -339,9 +313,8 @@ releases:
     codename: "Hoary Hedgehog"
     lts: false
     releaseDate: 2005-04-08
-    support: 2006-10-31
+    eoas: 2006-10-31
     eol: 2006-10-31
-    extendedSupport: false
     latest: "5.04"
     latestReleaseDate: 2005-04-08
 
@@ -349,9 +322,8 @@ releases:
     codename: "Warty Warthog"
     lts: false
     releaseDate: 2004-10-20
-    support: 2004-10-26
+    eoas: 2004-10-26
     eol: 2006-04-30
-    extendedSupport: false
     latest: "4.10"
     latestReleaseDate: 2004-10-20
 
@@ -402,7 +374,7 @@ to extend the support of Ubuntu LTS releases from 14.04 by another 2 years beyon
 | Main repository                                                                         | 5 years         | 10 years                     | 10 years      | 12 years       |
 | Restricted repository                                                                   | 5 years         | 10 years[^2]                 | 10 years [^2] | 12 years[^7]   |
 | Universe repository                                                                     | Best Effort[^6] | Best Effort                  | 10 years      | 12 years[^7]   |
-| Phone/Ticket Support                                                                    | No              | Yes                          | Yes           | Yes            | 
+| Phone/Ticket Support                                                                    | No              | Yes                          | Yes           | Yes            |
 | Kernel Live Patching                                                                    | No              | Yes                          | Yes           | Yes            |
 | [Security Certifications and Hardening](https://ubuntu.com/security/certifications)[^3] | No              | Yes                          | Yes           | Yes            |
 | [Ubuntu Landscape](https://ubuntu.com/landscape)                                        | No              | Yes                          | Yes           | No[^8]         |

--- a/products/umbraco.md
+++ b/products/umbraco.md
@@ -9,7 +9,7 @@ alternative_urls:
 releasePolicyLink: https://umbraco.com/products/knowledge-center/long-term-support-and-end-of-life/
 changelogTemplate: "https://our.umbraco.com/download/releases/{{'__LATEST__'|replace:'.',''}}"
 releaseDateColumn: true
-activeSupportColumn: Support
+eoasColumn: Support
 eolColumn: Security
 
 auto:
@@ -24,7 +24,7 @@ auto:
           column: "Version"
           regex: '^Umbraco (?P<value>\d+)$'
         releaseDate: "Release date"
-        support: "Security phase"
+        eoas: "Security phase"
         eol: "End-of-Life"
 
 # Only tracking major releases here, even if regressions are fixed on the last three minors.
@@ -36,21 +36,21 @@ releases:
 -   releaseCycle: "13"
     lts: true
     releaseDate: 2023-12-12
-    support: 2025-12-14
+    eoas: 2025-12-14
     eol: 2026-12-14
     latest: '13.2.2'
     latestReleaseDate: 2024-03-19
 
 -   releaseCycle: "12"
     releaseDate: 2023-06-27
-    support: 2024-03-29
+    eoas: 2024-03-29
     eol: 2024-06-29
     latest: '12.3.9'
     latestReleaseDate: 2024-03-19
 
 -   releaseCycle: "11"
     releaseDate: 2022-11-29
-    support: 2023-09-01
+    eoas: 2023-09-01
     eol: 2023-12-01
     latest: '11.5.0'
     latestReleaseDate: 2023-09-05
@@ -58,14 +58,14 @@ releases:
 -   releaseCycle: "10"
     lts: true
     releaseDate: 2022-06-10
-    support: 2024-06-16
+    eoas: 2024-06-16
     eol: 2025-06-16
     latest: '10.8.5'
     latestReleaseDate: 2024-03-18
 
 -   releaseCycle: "9"
     releaseDate: 2021-09-26
-    support: 2022-09-16
+    eoas: 2022-09-16
     eol: 2022-12-16
     latest: '9.5.4'
     latestReleaseDate: 2022-09-05
@@ -74,7 +74,7 @@ releases:
 -   releaseCycle: "8"
     lts: true
     releaseDate: 2019-02-21
-    support: 2024-02-24
+    eoas: 2024-02-24
     eol: 2025-02-24
     latest: '8.18.13'
     latestReleaseDate: 2024-02-06
@@ -83,7 +83,7 @@ releases:
 -   releaseCycle: "7"
     lts: true
     releaseDate: 2013-11-21
-    support: 2021-07-31
+    eoas: 2021-07-31
     eol: 2023-09-30
     latest: '7.15.11'
     latestReleaseDate: 2023-09-05
@@ -91,7 +91,7 @@ releases:
 -   releaseCycle: "6"
     # https://umbraco.com/blog/umbraco-600-released/
     releaseDate: 2013-03-27
-    support: 2018-05-01
+    eoas: 2018-05-01
     eol: 2018-05-01
     latest: '6.2.6'
     latestReleaseDate: 2016-03-03

--- a/products/unrealircd.md
+++ b/products/unrealircd.md
@@ -4,7 +4,7 @@ category: server-app
 permalink: /unrealircd
 versionCommand: ./unrealircd version
 releasePolicyLink: https://www.unrealircd.org/docs/UnrealIRCd_releases
-activeSupportColumn: true
+eoasColumn: true
 releaseDateColumn: true
 
 identifiers:
@@ -22,7 +22,7 @@ auto:
           column: "Series"
           regex: '^UnrealIRCd (?P<value>\d+(\.\d+)?)$'
         releaseDate: "First stable release"
-        support: "Security fixes only"
+        eoas: "Security fixes only"
         eol: "End of life (EOL)"
 
 # A list of releases, supported or not
@@ -30,7 +30,7 @@ auto:
 releases:
 -   releaseCycle: "6"
     releaseDate: 2021-12-17
-    support: true
+    eoas: false
     eol: false
     link: "https://github.com/unrealircd/unrealircd/blob/unreal60_dev/doc/RELEASE-NOTES.md#unrealircd-{{'__LATEST__'|replace:'.',''}}"
     latest: "6.1.4"
@@ -38,7 +38,7 @@ releases:
 
 -   releaseCycle: "5"
     releaseDate: 2019-12-13
-    support: 2022-07-01
+    eoas: 2022-07-01
     eol: 2023-07-01
     link: "https://github.com/unrealircd/unrealircd/blob/unreal52/doc/RELEASE-NOTES.md#unrealircd-{{'__LATEST__'|replace:'.',''}}"
     latest: "5.2.4"
@@ -46,7 +46,7 @@ releases:
 
 -   releaseCycle: "4"
     releaseDate: 2015-12-24
-    support: 2019-05-20
+    eoas: 2019-05-20
     eol: 2020-12-31
     link: https://github.com/unrealircd/unrealircd/blob/unreal42/doc/RELEASE-NOTES
     latest: "4.2.4.1"
@@ -54,7 +54,7 @@ releases:
 
 -   releaseCycle: "3.2"
     releaseDate: 2004-04-25
-    support: 2015-12-11
+    eoas: 2015-12-11
     eol: 2016-12-31
     link: https://forums.unrealircd.org/viewtopic.php?f=1&t=8588
     latest: "3.2.10.7"

--- a/products/veeam-backup-and-replication.md
+++ b/products/veeam-backup-and-replication.md
@@ -7,7 +7,7 @@ permalink: /veeam-backup-and-replication
 alternate_urls:
 -   /veeam-backup
 releasePolicyLink: https://www.veeam.com/product-lifecycle.html
-activeSupportColumn: End of Fix
+eoasColumn: End of Fix
 releaseColumn: true
 releaseDateColumn: true
 eolColumn: End of support
@@ -22,7 +22,7 @@ auto:
 releases:
 -   releaseCycle: "12"
     releaseDate: 2023-01-30
-    support: true # will be 13.0 GA date
+    eoas: false # will be 13.0 GA date
     eol: 2026-02-01
     link: "https://www.veeam.com/kb4420"
     latest: "12.1.1.56"
@@ -30,7 +30,7 @@ releases:
 
 -   releaseCycle: "11"
     releaseDate: 2021-02-11
-    support: 2023-02-01
+    eoas: 2023-02-01
     eol: 2024-02-01
     link: "https://www.veeam.com/kb4126"
     latest: "11.0.1.1261-P20240304"
@@ -38,7 +38,7 @@ releases:
 
 -   releaseCycle: "10"
     releaseDate: 2020-02-04
-    support: 2021-02-01
+    eoas: 2021-02-01
     eol: 2023-02-01
     link: "https://www.veeam.com/kb3161"
     latest: "10.0.1.4854-P20220304"
@@ -46,7 +46,7 @@ releases:
 
 -   releaseCycle: "9.5"
     releaseDate: 2016-11-16
-    support: 2020-02-01
+    eoas: 2020-02-01
     eol: 2022-01-01 # https://web.archive.org/web/20210614182742/https://www.veeam.com/product-lifecycle.html
     link: "https://www.veeam.com/kb2970"
     latest: "9.5.4.2866"
@@ -54,7 +54,7 @@ releases:
 
 -   releaseCycle: "9.0"
     releaseDate: 2016-01-12
-    support: false
+    eoas: true
     eol: true
     link: "https://www.veeam.com/kb2147"
     latest: "9.0.0.1715"
@@ -62,7 +62,7 @@ releases:
 
 -   releaseCycle: "8.0"
     releaseDate: 2014-11-06
-    support: false
+    eoas: true
     eol: true
     link: "https://www.veeam.com/kb2068"
     latest: "8.0.0.2084"
@@ -70,7 +70,7 @@ releases:
 
 -   releaseCycle: "7.0"
     releaseDate: 2013-08-20
-    support: false
+    eoas: true
     eol: true
     link: "https://www.veeam.com/kb1891"
     latest: "7.0.0.871"
@@ -78,7 +78,7 @@ releases:
 
 -   releaseCycle: "6.5"
     releaseDate: 2012-10-09
-    support: false
+    eoas: true
     eol: true
     link: "https://www.veeam.com/kb1751"
     latest: "6.5.0.144"
@@ -86,7 +86,7 @@ releases:
 
 -   releaseCycle: "6.1"
     releaseDate: 2012-06-04
-    support: false
+    eoas: true
     eol: true
     link: "https://www.veeam.com/kb1671"
     latest: "6.1.0.205"
@@ -94,7 +94,7 @@ releases:
 
 -   releaseCycle: "6.0"
     releaseDate: 2011-08-22
-    support: false
+    eoas: true
     eol: true
     link: "https://www.veeam.com/kb1442"
     latest: "6.0.0.181"
@@ -102,7 +102,7 @@ releases:
 
 -   releaseCycle: "5.0"
     releaseDate: 2010-08-30
-    support: false
+    eoas: true
     eol: true
     link: null
     latest: "5.0.0.179"
@@ -110,7 +110,7 @@ releases:
 
 -   releaseCycle: "4.0"
     releaseDate: 2009-10-29
-    support: false
+    eoas: true
     eol: true
     link: null
     latest: "4.1.2.125"
@@ -118,7 +118,7 @@ releases:
 
 -   releaseCycle: "3.0"
     releaseDate: 2009-10-21
-    support: false
+    eoas: true
     eol: true
     link: null
     latest: "3.0" # no information available
@@ -126,7 +126,7 @@ releases:
 
 -   releaseCycle: "2.0"
     releaseDate: 2008-07-30
-    support: false
+    eoas: true
     eol: true
     link: null
     latest: "2.0" # no information available
@@ -134,7 +134,7 @@ releases:
 
 -   releaseCycle: "1.0"
     releaseDate: 2008-02-26
-    support: false
+    eoas: true
     eol: true
     link: null
     latest: "1.0" # no information available

--- a/products/vue.md
+++ b/products/vue.md
@@ -8,9 +8,9 @@ alternate_urls:
 -   /vuejs
 versionCommand: npm list vue
 releasePolicyLink: https://vuejs.org/about/releases.html
-activeSupportColumn: true
+eoasColumn: true
 releaseDateColumn: true
-extendedSupportColumn: Commercial Support
+eoesColumn: Commercial Support
 
 auto:
   methods:
@@ -26,27 +26,25 @@ identifiers:
 releases:
 -   releaseCycle: "3"
     releaseDate: 2020-09-18
-    support: true
+    eoas: false
     eol: false
-    extendedSupport: false
     latest: "3.4.21"
     latestReleaseDate: 2024-02-28
     link: https://github.com/vuejs/core/blob/main/CHANGELOG.md
 
 -   releaseCycle: "2"
     releaseDate: 2016-09-30
-    support: 2022-03-18
+    eoas: 2022-03-18
     eol: 2023-12-31
-    extendedSupport: true
+    eoes: false
     latest: "2.7.16"
     latestReleaseDate: 2023-12-24
     link: https://github.com/vuejs/vue/blob/main/CHANGELOG.md
 
 -   releaseCycle: "1"
     releaseDate: 2015-10-27
-    support: false
+    eoas: true
     eol: true
-    extendedSupport: false
     latest: "1.0.28"
     latestReleaseDate: 2016-09-27
     link: https://github.com/vuejs/vue/releases/tag/v__LATEST__

--- a/products/vuetify.md
+++ b/products/vuetify.md
@@ -7,7 +7,7 @@ permalink: /vuetify
 versionCommand: npm list vuetify
 releasePolicyLink: https://vuetifyjs.com/introduction/long-term-support/
 changelogTemplate: https://github.com/vuetifyjs/vuetify/releases/tag/v__LATEST__
-activeSupportColumn: true
+eoasColumn: true
 releaseDateColumn: true
 
 identifiers:
@@ -27,7 +27,7 @@ auto:
           column: "Initial Release Date"
           regex: '^(?P<month>\w+) (?P<day>\d+)(st|nd|rd|th)?,? (?P<year>\d{4}).*$'
           template: "{{month}} {{day}} {{year}}"
-        support:
+        eoas:
           column: "LTS Start Date"
           regex: '^(?P<month>\w+) (?P<day>\d+)(st|nd|rd|th)?,? (?P<year>\d{4}).*$'
           template: "{{month}} {{day}} {{year}}"
@@ -39,21 +39,21 @@ auto:
 releases:
 -   releaseCycle: "3"
     releaseDate: 2022-10-31
-    support: true
+    eoas: false
     eol: false
     latest: "3.5.13"
     latestReleaseDate: 2024-03-28
 
 -   releaseCycle: "2"
     releaseDate: 2019-07-23
-    support: 2023-07-05
+    eoas: 2023-07-05
     eol: 2025-01-23
     latest: "2.7.2"
     latestReleaseDate: 2024-02-14
 
 -   releaseCycle: "1.5"
     releaseDate: 2019-02-05
-    support: 2019-06-24
+    eoas: 2019-06-24
     eol: 2020-07-31
     latest: "1.5.24"
     lts: 2019-07-31

--- a/products/wagtail.md
+++ b/products/wagtail.md
@@ -7,7 +7,7 @@ permalink: /wagtail
 versionCommand: python -c "import wagtail; print(wagtail.__version__)"
 releasePolicyLink: https://github.com/wagtail/wagtail/wiki/Release-schedule
 changelogTemplate: https://docs.wagtail.org/en/stable/releases/__LATEST__.html
-activeSupportColumn: true
+eoasColumn: true
 releaseDateColumn: true
 
 identifiers:
@@ -25,13 +25,13 @@ auto:
           column: "Version"
           regex: '^(?P<value>\d+\.\d+).*$'
         releaseDate: "Release date"
-        support: "Active support"
+        eoas: "Active support"
         eol: "Security support"
 
 releases:
 -   releaseCycle: "6.0"
     releaseDate: 2024-02-07
-    support: 2024-05-01
+    eoas: 2024-05-01
     eol: 2024-08-01
     latest: "6.0.1"
     latestReleaseDate: 2024-02-15
@@ -39,35 +39,35 @@ releases:
 -   releaseCycle: "5.2"
     lts: true
     releaseDate: 2023-11-01
-    support: 2025-02-03
+    eoas: 2025-02-03
     eol: 2025-02-03
     latest: "5.2.3"
     latestReleaseDate: 2024-01-23
 
 -   releaseCycle: "5.1"
     releaseDate: 2023-08-01
-    support: 2023-11-01
+    eoas: 2023-11-01
     eol: 2024-02-01
     latest: "5.1.3"
     latestReleaseDate: 2023-10-19
 
 -   releaseCycle: "5.0"
     releaseDate: 2023-05-02
-    support: 2023-08-01
+    eoas: 2023-08-01
     eol: 2023-11-01
     latest: "5.0.5"
     latestReleaseDate: 2023-10-19
 
 -   releaseCycle: "4.2"
     releaseDate: 2023-02-01
-    support: 2023-05-02
+    eoas: 2023-05-02
     eol: 2023-08-01
     latest: "4.2.4"
     latestReleaseDate: 2023-05-25
 
 -   releaseCycle: "4.1"
     releaseDate: 2022-11-01
-    support: 2024-02-01
+    eoas: 2024-02-01
     lts: true
     eol: 2024-02-01
     latest: "4.1.9"
@@ -75,21 +75,21 @@ releases:
 
 -   releaseCycle: "4.0"
     releaseDate: 2022-08-31
-    support: 2022-11-01
+    eoas: 2022-11-01
     eol: 2023-02-01
     latest: "4.0.4"
     latestReleaseDate: 2022-10-18
 
 -   releaseCycle: "3.0"
     releaseDate: 2022-05-16
-    support: 2022-08-31
+    eoas: 2022-08-31
     eol: 2022-11-01
     latest: "3.0.3"
     latestReleaseDate: 2022-09-05
 
 -   releaseCycle: "2.16"
     releaseDate: 2022-02-07
-    support: 2022-05-01
+    eoas: 2022-05-01
     eol: 2022-08-01
     latest: "2.16.3"
     latestReleaseDate: 2022-09-05
@@ -97,28 +97,28 @@ releases:
 -   releaseCycle: "2.15"
     lts: true
     releaseDate: 2021-11-04
-    support: 2023-02-01
+    eoas: 2023-02-01
     eol: 2023-02-01
     latest: "2.15.6"
     latestReleaseDate: 2022-09-05
 
 -   releaseCycle: "2.14"
     releaseDate: 2021-08-01
-    support: 2021-11-04
+    eoas: 2021-11-04
     eol: 2022-02-07
     latest: "2.14.2"
     latestReleaseDate: 2021-10-14
 
 -   releaseCycle: "2.13"
     releaseDate: 2021-05-12
-    support: 2021-08-01
+    eoas: 2021-08-01
     eol: 2021-11-04
     latest: "2.13.5"
     latestReleaseDate: 2021-10-14
 
 -   releaseCycle: "2.12"
     releaseDate: 2021-02-02
-    support: 2021-05-12
+    eoas: 2021-05-12
     eol: 2021-08-01
     latest: "2.12.6"
     latestReleaseDate: 2021-07-13
@@ -126,28 +126,28 @@ releases:
 -   releaseCycle: "2.11"
     lts: true
     releaseDate: 2020-11-02
-    support: 2022-02-01
+    eoas: 2022-02-01
     eol: 2022-02-01
     latest: "2.11.9"
     latestReleaseDate: 2022-01-24
 
 -   releaseCycle: "2.10"
     releaseDate: 2020-08-11
-    support: 2020-11-01
+    eoas: 2020-11-01
     eol: 2021-02-02
     latest: "2.10.2"
     latestReleaseDate: 2020-09-25
 
 -   releaseCycle: "2.9"
     releaseDate: 2020-05-04
-    support: 2020-08-11
+    eoas: 2020-08-11
     eol: 2020-11-02
     latest: "2.9.3"
     latestReleaseDate: 2020-07-20
 
 -   releaseCycle: "2.8"
     releaseDate: 2020-02-03
-    support: 2020-05-04
+    eoas: 2020-05-04
     eol: 2020-08-11
     latest: "2.8.2"
     latestReleaseDate: 2020-05-04
@@ -155,7 +155,7 @@ releases:
 -   releaseCycle: "2.7"
     lts: true
     releaseDate: 2019-11-06
-    support: 2021-02-03
+    eoas: 2021-02-03
     eol: 2021-02-03
     latest: "2.7.4"
     latestReleaseDate: 2020-07-20

--- a/products/watchos.md
+++ b/products/watchos.md
@@ -8,7 +8,7 @@ releasePolicyLink: https://en.wikipedia.org/wiki/WatchOS#Version_history
 # Release notes are not published for all minor or patch versions, so using only the major version.
 # Other release notes are easily accessible from that page, if available.
 changelogTemplate: "https://developer.apple.com/documentation/watchos-release-notes/watchos-__RELEASE_CYCLE__-release-notes"
-activeSupportColumn: true
+eoasColumn: true
 releaseDateColumn: true
 
 auto:
@@ -23,49 +23,49 @@ auto:
 releases:
 -   releaseCycle: "10"
     releaseDate: 2023-09-18
-    support: true
+    eoas: false
     eol: false
     latest: '10.4'
     latestReleaseDate: 2024-03-07
 
 -   releaseCycle: "9"
     releaseDate: 2022-09-12
-    support: 2023-09-18
+    eoas: 2023-09-18
     eol: false
     latestReleaseDate: 2023-09-21
     latest: '9.6.3'
 
 -   releaseCycle: "8"
     releaseDate: 2021-09-20
-    support: 2022-09-12
+    eoas: 2022-09-12
     eol: 2022-09-22
     latestReleaseDate: 2023-06-21
     latest: '8.8.1'
 
 -   releaseCycle: "7"
     releaseDate: 2020-09-16
-    support: 2021-09-20
+    eoas: 2021-09-20
     eol: 2021-10-11
     latestReleaseDate: 2021-09-13
     latest: '7.6.2'
 
 -   releaseCycle: "6"
     releaseDate: 2019-09-19
-    support: 2020-09-16
+    eoas: 2020-09-16
     eol: 2020-09-16
     latestReleaseDate: 2020-12-14
     latest: '6.3'
 
 -   releaseCycle: "5"
     releaseDate: 2018-09-17
-    support: 2019-09-19
+    eoas: 2019-09-19
     eol: 2019-09-30
     latestReleaseDate: 2020-11-05
     latest: '5.3.9'
 
 -   releaseCycle: "4"
     releaseDate: 2017-09-19
-    support: 2018-09-17
+    eoas: 2018-09-17
     eol: 2018-09-27
     latestReleaseDate: 2018-07-09
     latest: '4.3.2'
@@ -73,7 +73,7 @@ releases:
 
 -   releaseCycle: "3"
     releaseDate: 2016-09-13
-    support: 2017-09-19
+    eoas: 2017-09-19
     eol: 2017-10-04
     latestReleaseDate: 2017-07-19
     latest: '3.2.3'

--- a/products/windows.md
+++ b/products/windows.md
@@ -5,7 +5,7 @@ tags: microsoft windows
 permalink: /windows
 versionCommand: winver
 releasePolicyLink: https://learn.microsoft.com/lifecycle/products/?terms=Windows
-activeSupportColumn: true
+eoasColumn: true
 releaseDateColumn: true
 
 identifiers:
@@ -16,7 +16,7 @@ releases:
 -   releaseCycle: "11-23h2-e"
     releaseLabel: "11 23H2 (E)"
     releaseDate: 2023-10-31
-    support: 2026-11-10
+    eoas: 2026-11-10
     eol: 2026-11-10
     latest: 10.0.22631
     link: https://learn.microsoft.com/windows/release-health/windows11-release-information
@@ -24,7 +24,7 @@ releases:
 -   releaseCycle: "11-23h2-w"
     releaseLabel: "11 23H2 (W)"
     releaseDate: 2023-10-31
-    support: 2025-11-11
+    eoas: 2025-11-11
     eol: 2025-11-11
     latest: 10.0.22631
     link: https://learn.microsoft.com/windows/release-health/windows11-release-information
@@ -32,7 +32,7 @@ releases:
 -   releaseCycle: "10-22h2"
     releaseLabel: "10 22H2"
     releaseDate: 2022-10-18
-    support: 2025-10-14
+    eoas: 2025-10-14
     eol: 2025-10-14
     latest: 10.0.19045
     link: https://learn.microsoft.com/windows/release-health/release-information
@@ -40,7 +40,7 @@ releases:
 -   releaseCycle: "11-22h2-e"
     releaseLabel: "11 22H2 (E)"
     releaseDate: 2022-09-20
-    support: 2025-10-14
+    eoas: 2025-10-14
     eol: 2025-10-14
     latest: 10.0.22621
     link: https://learn.microsoft.com/windows/release-health/windows11-release-information
@@ -48,7 +48,7 @@ releases:
 -   releaseCycle: "11-22h2-w"
     releaseLabel: "11 22H2 (W)"
     releaseDate: 2022-09-20
-    support: 2024-10-08
+    eoas: 2024-10-08
     eol: 2024-10-08
     latest: 10.0.22621
     link: https://learn.microsoft.com/windows/release-health/windows11-release-information
@@ -57,7 +57,7 @@ releases:
     releaseLabel: "10 21H2 IoT"
     releaseDate: 2021-11-16
     lts: true
-    support: 2027-01-12
+    eoas: 2027-01-12
     eol: 2032-01-13
     latest: 10.0.19044
     link: https://learn.microsoft.com/windows/release-health/release-information#enterprise-and-iot-enterprise-ltsbltsc-editions
@@ -66,7 +66,7 @@ releases:
     releaseLabel: "10 21H2 (E)"
     releaseDate: 2021-11-16
     lts: true
-    support: 2027-01-12
+    eoas: 2027-01-12
     eol: 2027-01-12
     latest: 10.0.19044
     link: https://learn.microsoft.com/windows/release-health/release-information#enterprise-and-iot-enterprise-ltsbltsc-editions
@@ -75,7 +75,7 @@ releases:
 -   releaseCycle: "10-21h2-e"
     releaseLabel: "10 21H2 (E)"
     releaseDate: 2021-11-16
-    support: 2024-06-11
+    eoas: 2024-06-11
     eol: 2024-06-11
     latest: 10.0.19044
     link: https://learn.microsoft.com/lifecycle/products/windows-10-enterprise-and-education
@@ -83,7 +83,7 @@ releases:
 -   releaseCycle: "10-21h2-w"
     releaseLabel: "10 21H2 (W)"
     releaseDate: 2021-11-16
-    support: 2023-06-13
+    eoas: 2023-06-13
     eol: 2023-06-13
     latest: 10.0.19044
     link: https://learn.microsoft.com/windows/release-health/release-information
@@ -91,7 +91,7 @@ releases:
 -   releaseCycle: "11-21h2-e"
     releaseLabel: "11 21H2 (E)"
     releaseDate: 2021-10-04
-    support: 2024-10-08
+    eoas: 2024-10-08
     eol: 2024-10-08
     latest: 10.0.22000
     link: https://learn.microsoft.com/windows/release-health/windows11-release-information
@@ -99,7 +99,7 @@ releases:
 -   releaseCycle: "11-21h2-w"
     releaseLabel: "11 21H2 (W)"
     releaseDate: 2021-10-04
-    support: 2023-10-10
+    eoas: 2023-10-10
     eol: 2023-10-10
     latest: 10.0.22000
     link: https://learn.microsoft.com/windows/release-health/windows11-release-information
@@ -107,7 +107,7 @@ releases:
 -   releaseCycle: "10-21h1"
     releaseLabel: "10 21H1"
     releaseDate: 2021-05-18
-    support: 2022-12-13
+    eoas: 2022-12-13
     eol: 2022-12-13
     latest: 10.0.19043
     link: https://learn.microsoft.com/windows/release-health/status-windows-10-21h1
@@ -115,7 +115,7 @@ releases:
 -   releaseCycle: "10-20h2-e"
     releaseLabel: "10 20H2 (E)"
     releaseDate: 2020-10-20
-    support: 2023-05-09
+    eoas: 2023-05-09
     eol: 2023-05-09
     latest: 10.0.19042
     link: https://learn.microsoft.com/windows/release-health/status-windows-10-20h2
@@ -123,7 +123,7 @@ releases:
 -   releaseCycle: "10-20h2-w"
     releaseLabel: "10 20H2 (W)"
     releaseDate: 2020-10-20
-    support: 2022-05-10
+    eoas: 2022-05-10
     eol: 2022-05-10
     latest: 10.0.19042
     link: https://learn.microsoft.com/windows/release-health/status-windows-10-20h2
@@ -131,7 +131,7 @@ releases:
 -   releaseCycle: "10-2004"
     releaseLabel: "10 2004"
     releaseDate: 2020-05-27
-    support: 2021-12-14
+    eoas: 2021-12-14
     eol: 2021-12-14
     latest: 10.0.19041
     link: https://learn.microsoft.com/lifecycle/announcements/windows-10-version-2004-end-of-servicing
@@ -139,7 +139,7 @@ releases:
 -   releaseCycle: "10-1909-e"
     releaseLabel: "10 1909 (E)"
     releaseDate: 2019-11-12
-    support: 2022-05-10
+    eoas: 2022-05-10
     eol: 2022-05-10
     latest: 10.0.18363
     link: https://learn.microsoft.com/lifecycle/announcements/windows-10-1909-enterprise-education-eos
@@ -147,7 +147,7 @@ releases:
 -   releaseCycle: "10-1909-w"
     releaseLabel: "10 1909 (W)"
     releaseDate: 2019-11-12
-    support: 2021-05-11
+    eoas: 2021-05-11
     eol: 2021-05-11
     latest: 10.0.18363
     link: https://learn.microsoft.com/lifecycle/announcements/windows-10-1909-end-of-servicing
@@ -155,7 +155,7 @@ releases:
 -   releaseCycle: "10-1903"
     releaseLabel: "10 1903"
     releaseDate: 2019-08-29
-    support: 2020-12-08
+    eoas: 2020-12-08
     eol: 2020-12-08
     latest: 10.0.18362
     link: https://learn.microsoft.com/lifecycle/announcements/windows-10-1903-end-of-servicing
@@ -164,7 +164,7 @@ releases:
     releaseLabel: "10 1809 (E)"
     releaseDate: 2018-11-13
     lts: true
-    support: 2024-01-09
+    eoas: 2024-01-09
     eol: 2029-01-09
     latest: 10.0.17763
     link: https://learn.microsoft.com/windows/release-health/supported-versions-windows-client#enterprise-and-iot-enterprise-ltsbltsc-editions
@@ -173,7 +173,7 @@ releases:
 -   releaseCycle: "10-1809-e"
     releaseLabel: "10 1809 (E)"
     releaseDate: 2018-11-13
-    support: 2021-05-11
+    eoas: 2021-05-11
     eol: 2021-05-11
     latest: 10.0.17763
     link: https://learn.microsoft.com/lifecycle/announcements/windows-10-1803-1809-end-of-servicing
@@ -181,7 +181,7 @@ releases:
 -   releaseCycle: "10-1809-w"
     releaseLabel: "10 1809 (W)"
     releaseDate: 2018-11-13
-    support: 2020-11-10
+    eoas: 2020-11-10
     eol: 2020-11-10
     latest: 10.0.17763
     link: https://learn.microsoft.com/lifecycle/announcements/windows-10-1809-end-of-servicing
@@ -189,7 +189,7 @@ releases:
 -   releaseCycle: "10-1803-e"
     releaseLabel: "10 1803 (E)"
     releaseDate: 2018-04-30
-    support: 2020-05-11
+    eoas: 2020-05-11
     eol: 2021-05-11
     latest: 10.0.17134
     link: https://learn.microsoft.com/lifecycle/announcements/windows-10-1803-1809-end-of-servicing
@@ -197,7 +197,7 @@ releases:
 -   releaseCycle: "10-1803-w"
     releaseLabel: "10 1803 (W)"
     releaseDate: 2018-04-30
-    support: 2019-11-12
+    eoas: 2019-11-12
     eol: 2020-05-11
     latest: 10.0.17134
     link: https://learn.microsoft.com/lifecycle/announcements/windows-10-1803-end-of-servicing
@@ -205,7 +205,7 @@ releases:
 -   releaseCycle: "10-1709-e"
     releaseLabel: "10 1709 (E)"
     releaseDate: 2017-10-17
-    support: 2020-10-13
+    eoas: 2020-10-13
     eol: 2020-10-13
     latest: 10.0.16299
     link: https://learn.microsoft.com/lifecycle/announcements/windows-10-1709-end-of-servicing
@@ -213,7 +213,7 @@ releases:
 -   releaseCycle: "10-1709-w"
     releaseLabel: "10 1709 (W)"
     releaseDate: 2017-10-17
-    support: 2019-04-09
+    eoas: 2019-04-09
     eol: 2019-04-09
     latest: 10.0.16299
     link: https://learn.microsoft.com/lifecycle/announcements/windows-10-1709-end-of-servicing
@@ -221,7 +221,7 @@ releases:
 -   releaseCycle: "10-1703-e"
     releaseLabel: "10 1703 (E)"
     releaseDate: 2017-04-11
-    support: 2019-10-08
+    eoas: 2019-10-08
     eol: 2019-10-08
     latest: 10.0.15063
     link: https://techcommunity.microsoft.com/t5/windows-it-pro-blog/end-of-service-reminders-for-windows-10-versions-1703-and-1803/ba-p/903715
@@ -229,7 +229,7 @@ releases:
 -   releaseCycle: "10-1703-w"
     releaseLabel: "10 1703 (W)"
     releaseDate: 2017-04-11
-    support: 2018-10-09
+    eoas: 2018-10-09
     eol: 2018-10-09
     latest: 10.0.15063
     link: https://techcommunity.microsoft.com/t5/windows-it-pro-blog/end-of-service-reminders-for-windows-10-versions-1703-and-1803/ba-p/903715
@@ -238,7 +238,7 @@ releases:
     releaseLabel: "10 1607 (E)"
     releaseDate: 2016-08-02
     lts: true
-    support: 2021-10-12
+    eoas: 2021-10-12
     eol: 2026-10-13
     latest: 10.0.14393
     link: https://learn.microsoft.com/windows/release-health/supported-versions-windows-client#enterprise-and-iot-enterprise-ltsbltsc-editions
@@ -247,7 +247,7 @@ releases:
 -   releaseCycle: "10-1607-e"
     releaseLabel: "10 1607 (E)"
     releaseDate: 2016-08-02
-    support: 2019-04-09
+    eoas: 2019-04-09
     eol: 2019-04-09
     latest: 10.0.14393
     link: https://learn.microsoft.com/lifecycle/announcements/windows-10-1607-end-of-servicing
@@ -255,7 +255,7 @@ releases:
 -   releaseCycle: "10-1607-w"
     releaseLabel: "10 1607 (W)"
     releaseDate: 2016-08-02
-    support: 2018-04-10
+    eoas: 2018-04-10
     eol: 2018-04-10
     latest: 10.0.14393
     link: null
@@ -263,7 +263,7 @@ releases:
 -   releaseCycle: "10-1511"
     releaseLabel: "10 1511"
     releaseDate: 2015-11-10
-    support: 2017-10-10
+    eoas: 2017-10-10
     eol: 2017-10-10
     latest: 10.0.10586
     link: https://learn.microsoft.com/lifecycle/announcements/windows-10-1511-end-of-servicing
@@ -272,7 +272,7 @@ releases:
     releaseLabel: "10 1507 (E)"
     releaseDate: 2015-07-29
     lts: true
-    support: 2020-10-13
+    eoas: 2020-10-13
     eol: 2025-10-14
     latest: 10.0.10240
     link: https://learn.microsoft.com/windows/release-health/supported-versions-windows-client#enterprise-and-iot-enterprise-ltsbltsc-editions
@@ -281,7 +281,7 @@ releases:
 -   releaseCycle: "10-1507"
     releaseLabel: "10 1507"
     releaseDate: 2015-07-29
-    support: 2017-05-09
+    eoas: 2017-05-09
     eol: 2017-05-09
     latest: 10.0.10240
     link: https://learn.microsoft.com/lifecycle/announcements/windows-10-1507-cb-cbb-end-of-servicing
@@ -289,7 +289,7 @@ releases:
 -   releaseCycle: "8.1"
     releaseLabel: "8.1"
     releaseDate: 2013-11-13
-    support: 2018-01-09
+    eoas: 2018-01-09
     eol: 2023-01-10
     latest: 6.3.9600
     link: https://learn.microsoft.com/lifecycle/products/windows-81
@@ -297,7 +297,7 @@ releases:
 -   releaseCycle: "8"
     releaseLabel: "8"
     releaseDate: 2012-10-30
-    support: 2016-01-12
+    eoas: 2016-01-12
     eol: 2016-01-12
     latest: 6.2.9200
     link: https://learn.microsoft.com/lifecycle/products/windows-8
@@ -305,7 +305,7 @@ releases:
 -   releaseCycle: "7-sp1"
     releaseLabel: "7 SP1"
     releaseDate: 2011-02-22
-    support: 2015-01-13
+    eoas: 2015-01-13
     eol: 2020-01-14
     latest: 6.1.7601
     link: https://learn.microsoft.com/lifecycle/products/windows-7
@@ -313,7 +313,7 @@ releases:
 -   releaseCycle: "6-sp2"
     releaseLabel: "Vista SP2"
     releaseDate: 2009-04-29
-    support: 2012-04-10
+    eoas: 2012-04-10
     eol: 2017-04-11
     latest: 6.0.6200
     link: https://learn.microsoft.com/lifecycle/products/windows-vista
@@ -321,7 +321,7 @@ releases:
 -   releaseCycle: "5-sp3"
     releaseLabel: "XP SP3"
     releaseDate: 2008-04-21
-    support: 2009-04-14
+    eoas: 2009-04-14
     eol: 2014-04-08
     latest: 5.1.2600
     link: https://learn.microsoft.com/lifecycle/products/windows-xp

--- a/products/windowsEmbedded.md
+++ b/products/windowsEmbedded.md
@@ -10,42 +10,42 @@ releasePolicyLink: https://learn.microsoft.com/lifecycle/products/?terms=Windows
 releaseLabel: "Windows Embedded __RELEASE_CYCLE__"
 releaseColumn: false
 releaseDateColumn: true
-activeSupportColumn: true
+eoasColumn: true
 
 releases:
 -   releaseCycle: "8.1 Industry"
     releaseDate: 2013-11-25
-    support: 2018-07-10
+    eoas: 2018-07-10
     eol: 2023-07-11
     link: https://learn.microsoft.com/lifecycle/products/windows-embedded-81-industry
 
 -   releaseCycle: "8.1 Pro"
     releaseDate: 2013-11-13
-    support: 2018-01-09
+    eoas: 2018-01-09
     eol: 2023-01-10
     link: https://learn.microsoft.com/lifecycle/products/windows-embedded-81-pro
 
 -   releaseCycle: "Compact 2013"
     releaseDate: 2013-08-11
-    support: 2018-10-09
+    eoas: 2018-10-09
     eol: 2023-10-10
     link: https://learn.microsoft.com/lifecycle/products/windows-embedded-compact-2013
 
 -   releaseCycle: "POSReady 7"
     releaseDate: 2011-09-10
-    support: 2016-10-11
+    eoas: 2016-10-11
     eol: 2021-10-12
     link: https://learn.microsoft.com/lifecycle/products/windows-embedded-posready-7
 
 -   releaseCycle: "Compact 7"
     releaseDate: 2011-03-15
-    support: 2016-04-12
+    eoas: 2016-04-12
     eol: 2021-04-13
     link: https://learn.microsoft.com/lifecycle/products/windows-embedded-compact-7
 
 -   releaseCycle: "Standard 7 SP1"
     releaseDate: 2011-02-28
-    support: 2015-10-13
+    eoas: 2015-10-13
     eol: 2020-10-13
     link: https://learn.microsoft.com/lifecycle/products/windows-embedded-standard-7
 

--- a/products/windowsServer.md
+++ b/products/windowsServer.md
@@ -9,153 +9,140 @@ versionCommand: winver
 releasePolicyLink: https://learn.microsoft.com/lifecycle/products/?terms=Windows%20Server
 releaseLabel: 'Windows Server __RELEASE_CYCLE__'
 LTSLabel: "<abbr title='Long-Term Servicing Channel'>LTSC</abbr>"
-activeSupportColumn: true
+eoasColumn: true
 releaseDateColumn: true
-extendedSupportColumn: Extended Security Updates
+eoesColumn: Extended Security Updates
 
 releases:
 -   releaseCycle: "23H2"
     releaseDate: 2023-10-24
-    support: 2025-04-24
+    eoas: 2025-04-24
     eol: 2025-10-24
-    extendedSupport: false
     latest: 10.0.25398
     link: https://learn.microsoft.com/lifecycle/products/windows-server-annual-channel
 
 -   releaseCycle: "2022"
     releaseDate: 2021-08-18
-    support: 2026-10-13
+    eoas: 2026-10-13
     eol: 2031-10-14
-    extendedSupport: false
     latest: 10.0.20348
     lts: true
     link: https://learn.microsoft.com/windows/release-health/windows-server-release-info
 
 -   releaseCycle: "20H2"
     releaseDate: 2020-10-20
-    support: 2022-08-09
+    eoas: 2022-08-09
     eol: 2022-08-09
-    extendedSupport: false
     latest: 10.0.19042
     link: https://learn.microsoft.com/lifecycle/announcements/windows-server-20h2-retiring
 
 -   releaseCycle: "2004"
     releaseDate: 2020-05-27
-    support: 2021-12-14
+    eoas: 2021-12-14
     eol: 2021-12-14
-    extendedSupport: false
     latest: 10.0.19041
     link: https://learn.microsoft.com/lifecycle/announcements/windows-server-version-2004-end-of-servicing
 
 -   releaseCycle: "1909"
     releaseDate: 2019-11-12
-    support: 2021-05-11
+    eoas: 2021-05-11
     eol: 2021-05-11
-    extendedSupport: false
     latest: 10.0.18363
     link: https://learn.microsoft.com/lifecycle/announcements/windows-server-1909-end-of-servicing
 
 -   releaseCycle: "1809"
     releaseDate: 2018-11-13
-    support: 2020-11-10
+    eoas: 2020-11-10
     eol: 2020-11-10
-    extendedSupport: false
     latest: 10.0.17763
     link: https://learn.microsoft.com/lifecycle/announcements/windows-server-1809-end-of-servicing
 
 -   releaseCycle: "2019"
     releaseDate: 2018-11-13
     lts: true
-    support: 2024-01-09
+    eoas: 2024-01-09
     eol: 2029-01-09
-    extendedSupport: false
     latest: 10.0.17763
     link: https://learn.microsoft.com/windows/release-health/windows-server-release-info
 
 -   releaseCycle: "1903"
     releaseDate: 2018-05-21
-    support: 2020-12-08
+    eoas: 2020-12-08
     eol: 2020-12-08
-    extendedSupport: false
     latest: 10.0.18362
     link: https://learn.microsoft.com/lifecycle/announcements/windows-server-1809-end-of-servicing
 
 -   releaseCycle: "1803"
     releaseDate: 2018-04-30
-    support: 2019-11-12
+    eoas: 2019-11-12
     eol: 2019-11-12
-    extendedSupport: false
     latest: 10.0.17134
     link: https://learn.microsoft.com/lifecycle/announcements/windows-server-1803-end-of-servicing
 
 -   releaseCycle: "1709"
     releaseDate: 2017-10-17
-    support: 2019-04-09
+    eoas: 2019-04-09
     eol: 2019-04-09
-    extendedSupport: false
     latest: 10.0.16299
     link: https://techcommunity.microsoft.com/t5/windows-server-for-developers/windows-server-version-1709-lifecycle-announcement/m-p/379766
 
 -   releaseCycle: "2016"
     releaseDate: 2016-10-15
     lts: true
-    support: 2022-01-11
+    eoas: 2022-01-11
     eol: 2027-01-12
-    extendedSupport: false
     latest: 10.0.14393
     link: https://learn.microsoft.com/windows/release-health/windows-server-release-info
 
 -   releaseCycle: "2012-R2"
     releaseDate: 2013-11-25
     lts: true
-    support: 2018-10-09
+    eoas: 2018-10-09
     eol: 2023-10-10
-    extendedSupport: 2026-10-13
+    eoes: 2026-10-13
     latest: 6.3.9600
     link: https://learn.microsoft.com/lifecycle/products/windows-server-2012-r2
 
 -   releaseCycle: "2012"
     lts: true
     releaseDate: 2012-10-30
-    support: 2018-10-09
+    eoas: 2018-10-09
     eol: 2023-10-10
-    extendedSupport: 2026-10-13
+    eoes: 2026-10-13
     latest: 6.2.9200
     link: https://learn.microsoft.com/lifecycle/products/windows-server-2012
 
 -   releaseCycle: "2008-R2-SP1"
     releaseDate: 2011-02-22
     lts: true
-    support: 2015-01-13
+    eoas: 2015-01-13
     eol: 2020-01-14
-    extendedSupport: 2023-01-10
+    eoes: 2023-01-10
     latest: 6.1.7601
     link: https://learn.microsoft.com/lifecycle/products/windows-server-2008-r2
 
 -   releaseCycle: "2008-SP2"
     releaseDate: 2009-04-29
     lts: true
-    support: 2015-01-13
+    eoas: 2015-01-13
     eol: 2020-01-14
-    extendedSupport: 2023-01-10
+    eoes: 2023-01-10
     latest: 6.0.6003
     link: https://learn.microsoft.com/lifecycle/products/windows-server-2008
 
 -   releaseCycle: "2003-SP2"
     releaseDate: 2003-04-24
     lts: true
-    support: 2010-07-13
+    eoas: 2010-07-13
     eol: 2015-07-14
-    extendedSupport: false
     latest: 5.2.3790
     link: https://learn.microsoft.com/lifecycle/products/windows-server-2003-
 
 -   releaseCycle: "2000"
     releaseDate: 2000-02-17
     lts: true
-    support: 2005-06-30
+    eoas: 2005-06-30
     eol: 2010-07-13
-    extendedSupport: false
     latest: 5.0.2195
     link: null
 

--- a/products/zabbix.md
+++ b/products/zabbix.md
@@ -7,7 +7,7 @@ versionCommand: zabbix_server -V
 releasePolicyLink: https://www.zabbix.com/life_cycle_and_release_policy
 changelogTemplate: https://www.zabbix.com/rn/rn__LATEST__
 releaseDateColumn: true
-activeSupportColumn: true
+eoasColumn: true
 eolColumn: Security Support
 
 identifiers:
@@ -26,23 +26,23 @@ auto:
           column: "Release name"
           regex: '^Zabbix (?P<value>\d+\.\d+).*$'
         releaseDate: "Release date"
-        support: "End of Full Support*"
+        eoas: "End of Full Support*"
         eol: "End of Limited Support**"
 
 # For non-LTS releases :
-# - support(x) = release(x) + 6 months
+# - eoas(x) = release(x) + 6 months
 # - eol(x) = release(x) + 7 months
 releases:
 -   releaseCycle: "6.4"
     releaseDate: 2023-03-06
-    support: 2024-06-30
+    eoas: 2024-06-30
     eol: 2024-12-31
     latest: "6.4.13"
     latestReleaseDate: 2024-03-25
 
 -   releaseCycle: "6.2"
     releaseDate: 2022-07-04
-    support: 2023-01-31
+    eoas: 2023-01-31
     eol: 2023-02-28
     latest: "6.2.9"
     latestReleaseDate: 2023-03-27
@@ -50,21 +50,21 @@ releases:
 -   releaseCycle: "6.0"
     lts: true
     releaseDate: 2022-02-08
-    support: 2025-02-28
+    eoas: 2025-02-28
     eol: 2027-02-28
     latest: "6.0.28"
     latestReleaseDate: 2024-03-25
 
 -   releaseCycle: "5.4"
     releaseDate: 2021-05-17
-    support: 2022-02-28
+    eoas: 2022-02-28
     eol: 2022-03-31
     latest: "5.4.12"
 
 -   releaseCycle: "5.0"
     lts: true
     releaseDate: 2020-05-11
-    support: 2023-05-31
+    eoas: 2023-05-31
     eol: 2025-05-31
     latest: "5.0.42"
     latestReleaseDate: 2024-03-25
@@ -72,7 +72,7 @@ releases:
 -   releaseCycle: "4.0"
     lts: true
     releaseDate: 2018-10-01
-    support: 2021-10-31
+    eoas: 2021-10-31
     eol: 2023-10-31
     latest: "4.0.50"
     latestReleaseDate: 2023-10-30

--- a/products/zerto.md
+++ b/products/zerto.md
@@ -6,89 +6,89 @@ permalink: /zerto
 releasePolicyLink: https://help.zerto.com/bundle/Lifecycle.Matrix.HTML/page/product_version_lifecycle_matrix_for_zerto.html
 releaseColumn: false
 releaseDateColumn: true
-activeSupportColumn: General Support
+eoasColumn: General Support
 eolColumn: Critical Support
 
 releases:
 -   releaseCycle: "10.0_u2"
     releaseLabel: "10.0 Update 2"
     releaseDate: 2023-11-28
-    support: true # Next GA date
+    eoas: false # Next GA date
     eol: 2024-11-28
     link: "https://help.zerto.com/bundle/RN.HTML.10.0_U2/page/what_s_new_in_zerto_10_0_update_2.html"
 
 -   releaseCycle: "10.0_u1"
     releaseLabel: "10.0 Update 1"
     releaseDate: 2023-08-07
-    support: 2023-11-28
+    eoas: 2023-11-28
     eol: 2024-08-07
     link: "https://help.zerto.com/bundle/RN.HTML.10.0_U1/page/what_s_new_in_zerto_10_0_update_1.html"
 
 -   releaseCycle: "10.0"
     releaseDate: 2023-07-05
-    support: 2023-08-07
+    eoas: 2023-08-07
     eol: 2024-07-05
     link: "https://help.zerto.com/bundle/RN.HTML.10.0/page/10.0_Whats_New.htm"
 
 -   releaseCycle: "9.7"
     releaseDate: 2022-11-08
-    support: 2023-12-31
+    eoas: 2023-12-31
     eol: 2024-12-31
     link: "https://help.zerto.com/bundle/RN.HTML.97/page/9.7_Whats_New.htm"
 
 -   releaseCycle: "9.5"
     releaseDate: 2022-04-05
-    support: 2023-05-01
+    eoas: 2023-05-01
     eol: 2024-05-01
     link: "https://help.zerto.com/bundle/RN.95.HTML/page/9.5_Whats_New.htm"
 
 -   releaseCycle: "9.0"
     releaseDate: 2021-07-13
-    support: 2022-08-01
+    eoas: 2022-08-01
     eol: 2023-10-15
     link: "https://help.zerto.com/bundle/Zerto_v9.0_Release_Notes/resource/Zerto_v9.0_Release_Notes.pdf"
 
 -   releaseCycle: "8.5"
     releaseDate: 2020-11-01
-    support: 2022-01-01
+    eoas: 2022-01-01
     eol: 2023-01-01
     link: "https://help.zerto.com/bundle/Zerto_v8.5_Release_Notes/resource/Zerto_v8.5_Release_Notes.pdf"
 
 -   releaseCycle: "8.0"
     releaseDate: 2020-03-22
-    support: 2021-05-31
+    eoas: 2021-05-31
     eol: 2022-06-01
     link: "https://www.zerto.com/wp-content/uploads/2020/03/whats-new-in-zerto-8-0_DS.pdf"
 
 -   releaseCycle: "7.5"
     releaseDate: 2019-09-22
-    support: 2020-12-05
+    eoas: 2020-12-05
     eol: 2021-12-06
     link: "https://www.zerto.com/press-releases/zerto-announces-general-availability-of-zerto-7-5-raising-the-bar-for-continuous-data-protection/"
 
 -   releaseCycle: "7.0"
     releaseDate: 2019-04-26
-    support: 2020-05-30
+    eoas: 2020-05-30
     eol: 2021-05-30
 
 -   releaseCycle: "6.5"
     releaseDate: 2018-09-16
-    support: 2019-10-30
+    eoas: 2019-10-30
     eol: 2020-10-30
 
 -   releaseCycle: "6.0"
     releaseDate: 2018-02-15
-    support: 2019-03-30
+    eoas: 2019-03-30
     eol: 2020-03-30
 
 -   releaseCycle: "5.5"
     releaseDate: 2017-07-31
-    support: 2018-09-30
+    eoas: 2018-09-30
     eol: 2019-09-30
 
 -   releaseCycle: "5.0"
     releaseDate: 2016-11-08
-    support: 2018-08-31
+    eoas: 2018-08-31
     eol: 2018-08-31
 
 ---

--- a/products/zookeeper.md
+++ b/products/zookeeper.md
@@ -9,7 +9,7 @@ alternate_urls:
 releasePolicyLink: https://zookeeper.apache.org/releases.html
 changelogTemplate: https://zookeeper.apache.org/doc/r{{"__LATEST__"}}/releasenotes.html
 releaseDateColumn: true
-activeSupportColumn: true
+eoasColumn: true
 
 identifiers:
 -   repology: zookeeper
@@ -28,42 +28,42 @@ releases:
 -   releaseCycle: "3.9"
     releaseDate: 2023-07-19
     eol: false
-    support: true
+    eoas: false
     latest: "3.9.2"
     latestReleaseDate: 2024-02-12
 
 -   releaseCycle: "3.8"
     releaseDate: 2022-02-25
     eol: false
-    support: true
+    eoas: false
     latest: "3.8.4"
     latestReleaseDate: 2024-02-12
 
 -   releaseCycle: "3.7"
     releaseDate: 2021-03-17
     eol: 2024-01-19
-    support: 2023-07-19
+    eoas: 2023-07-19
     latest: "3.7.2"
     latestReleaseDate: 2023-10-06
 
 -   releaseCycle: "3.6"
     releaseDate: 2020-02-25
     eol: 2022-12-30
-    support: 2022-03-07
+    eoas: 2022-03-07
     latest: "3.6.4"
     latestReleaseDate: 2022-12-18
 
 -   releaseCycle: "3.5"
     releaseDate: 2019-05-03
     eol: 2022-06-01
-    support: 2021-03-27
+    eoas: 2021-03-27
     latest: "3.5.10"
     latestReleaseDate: 2022-05-29
 
 -   releaseCycle: "3.4"
     releaseDate: 2011-11-23
     eol: 2020-06-01
-    support: 2020-03-27
+    eoas: 2020-03-27
     latest: "3.4.14"
     latestReleaseDate: 2019-03-06
 


### PR DESCRIPTION
- rename `activeSupportColumn` to `eoasColumn` (`eoas` stands for _end of active support_),
- rename `support` fields to `eoas` and invert their value when they are boolean (`true` -> `false`, `false` -> `true`),
- rename `activeSupportWarnThreshold` to `eoasWarnThreshold`,
- rename `extendedSupportColumn` to `eoesColumn` (`eoes` stands for _end of extended support_),
- rename `extendedSupport` fields to `eoes` and invert their value when they are boolean (`true` -> `false`, `false` -> `true`),
- remove `extendedSupport` when value is `false` (as it means for now there is no extended support),
- rename `extendedSupportWarnThreshold` to `eoesWarnThreshold`.

API remained unchanged for backward compatibility.

Closes #4923.