### PR TITLE
[graalvm] Update 21.0.3, 17.0.11, 20 eol

### DIFF
--- a/products/graalvm.md
+++ b/products/graalvm.md
@@ -25,8 +25,8 @@ releases:
     releaseLabel: "JDK 21"
     releaseDate: 2023-09-19
     eol: false
-    latest: "jdk-21.0.2"
-    latestReleaseDate: 2024-01-16
+    latest: "jdk-21.0.3"
+    latestReleaseDate: 2024-04-16
 
 -   releaseCycle: "jdk-20"
     releaseLabel: "JDK 20"
@@ -39,8 +39,8 @@ releases:
     releaseLabel: "JDK 17"
     releaseDate: 2023-07-25
     eol: false
-    latest: "jdk-17.0.9"
-    latestReleaseDate: 2023-10-24
+    latest: "jdk-17.0.11"
+    latestReleaseDate: 2024-04-16
 
 -   releaseCycle: "22.3"
     releaseDate: 2022-10-25

--- a/products/graalvm.md
+++ b/products/graalvm.md
@@ -30,8 +30,8 @@ releases:
 
 -   releaseCycle: "jdk-20"
     releaseLabel: "JDK 20"
-    releaseDate: 2023-07-25
-    eol: false
+    releaseDate: 2023-06-13
+    eol: 2023-07-25
     latest: "jdk-20.0.2"
     latestReleaseDate: 2023-07-25
 


### PR DESCRIPTION
https://www.graalvm.org/release-calendar/#previous-releases

https://www.graalvm.org/release-notes/JDK_20/
newer version only available with commercial support