### PR TITLE
[electron] Adds v31

### DIFF
--- a/products/electron.md
+++ b/products/electron.md
@@ -24,6 +24,12 @@ auto:
         eol: "EOL"
 
 releases:
+-   releaseCycle: "31"
+    releaseDate: 2024-06-11
+    eol: 2025-01-07
+    latest: "31.0.0"
+    latestReleaseDate: 2024-06-11
+
 -   releaseCycle: "30"
     releaseDate: 2024-04-16
     eol: 2024-10-15
@@ -205,15 +211,9 @@ releases:
 > to maintain one JavaScript codebase and create cross-platform apps that work on Windows, macOS,
 > and Linux.
 
-Typically, the latest [_three_ stable major versions are currently supported](https://www.electronjs.org/blog/8-week-cadence).
+The latest [_three_ stable major versions are currently supported](https://www.electronjs.org/blog/8-week-cadence).
 Only the latest minor release in each major version is supported. A new major stable version is
 released every 8 weeks.
-
-ℹ️ Electron 22 is temporarily supported until October 10, 2023. This extended
-support is intended to help developers who still need support for Windows 7/8/8.1, which
-ended support in Electron 23. The October support date follows the extended support dates from
-both Chromium and Microsoft. On October 11, support will drop back to the
-latest three stable major versions.
 
 All supported release get fixes that were previously merged to main backported, though this may be
 on a case-by-case basis for some older supported releases. When an API is changed or removed in a
@@ -230,9 +230,6 @@ Chromium's beta or dev channel, it is back-ported.
 When a release branch reaches the end of its support cycle, the series will be deprecated in NPM and
 a final end-of-support release will be made. This release will add a warning to inform that an
 unsupported version of Electron is in use.
-
-The End-of-life dates for current releases are approximated using 6 months (8x3 weeks) as the
-lifecycle of a release.
 
 ## Other Links
 


### PR DESCRIPTION
Timelines as per https://www.electronjs.org/docs/latest/tutorial/electron-timelines

Since upstream declares EOL for current releases, we can drop the approximate note.

The "4 releases temporarily supported" policy
is no longer applicable, so we can drop that as well.

Marking as draft, can check back around June.