### PR TITLE
Update Ruby version to 3.3 for check-links.yml

### DIFF
--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Setup ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 3.1
+          ruby-version: 3.3
           bundler-cache: true
 
       - name: Perform URLs check


### PR DESCRIPTION
sass-embedded requires ruby version >= 3.2.