### PR TITLE
Add Chrome and Node version details to Electron

### DIFF
--- a/products/electron.md
+++ b/products/electron.md
@@ -9,6 +9,15 @@ releasePolicyLink: https://www.electronjs.org/docs/latest/tutorial/electron-time
 changelogTemplate: https://releases.electronjs.org/release/v__LATEST__
 eolColumn: Supported
 releaseDateColumn: true
+customColumns:
+  - property: chromeVersion
+    position: after-release-column
+    label: Chrome
+    description: Corresponding Chrome version used in the Electron release
+  - property: nodeVersion
+    position: after-release-column
+    label: Node
+    description: Corresponding Node version used in the Electron release
 
 # NPM is more accurate than git and remove unreleased version would.
 # 1.x versions are not in NPM, but it's not a big deal: the 1.x cycle is not displayed on this page.
@@ -29,174 +38,232 @@ releases:
     eol: 2024-10-15
     latest: "30.0.2"
     latestReleaseDate: 2024-05-02
+    chromeVersion: "M124"
+    nodeVersion: "20.11"
 
 -   releaseCycle: "29"
     releaseDate: 2024-02-20
     eol: 2024-08-20
     latest: "29.3.2"
     latestReleaseDate: 2024-05-03
+    chromeVersion: "M122"
+    nodeVersion: "20.9"
 
 -   releaseCycle: "28"
     releaseDate: 2023-12-04
     eol: 2024-06-11
     latest: "28.3.1"
     latestReleaseDate: 2024-04-17
+    chromeVersion: "M120"
+    nodeVersion: "18.18"
 
 -   releaseCycle: "27"
     releaseDate: 2023-10-10
     eol: 2024-04-16
     latest: "27.3.11"
     latestReleaseDate: 2024-04-16
+    chromeVersion: "M118"
+    nodeVersion: "18.17"
 
 -   releaseCycle: "26"
     releaseDate: 2023-08-14
     eol: 2024-02-20
     latest: "26.6.10"
     latestReleaseDate: 2024-02-19
+    chromeVersion: "M116"
+    nodeVersion: "18.16"
 
 -   releaseCycle: "25"
     releaseDate: 2023-05-29
     eol: 2023-12-05
     latestReleaseDate: 2023-12-06
     latest: "25.9.8"
+    chromeVersion: "M114"
+    nodeVersion: "18.15"
 
 -   releaseCycle: "24"
     releaseDate: 2023-04-04
     eol: 2023-10-10
     latest: "24.8.8"
     latestReleaseDate: 2023-10-11
+    chromeVersion: "M112"
+    nodeVersion: "18.14"
 
 -   releaseCycle: "23"
     releaseDate: 2023-02-07
     eol: 2023-08-15
     latest: "23.3.13"
     latestReleaseDate: 2023-08-16
+    chromeVersion: "M110"
+    nodeVersion: "18.12"
 
 -   releaseCycle: "22"
     releaseDate: 2022-11-30
     eol: 2023-10-10
     latest: "22.3.27"
     latestReleaseDate: 2023-10-09
+    chromeVersion: "M108"
+    nodeVersion: "16.17"
 
 -   releaseCycle: "21"
     releaseDate: 2022-09-26
     eol: 2023-04-04
     latest: "21.4.4"
     latestReleaseDate: 2023-04-04
+    chromeVersion: "M106"
+    nodeVersion: "16.16"
 
 -   releaseCycle: "20"
     releaseDate: 2022-08-01
     eol: 2023-02-07
     latest: "20.3.12"
     latestReleaseDate: 2023-02-09
+    chromeVersion: "M104"
+    nodeVersion: "16.15"
 
 -   releaseCycle: "19"
     releaseDate: 2022-05-23
     eol: 2022-11-29
     latest: "19.1.9"
     latestReleaseDate: 2022-11-30
+    chromeVersion: "M102"
+    nodeVersion: "16.14"
 
 -   releaseCycle: "18"
     releaseDate: 2022-03-29
     eol: 2022-09-27
     latest: "18.3.15"
     latestReleaseDate: 2022-09-27
+    chromeVersion: "M100"
+    nodeVersion: "16.13"
 
 -   releaseCycle: "17"
     releaseDate: 2022-02-01
     eol: 2022-08-02
     latest: "17.4.11"
     latestReleaseDate: 2022-08-01
