### PR TITLE
[ubuntu] Changes for new policy

### DIFF
--- a/products/ubuntu.md
+++ b/products/ubuntu.md
@@ -11,9 +11,8 @@ releaseImage: https://github.com/endoflife-date/endoflife.date/assets/1423115/c1
 releaseLabel: "__RELEASE_CYCLE__ '__CODENAME__'"
 changelogTemplate: https://wiki.ubuntu.com/{{"__CODENAME__"|replace:' ',''}}/ReleaseNotes/
 releaseDateColumn: true
-eoasColumn: Hardware & Maintenance
-eolColumn: Maintenance & Security Support
-eoesColumn: Extended Security Maintenance
+eolColumn: Standard Support
+eoesColumn: Expanded Security Maintenance
 
 # https://regex101.com/r/Fzt9US/1
 # We return v1 and v2 separated by newline in case 2 releases were marked
@@ -34,7 +33,6 @@ releases:
     codename: "Noble Numbat"
     lts: true
     releaseDate: 2024-04-25
-    eoas: 2026-06-01
     eol: 2029-06-01
     eoes: 2034-04-01
     latest: "24.04"
@@ -43,7 +41,6 @@ releases:
 -   releaseCycle: "23.10"
     codename: "Mantic Minotaur"
     releaseDate: 2023-10-12
-    eoas: 2024-07-01
     eol: 2024-07-01
     latest: "23.10"
     latestReleaseDate: 2023-10-12
@@ -51,7 +48,6 @@ releases:
 -   releaseCycle: "23.04"
     codename: "Lunar Lobster"
     releaseDate: 2023-04-20
-    eoas: 2024-01-20
     eol: 2024-01-20
     latest: "23.04"
     latestReleaseDate: 2023-04-20
@@ -59,7 +55,6 @@ releases:
 -   releaseCycle: "22.10"
     codename: "Kinetic Kudu"
     releaseDate: 2022-10-20
-    eoas: 2023-07-20
     eol: 2023-07-20
     latest: "22.10"
     latestReleaseDate: 2022-10-20
@@ -68,7 +63,6 @@ releases:
     codename: "Jammy Jellyfish"
     lts: true
     releaseDate: 2022-04-21
-    eoas: 2024-09-30
     eol: 2027-04-01
     eoes: 2032-04-09
     latest: "22.04.4"
@@ -77,7 +71,6 @@ releases:
 -   releaseCycle: "21.10"
     codename: "Impish Indri"
     releaseDate: 2021-10-14
-    eoas: 2022-07-14
     eol: 2022-07-14
     latest: "21.10"
     latestReleaseDate: 2021-10-14
@@ -85,7 +78,6 @@ releases:
 -   releaseCycle: "21.04"
     codename: "Hirsute Hippo"
     releaseDate: 2021-04-22
-    eoas: 2022-01-20
     eol: 2022-01-20
     latest: "21.04"
     latestReleaseDate: 2021-04-22
@@ -93,7 +85,6 @@ releases:
 -   releaseCycle: "20.10"
     codename: "Groovy Gorilla"
     releaseDate: 2020-10-22
-    eoas: 2021-07-22
     eol: 2021-07-22
     latest: "20.10"
     latestReleaseDate: 2020-10-22
@@ -102,7 +93,6 @@ releases:
     codename: "Focal Fossa"
     lts: true
     releaseDate: 2020-04-23
-    eoas: 2022-10-01
     eol: 2025-04-02
     eoes: 2030-04-02
     latest: "20.04.6"
@@ -111,7 +101,6 @@ releases:
 -   releaseCycle: "19.10"
     codename: "Eoan Ermine"
     releaseDate: 2019-10-17
-    eoas: 2020-07-06
     eol: 2020-07-06
     latest: "19.10"
     latestReleaseDate: 2019-10-17
@@ -119,7 +108,6 @@ releases:
 -   releaseCycle: "19.04"
     codename: "Disco Dingo"
     releaseDate: 2019-04-18
-    eoas: 2020-01-23
     eol: 2020-01-23
     latest: "19.04"
     latestReleaseDate: 2019-04-18
@@ -127,7 +115,6 @@ releases:
 -   releaseCycle: "18.10"
     codename: "Cosmic Cuttlefish"
     releaseDate: 2018-10-18
