### PR TITLE
update rhel 9 latest release to 9.4

### DIFF
--- a/products/redhat.md
+++ b/products/redhat.md
@@ -37,8 +37,8 @@ releases:
     eol: 2029-05-31
     lts: 2029-05-31
     eoes: 2032-05-31
-    latest: "8.9"
-    latestReleaseDate: 2023-11-14
+    latest: "8.10"
+    latestReleaseDate: 2024-05-22
 
 -   releaseCycle: "7"
     releaseDate: 2013-12-11

--- a/products/redhat.md
+++ b/products/redhat.md
@@ -28,8 +28,8 @@ releases:
     eol: 2032-05-31
     lts: 2032-05-31
     eoes: 2035-05-31
-    latest: "9.3"
-    latestReleaseDate: 2023-11-07
+    latest: "9.4"
+    latestReleaseDate: 2024-04-30
 
 -   releaseCycle: "8"
     releaseDate: 2019-05-07


### PR DESCRIPTION
Redhat released a new version for rhel 9, which is ```9.4```, as seen [here](https://access.redhat.com/articles/3078#RHEL9) or in the below screenshot:
![image](https://github.com/endoflife-date/endoflife.date/assets/74180172/30101caf-a57b-47e8-bf13-891ba0bec706)

Closes #5172.
