### PR TITLE
[NetBSD] Add automation

### DIFF
--- a/products/netbsd.md
+++ b/products/netbsd.md
@@ -10,6 +10,17 @@ changelogTemplate: https://www.netbsd.org/releases/formal-__RELEASE_CYCLE__/NetB
 releaseDateColumn: true
 eoasColumn: true
 
+auto:
+  methods:
+  -   release_table: https://www.netbsd.org/releases/formal.html
+      selector: ".informaltable table"
+      fields:
+        releaseCycle:
+          column: "Version"
+          regex: '^NetBSD\s+(?P<value>\d+\.\d+\.?\d{0,2}).*$'
+        releaseDate: "Released"
+        eol: "End of support"
+
 # eoas(x) = releaseDate(x+1)
 # For eol see https://www.netbsd.org/releases/formal.html
 releases:


### PR DESCRIPTION
Added automation for NetBSD by using the `release_table` method.
Reference to this endoflife-date/release-data/issues/343 issue.
<details>
  <summary>Sample of generated data</summary>

```json
{
  "releases": {
    "9.4": {
      "name": "9.4",
      "releaseDate": "2024-04-20"
    },
    "9.3": {
      "name": "9.3",
      "releaseDate": "2022-08-04"
    },
    "9.2": {
      "name": "9.2",
      "releaseDate": "2021-05-12"
    },
    "9.1": {
      "name": "9.1",
      "releaseDate": "2020-10-18"
    },
    "9.0": {
      "name": "9.0",
      "releaseDate": "2020-02-14"
    },
    "8.3": {
      "name": "8.3",
      "releaseDate": "2024-05-04",
      "eol": "2024-05-04"
    },
# ...
  }
}
```
</details>