### PR TITLE
[debian] update eol for 11

### DIFF
--- a/products/debian.md
+++ b/products/debian.md
@@ -43,9 +43,9 @@ releases:
 -   releaseCycle: "11"
     codename: "Bullseye"
     releaseDate: 2021-08-14
-    eol: 2024-08-31
+    eol: 2024-08-14
     eoes: 2026-08-31
-    link: https://www.debian.org/News/2024/2024062902
+    link: https://lists.debian.org/debian-release/2024/06/msg00700.html
     latest: "11.10"
     latestReleaseDate: 2024-06-29
 


### PR DESCRIPTION
Amended Bullseye release date - also added URL reference having updated wiki.debian.org

End of security support is 2024-08-14 two years after release.

Beginning of LTS will be 2024-08-31

Final point release of 11.11 is scheduled for 2024-08-31

URL is release manager confirming dates on debian-release mailing list - debian-release@lists.debian.org