### PR TITLE
Update EOL date for elasticsearch 8

### DIFF
--- a/products/elasticsearch.md
+++ b/products/elasticsearch.md
@@ -25,7 +25,7 @@ auto:
 releases:
 -   releaseCycle: "8"
     releaseDate: 2022-02-10
-    eol: false # later of 2024-08-10 or 6 months after the release date of 9.0
+    eol: false # later of 2024-08-10 or 18 months after the release date of 9.0
     latest: "8.14.1"
     latestReleaseDate: 2024-06-12
 
@@ -52,11 +52,11 @@ other products in the Elastic Stack (Kibana, Logstash, Beats...).
 
 Elastic Stack product releases follow [Semantic Versioning](https://semver.org/). Elastic provides
 maintenance for each major release series for the longest of 30 months after the GA date of the
-major release or 6 months after the GA date of the subsequent major release.
+major release or 18 months after the GA date of the subsequent major release.
 
 Therefore:
 
-* **Elasticsearch 8** will receive updates until 6 months after the release date of 9.0 (TBD).
+* **Elasticsearch 8** will receive updates until 18 months after the release date of 9.0 (TBD).
 * **Elasticsearch 7** will receive updates until the release date of 9.0 (TDB).
 
 End of life dates for Elasticsearch can be found on the [Elastic product EOL dates page](https://www.elastic.co/support/eol).


### PR DESCRIPTION
Per https://www.elastic.co/support/eol, version 8 will exipre "The later of 2024-08-10 or 18 months after the release date of 9.0 (TBD)"

![image](https://github.com/endoflife-date/endoflife.date/assets/404857/8c5b011f-95ef-43cf-9bcb-9912c26542da)
