### PR TITLE
[keycloak] Switch automation to GitHub releases

### DIFF
--- a/products/keycloak.md
+++ b/products/keycloak.md
@@ -14,7 +14,7 @@ identifiers:
 
 auto:
   methods:
-  -   git: https://github.com/keycloak/keycloak.git
+  -   github_releases: "keycloak/keycloak"
 
 # eol(x) = release(x+1)
 releases:
@@ -33,8 +33,8 @@ releases:
 -   releaseCycle: "22.0"
     releaseDate: 2023-07-11
     eol: 2023-11-23
-    latest: "22.0.10"
-    latestReleaseDate: 2024-03-25
+    latest: "22.0.5"
+    latestReleaseDate: 2023-10-24
 
 -   releaseCycle: "21.1"
     releaseDate: 2023-04-19

--- a/products/keycloak.md
+++ b/products/keycloak.md
@@ -137,4 +137,4 @@ lower severity vulnerabilities or hardening, in the following release.
 
 Commercial offerings with long term support of specific versions of Keycloak are provided by Red Hat
 with [Red Hat Single Sign-On (RH-SSO)](https://access.redhat.com/products/red-hat-single-sign-on/)
-and [Red Hat build of Quarkus](https://access.redhat.com/products/red-hat-build-of-keycloak).
+and [Red Hat build of Keycloak](https://access.redhat.com/products/red-hat-build-of-keycloak).

--- a/products/keycloak.md
+++ b/products/keycloak.md
@@ -135,6 +135,6 @@ Only the latest major version gets active development and security fixes.
 Depending on the severity of a vulnerability, the issue may be fixed in the current release or, for
 lower severity vulnerabilities or hardening, in the following release.
 
-A commercial offering with long term support of specific versions of Keycloak is provided by Red Hat
-with [Red Hat Single Sign-On (RH-SSO)](https://access.redhat.com/products/red-hat-single-sign-on/).
-It should be noted that RH-SSO must be running [under a supported configuration](https://access.redhat.com/articles/2342861).
+Commercial offerings with long term support of specific versions of Keycloak are provided by Red Hat
+with [Red Hat Single Sign-On (RH-SSO)](https://access.redhat.com/products/red-hat-single-sign-on/)
+and [Red Hat build of Quarkus](https://access.redhat.com/products/red-hat-build-of-keycloak).


### PR DESCRIPTION
The repository contains tag for the the Red Hat build of Keycloack builds, such as 22.0.10 (https://access.redhat.com/documentation/en-us/red_hat_build_of_keycloak/22.0/html/release_notes/red_hat_build_of_keycloak_22_0#updates_for_22_0_10), and GitHub releases are only declared for OSS versions.

Closes #5049.