### PR TITLE
[prometheus] Adds 2.53 - Check on July 2

### DIFF
--- a/products/prometheus.md
+++ b/products/prometheus.md
@@ -35,10 +35,11 @@ auto:
 # For LTS, as per https://prometheus.io/docs/introduction/release-cycle/#long-term-support
 releases:
 -   releaseCycle: "2.53"
-    releaseDate: 2024-07-01
+    lts: true
+    releaseDate: 2024-06-19
     eol: 2025-07-31
     latest: "2.53.0"
-    latestReleaseDate: 2024-07-01
+    latestReleaseDate: 2024-06-19
 
 -   releaseCycle: "2.52"
     releaseDate: 2024-05-08

--- a/products/prometheus.md
+++ b/products/prometheus.md
@@ -11,7 +11,12 @@ eolWarnThreshold: 14
 identifiers:
 -   repology: prometheus
 -   purl: pkg:docker/prom/prometheus
+-   purl: pkg:docker/bitnami/prometheus
+-   purl: pkg:docker/rapidfort/prometheus
+-   purl: pkg:docker/chainguard/prometheus
+-   purl: pkg:docker/bitnami/prometheus
 -   purl: pkg:oci/prometheus?repository_url=quay.io/repository/prometheus
+-   purl: pkg:oci/prometheus?repository_url=cgr.dev/chainguard
 -   purl: pkg:github/prometheus/prometheus
 
 auto:
@@ -29,6 +34,12 @@ auto:
 # eol(x) = releaseDate(x) + 6w (non-LTS)
 # For LTS, as per https://prometheus.io/docs/introduction/release-cycle/#long-term-support
 releases:
+-   releaseCycle: "2.53"
+    releaseDate: 2024-07-01
+    eol: 2025-07-31
+    latest: "2.53.0"
+    latestReleaseDate: 2024-07-01
+
 -   releaseCycle: "2.52"
     releaseDate: 2024-05-08
     eol: 2024-06-19


### PR DESCRIPTION
Updated at https://prometheus.io/docs/introduction/release-cycle/, release expected on 1st July
Adds a few more identifiers.