### PR TITLE
[vue] Fix YAML

### DIFF
--- a/products/vue.md
+++ b/products/vue.md
@@ -12,7 +12,7 @@ eoasColumn: true
 releaseDateColumn: true
 eoesColumn: Commercial Support
 changelogTemplate: https://github.com/vuejs/core/releases/tag/v__LATEST__
-oldChangelogTemplate: &old https://github.com/vuejs/vue/releases/tag/v__LATEST__
+oldChangelogTemplate: &old "https://github.com/vuejs/vue/releases/tag/v__LATEST__"
 
 auto:
   methods:
@@ -67,7 +67,7 @@ releases:
     eoes: false
     latest: "2.7.16"
     latestReleaseDate: 2023-12-24
-    link: &old https://github.com/vuejs/vue/releases/tag/v__LATEST__
+    link: *old
 
 
 -   releaseCycle: "2.6"
@@ -77,7 +77,7 @@ releases:
     eoes: false
     latest: "2.6.14"
     latestReleaseDate: 2021-06-07
-    link: &old https://github.com/vuejs/vue/releases/tag/v__LATEST__
+    link: *old
 
 
 -   releaseCycle: "2.5"
@@ -87,7 +87,7 @@ releases:
     eoes: true
     latest: "2.5.22"
     latestReleaseDate: 2019-01-11
-    link: &old https://github.com/vuejs/vue/releases/tag/v__LATEST__
+    link: *old
 
 
 -   releaseCycle: "2.4"
@@ -97,7 +97,7 @@ releases:
     eoes: true
     latest: "2.4.4"
     latestReleaseDate: 2017-09-14
-    link: &old https://github.com/vuejs/vue/releases/tag/v__LATEST__
+    link: *old
 
 
 -   releaseCycle: "2.3"
@@ -107,7 +107,7 @@ releases:
     eoes: true
     latest: "2.3.4"
     latestReleaseDate: 2017-06-08
-    link: &old https://github.com/vuejs/vue/releases/tag/v__LATEST__
+    link: *old
 
 
 -   releaseCycle: "2.2"
@@ -117,7 +117,7 @@ releases:
     eoes: true
     latest: "2.2.6"
     latestReleaseDate: 2017-03-27
-    link: &old https://github.com/vuejs/vue/releases/tag/v__LATEST__
+    link: *old
 
 
 -   releaseCycle: "2.1"
@@ -127,7 +127,7 @@ releases:
     eoes: true
     latest: "2.1.10"
     latestReleaseDate: 2017-01-17
-    link: &old https://github.com/vuejs/vue/releases/tag/v__LATEST__
+    link: *old
 
 
 -   releaseCycle: "2.0"
@@ -137,7 +137,7 @@ releases:
     eoes: true
     latest: "2.0.8"
     latestReleaseDate: 2016-11-20
-    link: &old https://github.com/vuejs/vue/releases/tag/v__LATEST__
+    link: *old
 
 
 -   releaseCycle: "1"
@@ -146,7 +146,7 @@ releases:
     eol: true
     latest: "1.0.28"
     latestReleaseDate: 2016-09-27
-    link: &old https://github.com/vuejs/vue/releases/tag/v__LATEST__
+    link: *old
 
 
 


### PR DESCRIPTION
YAML anchors should not repeat the content, obviously. This broke the Python side of things, while the ruby parser didn't complain