### PR TITLE
[centos] add comment about website status

### DIFF
--- a/products/centos.md
+++ b/products/centos.md
@@ -44,7 +44,7 @@ releases:
 
 ---
 
-> [CentOS Linux](https://centos.org/centos-linux/) was a Linux distribution that provided a free,
+> [CentOS Linux](https://centos.org/centos-linux/) (archived copy) was a Linux distribution that provided a free,
 > enterprise-class, community-supported computing platform functionally compatible with Red Hat
 > Enterprise Linux.
 


### PR DESCRIPTION
Made it clear that the CentOS Linux website is no longer live and updated by adding (archived copy)