### PR TITLE
[oracle-jdk] Set render_javascript_wait_until

### DIFF
--- a/products/oracle-jdk.md
+++ b/products/oracle-jdk.md
@@ -35,6 +35,7 @@ auto:
   # Fix the release date, as only month-year dates are provided in the previous table.
   -   release_table: https://www.java.com/releases/
       render_javascript: true
+      render_javascript_wait_until: networkidle
       selector: "table.releaselist"
       header_selector: "tbody#released tr:nth-of-type(3)"
       rows_selector: "tbody#released tr"


### PR DESCRIPTION
It is not set by default anymore, see https://github.com/endoflife-date/release-data/pull/340.