### PR TITLE
[eks] 1.30 latest is eks2

### DIFF
--- a/products/eks.md
+++ b/products/eks.md
@@ -29,7 +29,7 @@ releases:
     releaseDate: 2024-05-23
     eol: 2025-07-23
     eoes: 2026-07-23
-    latest: '1.30-eks-4'
+    latest: '1.30-eks-2'
     latestReleaseDate: 2024-05-23
     link: https://aws.amazon.com/about-aws/whats-new/2024/05/amazon-eks-distro-kubernetes-version-1-30/
 


### PR DESCRIPTION
I'd guessed eks4 based on some link I can't find, but https://docs.aws.amazon.com/eks/latest/userguide/platform-versions.html now lists 1.30-eks-2 as the latest version on EKS