### PR TITLE
[apache-subversion] Suppress 1.0 link

### DIFF
--- a/products/apache-subversion.md
+++ b/products/apache-subversion.md
@@ -124,6 +124,7 @@ releases:
     eol: true
     latest: "1.0.9"
     latestReleaseDate: 2004-10-13
+    link: null
 
 ---
 


### PR DESCRIPTION
There are not release notes for 1.0, see https://subversion.apache.org/docs/release-notes/.