### PR TITLE
[nginx] add 1.27.x

### DIFF
--- a/products/nginx.md
+++ b/products/nginx.md
@@ -28,15 +28,23 @@ auto:
 # eol(x) = releaseDate(x+2)
 
 releases:
+-   releaseCycle: "1.27"
+    releaseDate: 2024-05-29
+    eol: false
+    link: https://nginx.org/en/CHANGES
+    latest: "1.27.0"
+    latestReleaseDate: 2024-05-29
+
 -   releaseCycle: "1.26"
     releaseDate: 2024-04-23
     eol: false
+    link: https://nginx.org/en/CHANGES
     latest: "1.26.0"
     latestReleaseDate: 2024-04-23
-    
+
 -   releaseCycle: "1.25"
     releaseDate: 2023-05-23
-    eol: false
+    eol: 2024-05-29
     link: https://nginx.org/en/CHANGES
     latest: "1.25.5"
     latestReleaseDate: 2024-04-16
@@ -44,6 +52,7 @@ releases:
 -   releaseCycle: "1.24"
     releaseDate: 2023-04-11
     eol: 2024-04-23
+    link: https://nginx.org/en/CHANGES
     latest: "1.24.0"
     latestReleaseDate: 2023-04-11
 

--- a/products/nginx.md
+++ b/products/nginx.md
@@ -38,7 +38,6 @@ releases:
 -   releaseCycle: "1.26"
     releaseDate: 2024-04-23
     eol: false
-    link: https://nginx.org/en/CHANGES
     latest: "1.26.0"
     latestReleaseDate: 2024-04-23
 
@@ -52,7 +51,6 @@ releases:
 -   releaseCycle: "1.24"
     releaseDate: 2023-04-11
     eol: 2024-04-23
-    link: https://nginx.org/en/CHANGES
     latest: "1.24.0"
     latestReleaseDate: 2023-04-11
 


### PR DESCRIPTION
- https://nginx.org/en/CHANGES

> Changes with nginx 1.27.0                                        29 May 2024
>
>    *) Security: when using HTTP/3, processing of a specially crafted QUIC
>       session might cause a worker process crash, worker process memory
>       disclosure on systems with MTU larger than 4096 bytes, or might have
>       potential other impact (CVE-2024-32760, CVE-2024-31079,
>       CVE-2024-35200, CVE-2024-34161).
>       Thanks to Nils Bars of CISPA.
>
>    *) Feature: variables support in the "proxy_limit_rate",
>       "fastcgi_limit_rate", "scgi_limit_rate", and "uwsgi_limit_rate"
>       directives.
>
>    *) Bugfix: reduced memory consumption for long-lived requests if "gzip",
>       "gunzip", "ssi", "sub_filter", or "grpc_pass" directives are used.
>
>    *) Bugfix: nginx could not be built by gcc 14 if the --with-atomic
>       option was used.
>       Thanks to Edgar Bonet.
>
>    *) Bugfixes in HTTP/3.