### PR TITLE
[openssl] add 3.3.x

### DIFF
--- a/products/openssl.md
+++ b/products/openssl.md
@@ -18,10 +18,10 @@ auto:
 # EOL dates and LTS infos on https://www.openssl.org/policies/releasestrat.html
 releases:
 -   releaseCycle: "3.3"
-    releaseDate: 2024-04-11
-    eol: 2026-04-11
+    releaseDate: 2024-04-10
+    eol: 2026-04-10
     latest: "3.3.0"
-    latestReleaseDate: 2024-04-11
+    latestReleaseDate: 2024-04-10
 
 -   releaseCycle: "3.2"
     releaseDate: 2023-11-23

--- a/products/openssl.md
+++ b/products/openssl.md
@@ -17,6 +17,12 @@ auto:
 
 # EOL dates and LTS infos on https://www.openssl.org/policies/releasestrat.html
 releases:
+-   releaseCycle: "3.3"
+    releaseDate: 2024-04-11
+    eol: 2026-04-11
+    latest: "3.3.0"
+    latestReleaseDate: 2024-04-11
+
 -   releaseCycle: "3.2"
     releaseDate: 2023-11-23
     eol: 2025-11-23


### PR DESCRIPTION
- release notes, https://www.openssl.org/blog/blog/2024/04/10/3.3-Final-Release/index.html
- for https://www.openssl.org/policies/releasestrat.html, the 3.3 is not added yet.