### PR TITLE
[pan-os] Updated Pan-OS to 10.2.9

### DIFF
--- a/products/pan-os.md
+++ b/products/pan-os.md
@@ -40,9 +40,9 @@ releases:
 -   releaseCycle: "10.2"
     releaseDate: 2022-02-27
     eol: 2025-08-27
-    latest: "10.2.8"
-    latestReleaseDate: 2024-02-12
-    link: https://docs.paloaltonetworks.com/pan-os/10-2/pan-os-release-notes/pan-os-10-2-8-known-and-addressed-issues/pan-os-10-2-8-addressed-issues
+    latest: "10.2.9"
+    latestReleaseDate: 2024-04-01
+    link: https://docs.paloaltonetworks.com/pan-os/10-2/pan-os-release-notes/pan-os-10-2-9-known-and-addressed-issues/pan-os-10-2-9-addressed-issues
 
 -   releaseCycle: "10.1"
     releaseDate: 2021-05-31


### PR DESCRIPTION
Updated Pan-OS from 10.2.8 to 10.2.9.

Released 2024/04/01

https://docs.paloaltonetworks.com/pan-os/10-2/pan-os-release-notes/pan-os-10-2-9-known-and-addressed-issues/pan-os-10-2-9-addressed-issues
