### PR TITLE
[panos]Updated Pan-OS from 10.2.10 to 10.2.10-h2

### DIFF
--- a/products/pan-os.md
+++ b/products/pan-os.md
@@ -49,9 +49,9 @@ releases:
 -   releaseCycle: "10.2"
     releaseDate: 2022-02-27
     eol: 2025-08-27
-    latest: "10.2.10"
-    latestReleaseDate: 2024-06-24
-    link: https://docs.paloaltonetworks.com/pan-os/10-2/pan-os-release-notes/pan-os-10-2-10-known-and-addressed-issues/pan-os-10-2-10-addressed-issues
+    latest: "10.2.10-h2"
+    latestReleaseDate: 2024-07-16
+    link: https://docs.paloaltonetworks.com/pan-os/10-2/pan-os-release-notes/pan-os-10-2-10-known-and-addressed-issues/pan-os-10-2-10-h2-addressed-issues
 
 -   releaseCycle: "10.1"
     releaseDate: 2021-05-31


### PR DESCRIPTION
Updated Pan-OS from 10.2.10 to 10.2.10-h2

Released: 2024-07-16

Release Notes: https://docs.paloaltonetworks.com/pan-os/10-2/pan-os-release-notes/pan-os-10-2-10-known-and-addressed-issues/pan-os-10-2-10-h2-addressed-issues

