### PR TITLE
[panos] Update PAN-OS version 10.0.12-h5 to 10.0.12-h6 and 10.2.10-h2 to 10.2.10-h3

### DIFF
--- a/products/pan-os.md
+++ b/products/pan-os.md
@@ -49,9 +49,9 @@ releases:
 -   releaseCycle: "10.2"
     releaseDate: 2022-02-27
     eol: 2025-08-27
-    latest: "10.2.10-h2"
-    latestReleaseDate: 2024-07-16
-    link: https://docs.paloaltonetworks.com/pan-os/10-2/pan-os-release-notes/pan-os-10-2-10-known-and-addressed-issues/pan-os-10-2-10-h2-addressed-issues
+    latest: "10.2.10-h3"
+    latestReleaseDate: 2024-07-31
+    link: https://docs.paloaltonetworks.com/pan-os/10-2/pan-os-release-notes/pan-os-10-2-10-known-and-addressed-issues/pan-os-10-2-10-h3-addressed-issues
 
 -   releaseCycle: "10.1"
     releaseDate: 2021-05-31

--- a/products/pan-os.md
+++ b/products/pan-os.md
@@ -63,9 +63,9 @@ releases:
 -   releaseCycle: "10.0"
     releaseDate: 2020-07-16
     eol: 2022-07-16
-    latest: "10.0.12-h5"
-    latestReleaseDate: 2023-12-18
-    link: https://docs.paloaltonetworks.com/pan-os/10-0/pan-os-release-notes/pan-os-10-0-addressed-issues/pan-os-10-0-12-h5-addressed-issues
+    latest: "10.0.12-h6"
+    latestReleaseDate: 2024-05-29
+    link: https://docs.paloaltonetworks.com/pan-os/10-0/pan-os-release-notes/pan-os-10-0-addressed-issues/pan-os-10-0-12-h6-addressed-issues
 
 -   releaseCycle: "9.1"
     releaseDate: 2019-12-13


### PR DESCRIPTION
[panos] This PR updates the PAN-OS versions and their release dates.
 Pan-OS Version: 10.0.12-h6
 Released: 2024-05-29
 Pan-OS Version 10.2.10-h3
 Released: 2024-07-31
