### PR TITLE
Validate CPE 2.2 and 2.3 identifiers

### DIFF
--- a/_plugins/identifier-to-url.rb
+++ b/_plugins/identifier-to-url.rb
@@ -13,8 +13,20 @@ class IdentifierToUrl
     type = identifier_hash.keys[0]
     identifier = identifier_hash.values[0]
     if ['cpe'].include?(type)
-      # No known way to generate URLs for CPEs
-      return nil
+      # Regex found on https://csrc.nist.gov/schema/cpe/2.3/cpe-naming_2.3.xsd.
+      # Regex for 2.3 has been simplified as I coud not make it work with Ruby.
+      cpe2_2_regex = /^[c][pP][eE]:\/[AHOaho]?(:[A-Za-z0-9\._\-~%]*){0,6}$/
+      if identifier.match(cpe2_2_regex)
+        # No known way to generate URLs for CPEs
+        return nil
+      end
+
+      cpe2_3_regex = /^[c][pP][eE]:2\.3:[AHOaho]?(:[A-Za-z0-9\._\-~%]*){0,6}$/
+      if identifier.match(cpe2_3_regex)
+        return "https://services.nvd.nist.gov/rest/json/cpes/2.0?cpeMatchString=#{identifier}"
+      end
+
+      raise "Invalid CPE: should match either #{cpe2_2_regex} for CPE 2.2 or #{cpe2_3_regex} for CPE 2.3"
 
     elsif type == 'repology'
       return _build_repology_url(identifier)


### PR DESCRIPTION
This also generate a link to https://services.nvd.nist.gov for CPE 2.3 identifiers.

Relates to #5356.