### PR TITLE
New product: CouchDB

### DIFF
--- a/products/apache-couchdb.md
+++ b/products/apache-couchdb.md
@@ -1,6 +1,7 @@
 ---
 title: CouchDB
 category: database
+iconSlug: apachecouchdb
 permalink: /apache-couchdb
 alternate_urls:
 -   /couchdb
@@ -13,7 +14,7 @@ auto:
 
 identifiers:
 -   purl: pkg:github/apache/couchdb
--   purl: pkg:docker/couchdb
+-   purl: pkg:docker/apache/couchdb
 -   repology: couchdb
 
 # eol(x) = releaseDate(x+2)

--- a/products/apache-couchdb.md
+++ b/products/apache-couchdb.md
@@ -38,7 +38,7 @@ releases:
 
 ---
 
-> Apache CouchDB is an open-source, document-oriented NoSQL database implemented
+> [Apache CouchDB](https://couchdb.apache.org/) is an open-source, document-oriented NoSQL database implemented
 > in Erlang. CouchDB uses various formats and protocols to store, transfer, and
 > process data, with JSON as its primary data storage format.
 

--- a/products/apache-couchdb.md
+++ b/products/apache-couchdb.md
@@ -1,0 +1,41 @@
+---
+title: CouchDB
+category: database
+permalink: /apache-couchdb
+alternate_urls:
+-   /couchdb
+changelogTemplate: "https://docs.couchdb.org/en/stable/whatsnew/{{'__LATEST__'|split:'.'|slice:':2'|join:'.'}}.html#version-{{'__LATEST__'|replace:'.','-'}}"
+releaseDateColumn: true
+
+auto:
+  methods:
+  -   git: https://github.com/apache/couchdb.git
+
+identifiers:
+-   purl: pkg:github/apache/couchdb
+-   purl: pkg:docker/couchdb
+-   repology: couchdb
+
+# eol(x) = releaseDate(x+2)
+releases:
+-   releaseCycle: "3.3"
+    releaseDate: 2022-12-28
+    eol: false
+    latest: "3.3.3"
+    latestReleaseDate: 2023-12-04
+
+-   releaseCycle: "3.2"
+    releaseDate: 2021-10-08
+    eol: false
+    latest: "3.2.3"
+    latestReleaseDate: 2023-04-25
+
+---
+
+> Apache CouchDB is an open-source, document-oriented NoSQL database implemented
+> in Erlang. CouchDB uses various formats and protocols to store, transfer, and
+> process data, with JSON as its primary data storage format.
+
+CouchDB maintains the two most recent releases for CVEs. Older versions are
+not supported, but they may publish further backports at their discretion. See:
+[Security issues / CVEs](https://github.com/apache/couchdb/blob/main/src/docs/src/cve/index.rst#security-issues--cves).

--- a/products/apache-couchdb.md
+++ b/products/apache-couchdb.md
@@ -1,6 +1,7 @@
 ---
 title: CouchDB
 category: database
+tags: apache erlang-runtime
 iconSlug: apachecouchdb
 permalink: /apache-couchdb
 alternate_urls:

--- a/products/apache-couchdb.md
+++ b/products/apache-couchdb.md
@@ -1,5 +1,5 @@
 ---
-title: CouchDB
+title: Apache CouchDB
 category: database
 tags: apache erlang-runtime
 iconSlug: apachecouchdb

--- a/products/apache-couchdb.md
+++ b/products/apache-couchdb.md
@@ -44,5 +44,4 @@ releases:
 > process data, with JSON as its primary data storage format.
 
 CouchDB maintains the two most recent releases for CVEs. Older versions are
-not supported, but they may publish further backports at their discretion. See:
-[Security issues / CVEs](https://github.com/apache/couchdb/blob/main/src/docs/src/cve/index.rst#security-issues--cves).
+not supported, but they may publish further backports at their discretion.

--- a/products/apache-couchdb.md
+++ b/products/apache-couchdb.md
@@ -5,7 +5,9 @@ iconSlug: apachecouchdb
 permalink: /apache-couchdb
 alternate_urls:
 -   /couchdb
+releasePolicyLink: https://docs.couchdb.org/en/latest/cve/index.html#security-issues-cves
 changelogTemplate: "https://docs.couchdb.org/en/stable/whatsnew/{{'__LATEST__'|split:'.'|slice:':2'|join:'.'}}.html#version-{{'__LATEST__'|replace:'.','-'}}"
+versionCommand: curl http://localhost:5984/_config/vendor/version
 releaseDateColumn: true
 
 auto:

--- a/products/apache-couchdb.md
+++ b/products/apache-couchdb.md
@@ -17,6 +17,9 @@ auto:
 identifiers:
 -   purl: pkg:github/apache/couchdb
 -   purl: pkg:docker/apache/couchdb
+-   purl: pkg:docker/library/couchdb
+-   purl: pkg:docker/bitnami/couchdb
+-   purl: pkg:docker/rapidfort/couchdb
 -   repology: couchdb
 
 # eol(x) = releaseDate(x+2)


### PR DESCRIPTION
Create new product for CouchDB.  Upstream maintains two versions at a given time (latest and -1). If helpful, I did query [what versions were supported,](https://github.com/apache/couchdb/issues/5159) and as a result got their docs updated. We're using that docs link in the product registration in this PR.