### PR TITLE
[exim] Fix 4.98

### DIFF
--- a/products/exim.md
+++ b/products/exim.md
@@ -21,7 +21,7 @@ releases:
 -   releaseCycle: "4.98"
     releaseDate: 2024-07-10
     eol: false
-    latest: "4.98.0"
+    latest: "4.98"
     latestReleaseDate: 2024-07-10
 
 -   releaseCycle: "4.97"


### PR DESCRIPTION
First release of a cycle does not have a patch number, see https://github.com/Exim/exim/releases/tag/exim-4.98.