### PR TITLE
[gke] Document channel information

### DIFF
--- a/products/gke.md
+++ b/products/gke.md
@@ -117,7 +117,7 @@ releases:
 > Kubernetes service from Google.
 
 {: .warning }
-> This page is using release information from the _No Channel (Static)_ channel.
+> This page uses release information from the _No Channel (Static)_ channel.
 > Releases only present in the _Rapid_ channel are not considered stable because they are excluded from
 > [GKE SLA](https://cloud.google.com/kubernetes-engine/sla).
 

--- a/products/gke.md
+++ b/products/gke.md
@@ -116,6 +116,11 @@ releases:
 > [Google Kubernetes Engine](https://cloud.google.com/kubernetes-engine) is the fully managed
 > Kubernetes service from Google.
 
+{: .warning }
+> This page is using release information from the _No Channel (Static)_ channel.
+> Releases from the _Rapid_ channel are not considered stable because they are excluded from
+> [GKE SLA](https://cloud.google.com/kubernetes-engine/sla).
+
 GKE offers two modes of operations:
 [Standard and Autopilot](https://cloud.google.com/kubernetes-engine/docs/concepts/autopilot-overview#comparison "Comparing Autopilot and Standard modes at GKE Docs"):
 
@@ -150,8 +155,6 @@ release will match the above, regardless.
 Clusters with a static GKE version are not enrolled in a release channel. Users are responsible for
 managing their upgrade strategy in this case. They must still adhere to the Kubernetes version and
 version skew support policy, and use supported GKE versions.
-
-This is the reference used to obtain the release information displayed on this page.
 
 Google may automatically [upgrade your nodes for security and compatibility purposes](https://cloud.google.com/kubernetes-engine/upgrades#automatic_node_upgrades_for_security_and_compatibility "Requirements for GKE force upgrades")
 in select cases.

--- a/products/gke.md
+++ b/products/gke.md
@@ -151,6 +151,8 @@ Clusters with a static GKE version are not enrolled in a release channel. Users 
 managing their upgrade strategy in this case. They must still adhere to the Kubernetes version and
 version skew support policy, and use supported GKE versions.
 
+This is the reference used to obtain the release information displayed on this page.
+
 Google may automatically [upgrade your nodes for security and compatibility purposes](https://cloud.google.com/kubernetes-engine/upgrades#automatic_node_upgrades_for_security_and_compatibility "Requirements for GKE force upgrades")
 in select cases.
 

--- a/products/gke.md
+++ b/products/gke.md
@@ -118,7 +118,7 @@ releases:
 
 {: .warning }
 > This page is using release information from the _No Channel (Static)_ channel.
-> Releases from the _Rapid_ channel are not considered stable because they are excluded from
+> Releases only present in the _Rapid_ channel are not considered stable because they are excluded from
 > [GKE SLA](https://cloud.google.com/kubernetes-engine/sla).
 
 GKE offers two modes of operations:


### PR DESCRIPTION
Hello this fixes #5353 by documenting which source (static) is used to get GKE release information.