### PR TITLE
[mattermost] Switch to github_releases auto method

### DIFF
--- a/products/mattermost.md
+++ b/products/mattermost.md
@@ -13,7 +13,6 @@ releaseDateColumn: true
 
 auto:
   methods:
-  -   git: https://github.com/mattermost/mattermost-server.git
   -   release_table: https://docs.mattermost.com/about/mattermost-server-releases.html
       selector: "table"
       fields:

--- a/products/mattermost.md
+++ b/products/mattermost.md
@@ -13,6 +13,7 @@ releaseDateColumn: true
 
 auto:
   methods:
+  -   github_releases: mattermost/mattermost-server
   -   release_table: https://docs.mattermost.com/about/mattermost-server-releases.html
       selector: "table"
       fields:


### PR DESCRIPTION
9.11.0 is actually a pre-release, might be good to remove the git automation?

<img width="707" alt="image" src="https://github.com/user-attachments/assets/deaf5f41-8f93-4cf3-ac20-599b0633af25">


---

related github action run, https://github.com/endoflife-date/release-data/actions/runs/10220616442