### PR TITLE
[openssl] Update links

### DIFF
--- a/products/openssl.md
+++ b/products/openssl.md
@@ -4,8 +4,8 @@ category: framework
 iconSlug: openssl
 permalink: /openssl
 versionCommand: openssl version
-releasePolicyLink: https://www.openssl.org/policies/releasestrat.html
-changelogTemplate: "https://www.openssl.org/news/cl{{'__RELEASE_CYCLE__'|replace:'.',''}}.txt"
+releasePolicyLink: https://openssl-library.org/policies/releasestrat/index.html
+changelogTemplate: https://openssl-library.org/news/openssl-__RELEASE_CYCLE__-notes/index.html
 releaseDateColumn: true
 eolColumn: Supported
 eoesColumn: Premium support
@@ -75,7 +75,7 @@ releases:
 
 ---
 
-> [OpenSSL](https://www.openssl.org/) is a software library for applications that secure
+> [OpenSSL](https://openssl-library.org/) is a software library for applications that secure
 > communications over computer networks against eavesdropping or need to identify the party at the
 > other end. It is widely used by Internet servers, including the majority of HTTPS websites.
 
@@ -101,6 +101,6 @@ combination.
   functions in these releases.
 
 In addition to community support, the _OpenSSL Software Services_ provide commercial extended
-support through the [Premium Enterprise Level Support contract](https://www.openssl.org/support/contracts.html#premium).
+support through the [Premium Enterprise Level Support contract](https://openssl-corporation.org/support/#premium).
 With this contract, LTS releases remain supported beyond the public EOL date for as long as it
 remains commercially viable for OpenSSL Software Services.

--- a/products/openssl.md
+++ b/products/openssl.md
@@ -55,14 +55,14 @@ releases:
     eoes: false
     latest: "1.1.1w"
     latestReleaseDate: 2023-09-12
-    link: https://www.openssl.org/news/changelog.txt
+    link: https://openssl-library.org/news/vulnerabilities-1.1.1/
 
 -   releaseCycle: "1.1.0"
     releaseDate: 2016-08-25
     eol: 2019-09-11
     latest: "1.1.0l"
     latestReleaseDate: 2019-09-10
-    link: https://www.openssl.org/news/changelog.txt
+    link: https://openssl-library.org/news/vulnerabilities-1.1.0/
 
 -   releaseCycle: "1.0.2"
     lts: true
@@ -71,7 +71,8 @@ releases:
     eoes: false
     latest: "1.0.2u"
     latestReleaseDate: 2019-12-20
-    link: https://www.openssl.org/news/changelog.txt
+    link: https://openssl-library.org/news/vulnerabilities-1.0.2/
+    
 
 ---
 


### PR DESCRIPTION
https://www.openssl.org/ has been moved to https://openssl-library.org/.