### PR TITLE
[flux] Add 2.3, update 2.0 eol

### DIFF
--- a/products/flux.md
+++ b/products/flux.md
@@ -20,6 +20,12 @@ auto:
 
 # eol(X) = releaseDate(X+3)
 releases:
+-   releaseCycle: "2.3"
+    releaseDate: 2024-05-13
+    eol: false
+    latest: "2.3.0"
+    latestReleaseDate: 2024-05-13
+
 -   releaseCycle: "2.2"
     releaseDate: 2023-12-12
     eol: false
@@ -34,7 +40,7 @@ releases:
 
 -   releaseCycle: "2.0"
     releaseDate: 2023-07-05
-    eol: false
+    eol: 2024-05-13 # https://fluxcd.io/blog/2024/05/flux-v2.3.0/#supported-versions -> Flux v2.0 has reached end-of-life and is no longer supported.
     latest: "2.0.1"
     latestReleaseDate: 2023-07-11
 

--- a/products/flux.md
+++ b/products/flux.md
@@ -40,7 +40,7 @@ releases:
 
 -   releaseCycle: "2.0"
     releaseDate: 2023-07-05
-    eol: 2024-05-13 # https://fluxcd.io/blog/2024/05/flux-v2.3.0/#supported-versions -> Flux v2.0 has reached end-of-life and is no longer supported.
+    eol: 2024-05-13 # https://fluxcd.io/blog/2024/05/flux-v2.3.0/#supported-versions
     latest: "2.0.1"
     latestReleaseDate: 2023-07-11
 


### PR DESCRIPTION
https://fluxcd.io/blog/2024/05/flux-v2.3.0/
https://github.com/fluxcd/flux2/releases/tag/v2.3.0
https://fluxcd.io/blog/2024/05/flux-v2.3.0/#supported-versions:
> Flux v2.0 has reached end-of-life and is no longer supported.