### PR TITLE
[coder]: fix eol and eoas for 2.12

### DIFF
--- a/products/coder.md
+++ b/products/coder.md
@@ -38,8 +38,8 @@ releases:
 
 -   releaseCycle: "2.12"
     releaseDate: 2024-06-04
-    eoas: false # releaseDate 2.14
-    eol: false # releaseDate 2.15
+    eoas: 2024-08-06 # releaseDate 2.14
+    eol: 2024-09-03 # releaseDate 2.15
     latest: "2.12.6"
     latestReleaseDate: 2024-08-01
 


### PR DESCRIPTION
After 2.14 is releases 2.12 is no more in active support and will be eol on 2.15 release as per release calendar. 