### PR TITLE
[godot] Update changelogTemplate

### DIFF
--- a/products/godot.md
+++ b/products/godot.md
@@ -34,7 +34,6 @@ releases:
     eol: false
     latest: "4.2.2"
     latestReleaseDate: 2024-04-16
-    link: https://godotengine.org/article/godot-4-2-arrives-in-style/
 
 -   releaseCycle: "4.1"
     releaseDate: 2023-07-05

--- a/products/godot.md
+++ b/products/godot.md
@@ -7,8 +7,7 @@ alternate_urls:
 -   /godotengine
 versionCommand: godot --version
 releasePolicyLink: https://docs.godotengine.org/en/latest/about/release_policy.html
-changelogTemplate: |
-  https://godotengine.org/article/maintenance-release-godot-{{"__LATEST__" | replace:'.','-'}}
+changelogTemplate: https://github.com/godotengine/godot/releases/tag/__LATEST__-stable
 eolColumn: Critical, Security and Platform support
 eoasColumn: true
 releaseDateColumn: true


### PR DESCRIPTION
Looks like the entry on godotengine.com is no more predictable (ex. https://godotengine.org/article/maintenance-release-godot-4-2-2-and-4-1-4/), so switch to GitHub releases.