### PR TITLE
[pan-gp]Updated GlobalProtect from 6.2.3 to 6.2.4

### DIFF
--- a/products/pan-gp.md
+++ b/products/pan-gp.md
@@ -37,8 +37,8 @@ releases:
     releaseDate: 2023-05-23
     eol: 2025-05-23
     eoas: 2025-05-23
-    latest: "6.2.3"
-    latestReleaseDate: 2024-04-10
+    latest: "6.2.4"
+    latestReleaseDate: 2024-07-15
     link: https://docs.paloaltonetworks.com/globalprotect/6-2/globalprotect-app-release-notes/globalprotect-addressed-issues
 
 -   releaseCycle: "6.1"


### PR DESCRIPTION
Updated GlobalProtect from 6.2.3 to 6.2.4

Released: 2024-07-15

Release Notes: https://docs.paloaltonetworks.com/globalprotect/6-2/globalprotect-app-release-notes/globalprotect-addressed-issues
