### PR TITLE
[ruby] update eol for 3.0

### DIFF
--- a/products/ruby.md
+++ b/products/ruby.md
@@ -44,9 +44,9 @@ releases:
 
 -   releaseCycle: "3.0"
     releaseDate: 2020-12-25
-    eol: 2024-03-31
-    latest: "3.0.6"
-    latestReleaseDate: 2023-03-30
+    eol: 2024-04-24
+    latest: "3.0.7"
+    latestReleaseDate: 2024-04-24
 
 -   releaseCycle: "2.7"
     releaseDate: 2019-12-25

--- a/products/ruby.md
+++ b/products/ruby.md
@@ -44,9 +44,9 @@ releases:
 
 -   releaseCycle: "3.0"
     releaseDate: 2020-12-25
-    eol: 2024-04-24
+    eol: 2024-04-23
     latest: "3.0.7"
-    latestReleaseDate: 2024-04-24
+    latestReleaseDate: 2024-04-23
 
 -   releaseCycle: "2.7"
     releaseDate: 2019-12-25


### PR DESCRIPTION
> After this release, Ruby 3.0 reaches EOL. In other words, this is expected to be the last release of Ruby 3.0 series. We will not release Ruby 3.0.8 even if a security vulnerability is found (but could release if a severe regression is found). We recommend all Ruby 3.0 users to start migration to Ruby 3.3, 3.2, or 3.1 immediately.



- https://www.ruby-lang.org/en/news/2024/04/23/ruby-3-0-7-released/
- https://github.com/Homebrew/homebrew-core/pull/169918