### PR TITLE
Update 24.04 'Noble Numbat'

### DIFF
--- a/products/ubuntu.md
+++ b/products/ubuntu.md
@@ -30,9 +30,10 @@ identifiers:
 releases:
 -   releaseCycle: "24.04"
     codename: "Noble Numbat"
+    lts: true
     releaseDate: 2024-04-25
-    eoas: 2036-04-25
-    eol: 2036-04-25
+    eoas: 2029-05-31
+    eol: 2034-04-25
     latest: "24.04"
     latestReleaseDate: 2024-04-25
 


### PR DESCRIPTION
Update 24.04 'Noble Numbat' to LTS and updated EOL dates ubuntu.md

Sources:
https://wiki.ubuntu.com/Releases
https://ubuntu.com/about/release-cycle
https://en.wikipedia.org/wiki/Ubuntu_version_history (More specific dates)