-    eoas: 2019-07-18
     eol: 2019-07-18
     latest: "18.10"
     latestReleaseDate: 2018-10-18
@@ -136,7 +123,6 @@ releases:
     codename: "Bionic Beaver"
     lts: true
     releaseDate: 2018-04-26
-    eoas: 2023-05-31
     eol: 2023-05-31
     eoes: 2028-04-01
     latest: "18.04.6"
@@ -145,7 +131,6 @@ releases:
 -   releaseCycle: "17.10"
     codename: "Artful Aardvark"
     releaseDate: 2017-10-19
-    eoas: 2018-07-19
     eol: 2018-07-19
     latest: "17.10"
     latestReleaseDate: 2017-10-19
@@ -153,7 +138,6 @@ releases:
 -   releaseCycle: "17.04"
     codename: "Zesty Zapus"
     releaseDate: 2017-04-13
-    eoas: 2018-01-13
     eol: 2018-01-13
     latest: "17.04"
     latestReleaseDate: 2017-04-13
@@ -162,7 +146,6 @@ releases:
     codename: "Xenial Xerus"
     lts: true
     releaseDate: 2016-04-21
-    eoas: 2021-04-02
     eol: 2021-04-02
     eoes: 2026-04-02
     latest: "16.04.7"
@@ -171,7 +154,6 @@ releases:
 -   releaseCycle: "15.10"
     codename: "Wily Werewolf"
     releaseDate: 2015-10-22
-    eoas: 2016-07-28
     eol: 2016-07-28
     latest: "15.10"
     latestReleaseDate: 2015-10-22
@@ -179,7 +161,6 @@ releases:
 -   releaseCycle: "15.04"
     codename: "Vivid Vervet"
     releaseDate: 2015-04-23
-    eoas: 2016-02-04
     eol: 2016-02-04
     latest: "15.04"
     latestReleaseDate: 2015-04-23
@@ -187,7 +168,6 @@ releases:
 -   releaseCycle: "14.10"
     codename: "Utopic Unicorn"
     releaseDate: 2014-10-23
-    eoas: 2015-07-23
     eol: 2015-07-23
     latest: "14.10"
     latestReleaseDate: 2014-10-23
@@ -196,7 +176,6 @@ releases:
     codename: "Trusty Tahr"
     lts: true
     releaseDate: 2014-04-17
-    eoas: 2019-04-02
     eol: 2019-04-02
     eoes: 2024-04-02
     latest: "14.04.6"
@@ -206,7 +185,6 @@ releases:
     codename: "Precise Pangolin"
     lts: true
     releaseDate: 2012-04-26
-    eoas: 2017-04-28
     eol: 2017-04-28
     eoes: 2019-04-26
     latest: "12.04.5"
@@ -216,7 +194,6 @@ releases:
     codename: "Oneiric Ocelot"
     lts: false
     releaseDate: 2011-10-13
-    eoas: 2013-05-09
     eol: 2013-05-09
     latest: "11.10"
     latestReleaseDate: 2011-10-13
@@ -225,7 +202,6 @@ releases:
     codename: "Natty Narwhal"
     lts: false
     releaseDate: 2011-04-28
-    eoas: 2012-10-28
     eol: 2012-10-28
     latest: "11.04"
     latestReleaseDate: 2011-04-28
@@ -234,7 +210,6 @@ releases:
     codename: "Maverick Meerkat"
     lts: false
     releaseDate: 2010-10-10
-    eoas: 2012-04-10
     eol: 2012-04-10
     latest: "10.10"
     latestReleaseDate: 2010-10-10
@@ -243,7 +218,6 @@ releases:
     codename: "Lucid Lynx"
     lts: true
     releaseDate: 2010-04-29
-    eoas: 2013-05-09
     eol: 2013-05-09
     latest: "10.04.4"
     latestReleaseDate: 2012-02-16
@@ -252,7 +226,6 @@ releases:
     codename: "Karmic Koala"
     lts: false
     releaseDate: 2009-10-29
-    eoas: 2011-04-30
     eol: 2011-04-30
     latest: "9.10"
     latestReleaseDate: 2009-10-29
