### PR TITLE
[antixlinux] Drop identifiers

### DIFF
--- a/products/antixlinux.md
+++ b/products/antixlinux.md
@@ -13,9 +13,6 @@ releaseLabel: "__RELEASE_CYCLE__ (__CODENAME__)"
 eoasColumn: true
 releaseDateColumn: true
 
-identifiers:
--   purl: pkg:os/antix
-
 auto:
   methods:
   -   distrowatch: antix


### PR DESCRIPTION
Looks like it was wrong, see #5356.