### PR TITLE
[apache-hop] Switch to maven method for automation

### DIFF
--- a/products/apache-hop.md
+++ b/products/apache-hop.md
@@ -12,7 +12,7 @@ eolColumn: Support
 
 auto:
   methods:
-  -   github_releases: 'apache/hop'
+  -   maven: 'org.apache.hop/hop-engine'
 
 # eol(x) = releaseDate(x+1)
 releases:


### PR DESCRIPTION
Releases, such as https://github.com/apache/hop/releases/tag/2.9.0-rc1, are created on RC tags and not on the final tags (such as https://github.com/apache/hop/releases/tag/hop-2.9.0), which makes it harder to parse.