### PR TITLE
Add new 'discontinued' tag

### DIFF
--- a/_layouts/product.html
+++ b/_layouts/product.html
@@ -173,7 +173,9 @@ layout: default
 {% endif %}
 
 {% if page.releaseColumn %}
+{% unless page.tags contains "discontinued" %}
 <p>You should be running one of the supported release numbers listed above in the rightmost column.</p>
+{% endunless %}
 {% endif %}
 
 {% if page.versionCommand %}
@@ -192,8 +194,7 @@ layout: default
     on GitHub
     <img class="emoji" title=":octocat:" alt=":octocat:" src="https://github.githubassets.com/images/icons/emoji/octocat.png" width="20" height="20">
   </a>.
-  This page has a corresponding <a title="Talk Page for {{page.title}}" href="https://github.com/endoflife-date/talk/wiki{{page.permalink}}">
-  Talk Page</a>.
+  This page has a corresponding <a title="Talk Page for {{page.title}}" href="https://github.com/endoflife-date/talk/wiki{{page.permalink}}">Talk Page</a>.
 </p>
 
 <p>

--- a/products/angularjs.md
+++ b/products/angularjs.md
@@ -1,7 +1,7 @@
 ---
 title: AngularJS
 category: framework
-tags: google javascript-runtime
+tags: discontinued google javascript-runtime
 permalink: /angularjs
 alternate_urls:
 -   /angular-js

--- a/products/centos.md
+++ b/products/centos.md
@@ -1,7 +1,7 @@
 ---
 title: CentOS
 category: os
-tags: linux-distribution
+tags: discontinued linux-distribution
 iconSlug: centos
 permalink: /centos
 versionCommand: cat /etc/redhat-release

--- a/products/google-nexus.md
+++ b/products/google-nexus.md
@@ -1,7 +1,7 @@
 ---
 title: Google Nexus
 category: device
-tags: google mobile-phone tablet
+tags: discontinued google mobile-phone tablet
 iconSlug: google
 permalink: /google-nexus
 versionCommand: "Settings -> About Phone -> Regulatory labels"

--- a/products/isc-dhcp.md
+++ b/products/isc-dhcp.md
@@ -1,6 +1,7 @@
 ---
 title: ISC DHCP
 category: server-app
+tags: discontinued
 permalink: /isc-dhcp
 releasePolicyLink: https://kb.isc.org/docs/aa-00896#isc-dhcp-eol
 changelogTemplate: https://ftp.isc.org/isc/dhcp/__LATEST__/dhcp-__LATEST__-RELNOTES


### PR DESCRIPTION
Applied this new tag on products officially discontinued and having all their releases EOL.

Products having this tag also don't have the _You should be running one of the supported release..._ mention anymore.