### PR TITLE
[go] add 1.23.0

### DIFF
--- a/products/go.md
+++ b/products/go.md
@@ -27,6 +27,12 @@ auto:
 
 # eol(x) = releaseDate(x+2)
 releases:
+-   releaseCycle: "1.23"
+    releaseDate: 2024-08-13
+    eol: false
+    latest: "1.23.0"
+    latestReleaseDate: 2024-08-13
+
 -   releaseCycle: "1.22"
     releaseDate: 2024-02-06
     eol: false
@@ -35,7 +41,7 @@ releases:
 
 -   releaseCycle: "1.21"
     releaseDate: 2023-08-08
-    eol: false
+    eol: 2024-08-13
     latest: "1.21.13"
     latestReleaseDate: 2024-08-06
 


### PR DESCRIPTION
Go v1.23.0 was released 2024-08-13: my first PR here, but I think this one is pretty straightforward.

Refs: https://tip.golang.org/doc/go1.23 and https://go.dev/doc/devel/release