### PR TITLE
Update quarkus.md to mark RHBQ 3.8 available

### DIFF
--- a/products/quarkus.md
+++ b/products/quarkus.md
@@ -43,6 +43,7 @@ releases:
     lts: true
     releaseDate: 2024-02-28
     eol: 2025-02-28
+    eoes: false
     latest: "3.8.4"
     latestReleaseDate: 2024-04-17
 


### PR DESCRIPTION
RHBQ 3.8.3.redhat-00003 and 3.8.4.redhat-00002 were recently released: https://maven.repository.redhat.com/ga/com/redhat/quarkus/platform/quarkus-bom/