### PR TITLE
[windows-server-core] Add 2008 and 2012 builds

### DIFF
--- a/products/windows-server-core.md
+++ b/products/windows-server-core.md
@@ -94,9 +94,45 @@ releases:
     latest: 10.0.14393
     link: https://learn.microsoft.com/virtualization/windowscontainers/deploy-containers/base-image-lifecycle
 
+-   releaseCycle: "2012-R2"
+    releaseDate: 2013-11-25
+    lts: true
+    eoas: 2018-10-09
+    eol: 2023-10-10
+    eoes: 2026-10-13
+    latest: 6.3.9600
+    link: https://learn.microsoft.com/lifecycle/products/windows-server-2012-r2
+
+-   releaseCycle: "2012"
+    lts: true
+    releaseDate: 2012-10-30
+    eoas: 2018-10-09
+    eol: 2023-10-10
+    eoes: 2026-10-13
+    latest: 6.2.9200
+    link: https://learn.microsoft.com/lifecycle/products/windows-server-2012
+
+-   releaseCycle: "2008-R2-SP1"
+    releaseDate: 2011-02-22
+    lts: true
+    eoas: 2015-01-13
+    eol: 2020-01-14
+    eoes: 2023-01-10
+    latest: 6.1.7601
+    link: https://learn.microsoft.com/lifecycle/products/windows-server-2008-r2
+
+-   releaseCycle: "2008-SP2"
+    releaseDate: 2009-04-29
+    lts: true
+    eoas: 2015-01-13
+    eol: 2020-01-14
+    eoes: 2023-01-10
+    latest: 6.0.6003
+    link: https://learn.microsoft.com/lifecycle/products/windows-server-2008
+
 ---
 
 > Windows Server Core is a minimal installation option of Windows Server offering a smaller disc footprint with a smaller attack surface.
-> It's also offered as Windows container base image.
+> It's also offered as Windows container base image starting with 2016 (1607).
 
 See [Windows Server Servicing channels](/windows-server#servicing-channels) for information on the servicing channels.


### PR DESCRIPTION
In #5323 I missed the 2008 and 2012 variants as they were not listed on https://learn.microsoft.com/virtualization/windowscontainers/deploy-containers/base-image-lifecycle

On those 2 releases (with the R2 variants), it only existed as build option but not as container image. They share the lifecycle / EoS dates of the `windows-server` variant.

See the following links to prove their existance:
* https://learn.microsoft.com/en-us/previous-versions/windows/desktop/legacy/ee391645(v=vs.85)
* https://learn.microsoft.com/en-us/previous-versions/windows/desktop/legacy/ee391631(v=vs.85)
* https://learn.microsoft.com/en-us/previous-versions/windows/desktop/legacy/hh846323(v=vs.85)

This came up during https://github.com/dotnet/core/pull/9441

/CC @BiNZGi for review