### PR TITLE
Ruby: Change EOL policy link

### DIFF
--- a/products/ruby.md
+++ b/products/ruby.md
@@ -4,7 +4,7 @@ category: lang
 iconSlug: ruby
 permalink: /ruby
 versionCommand: ruby --version
-releasePolicyLink: https://www.ruby-lang.org/en/downloads/releases/
+releasePolicyLink: https://www.ruby-lang.org/en/downloads/branches/
 changelogTemplate: "https://rubychangelog.com/versions-all/#ruby-{{'__LATEST__'|replace:'.',''}}"
 releaseDateColumn: true
 eolColumn: Support Status


### PR DESCRIPTION
https://www.ruby-lang.org/en/downloads/releases/ only display the release date while https://www.ruby-lang.org/en/downloads/branches/ also show normal maintenance date, EOL date and support status.