### PR TITLE
[panos]Update Pan-OS 10.1.13-h1 to 10.1.14

### DIFF
--- a/products/pan-os.md
+++ b/products/pan-os.md
@@ -54,9 +54,9 @@ releases:
 -   releaseCycle: "10.1"
     releaseDate: 2021-05-31
     eol: 2024-12-01
-    latest: "10.1.13-h1"
-    latestReleaseDate: 2024-05-02
-    link: https://docs.paloaltonetworks.com/pan-os/10-1/pan-os-release-notes/pan-os-10-1-13-known-and-addressed-issues/pan-os-10-1-13-h1-addressed-issues
+    latest: "10.1.14"
+    latestReleaseDate: 2024-05-30
+    link: https://docs.paloaltonetworks.com/pan-os/10-1/pan-os-release-notes/pan-os-10-1-14-known-and-addressed-issues/pan-os-10-1-14-addressed-issues
 
 -   releaseCycle: "10.0"
     releaseDate: 2020-07-16


### PR DESCRIPTION
Update Pan-OS 10.1.13-h1 to 10.1.14

Released: 2024-05-30

https://docs.paloaltonetworks.com/pan-os/10-1/pan-os-release-notes/pan-os-10-1-14-known-and-addressed-issues/pan-os-10-1-14-addressed-issues
