### PR TITLE
[pan-os]Updated 11.2.0 to 11.2.1

### DIFF
--- a/products/pan-os.md
+++ b/products/pan-os.md
@@ -28,9 +28,9 @@ releases:
 -   releaseCycle: "11.2"
     releaseDate: 2024-05-02
     eol: 2027-05-02
-    latest: "11.2.0"
-    latestReleaseDate: 2024-05-02
-    link: https://docs.paloaltonetworks.com/pan-os/11-2/pan-os-release-notes/pan-os-11-2-0-known-and-addressed-issues/pan-os-11-2-0-addressed-issues
+    latest: "11.2.1"
+    latestReleaseDate: 2024-07-08
+    link: https://docs.paloaltonetworks.com/pan-os/11-2/pan-os-release-notes/pan-os-11-2-1-known-and-addressed-issues/pan-os-11-2-1-addressed-issues
 
 -   releaseCycle: "11.1"
     releaseDate: 2023-11-03


### PR DESCRIPTION
[pan-os]Updated 11.2.0 to 11.2.1

Released: 2024/07/08

Release notes: https://docs.paloaltonetworks.com/pan-os/11-2/pan-os-release-notes/pan-os-11-2-1-known-and-addressed-
issues/pan-os-11-2-1-addressed-issues

I've created a new repo containing the latest palo alto versions. It's pulling the version information directly from the firewall using palo alto's API.

https://github.com/mrjcap/panos-versions/
