### PR TITLE
Remove EOL status for Keycloak v22, which is getting patch releases

### DIFF
--- a/products/keycloak.md
+++ b/products/keycloak.md
@@ -32,7 +32,6 @@ releases:
 
 -   releaseCycle: "22.0"
     releaseDate: 2023-07-11
-    eol: 2023-11-23
     latest: "22.0.10"
     latestReleaseDate: 2024-03-25
 


### PR DESCRIPTION
Keycloak is actively getting patch releases for the v22 stream. For example we can see release tags being cut here:
 - https://github.com/keycloak/keycloak/tags
 
They don't have any mention in their docs that they are continuing to maintain this release, but it's clear if following their recent v22 git tags