### PR TITLE
[OpenSearch] update to 2.13

### DIFF
--- a/products/opensearch.md
+++ b/products/opensearch.md
@@ -26,8 +26,8 @@ releases:
     releaseDate: 2022-05-18
     eoas: false
     eol: false
-    latest: "2.12.0"
-    latestReleaseDate: 2024-02-19
+    latest: "2.13.0"
+    latestReleaseDate: 2024-04-02
 
 -   releaseCycle: "1"
     releaseDate: 2021-07-02


### PR DESCRIPTION
cf https://opensearch.org/blog/2.13-is-ready-for-download/

> OpenSearch 2.13 is live and available for [download](https://opensearch.org/downloads.html)! The latest version of OpenSearch arrives with a range of machine learning (ML) tools to help you build AI-powered applications, along with upgrades that make it easier to access and analyze your operational data and new ways to enhance the resiliency of your OpenSearch clusters. To explore the release for yourself, visit [OpenSearch Playground](https://playground.opensearch.org/app/home#/). For a fuller view of what’s new, check out the [release notes](https://github.com/opensearch-project/opensearch-build/blob/main/release-notes/opensearch-release-notes-2.13.0.md).

![image](https://github.com/endoflife-date/endoflife.date/assets/5235127/d6d70613-928a-4c1e-9195-0f68546f0909)
