### PR TITLE
Update debian.md

### DIFF
--- a/products/debian.md
+++ b/products/debian.md
@@ -43,7 +43,7 @@ releases:
 -   releaseCycle: "11"
     codename: "Bullseye"
     releaseDate: 2021-08-14
-    eol: 2024-07-31
+    eol: 2024-08-14
     eoes: 2026-06-30
     link: https://www.debian.org/News/2024/2024021002
     latest: "11.10"


### PR DESCRIPTION
Checked on IRC channel #debian-release

https://www.debian.org/releases/bullseye/ says August 14

Security support extended to 2024-08-14

Next (and last) point release scheduled for 2024-08-31 as 11.11

(amacater@debian.org)