@@ -261,7 +234,6 @@ releases:
     codename: "Jaunty Jackalope"
     lts: false
     releaseDate: 2009-04-23
-    eoas: 2010-10-23
     eol: 2010-10-23
     latest: "9.04"
     latestReleaseDate: 2009-04-23
@@ -270,7 +242,6 @@ releases:
     codename: "Hardy Heron"
     lts: true
     releaseDate: 2008-04-24
-    eoas: 2013-05-09
     eol: 2013-05-09
     latest: "8.04.4"
     latestReleaseDate: 2010-01-29
@@ -279,7 +250,6 @@ releases:
     codename: "Gutsy Gibbon"
     lts: false
     releaseDate: 2007-10-18
-    eoas: 2009-04-18
     eol: 2009-04-18
     latest: "7.10"
     latestReleaseDate: 2007-10-18
@@ -288,7 +258,6 @@ releases:
     codename: "Feisty Fawn"
     lts: false
     releaseDate: 2007-04-19
-    eoas: 2008-10-19
     eol: 2008-10-19
     latest: "7.04"
     latestReleaseDate: 2007-04-19
@@ -297,7 +266,6 @@ releases:
     codename: "Edgy Eft"
     lts: false
     releaseDate: 2006-10-26
-    eoas: 2006-10-26
     eol: 2008-04-26
     latest: "6.10"
     latestReleaseDate: 2006-10-26
@@ -305,7 +273,6 @@ releases:
 -   releaseCycle: "6.06"
     codename: "Dapper Drake"
     lts: true
-    eoas: 2011-06-01
     releaseDate: 2006-08-10
     eol: 2011-06-01
     latest: "6.06.2"
@@ -315,7 +282,6 @@ releases:
     codename: "Breezy Badger"
     lts: false
     releaseDate: 2005-10-13
-    eoas: 2007-04-13
     eol: 2007-04-13
     latest: "5.10"
     latestReleaseDate: 2005-10-13
@@ -324,7 +290,6 @@ releases:
     codename: "Hoary Hedgehog"
     lts: false
     releaseDate: 2005-04-08
-    eoas: 2006-10-31
     eol: 2006-10-31
     latest: "5.04"
     latestReleaseDate: 2005-04-08
@@ -333,7 +298,6 @@ releases:
     codename: "Warty Warthog"
     lts: false
     releaseDate: 2004-10-20
-    eoas: 2004-10-26
     eol: 2006-04-30
     latest: "4.10"
     latestReleaseDate: 2004-10-20
