### PR TITLE
Update windows.md

### DIFF
--- a/products/windows.md
+++ b/products/windows.md
@@ -267,7 +267,7 @@ releases:
     eol: 2017-10-10
     latest: 10.0.10586
     link: https://learn.microsoft.com/lifecycle/announcements/windows-10-1511-end-of-servicing
-    
+
 -   releaseCycle: "10-1507-e-lts"
     releaseLabel: "10 1507 (E)"
     releaseDate: 2015-07-29
@@ -276,15 +276,6 @@ releases:
     eol: 2025-10-14
     latest: 10.0.10240
     link: https://learn.microsoft.com/windows/release-health/supported-versions-windows-client#enterprise-and-iot-enterprise-ltsbltsc-editions
-
--   releaseCycle: "10-1507-iot"
-    releaseLabel: "10 1507 IOT"
-    releaseDate: 2015-04-29
-    lts: false
-    eoas: 2020-11-10
-    eol: 2020-11-10
-    latest: 10.0.10240
-    link: https://learn.microsoft.com/en-us/lifecycle/products/windows-10-iot-core
     
     # This cycle includes 10 1507 (E) non-LTS version
 -   releaseCycle: "10-1507"
@@ -294,6 +285,15 @@ releases:
     eol: 2017-05-09
     latest: 10.0.10240
     link: https://learn.microsoft.com/lifecycle/announcements/windows-10-1507-cb-cbb-end-of-servicing
+
+-   releaseCycle: "10-1507-iot"
+    releaseLabel: "10 1507 IOT"
+    releaseDate: 2015-04-29
+    lts: false
+    eoas: 2020-11-10
+    eol: 2020-11-10
+    latest: 10.0.10240
+    link: https://learn.microsoft.com/en-us/lifecycle/products/windows-10-iot-core
 
 -   releaseCycle: "8.1"
     releaseLabel: "8.1"

--- a/products/windows.md
+++ b/products/windows.md
@@ -276,7 +276,7 @@ releases:
     eol: 2025-10-14
     latest: 10.0.10240
     link: https://learn.microsoft.com/windows/release-health/supported-versions-windows-client#enterprise-and-iot-enterprise-ltsbltsc-editions
-    
+
     # This cycle includes 10 1507 (E) non-LTS version
 -   releaseCycle: "10-1507"
     releaseLabel: "10 1507"

--- a/products/windows.md
+++ b/products/windows.md
@@ -267,15 +267,6 @@ releases:
     eol: 2017-10-10
     latest: 10.0.10586
     link: https://learn.microsoft.com/lifecycle/announcements/windows-10-1511-end-of-servicing
-
--   releaseCycle: "10-1507-iot"
-    releaseLabel: "10 1507 IOT"
-    releaseDate: 2015-04-29
-    lts: false
-    eoas: 2020-11-10
-    eol: 2020-11-10
-    latest: 10.0.10240
-    link: https://learn.microsoft.com/en-us/lifecycle/products/windows-10-iot-core
     
 -   releaseCycle: "10-1507-e-lts"
     releaseLabel: "10 1507 (E)"
@@ -286,6 +277,15 @@ releases:
     latest: 10.0.10240
     link: https://learn.microsoft.com/windows/release-health/supported-versions-windows-client#enterprise-and-iot-enterprise-ltsbltsc-editions
 
+-   releaseCycle: "10-1507-iot"
+    releaseLabel: "10 1507 IOT"
+    releaseDate: 2015-04-29
+    lts: false
+    eoas: 2020-11-10
+    eol: 2020-11-10
+    latest: 10.0.10240
+    link: https://learn.microsoft.com/en-us/lifecycle/products/windows-10-iot-core
+    
     # This cycle includes 10 1507 (E) non-LTS version
 -   releaseCycle: "10-1507"
     releaseLabel: "10 1507"

--- a/products/windows.md
+++ b/products/windows.md
@@ -268,6 +268,15 @@ releases:
     latest: 10.0.10586
     link: https://learn.microsoft.com/lifecycle/announcements/windows-10-1511-end-of-servicing
 
+-   releaseCycle: "10-1507-iot"
+    releaseLabel: "10 1507 IOT"
+    releaseDate: 2015-04-29
+    lts: false
+    eoas: 2020-11-10
+    eol: 2020-11-10
+    latest: 10.0.10240
+    link: https://learn.microsoft.com/en-us/lifecycle/products/windows-10-iot-core
+    
 -   releaseCycle: "10-1507-e-lts"
     releaseLabel: "10 1507 (E)"
     releaseDate: 2015-07-29


### PR DESCRIPTION
Windows 10 IoT Core version 1507 has a different EOL date than the Home/Pro editions.

Home/Pro: https://learn.microsoft.com/en-us/lifecycle/products/windows-10-home-and-pro 
Windows 10 IoT Core ( Original Release 1507 ): https://learn.microsoft.com/en-us/lifecycle/products/windows-10-iot-core