### PR TITLE
[samsungmobile] Add Galaxy Tab S9 variants

### DIFF
--- a/products/samsungmobile.md
+++ b/products/samsungmobile.md
@@ -68,7 +68,7 @@ releases:
     link: https://doc.samsungmobile.com/SM-X910/XJP/doc.html
 
 -   releaseCycle: "Galaxy Tab S9 FE"
-    releaseDate: 2023-08-11
+    releaseDate: 2023-10-16
     eoas: false
     eol: false
     link: https://doc.samsungmobile.com/SM-X816B/INS/doc.html

--- a/products/samsungmobile.md
+++ b/products/samsungmobile.md
@@ -48,8 +48,32 @@ releases:
     eoas: false # "four generations of OS upgrades"
     eol: 2028-03-24 # "five years of security updates" (https://news.samsung.com/global/the-samsung-galaxy-a54-5g-and-galaxy-a34-5g-awesome-experiences-for-all)
     link: https://doc.samsungmobile.com/SM-A546U/TMB/doc.html
-    
+
+-   releaseCycle: "Galaxy Tab S9"
+    releaseDate: 2023-08-11
+    eoas: false
+    eol: false
+    link: https://doc.samsungmobile.com/SM-X816B/INS/doc.html
+
 -   releaseCycle: "Galaxy Tab S9+ 5G"
+    releaseDate: 2023-08-11
+    eoas: false
+    eol: false
+    link: https://doc.samsungmobile.com/SM-X816B/INS/doc.html
+
+-   releaseCycle: "Galaxy Tab S9 Ultra"
+    releaseDate: 2023-08-11
+    eoas: false
+    eol: false
+    link: https://doc.samsungmobile.com/SM-X816B/INS/doc.html
+
+-   releaseCycle: "Galaxy Tab S9 FE"
+    releaseDate: 2023-08-11
+    eoas: false
+    eol: false
+    link: https://doc.samsungmobile.com/SM-X816B/INS/doc.html
+
+-   releaseCycle: "Galaxy Tab S9 FE+"
     releaseDate: 2023-08-11
     eoas: false
     eol: false

--- a/products/samsungmobile.md
+++ b/products/samsungmobile.md
@@ -65,7 +65,7 @@ releases:
     releaseDate: 2023-08-11
     eoas: false
     eol: false
-    link: https://doc.samsungmobile.com/SM-X816B/INS/doc.html
+    link: https://doc.samsungmobile.com/SM-X910/XJP/doc.html
 
 -   releaseCycle: "Galaxy Tab S9 FE"
     releaseDate: 2023-08-11

--- a/products/samsungmobile.md
+++ b/products/samsungmobile.md
@@ -53,7 +53,7 @@ releases:
     releaseDate: 2023-08-11
     eoas: false
     eol: false
-    link: https://doc.samsungmobile.com/SM-X816B/INS/doc.html
+    link: https://doc.samsungmobile.com/sm-x710/eux/doc.html
 
 -   releaseCycle: "Galaxy Tab S9+ 5G"
     releaseDate: 2023-08-11

--- a/products/samsungmobile.md
+++ b/products/samsungmobile.md
@@ -48,7 +48,13 @@ releases:
     eoas: false # "four generations of OS upgrades"
     eol: 2028-03-24 # "five years of security updates" (https://news.samsung.com/global/the-samsung-galaxy-a54-5g-and-galaxy-a34-5g-awesome-experiences-for-all)
     link: https://doc.samsungmobile.com/SM-A546U/TMB/doc.html
-
+    
+-   releaseCycle: "Galaxy Tab S9+ 5G"
+    releaseDate: 2023-08-11
+    eoas: false
+    eol: false
+    link: https://doc.samsungmobile.com/SM-X816B/INS/doc.html
+    
 -   releaseCycle: "Galaxy A34 5G"
     releaseDate: 2023-03-24
     eoas: false # "four generations of OS upgrades"

--- a/products/samsungmobile.md
+++ b/products/samsungmobile.md
@@ -77,7 +77,7 @@ releases:
     releaseDate: 2023-10-16
     eoas: false
     eol: false
-    link: https://doc.samsungmobile.com/SM-X816B/INS/doc.html
+    link: https://doc.samsungmobile.com/SM-X610/ZTO/doc.html
     
 -   releaseCycle: "Galaxy A34 5G"
     releaseDate: 2023-03-24

--- a/products/samsungmobile.md
+++ b/products/samsungmobile.md
@@ -74,7 +74,7 @@ releases:
     link: https://doc.samsungmobile.com/SM-X510/ZTO/doc.html
 
 -   releaseCycle: "Galaxy Tab S9 FE+"
-    releaseDate: 2023-08-11
+    releaseDate: 2023-10-16
     eoas: false
     eol: false
     link: https://doc.samsungmobile.com/SM-X816B/INS/doc.html

--- a/products/samsungmobile.md
+++ b/products/samsungmobile.md
@@ -71,7 +71,7 @@ releases:
     releaseDate: 2023-10-16
     eoas: false
     eol: false
-    link: https://doc.samsungmobile.com/SM-X816B/INS/doc.html
+    link: https://doc.samsungmobile.com/SM-X510/ZTO/doc.html
 
 -   releaseCycle: "Galaxy Tab S9 FE+"
     releaseDate: 2023-08-11


### PR DESCRIPTION
Added missing Galaxz Tab S9+ 5G. According to https://security.samsungmobile.com/workScope.smsb the devices receives quarterly security updates. Therefore EOL and EOS are both `false`