### PR TITLE
[panos] Updated Pan-OS 11.1.4

### DIFF
--- a/products/pan-os.md
+++ b/products/pan-os.md
@@ -33,9 +33,9 @@ releases:
 -   releaseCycle: "11.1"
     releaseDate: 2023-11-03
     eol: 2027-05-03
-    latest: "11.1.3-h1"
-    latestReleaseDate: 2024-06-06
-    link: https://docs.paloaltonetworks.com/pan-os/11-1/pan-os-release-notes/pan-os-11-1-3-known-and-addressed-issues/pan-os-11-1-3-h1-addressed-issues
+    latest: "11.1.4"
+    latestReleaseDate: 2024-06-27
+    link: https://docs.paloaltonetworks.com/pan-os/11-1/pan-os-release-notes/pan-os-11-1-4-known-and-addressed-issues/pan-os-11-1-4-addressed-issues
 
 -   releaseCycle: "11.0"
     releaseDate: 2022-11-17


### PR DESCRIPTION
Updated Pan-OS from 11.1.3-h1 to 11.1.4.

Released: 2024-06-27

Release notes: https://docs.paloaltonetworks.com/pan-os/11-1/pan-os-release-notes/pan-os-11-1-4-known-and-addressed-issues/pan-os-11-1-4-addressed-issues