@@ -343,19 +307,17 @@ releases:
 >[Ubuntu](https://ubuntu.com) is a free and open-source Linux distribution based on Debian. Ubuntu
 > is officially released in three editions: Desktop, Server, and Core (for IoT devices and robots).
 
-## Release Cadence
+## [Release Cycle](https://ubuntu.com/about/release-cycle)
 
-Releases of Ubuntu get a development codename ("Breezy Badger") and are versioned by the year and
+Releases of Ubuntu get a development codename (such as "Breezy Badger") and are versioned by the year and
 month of delivery - for example Ubuntu 17.10 was released in October 2017. LTS or "Long Term
 Support" releases are published every two years in April. Every six months between LTS versions,
-Canonical publishes an interim release of Ubuntu. See [this link](https://ubuntu.com/about/release-cycle)
-for more details on the Ubuntu Release Cycle.
+Canonical publishes an interim release of Ubuntu.
 
 ## Support Lifecycle
 
-LTS releases are in "General Support" for 5 years and "Extended Security Maintenance" (see below)
-for an additional 5 years. Ubuntu breaks General Support into "Hardware and Maintenance updates"
-(2 years) followed by "Maintenance Updates" for another 3 years[^5]. Interim releases (non-LTS) are
+LTS releases are in "General Support" for 5 years and "Expanded Security Maintenance" (see below)
+for an additional 5 years. Interim releases (non-LTS) are
 supported for 9 months. Packages in `main` and `restricted` are supported for 5 years in long term
 support (LTS) releases. Ubuntu [Flavors](https://wiki.ubuntu.com/UbuntuFlavors) generally support
 their packages for 3 years in LTS releases but there are exceptions.
@@ -365,9 +327,9 @@ Maintenance covers binary packages that reside in the `main` and `restricted` co
 Ubuntu archive, typically for a period of 5 years from LTS release.
 
 Packages in `universe` are expected to be community-supported on a best-effort basis during the LTS
-phase, but in practice, security-updates are only released to pro subscriptions.
+phase, but in practice, security-updates are only released to Ubuntu Pro subscribers.
 
-Extended Security Maintenance (ESM) provides security updates on Ubuntu LTS releases for additional
+Expanded Security Maintenance (ESM) provides security updates on Ubuntu LTS releases for additional
 5 years. It is available with the [Ubuntu Pro](https://ubuntu.com/pro) subscription or a
 [Free subscription for personal use](https://ubuntu.com/blog/ubuntu-pro-beta-release)[^4].
 
@@ -376,7 +338,8 @@ Ubuntu Pro offers security fixes for critical, high, and selected medium CVEs in
 the `main` repository.
 
 Canonical also offers [Ubuntu Legacy Support](https://ubuntu.com//blog/canonical-expands-long-term-support-to-12-years-starting-with-ubuntu-14-04-lts),
-to extend the support of Ubuntu LTS releases from 14.04 by another 2 years beyond Extended Security Maintenance (ESM). This offer is only available for Ubuntu Pro paying customers.
+to extend the support of Ubuntu LTS releases from 14.04 by another 2 years beyond Extended Security Maintenance (ESM).
+This offer is only available for Ubuntu Pro paying customers.
 
 ## Support Comparison
 
@@ -401,7 +364,6 @@ For package specific support details, the following commands are available:
 [^2]: The restricted repository isn't explicitly listed in the Ubuntu Pro list of supported repositories, but it is likely supported.
 [^3]: This includes NIST-certified FIPS crypto-modules, USG hardening with CIS and DISA-STIG profiles, and Common Criteria EAL2.
 [^4]: Anyone can use Ubuntu Pro for free on up to 5 machines, or 50 if you are an official Ubuntu Community member.
-[^5]: The difference between these two is unclear, and not explained.
 [^6]: While promised, Canonical doesn't seem to be backporting any security-fixes in the universe repository to users without a Pro subscription.
-[^7]: The announcement for Legacy Support does not clarify which repositories are supported, so this is an estimate.
+[^7]: The announcement for Legacy Support does not clarify which repositories are supported, so this a guess.
 [^8]: [Ubuntu Landscape](https://ubuntu.com/landscape/docs/self-hosted-landscape) can manage all versions of Ubuntu above 16.04, and Legacy Support is limited to 14.04 for now.

--- a/products/ubuntu.md
+++ b/products/ubuntu.md
@@ -14,6 +14,12 @@ releaseDateColumn: true
 eolColumn: Standard Support
 eoesColumn: Expanded Security Maintenance
 
+customColumns:
+-   property: legacySupport
+    position: before-latest-column
+    label: Legacy Support
+    description: Legacy Support
+    link: https://ubuntu.com//blog/canonical-expands-long-term-support-to-12-years-starting-with-ubuntu-14-04-lts
 # https://regex101.com/r/Fzt9US/1
 # We return v1 and v2 separated by newline in case 2 releases were marked
 # under the same headline
@@ -178,6 +184,7 @@ releases:
     releaseDate: 2014-04-17
     eol: 2019-04-02
     eoes: 2024-04-02
+    legacySupport: 2026-04-02
     latest: "14.04.6"
     latestReleaseDate: 2019-03-07
 

--- a/products/ubuntu.md
+++ b/products/ubuntu.md
@@ -19,7 +19,7 @@ customColumns:
     position: before-latest-column
     label: Legacy Support
     description: Legacy Support
-    link: https://ubuntu.com//blog/canonical-expands-long-term-support-to-12-years-starting-with-ubuntu-14-04-lts
+    link: https://ubuntu.com/blog/canonical-expands-long-term-support-to-12-years-starting-with-ubuntu-14-04-lts
 # https://regex101.com/r/Fzt9US/1
 # We return v1 and v2 separated by newline in case 2 releases were marked
 # under the same headline


### PR DESCRIPTION
The new website and wiki do not use the "Hardware Maintenance" wording, so drop `eoas` column entirely. Adds a custom legacySupport column for now. And changes the ESM wording from Extended to Expanded.