### PR TITLE
fix : Amazon Neptune `1.3.1.0` latest version point to `1.3.2.0` instead of `1.3.1.0`

### DIFF
--- a/products/amazon-neptune.md
+++ b/products/amazon-neptune.md
@@ -36,7 +36,7 @@ releases:
 
 -   releaseCycle: "1.3.1.0"
     releaseDate: 2024-06-06
-    upgradeVersion: "1.3.1.0"
+    upgradeVersion: "1.3.2.0"
     eol: 2025-11-30
     latest: "1.3.1.0"
     latestReleaseDate: 2024-06-06

--- a/products/amazon-neptune.md
+++ b/products/amazon-neptune.md
@@ -36,9 +36,9 @@ releases:
 
 -   releaseCycle: "1.3.1.0"
     releaseDate: 2024-06-06
-    upgradeVersion: "1.3.2.0"
+    upgradeVersion: "1.3.1.0"
     eol: 2025-11-30
-    latest: "1.3.2.0"
+    latest: "1.3.1.0"
     latestReleaseDate: 2024-06-06
 
 -   releaseCycle: "1.3.0.0"


### PR DESCRIPTION
#  :grey_question: About

[Amazon Neptune](https://endoflife.date/amazon-neptune) `1.3.1.0` 's latest version point to `1.3.2.0` : 

![image](https://github.com/endoflife-date/endoflife.date/assets/5235127/8f6221f0-a233-4202-832c-0cd7af9b6164)

# :scroll: Info

I got the alarm from [⏳ endoflife.date daily database snapshots 🦆](https://www.kaggle.com/code/adriensales/endoflife-date-daily-database-snapshots) : 

![image](https://github.com/endoflife-date/endoflife.date/assets/5235127/5f0529a7-ee72-4340-a56c-4f1e6ee28f45)
