### PR TITLE
[ubuntu] Drop releaseImage

### DIFF
--- a/products/ubuntu.md
+++ b/products/ubuntu.md
@@ -6,8 +6,6 @@ iconSlug: ubuntu
 permalink: /ubuntu
 versionCommand: lsb_release --release
 releasePolicyLink: https://wiki.ubuntu.com/Releases
-releaseImage: https://github.com/endoflife-date/endoflife.date/assets/1423115/c1d812cd-9179-4ff6-9607-520dbf37fa3e
-
 releaseLabel: "__RELEASE_CYCLE__ '__CODENAME__'"
 changelogTemplate: https://wiki.ubuntu.com/{{"__CODENAME__"|replace:' ',''}}/ReleaseNotes/
 releaseDateColumn: true


### PR DESCRIPTION
Release image on https://ubuntu.com/about/release-cycle is now an embedded svg and cannot be referenced anymore on endoflife.date.