### PR TITLE
[kotlin] Update latest release for release cycle 2.0.0

### DIFF
--- a/products/kotlin.md
+++ b/products/kotlin.md
@@ -24,8 +24,8 @@ releases:
 -   releaseCycle: "2.0"
     releaseDate: 2024-05-21
     eol: false
-    latest: "2.0.0"
-    latestReleaseDate: 2024-05-21
+    latest: "2.0.20"
+    latestReleaseDate: 2024-08-22
 
 -   releaseCycle: "1.9"
     releaseDate: 2023-07-06


### PR DESCRIPTION
https://kotlinlang.org/docs/releases.html#kotlin-release-compatibility


It looks automatic update is not working for 2.0.0 release.

2.0.10 released on 2024-08-06
2.0.20 released on 2024-08-22