### PR TITLE
[numpy] 2.0 Release

### DIFF
--- a/products/numpy.md
+++ b/products/numpy.md
@@ -20,6 +20,12 @@ auto:
 # EOL(R) = releaseDate(R) + 2 year + 1 day
 # But at no point should any of the last 3 releases become unsupported.
 releases:
+-   releaseCycle: "2.0"
+    releaseDate: 2024-06-16
+    eol: 2026-06-17
+    latest: "2.0.0"
+    latestReleaseDate: 2024-06-16
+
 -   releaseCycle: "1.26"
     releaseDate: 2023-09-16
     eol: 2025-09-17
@@ -106,7 +112,7 @@ releases:
 All minor versions of NumPy released in the prior 24 months, and at minimum the last three minor
 versions, are supported. NumPy follows SemVer.
 
-NumPy's support policy is defined via [NEP-29](https://numpy.org/neps/nep-0029-deprecation_policy.html),
+NumPy's support policy is defined via [SPEC 0](https://scientific-python.org/specs/spec-0000/),
 which is also followed by other tooling in the Scientific Python Ecosystem.
 
 ## Python Support
@@ -114,14 +120,13 @@ which is also followed by other tooling in the Scientific Python Ecosystem.
 All minor versions of Python released 42 months prior, and at minimum the two latest minor versions
 are supported. Python support is only dropped in a major/minor version, and never on a patch release.
 
-| NumPy | Python |
-|-------|--------|
-| 1.25  | 3.9+   |
-| 1.24  | 3.8+   |
-| 1.23  | 3.8+   |
-| 1.22  | 3.8+   |
-| 1.21  | 3.7+   |
-| 1.20  | 3.7+   |
-
-NumPy stopped supporting Python 3.7 from Dec 26, 2021. Any older releases (1.20, 1.21) still support
-Python 3.7. Releases made after that only support Python 3.8 and above.
+| NumPy | Python   |
+|-------|----------|
+| 2.0   | 3.9-3.12 |
+| 1.26  | 3.9-3.12 |
+| 1.25  | 3.9+     |
+| 1.24  | 3.8+     |
+| 1.23  | 3.8+     |
+| 1.22  | 3.8+     |
+| 1.21  | 3.7+     |
+| 1.20  | 3.7+     |


### PR DESCRIPTION
Refs:

- https://numpy.org/devdocs/release/2.0.0-notes.html
- https://numpy.org/news/#numpy-20-release-date-june-16

The first link states that "The release of 2.0 is in progress", so this should be merged once the release is complete.