### PR TITLE
[bun] Update changelogTemplate

### DIFF
--- a/products/bun.md
+++ b/products/bun.md
@@ -6,7 +6,7 @@ iconSlug: bun
 permalink: /bun
 versionCommand: bun --version
 releasePolicyLink: https://github.com/oven-sh/bun/releases
-changelogTemplate: https://bun.sh/blog/bun-v__LATEST__
+changelogTemplate: https://github.com/oven-sh/bun/releases/tag/bun-v__LATEST__
 releaseDateColumn: true
 
 identifiers:


### PR DESCRIPTION
Using GitHub releases is safer than using https://bun.sh/ as sometime the link on bun.sh does not exist (example https://bun.sh/blog/bun-v1.1.20 vs https://github.com/oven-sh/bun/releases/tag/bun-v1.1.20).