### PR TITLE
[fortios] 7.6 release

### DIFF
--- a/products/fortios.md
+++ b/products/fortios.md
@@ -14,6 +14,11 @@ eolColumn: End of Support
 eoasColumn: End of Engineering Support
 
 releases:
+-   releaseCycle: "7.6"
+    releaseDate: 2024-04-02
+    eoas: 2027-05-11
+    eol: 2028-11-11
+
 -   releaseCycle: "7.4"
     releaseDate: 2023-05-11
     eoas: 2026-05-11


### PR DESCRIPTION
https://www.fortinet.com/corporate/about-us/newsroom/press-releases/2024/fortinet-introduces-expansive-upgrades-to-real-time-network-security-operating-system

But it doesn't seem available yet. Keeping this in Draft till this is available. Dates are _incorrect_ as of now.