### PR TITLE
Update 24.04 'Noble Numbat' Ubuntu

### DIFF
--- a/products/ubuntu.md
+++ b/products/ubuntu.md
@@ -30,9 +30,11 @@ identifiers:
 releases:
 -   releaseCycle: "24.04"
     codename: "Noble Numbat"
+    lts: true
     releaseDate: 2024-04-25
-    eoas: 2036-04-25
-    eol: 2036-04-25
+    eoas: 2029-05-31
+    eol: 2029-05-31
+    eoes: 2036-04-25
     latest: "24.04"
     latestReleaseDate: 2024-04-25
 

--- a/products/ubuntu.md
+++ b/products/ubuntu.md
@@ -32,8 +32,8 @@ releases:
     codename: "Noble Numbat"
     lts: true
     releaseDate: 2024-04-25
-    eoas: 2029-05-25
-    eol: 2029-05-25
+    eoas: 2029-04-25
+    eol: 2029-04-25
     eoes: 2036-04-25
     latest: "24.04"
     latestReleaseDate: 2024-04-25

--- a/products/ubuntu.md
+++ b/products/ubuntu.md
@@ -32,8 +32,8 @@ releases:
     codename: "Noble Numbat"
     lts: true
     releaseDate: 2024-04-25
-    eoas: 2029-05-31
-    eol: 2029-05-31
+    eoas: 2029-05-25
+    eol: 2029-05-25
     eoes: 2036-04-25
     latest: "24.04"
     latestReleaseDate: 2024-04-25


### PR DESCRIPTION

Update 24.04 'Noble Numbat'

Update 24.04 'Noble Numbat' to LTS and updated EOL dates ubuntu.md

Sources:
https://wiki.ubuntu.com/Releases
https://ubuntu.com/about/release-cycle
https://canonical.com/blog/canonical-expands-long-term-support-to-12-years-starting-with-ubuntu-14-04-lts