### PR TITLE
Fix PAN-OS

### DIFF
--- a/products/pan-os.md
+++ b/products/pan-os.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: Palo Alto Networks PAN-OS
 category: os
 tags: palo-alto-networks
@@ -28,9 +28,9 @@ releases:
 -   releaseCycle: "11.2"
     releaseDate: 2024-05-02
     eol: 2027-05-02
-    latest: "11.2.2-h1"
-    latestReleaseDate: 2024-08-02
-    link: https://docs.paloaltonetworks.com/pan-os/11-2/pan-os-release-notes/pan-os-11-2-2-known-and-addressed-issues/pan-os-11-2-2-h1-addressed-issues
+    latest: "11.2.2"
+    latestReleaseDate: 2024-07-30
+    link: https://docs.paloaltonetworks.com/pan-os/11-2/pan-os-release-notes/pan-os-11-2-2-known-and-addressed-issues/pan-os-11-2-2-addressed-issues
 
 -   releaseCycle: "11.1"
     releaseDate: 2023-11-03

--- a/products/pan-os.md
+++ b/products/pan-os.md
@@ -28,9 +28,9 @@ releases:
 -   releaseCycle: "11.2"
     releaseDate: 2024-05-02
     eol: 2027-05-02
-    latest: "11.2.2"
-    latestReleaseDate: 2024-07-30
-    link: https://docs.paloaltonetworks.com/pan-os/11-2/pan-os-release-notes/pan-os-11-2-2-known-and-addressed-issues/pan-os-11-2-2-addressed-issues
+    latest: "11.2.2-h1"
+    latestReleaseDate: 2024-08-02
+    link: https://docs.paloaltonetworks.com/pan-os/11-2/pan-os-release-notes/pan-os-11-2-2-known-and-addressed-issues/pan-os-11-2-2-h1-addressed-issues
 
 -   releaseCycle: "11.1"
     releaseDate: 2023-11-03


### PR DESCRIPTION
The PAN-OS web page is no longer viewable due to the fix in https://github.com/endoflife-date/endoflife.date/pull/5605.

Accessing it results in a 404 error.
https://endoflife.date/panos
<img width="418" alt="スクリーンショット 2024-08-06 15 22 00" src="https://github.com/user-attachments/assets/5231f1db-1da9-416e-b89e-c6b89b361fd1">

Format is broken.
https://github.com/endoflife-date/endoflife.date/blob/be4d9f0c7bca0f029240982219fcf5d37cf8e999/products/pan-os.md
<img width="1201" alt="スクリーンショット 2024-08-06 15 21 23" src="https://github.com/user-attachments/assets/1f83373a-487e-451d-9151-b668f5dd6fdd">

The fix has been reverted and the appropriate fix has been recommitted.