### PR TITLE
[prometheus] Rollback latest 2.52 to 2.52.0

### DIFF
--- a/products/prometheus.md
+++ b/products/prometheus.md
@@ -44,8 +44,8 @@ releases:
 -   releaseCycle: "2.52"
     releaseDate: 2024-05-08
     eol: 2024-06-19
-    latest: "2.52.1"
-    latestReleaseDate: 2024-05-30
+    latest: "2.52.0"
+    latestReleaseDate: 2024-05-08
 
 -   releaseCycle: "2.51"
     releaseDate: 2024-03-19


### PR DESCRIPTION
The 2.52.1 tag does not exist anymore. It was removed in https://github.com/endoflife-date/release-data/commit/335b5ed19ae86c9489a18f24d93d837c1c8c87cf.