### PR TITLE
Add Rails 7.2, explain new EOL policy, and update EOL dates

### DIFF
--- a/products/ruby-on-rails.md
+++ b/products/ruby-on-rails.md
@@ -42,7 +42,7 @@ releases:
 -   releaseCycle: "7.0"
     releaseDate: 2021-12-15
     eoas: 2023-10-15
-    eol: 2025-04-01
+    eol: 2025-04-01 # see https://rubyonrails.org/maintenance
     latest: "7.0.8.4"
     latestReleaseDate: 2024-06-04
 

--- a/products/ruby-on-rails.md
+++ b/products/ruby-on-rails.md
@@ -9,7 +9,7 @@ alternate_urls:
 -   /ruby-on-rails
 -   /roro
 -   /ror
-releasePolicyLink: https://guides.rubyonrails.org/maintenance_policy.html
+releasePolicyLink: https://rubyonrails.org/maintenance
 changelogTemplate: https://github.com/rails/rails/releases/tag/v__LATEST__
 releaseDateColumn: true
 eolColumn: Security Support
@@ -35,7 +35,7 @@ releases:
 
 -   releaseCycle: "7.1"
     releaseDate: 2023-10-05
-    eoas: 2024-08-09
+    eoas: 2024-10-01
     eol: 2025-10-01 # see https://rubyonrails.org/maintenance
     latest: "7.1.3.4"
     latestReleaseDate: 2024-06-04
