### PR TITLE
[squid] Update auto configuration

### DIFF
--- a/products/squid.md
+++ b/products/squid.md
@@ -23,20 +23,14 @@ identifiers:
 # v2,3 had stable releases as major.minor.patch, where patch=0 was for RC releases.
 auto:
   methods:
-  # v2 sources are now archived in a separate repo, we use that as well
-  -   git: https://github.com/squid-cache/squid2.git
+  -   git: https://github.com/squid-cache/squid
       regex:
-      # https://regex101.com/r/yMRzJO/1
-      -   ^SQUID_(?P<major>[2-3])_(?P<minor>\d)_((STABLE)?(?P<patch>\d+))$
-      # https://regex101.com/r/psotaU/1
-      -   ^SQUID_(?P<major>[4-9])_(?P<minor>\d+)$
-  # the squidadm repository is the one where releases are made
-  -   git: https://github.com/squidadm/squid.git
+      -   ^SQUID_(?P<major>[2-3])_(?P<minor>\d)_((STABLE)?(?P<patch>\d+))$ # https://regex101.com/r/yMRzJO/1
+      -   ^SQUID_(?P<major>[4-9])_(?P<minor>\d+)$ # https://regex101.com/r/psotaU/1
+  -   git: https://github.com/squid-cache/squid2.git # v2 sources are now archived in a separate repo, we use that as well
       regex:
-      # https://regex101.com/r/yMRzJO/1
-      -   ^SQUID_(?P<major>[2-3])_(?P<minor>\d)_((STABLE)?(?P<patch>\d+))$
-      # https://regex101.com/r/psotaU/1
-      -   ^SQUID_(?P<major>[4-9])_(?P<minor>\d+)$
+      -   ^SQUID_(?P<major>[2-3])_(?P<minor>\d)_((STABLE)?(?P<patch>\d+))$ # https://regex101.com/r/yMRzJO/1
+      -   ^SQUID_(?P<major>[4-9])_(?P<minor>\d+)$ # https://regex101.com/r/psotaU/1
 
 releases:
 -   releaseCycle: "6"


### PR DESCRIPTION
Only https://github.com/squid-cache/squid holds the correct tags now.

Closes #5436.