### PR TITLE
Add Electron 30

### DIFF
--- a/products/electron.md
+++ b/products/electron.md
@@ -24,6 +24,12 @@ auto:
         eol: "EOL"
 
 releases:
+-   releaseCycle: "30"
+    releaseDate: 2024-04-16
+    eol: 2024-10-15
+    latest: "30.0.0"
+    latestReleaseDate: 2024-04-16
+
 -   releaseCycle: "29"
     releaseDate: 2024-02-20
     eol: 2024-08-20


### PR DESCRIPTION
Adds [electron 30] to releases, according to the [release timeline].

[electron 30]: https://github.com/electron/electron/releases/tag/v30.0.0
[release timeline]: https://github.com/electron/electron/pull/41825/files#diff-48e53185123b309254b27d7de6452779c01f49e0af8fa970ffe5a5606d7f7c89R13