### PR TITLE
[eks] Adds 1.30

### DIFF
--- a/products/eks.md
+++ b/products/eks.md
@@ -25,6 +25,14 @@ auto:
         eoes: "End of extended support"
 
 releases:
+-   releaseCycle: "1.30"
+    releaseDate: 2024-05-23
+    eol: 2025-07-23
+    eoes: 2026-07-23
+    latest: '1.30-eks-4'
+    latestReleaseDate: 2024-05-23
+    link: https://aws.amazon.com/about-aws/whats-new/2024/05/amazon-eks-distro-kubernetes-version-1-30/
+
 -   releaseCycle: "1.29"
     releaseDate: 2024-01-23
     eol: 2025-03-23


### PR DESCRIPTION
Release announced: https://aws.amazon.com/about-aws/whats-new/2024/05/amazon-eks-distro-kubernetes-version-1-30/

But eks-distro tags are not yet published.