### PR TITLE
Update windows.md 10-1803-w EOL date

### DIFF
--- a/products/windows.md
+++ b/products/windows.md
@@ -198,7 +198,7 @@ releases:
     releaseLabel: "10 1803 (W)"
     releaseDate: 2018-04-30
     eoas: 2019-11-12
-    eol: 2020-05-11
+    eol: 2019-11-12
     latest: 10.0.17134
     link: https://learn.microsoft.com/lifecycle/announcements/windows-10-1803-end-of-servicing
 


### PR DESCRIPTION
Incorrect EOL date for Windows 10 Home and Pro editions, version 1803.

Reference Link: https://learn.microsoft.com/en-us/lifecycle/products/windows-10-home-and-pro