### PR TITLE
[pan-gp]Updated Pan-GP 6.1.4 to 6.1.5

### DIFF
--- a/products/pan-gp.md
+++ b/products/pan-gp.md
@@ -22,6 +22,15 @@ auto:
         eol: "End-of-Life Date"
 
 releases:
+
+-   releaseCycle: "6.3"
+    releaseDate: 2024-06-13
+    eol: false
+    eoas: false
+    latest: "6.3.0"
+    latestReleaseDate: 2024-06-13
+    link: https://docs.paloaltonetworks.com/globalprotect/6-3/globalprotect-app-release-notes/globalprotect-addressed-issues
+
 -   releaseCycle: "6.2"
     releaseDate: 2023-05-23
     eol: 2025-05-23

--- a/products/pan-gp.md
+++ b/products/pan-gp.md
@@ -34,8 +34,8 @@ releases:
     releaseDate: 2022-09-01
     eol: 2025-03-01
     eoas: 2024-09-01
-    latest: "6.1.4"
-    latestReleaseDate: 2024-01-29
+    latest: "6.1.5"
+    latestReleaseDate: 2024-06-20
     link: https://docs.paloaltonetworks.com/globalprotect/6-1/globalprotect-app-release-notes//globalprotect-addressed-issues
 
 -   releaseCycle: "6.0"


### PR DESCRIPTION
Updated Pan-GP 6.1.4 to 6.1.5

Relased: 2024-06-20

https://docs.paloaltonetworks.com/globalprotect/6-1/globalprotect-app-release-notes//globalprotect-addressed-issues


Also Pan-GP 6.3 was released at 2024-06-13 but they haven't updated the EOL docs yet.

