### PR TITLE
[electron] Automate releaseDate retrieval

### DIFF
--- a/products/electron.md
+++ b/products/electron.md
@@ -30,6 +30,7 @@ auto:
         releaseCycle:
           column: "Electron"
           regex: '^(?P<value>\d+)\.0\.0$'
+        releaseDate: "Stable"
         eol: "EOL"
 
 releases:


### PR DESCRIPTION
This will also prevent having alters for unreleased versions, such as in https://github.com/endoflife-date/endoflife.date/pull/5324.