### PR TITLE
[scala] update to use github_releases

### DIFF
--- a/products/scala.md
+++ b/products/scala.md
@@ -20,8 +20,8 @@ identifiers:
 
 auto:
   methods:
-  -   git: https://github.com/scala/scala.git # Scala < 3
-  -   git: https://github.com/lampepfl/dotty.git # Scala >= 3
+  -   github_releases: scala/scala # Scala < 3
+  -   github_releases: lampepfl/dotty # Scala >= 3
 
 # For 3.x : eoas(x) = eol(x) = releaseDate(x+1)
 releases:

--- a/products/scala.md
+++ b/products/scala.md
@@ -18,6 +18,8 @@ identifiers:
 -   cpe: cpe:/a:scala-lang:scala
 -   cpe: cpe:2.3:a:scala-lang:scala
 
+# Some old scala releases are only tagged and don't have any associated GitHub releases.
+# But releases may be tagged from a few days to a few weeks to before being officially released, so overall using GitHub releases is better.
 auto:
   methods:
   -   github_releases: scala/scala # Scala < 3


### PR DESCRIPTION
scala 3.4.2 is still the latest

<img width="724" alt="image" src="https://github.com/user-attachments/assets/25f9abdb-f09c-4fce-88ee-68cf76535d15">
