### PR TITLE
[controlm] Fix cpe identifier

### DIFF
--- a/products/controlm.md
+++ b/products/controlm.md
@@ -12,7 +12,7 @@ eolColumn: Limited Support
 eoasColumn: Full Support
 
 identifiers:
--   cpe:2.3:a:bmc:control-m
+-   cpe: cpe:2.3:a:bmc:control-m
 
 # Latest releases can be found on https://docs.bmc.com/docs/controlm/.
 releases:


### PR DESCRIPTION
Got following error on netlify:
```
2:34:26 PM:  Product Validator: Invalid identifiers 'cpe:2.3:a:bmc:control-m' for controlm.md, expecting an identifier hash with a single string value, got cpe:2.3:a:bmc:control-m.
2:34:27 PM:        Jekyll Feed: Generating feed for posts
2:34:27 PM:          Tag pages: Generating...
2:34:27 PM:          Tag pages: Done in 0.002 seconds.
2:34:29 PM:   Liquid Exception: expecting an identifier hash with a single string value, got cpe:2.3:a:bmc:control-m in /opt/build/repo/_layouts/product.html
2:34:29 PM: /opt/build/repo/_plugins/identifier-to-url.rb:10:in `render': expecting an identifier hash with a single string value, got cpe:2.3:a:bmc:control-m (RuntimeError)
	from /opt/build/repo/_plugins/end-of-life-filters.rb:133:in `identifier_to_url'
```
Try to fix...