### PR TITLE
[freebsd] update stable/13 EoL

### DIFF
--- a/products/freebsd.md
+++ b/products/freebsd.md
@@ -39,7 +39,7 @@ releases:
 
 -   releaseCycle: "stable/13"
     releaseDate: 2021-04-13
-    eol: 2026-01-31
+    eol: 2026-04-30
     link: null
 
 -   releaseCycle: "releng/12.4"


### PR DESCRIPTION
The date was changed on 2023-12-11, see https://cgit.freebsd.org/doc/commit/?id=593c16f52c