### PR TITLE
[vue] Remove incorrect repology identifier

### DIFF
--- a/products/vue.md
+++ b/products/vue.md
@@ -18,7 +18,6 @@ auto:
 
 identifiers:
 -   repology: vue.js
--   repology: vue
 -   purl: pkg:npm/vue
 -   purl: pkg:github/vuejs/vue
 -   purl: pkg:github/vuejs/core


### PR DESCRIPTION
https://repology.org/project/vue/information is not vue.js