### PR TITLE
[jenkins] Add 2.452 LTS

### DIFF
--- a/products/jenkins.md
+++ b/products/jenkins.md
@@ -31,10 +31,17 @@ releases:
     latest: "2.459"
     latestReleaseDate: 2024-05-21
 
+-   releaseCycle: "2.452"
+    releaseDate: 2024-04-02
+    lts: 2024-05-15
+    eol: false
+    latest: "2.452.1"
+    latestReleaseDate: 2024-05-15
+
 -   releaseCycle: "2.440"
     releaseDate: 2024-01-10
     lts: 2024-02-21
-    eol: false
+    eol: 2024-05-15
     latest: "2.440.3"
     latestReleaseDate: 2024-04-17
 


### PR DESCRIPTION
See [Upgrading to Jenkins LTS 2.452.x](https://www.jenkins.io/doc/upgrade-guide/2.452/)