### PR TITLE
[ubuntu] Fix 24.04

### DIFF
--- a/products/ubuntu.md
+++ b/products/ubuntu.md
@@ -32,9 +32,11 @@ identifiers:
 releases:
 -   releaseCycle: "24.04"
     codename: "Noble Numbat"
+    lts: true
     releaseDate: 2024-04-25
-    eoas: 2036-04-25
-    eol: 2036-04-25
+    eoas: 2026-06-01
+    eol: 2029-06-01
+    eoes: 2034-04-01
     latest: "24.04"
     latestReleaseDate: 2024-04-25
 


### PR DESCRIPTION
The release is missing it's LTS status, and dates are wrong.