### PR TITLE
Update the latest releases of JBoss 7 and 8

### DIFF
--- a/products/red-hat-jboss-eap.md
+++ b/products/red-hat-jboss-eap.md
@@ -10,7 +10,7 @@ alternate_urls:
 -   /red-hat-jboss-eap
 versionCommand: $JBOSS_HOME/bin/version.sh
 releasePolicyLink: https://access.redhat.com/support/policy/updates/jboss_notes
-changelogTemplate: "https://access.redhat.com/documentation/en-us/red_hat_jboss_enterprise_application_platform/{{'__LATEST__'|split:'.'|pop|join:'.'}}"
+changelogTemplate: "https://access.redhat.com/documentation/en-us/red_hat_jboss_enterprise_application_platform/{{'__LATEST__'|split:'.'|slice:0,2|join:'.'}}"
 releaseDateColumn: true
 eoasColumn: Full Support
 eolColumn: Maintenance Support

--- a/products/red-hat-jboss-eap.md
+++ b/products/red-hat-jboss-eap.md
@@ -25,16 +25,16 @@ releases:
     eoas: 2028-02-05
     eol: 2031-02-05
     eoes: 2033-02-05
-    latest: "8.0.0"
-    latestReleaseDate: 2024-02-05
+    latest: "8.0.2.1"
+    latestReleaseDate: 2024-07-08
 
 -   releaseCycle: "7"
     releaseDate: 2016-05-01
     eoas: 2023-12-31
     eol: 2025-06-30
     eoes: 2026-11-30
-    latest: "7.4.16"
-    latestReleaseDate: 2024-04-04
+    latest: "7.4.18"
+    latestReleaseDate: 2024-08-08
 
 -   releaseCycle: "6"
     releaseDate: 2012-06-01


### PR DESCRIPTION
Update the latest releases of JBoss 7 and 8 and fix the changelog template function to work when release numbers have more than 3 components (eg. "8.0.2.1")

* JBoss 8.0.2.1 release notes: https://access.redhat.com/articles/7073035
* JBoss 7.4.18 release notes: https://access.redhat.com/articles/7073034
* JBoss 8 patches:
https://access.redhat.com/jbossnetwork/restricted/listSoftware.html?downloadType=patches&product=appplatform&version=8.0
* JBoss 7 patches: https://access.redhat.com/jbossnetwork/restricted/listSoftware.html?downloadType=patches&product=appplatform&version=7.4