### PR TITLE
[freebsd] Fix release cycles order

### DIFF
--- a/products/freebsd.md
+++ b/products/freebsd.md
@@ -17,6 +17,10 @@ releases:
     releaseDate: 2024-06-04
     eol: 2025-03-31
 
+-   releaseCycle: "releng/13.3"
+    releaseDate: 2024-03-05
+    eol: 2024-12-31
+
 -   releaseCycle: "releng/14.0"
     releaseDate: 2023-11-21
     eol: 2024-09-30
@@ -26,17 +30,21 @@ releases:
     eol: 2028-11-30
     link: null
 
--   releaseCycle: "releng/13.3"
-    releaseDate: 2024-03-05
-    eol: 2024-12-31
-
 -   releaseCycle: "releng/13.2"
     releaseDate: 2023-04-11
     eol: 2024-06-30
 
+-   releaseCycle: "releng/12.4"
+    releaseDate: 2022-12-05
+    eol: 2023-12-31
+
 -   releaseCycle: "releng/13.1"
     releaseDate: 2022-05-16
     eol: 2023-07-31
+
+-   releaseCycle: "releng/12.3"
+    releaseDate: 2021-12-07
+    eol: 2023-03-05
 
 -   releaseCycle: "releng/13.0"
     releaseDate: 2021-04-13
@@ -47,17 +55,13 @@ releases:
     eol: 2026-04-30
     link: null
 
--   releaseCycle: "releng/12.4"
-    releaseDate: 2022-12-05
-    eol: 2023-12-31
-
--   releaseCycle: "releng/12.3"
-    releaseDate: 2021-12-07
-    eol: 2023-03-05
-
 -   releaseCycle: "releng/12.2"
     releaseDate: 2020-10-27
     eol: 2022-03-31
+
+-   releaseCycle: "releng/11.4"
+    releaseDate: 2020-06-16
+    eol: 2021-09-30
 
 -   releaseCycle: "releng/12.1"
     releaseDate: 2019-11-04
@@ -72,18 +76,14 @@ releases:
     eol: 2023-12-31
     link: null
 
--   releaseCycle: "releng/11.4"
-    releaseDate: 2020-06-16
-    eol: 2021-09-30
+-   releaseCycle: "releng/10.4"
+    releaseDate: 2017-10-03
+    eol: 2018-10-31
 
 -   releaseCycle: "stable/11"
     releaseDate: 2016-10-10
     eol: 2021-09-30
     link: null
-
--   releaseCycle: "releng/10.4"
-    releaseDate: 2017-10-03
-    eol: 2018-10-31
 
 -   releaseCycle: "releng/10.3"
     releaseDate: 2016-04-04
@@ -97,6 +97,10 @@ releases:
     releaseDate: 2014-11-14
     eol: 2016-12-31
 
+-   releaseCycle: "releng/9.3"
+    releaseDate: 2014-07-16
+    eol: 2016-12-31
+
 -   releaseCycle: "releng/10.0"
     releaseDate: 2014-01-20
     eol: 2015-02-28
@@ -106,17 +110,21 @@ releases:
     eol: 2018-10-31
     link: null
 
--   releaseCycle: "releng/9.3"
-    releaseDate: 2014-07-16
-    eol: 2016-12-31
-
 -   releaseCycle: "releng/9.2"
     releaseDate: 2013-09-30
     eol: 2014-12-31
 
+-   releaseCycle: "releng/8.4"
+    releaseDate: 2013-06-09
+    eol: 2015-08-01
+
 -   releaseCycle: "releng/9.1"
     releaseDate: 2012-12-30
     eol: 2014-12-31
+
+-   releaseCycle: "releng/8.3"
+    releaseDate: 2012-04-18
+    eol: 2014-04-30
 
 -   releaseCycle: "releng/9.0"
     releaseDate: 2012-01-10
@@ -127,13 +135,9 @@ releases:
     eol: 2016-12-31
     link: null
 
--   releaseCycle: "releng/8.4"
-    releaseDate: 2013-06-09
-    eol: 2015-08-01
-
--   releaseCycle: "releng/8.3"
-    releaseDate: 2012-04-18
-    eol: 2014-04-30
+-   releaseCycle: "releng/7.4"
+    releaseDate: 2011-02-24
+    eol: 2013-02-28
 
 -   releaseCycle: "releng/8.2"
     releaseDate: 2011-02-24
@@ -142,6 +146,10 @@ releases:
 -   releaseCycle: "releng/8.1"
     releaseDate: 2010-07-23
     eol: 2012-07-31
+
+-   releaseCycle: "releng/7.3"
+    releaseDate: 2010-03-23
+    eol: 2012-03-31
 
 -   releaseCycle: "releng/8.0"
     releaseDate: 2009-11-25
@@ -152,14 +160,6 @@ releases:
     eol: 2015-08-01
     link: null
 
--   releaseCycle: "releng/7.4"
-    releaseDate: 2011-02-24
-    eol: 2013-02-28
-
--   releaseCycle: "releng/7.3"
-    releaseDate: 2010-03-23
-    eol: 2012-03-31
-
 -   releaseCycle: "releng/7.2"
     releaseDate: 2009-03-04
     eol: 2010-06-30
@@ -167,6 +167,10 @@ releases:
 -   releaseCycle: "releng/7.1"
     releaseDate: 2009-01-04
     eol: 2011-02-28
+
+-   releaseCycle: "releng/6.4"
+    releaseDate: 2008-11-28
+    eol: 2010-11-30
 
 -   releaseCycle: "releng/7.0"
     releaseDate: 2008-02-27
@@ -177,16 +181,16 @@ releases:
     eol: 2013-02-28
     link: null
 
--   releaseCycle: "releng/6.4"
-    releaseDate: 2008-11-28
-    eol: 2010-11-30
-
 -   releaseCycle: "releng/6.3"
     releaseDate: 2008-01-18
     eol: 2010-01-31
 
 -   releaseCycle: "releng/6.2"
     releaseDate: 2007-01-15
+    eol: 2008-05-31
+
+-   releaseCycle: "releng/5.5"
+    releaseDate: 2006-05-25
     eol: 2008-05-31
 
 -   releaseCycle: "releng/6.1"
@@ -202,13 +206,13 @@ releases:
     eol: 2010-11-30
     link: null
 
--   releaseCycle: "releng/5.5"
-    releaseDate: 2006-05-25
-    eol: 2008-05-31
-
 -   releaseCycle: "releng/5.4"
     releaseDate: 2005-05-09
     eol: 2006-10-31
+
+-   releaseCycle: "releng/4.11"
+    releaseDate: 2005-01-25
+    eol: 2007-01-31
 
 -   releaseCycle: "releng/5.3"
     releaseDate: 2004-11-06
@@ -218,10 +222,6 @@ releases:
     releaseDate: 2004-11-06
     eol: 2008-05-31
     link: null
-
--   releaseCycle: "releng/4.11"
-    releaseDate: 2005-01-25
-    eol: 2007-01-31
 
 -   releaseCycle: "stable/4"
     releaseDate: 2000-03-14


### PR DESCRIPTION
Most of the page on endoflife.date have their release cycles ordered by release date. This applies this rule to FreeBSD.

Relates to #3961.