### PR TITLE
[kubernetes-csi-node-driver-registrar] Drop 0.4

### DIFF
--- a/products/kubernetes-csi-node-driver-registrar.md
+++ b/products/kubernetes-csi-node-driver-registrar.md
@@ -95,12 +95,6 @@ releases:
     latest: "1.2.0"
     latestReleaseDate: 2019-09-09
 
--   releaseCycle: "0.4"
-    releaseDate: 2018-10-11
-    eol: true
-    latest: "0.4.2"
-    latestReleaseDate: 2018-12-20
-
 ---
 
 > The node-driver-registrar is a sidecar container for Kubernetes that registers the [CSI](https://kubernetes-csi.github.io/docs/introduction.html) driver with Kubelet using the kubelet plugin registration mechanism.


### PR DESCRIPTION
0.x versions are usually not documented on endoflife.date.

Moreover the current link (https://github.com/kubernetes-csi/node-driver-registrar/releases/tag/v0.4.2) is a 404.