### PR TITLE
[couchbase-server] Fix 7.6 release date

### DIFF
--- a/products/couchbase-server.md
+++ b/products/couchbase-server.md
@@ -31,7 +31,7 @@ auto:
 
 releases:
 -   releaseCycle: "7.6"
-    releaseDate: 2023-03-20
+    releaseDate: 2024-03-31
     eol: 2026-07-31
     latest: "7.6.2"
     latestReleaseDate: 2024-07-31


### PR DESCRIPTION
See https://docs.couchbase.com/server/current/release-notes/relnotes.html#release-7-6-0-march-2024.

Relates to #3961.