+    chromeVersion: "M98"
+    nodeVersion: "16.13"
 
 -   releaseCycle: "16"
     releaseDate: 2021-11-16
     eol: 2022-05-24
     latest: "16.2.8"
     latestReleaseDate: 2022-05-24
+    chromeVersion: "M96"
+    nodeVersion: "16.9"
 
 -   releaseCycle: "15"
     releaseDate: 2021-09-21
     eol: 2022-05-24
     latest: "15.5.7"
     latestReleaseDate: 2022-05-24
+    chromeVersion: "M94"
+    nodeVersion: "16.5"
 
 -   releaseCycle: "14"
     releaseDate: 2021-08-30
     eol: 2022-03-29
     latest: "14.2.9"
     latestReleaseDate: 2022-03-30
+    chromeVersion: "M93"
+    nodeVersion: "14.17"
 
 -   releaseCycle: "13"
     releaseDate: 2021-05-25
     eol: 2022-02-01
     latest: "13.6.9"
     latestReleaseDate: 2022-02-01
+    chromeVersion: "M91"
+    nodeVersion: "14.16"
 
 -   releaseCycle: "12"
     releaseDate: 2021-03-02
     eol: 2021-11-16
     latest: "12.2.3"
     latestReleaseDate: 2021-11-15
+    chromeVersion: "M89"
+    nodeVersion: "14.16"
 
 -   releaseCycle: "11"
     releaseDate: 2020-11-16
     eol: 2021-08-31
     latest: "11.5.0"
     latestReleaseDate: 2021-08-31
+    chromeVersion: "M87"
+    nodeVersion: "12.18"
 
 -   releaseCycle: "10"
     releaseDate: 2020-08-24
     eol: 2021-05-25
     latest: "10.4.7"
     latestReleaseDate: 2021-05-24
+    chromeVersion: "M85"
+    nodeVersion: "12.16"
 
 -   releaseCycle: "9"
     releaseDate: 2020-05-19
     eol: 2021-03-02
     latest: "9.4.4"
     latestReleaseDate: 2021-03-03
+    chromeVersion: "M83"
+    nodeVersion: "12.14"
 
 -   releaseCycle: "8"
     releaseDate: 2020-02-03
     eol: 2020-11-17
     latest: "8.5.5"
     latestReleaseDate: 2020-11-18
+    chromeVersion: "M80"
+    nodeVersion: "12.13"
 
 -   releaseCycle: "7"
     releaseDate: 2019-10-21
     eol: 2020-08-25
     latest: "7.3.3"
     latestReleaseDate: 2020-08-25
+    chromeVersion: "M78"
+    nodeVersion: "12.8"
 
 -   releaseCycle: "6"
     releaseDate: 2019-07-29
     eol: 2020-05-19
     latest: "6.1.12"
     latestReleaseDate: 2020-05-18
+    chromeVersion: "M76"
+    nodeVersion: "12.14.0"
 
 -   releaseCycle: "5"
     releaseDate: 2019-04-24
     eol: 2020-02-04
     latest: "5.0.13"
     latestReleaseDate: 2019-12-17
+    chromeVersion: "M73"
+    nodeVersion: "12.0"
 
 -   releaseCycle: "4"
     releaseDate: 2018-12-20
     eol: 2019-10-22
     latest: "4.2.12"
     latestReleaseDate: 2019-10-16
+    chromeVersion: "M69"
+    nodeVersion: "10.11"
 
 -   releaseCycle: "3"
     releaseDate: 2018-09-18
     eol: 2019-07-30
     latest: "3.1.13"
     latestReleaseDate: 2019-07-31
+    chromeVersion: "M66"
+    nodeVersion: "10.2"
 
 -   releaseCycle: "2"
     releaseDate: 2018-05-01
     eol: 2019-04-23
     latest: "2.0.18"
     latestReleaseDate: 2019-03-08
+    chromeVersion: "M61"
+    nodeVersion: "v8.9"
 
 ---
 


### PR DESCRIPTION
Adds Chrome and Node version details as custom columns.

I created this as a test for [Copilot Workspace](https://github.blog/2024-04-29-github-copilot-workspace/). Not sure if the session is share-able, but this is the link: [Copilot Workspace session](https://copilot-workspace.githubnext.com/endoflife-date/endoflife.date/issues/4667?shareId=5ecd6623-b0f5-480b-9696-eeadbd30822b).

I pasted all of the raw data from upstream in the "specification", and it still got a few rows incorrect. It also decided to drop all of the markdown text from the file, so I had to cleanup a bit after it.

Fixes #4667