### PR TITLE
[Update] Amazon RDS Extended Support for MySQL and PostgreSQL

### DIFF
--- a/products/amazon-rds-mysql.md
+++ b/products/amazon-rds-mysql.md
@@ -6,6 +6,7 @@ iconSlug: amazonrds
 permalink: /amazon-rds-mysql
 releasePolicyLink: https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/MySQL.Concepts.VersionMgmt.html
 releaseDateColumn: true
+eoesColumn: Extended Support
 
 auto:
   methods:
@@ -17,23 +18,27 @@ auto:
           column: "MySQL major version"
           regex: '^MySQL\s+(?P<value>\d+\.\d+).*$'
         eol: "RDS end of standard support date"
+        eoes: "RDS end of Extended Support date"
 
 releases:
 -   releaseCycle: "8.0"
     releaseDate: 2018-10-23
     eol: 2026-07-31
+    eoes: 2029-07-31
     latest: "8.0.37"
     latestReleaseDate: 2024-06-18
 
 -   releaseCycle: "5.7"
     releaseDate: 2016-02-22
     eol: 2024-02-29
+    eoes: 2027-02-28
     latest: "5.7.44"
     latestReleaseDate: 2023-11-02
 
 -   releaseCycle: "5.6"
     releaseDate: 2013-07-01
     eol: 2022-03-01
+    eoes: true
     latest: "5.6"
     latestReleaseDate: 2013-07-01
 
@@ -62,3 +67,7 @@ overridden in the AWS console.
 
 For the most up-to-date information about the Amazon RDS deprecation policy for MySQL, see [Amazon
 RDS FAQs](http://aws.amazon.com/rds/faqs/).
+
+On the RDS end of standard support date, Amazon RDS automatically enrolls your databases in RDS Extended Support.
+RDS Extended Support is a  paid offering available for up to 3 years past the RDS end of standard support date for a major engine version, see
+[Using Amazon RDS Extended Support](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/extended-support.html).

--- a/products/amazon-rds-postgresql.md
+++ b/products/amazon-rds-postgresql.md
@@ -6,6 +6,7 @@ iconSlug: amazonrds
 permalink: /amazon-rds-postgresql
 releasePolicyLink: https://docs.aws.amazon.com/AmazonRDS/latest/PostgreSQLReleaseNotes/postgresql-release-calendar.html
 releaseDateColumn: true
+eoesColumn: Extended Support
 
 auto:
   methods:
@@ -17,58 +18,64 @@ auto:
           column: "PostgreSQL major version"
           regex: '^PostgreSQL\s+(?P<value>\d+(\.\d+)?).*$'
         eol: "RDS end of standard support date"
+        eoes: "RDS end of Extended Support date"
 
 releases:
 -   releaseCycle: "16"
     releaseDate: 2023-11-17
     eol: 2029-02-28
+    eoes: 2032-02-29
     latest: "16.3"
     latestReleaseDate: 2024-05-09
 
 -   releaseCycle: "15"
     releaseDate: 2023-02-27
     eol: 2028-02-29
+    eoes: 2031-02-28
     latest: "15.7"
     latestReleaseDate: 2024-05-09
 
 -   releaseCycle: "14"
     releaseDate: 2022-02-03
     eol: 2027-02-28
+    eoes: 2030-02-28
     latest: "14.12"
     latestReleaseDate: 2024-05-09
 
 -   releaseCycle: "13"
     releaseDate: 2021-02-24
     eol: 2026-02-28
+    eoes: 2029-02-28
     latest: "13.15"
     latestReleaseDate: 2024-05-09
 
 -   releaseCycle: "12"
     releaseDate: 2020-03-31
     eol: 2025-02-28
+    eoes: 2028-02-28
     latest: "12.19"
     latestReleaseDate: 2024-05-09
 
 -   releaseCycle: "11"
     releaseDate: 2019-03-13
     eol: 2024-02-29
+    eoes: 2027-03-31
     latest: "11.22"
     latestReleaseDate: 2023-11-17
 
 -   releaseCycle: "10"
     releaseDate: 2018-02-27
     eol: 2023-04-30
+    eoes: true
     latest: "10.23"
     latestReleaseDate: 2023-01-24
 
 -   releaseCycle: "9.6"
     releaseDate: 2016-11-11
     eol: 2022-04-30
+    eoes: true
     # https://docs.aws.amazon.com/AmazonRDS/latest/PostgreSQLReleaseNotes/postgresql-versions.html#postgresql-versions-version96
     latest: "9.6.24"
-
-
-
 
 ---
 
@@ -95,3 +102,7 @@ overridden in the AWS console.
 
 For the most up-to-date information about the Amazon RDS deprecation policy for PostgreSQL, see
 [Amazon RDS FAQs](http://aws.amazon.com/rds/faqs/).
+
+On the RDS end of standard support date, Amazon RDS automatically enrolls your databases in RDS Extended Support.
+RDS Extended Support is a  paid offering available for up to 3 years past the RDS end of standard support date for a major engine version, see
+[Using Amazon RDS Extended Support](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/extended-support.html).


### PR DESCRIPTION
Amazon is providing paid Extended Support for RDS engines MySQL and PostgreSQL, see [Extended Support Overview](
https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/extended-support-overview.html).

So I tried to reflect this feature on the corresponding eol pages.

Cheers 🍰 