### PR TITLE
Revert "[ubuntu] Drop releaseImage"

### DIFF
--- a/products/ubuntu.md
+++ b/products/ubuntu.md
@@ -6,6 +6,8 @@ iconSlug: ubuntu
 permalink: /ubuntu
 versionCommand: lsb_release --release
 releasePolicyLink: https://wiki.ubuntu.com/Releases
+releaseImage: https://github.com/endoflife-date/endoflife.date/assets/1423115/c1d812cd-9179-4ff6-9607-520dbf37fa3e
+
 releaseLabel: "__RELEASE_CYCLE__ '__CODENAME__'"
 changelogTemplate: https://wiki.ubuntu.com/{{"__CODENAME__"|replace:' ',''}}/ReleaseNotes/
 releaseDateColumn: true


### PR DESCRIPTION
Reverts endoflife-date/endoflife.date#5072

With #5087 merged, this image link ought to work again.