### PR TITLE
[red-hat-satellite] Update 6.0 and 6.1 links

### DIFF
--- a/products/red-hat-satellite.md
+++ b/products/red-hat-satellite.md
@@ -129,6 +129,7 @@ releases:
     eol: 2018-10-30
     latest: "6.1.12"
     latestReleaseDate: 2017-06-29
+    link: https://web.archive.org/web/20190719230423/https://access.redhat.com/documentation/en-us/red_hat_satellite/6.1/html/release_notes/index
 
 -   releaseCycle: "6.0"
     releaseDate: 2014-09-10
@@ -136,6 +137,7 @@ releases:
     eol: 2018-02-21
     latest: "6.0.8"
     latestReleaseDate: 2015-02-20
+    link: https://web.archive.org/web/20190719183026/https://access.redhat.com/documentation/en-us/red_hat_satellite/6.0/html/release_notes/index
 
 ---
 


### PR DESCRIPTION
Those are not available anymore on https://access.redhat.com.