@@ -94,7 +94,7 @@ releases:
 >[Ruby on Rails](https://rubyonrails.org/), or Rails, is a server-side web application framework
 > written in Ruby.
 
-Each minor release cycle (7.2, 8.0, etc.) is officially supported based on a fixed, yearly duration: 1 year for bug fixes and 2 years for security fixes. For example, if a theoretical 1.1.0 is released on January 1, 2023, it will receive bug and security fixes until January 1, 2024 (1 year), and then receive security fixes only until January 1, 2025 (2 years). After that, it will reach its end-of-life.
+Starting with 7.2, each release cycle (7.2, 8.0, etc.) is officially supported based on a fixed, yearly duration: 1 year for bug fixes and 2 years for security fixes. For example, if a theoretical 1.1.0 is released on January 1, 2023, it will receive bug and security fixes until January 1, 2024 (1 year), and then receive security fixes only until January 1, 2025 (2 years). After that, it will reach its end-of-life.
 
 A complete list of historic versions is available on [RubyGems](https://rubygems.org/gems/rails/versions).
 New releases are published on the [Rails blog](https://rubyonrails.org/category/releases).

--- a/products/ruby-on-rails.md
+++ b/products/ruby-on-rails.md
@@ -11,7 +11,10 @@ alternate_urls:
 -   /ror
 releasePolicyLink: https://guides.rubyonrails.org/maintenance_policy.html
 changelogTemplate: https://github.com/rails/rails/releases/tag/v__LATEST__
+
 releaseDateColumn: true
+eolColumn: Security Support
+eoasColumn: Active Support
 
 identifiers:
   - repology: ruby:rails
@@ -23,21 +26,31 @@ auto:
   -   git: https://github.com/rails/rails.git
 
 releases:
+-   releaseCycle: "7.2"
+    releaseDate: 2024-08-09
+    eoas: 2025-08-09
+    eol: 2026-08-09
+    latest: "7.2.0"
+    latestReleaseDate: 2024-08-09
+
 -   releaseCycle: "7.1"
     releaseDate: 2023-10-05
-    eol: false
+    eoas: 2024-08-09
+    eol: 2025-10-01
     latest: "7.1.3.4"
     latestReleaseDate: 2024-06-04
 
 -   releaseCycle: "7.0"
     releaseDate: 2021-12-15
-    eol: false
+    eoas: 2023-10-15
+    eol: 2025-04-01
     latest: "7.0.8.4"
     latestReleaseDate: 2024-06-04
 
 -   releaseCycle: "6.1"
     releaseDate: 2020-12-09
-    eol: false
+    eoas: 2021-12-15
+    eol: 2024-10-01
     latest: "6.1.7.8"
     latestReleaseDate: 2024-06-04
 
@@ -81,10 +94,7 @@ releases:
 >[Ruby on Rails](https://rubyonrails.org/), or Rails, is a server-side web application framework
 > written in Ruby.
 
-Only the latest Rails version gets bug fixes, and the version before that gets security fixes.
-Severe security issues (as judged by the core team) are backported further; e.g., v5.2.8.1 is a
-[severe security fix](https://rubyonrails.org/2022/7/12/Rails-Versions-7-0-3-1-6-1-6-1-6-0-5-1-and-5-2-8-1-have-been-released)
-that was created after v5.2 was no longer receiving (non-severe) security updates.
+Each minor release cycle (7.2, 8.0, etc.) is officially supported based on a fixed, yearly duration: 1 year for bug fixes and 2 years for security fixes. For example, if a theoretical 1.1.0 is released on January 1, 2023, it will receive bug and security fixes until January 1, 2024 (1 year), and then receive security fixes only until January 1, 2025 (2 years). After that, it will reach its end-of-life.
 
 A complete list of historic versions is available on [RubyGems](https://rubygems.org/gems/rails/versions).
 New releases are published on the [Rails blog](https://rubyonrails.org/category/releases).

--- a/products/ruby-on-rails.md
+++ b/products/ruby-on-rails.md
@@ -35,7 +35,7 @@ releases:
 -   releaseCycle: "7.1"
     releaseDate: 2023-10-05
     eoas: 2024-08-09
-    eol: 2025-10-01
+    eol: 2025-10-01 # see https://rubyonrails.org/maintenance
     latest: "7.1.3.4"
     latestReleaseDate: 2024-06-04
 

--- a/products/ruby-on-rails.md
+++ b/products/ruby-on-rails.md
@@ -94,7 +94,7 @@ releases:
 >[Ruby on Rails](https://rubyonrails.org/), or Rails, is a server-side web application framework
 > written in Ruby.
 
-Starting with 7.2, each release cycle (7.2, 8.0, etc.) is officially supported based on a fixed, yearly duration: 1 year for bug fixes and 2 years for security fixes. For example, if a theoretical 1.1.0 is released on January 1, 2023, it will receive bug and security fixes until January 1, 2024 (1 year), and then receive security fixes only until January 1, 2025 (2 years). After that, it will reach its end-of-life.
+[Starting with 7.2](https://github.com/rails/rails/pull/52471#issuecomment-2271508281), each minor release (7.2, 8.0, etc.) is officially supported based on a fixed, yearly duration: 1 year for bug fixes and 2 years for security fixes. For example, if a theoretical 1.1.0 is released on January 1, 2023, it will receive bug and security fixes until January 1, 2024 (1 year), and then receive security fixes only until January 1, 2025 (2 years). After that, it will reach its end-of-life.
 
 A complete list of historic versions is available on [RubyGems](https://rubygems.org/gems/rails/versions).
 New releases are published on the [Rails blog](https://rubyonrails.org/category/releases).

--- a/products/ruby-on-rails.md
+++ b/products/ruby-on-rails.md
@@ -24,6 +24,7 @@ auto:
   methods:
   -   git: https://github.com/rails/rails.git
 
+# Some dates can be found on https://rubyonrails.org/maintenance.
 releases:
 -   releaseCycle: "7.2"
     releaseDate: 2024-08-09

--- a/products/ruby-on-rails.md
+++ b/products/ruby-on-rails.md
@@ -11,7 +11,6 @@ alternate_urls:
 -   /ror
 releasePolicyLink: https://guides.rubyonrails.org/maintenance_policy.html
 changelogTemplate: https://github.com/rails/rails/releases/tag/v__LATEST__
-
 releaseDateColumn: true
 eolColumn: Security Support
 eoasColumn: Active Support

--- a/products/ruby-on-rails.md
+++ b/products/ruby-on-rails.md
@@ -49,7 +49,7 @@ releases:
 -   releaseCycle: "6.1"
     releaseDate: 2020-12-09
     eoas: 2021-12-15
-    eol: 2024-10-01
+    eol: 2024-10-01 # see https://rubyonrails.org/maintenance
     latest: "6.1.7.8"
     latestReleaseDate: 2024-06-04
 


### PR DESCRIPTION
This PR adds Rails 7.2 and updates the active-support and eol dates for 7.2 and prior releases.

With the release of Rails 7.2, the Rails team has updated its maintenance policy. To summarize the new policy:

> Releases are maintained by a pre-defined, fixed period of time. One year for bug fixes and two years for security fixes.

Ref: https://github.com/rails/rails/pull/52471

This new policy applies to new releases starting with Rails 7.2. For older releases, the EOL dates have been clarified as follows:

> 6.1 will reach end-of-life in October 2024.
> For 7.0, it will be April 2025
> For 7.1, it will be October 2025.

Ref: https://github.com/rails/rails/pull/52471#issuecomment-2271622034

Preview:

_Edit: new screenshot with updated dates as of c34d8288_

![Screenshot 2024-08-11 at 7 57 12 AM](https://github.com/user-attachments/assets/3724845b-f645-48f6-9491-c3cb244a5ba8)