### PR TITLE
[ubuntu] Add missing LTS tag for 24.04

### DIFF
--- a/products/ubuntu.md
+++ b/products/ubuntu.md
@@ -32,6 +32,7 @@ identifiers:
 releases:
 -   releaseCycle: "24.04"
     codename: "Noble Numbat"
+    lts: true
     releaseDate: 2024-04-25
     eoas: 2036-04-25
     eol: 2036-04-25


### PR DESCRIPTION
src : https://ubuntu.com/blog/ubuntu-desktop-24-04-noble-numbat-deep-dive