### PR TITLE
[pci-dss] Minor updates for 3.2.1 EOL

### DIFF
--- a/products/pci-dss.md
+++ b/products/pci-dss.md
@@ -36,18 +36,19 @@ releases:
 
 ---
 
-> [PCI-DSS](https://www.pcisecuritystandards.org) is an information security standard for
+> [PCI DSS](https://www.pcisecuritystandards.org) is an information security standard for
 > organizations that handle branded credit cards from the major card schemes.
 
-- PCI DSS v3.2.1 will remain active till March 2024. This provides organizations time to become
-  familiar with the new version, and plan for and implement the changes needed. A
-  [summary of changes](https://docs-prv.pcisecuritystandards.org/PCI%20DSS/Standard/PCI-DSS-v3-2-1-to-v4-0-Summary-of-Changes-r1.pdf)
-  from v3.2.1 to v4.0 is available.
+{: .note }
+> The period for which an entity's PCI DSS assessment result is valid does not change
+> if the standard against which the entity was assessed has been retired[^1].
 
 - Future-dated new requirements introduced in v4.0 will become effective on 31st March 2025.
-
-- PCI DSS 3.2 remained valid till 31 December 2018 and was retired on 1 January 2019.
-
-- PCI DSS [3.1 retired on 31 October 2016](https://listings.pcisecuritystandards.org/pdfs/PCI_DSS_Resource_Guide_%28003%29.pdf).
-  The new requirements introduced in PCI DSS 3.2 were considered best practices until 31 January 2018.
+- PCI DSS v3.2.1 was retired on 31st March 2024. Changes from v3.2.1 to v4 are documented in the
+[Summary of Changes](https://docs-prv.pcisecuritystandards.org/PCI%20DSS/Standard/PCI-DSS-v3-2-1-to-v4-0-Summary-of-Changes-r2.pdf)
+- PCI DSS v3.2 remained valid till 31 December 2018 and was retired on 1 January 2019.
+- PCI DSS [v3.1 retired on 31 October 2016](https://listings.pcisecuritystandards.org/pdfs/PCI_DSS_Resource_Guide_%28003%29.pdf).
+  The new requirements introduced in PCI DSS v3.2 were considered best practices until 31 January 2018.
   Starting 1 February 2018 they are effective as requirements and must be used.
+
+[^1]: https://www.pcisecuritystandards.org/faq/articles/Frequently_Asked_Question/Does-an-entity-s-PCI-DSS-assessment-result-expire-when-the-standard-against-which-the-entity-was-assessed-is-retired/


### PR DESCRIPTION
Updates to mark 3.2.1 EOL in the past.

Resolves https://github.com/endoflife-date/endoflife.date/issues/5623. Other changes:

- Use PCI DSS instead of PCI-DSS in text
- Add a note about assessment validity post retirement
- Change link for summary to https://docs-prv.pcisecuritystandards.org/PCI%20DSS/Standard/PCI-DSS-v3-2-1-to-v4-0-Summary-of-Changes-r2.pdf, which gives options for both `3.2.1->4.0`, as well as `4.0->4.0.1`.
- Use `v` as the prefix for all places where versions are mentioned - match what the official website uses.