### PR TITLE
[jenkins] Add 2.462 LTS

### DIFF
--- a/products/jenkins.md
+++ b/products/jenkins.md
@@ -37,10 +37,17 @@ releases:
     latest: "2.472"
     latestReleaseDate: 2024-08-13
 
+-   releaseCycle: "2.462"
+    releaseDate: 2024-06-10
+    lts: 2024-08-07
+    eol: false
+    latest: "2.462.1"
+    latestReleaseDate: 2024-08-07
+
 -   releaseCycle: "2.452"
     releaseDate: 2024-04-02
     lts: 2024-05-15
-    eol: false
+    eol: 2024-08-07
     latest: "2.452.4"
     latestReleaseDate: 2024-08-05
 


### PR DESCRIPTION
See [Upgrading to Jenkins LTS 2.462.x](https://www.jenkins.io/doc/upgrade-guide/2.462/)