### PR TITLE
[MariaDB] Set EOL for 11.3

### DIFF
--- a/products/mariadb.md
+++ b/products/mariadb.md
@@ -62,7 +62,7 @@ releases:
 
 -   releaseCycle: "11.3"
     releaseDate: 2024-02-16
-    eol: false # rolling release, eol not yet on https://mariadb.org/about/#maintenance-policy
+    eol: 2024-05-29
     latest: "11.3.2"
     latestReleaseDate: 2024-02-16
 


### PR DESCRIPTION
11.3 is now listed under Unmaintained releases.

i suggest to use the releasedate for the next version, in this case 11.4 as EOL for previous rolling release.

https://web.archive.org/web/20240611191648/https://mariadb.org/about/#maintenance-policy

on june 1st i was still listed under rolling release.

https://web.archive.org/web/20240601041704/https://mariadb.org/about/