### PR TITLE
[unity]: Update latest for Unity 6 and 2022.3

### DIFF
--- a/products/unity.md
+++ b/products/unity.md
@@ -19,8 +19,8 @@ releases:
 -   releaseCycle: "6"
     releaseDate: 2024-04-29
     eol: false
-    latest: "6000.0.11f1"
-    latestReleaseDate: 2024-07-17
+    latest: "6000.0.12f1"
+    latestReleaseDate: 2024-07-25
 
 -   releaseCycle: "2023.2"
     releaseDate: 2023-11-14
@@ -38,8 +38,8 @@ releases:
     lts: true
     releaseDate: 2023-05-30
     eol: false
-    latest: "2022.3.38f1"
-    latestReleaseDate: 2024-07-16
+    latest: "2022.3.40f1"
+    latestReleaseDate: 2024-07-30
 
 -   releaseCycle: "2022.2"
     releaseDate: 2022-12-07

--- a/products/unity.md
+++ b/products/unity.md
@@ -24,7 +24,7 @@ releases:
 
 -   releaseCycle: "2023.2"
     releaseDate: 2023-11-14
-    eol: false
+    eol: 2024-04-29
     latest: "2023.2.20f1"
     latestReleaseDate: 2024-04-25
 


### PR DESCRIPTION
Update latest for Unity 6 and 2022.3

I suggest to add end of security support for 2023.2, since now there is Unity 6 and there is no update for this release cycle since April.

What do you think?