### PR TITLE
fix: correct the path for openapi.yml in documentation

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -103,7 +103,7 @@ The API is just JSON files generated in the `api` directory by `_plugins/create-
 
 ### API Documentation
 
-The API Documentation is available at <https://endoflife.date/docs/api> and is generated from an OpenAPI Specification file located at `_data/openapi.yml`. The documentation is rendered [Stoplight Elements](https://meta.stoplight.io/docs/elements/ZG9jOjMyNjU4OTY0-introduction-to-elements).
+The API Documentation is available at <https://endoflife.date/docs/api> and is generated from an OpenAPI Specification file located at `assets/openapi.yml`. The documentation is rendered [Stoplight Elements](https://meta.stoplight.io/docs/elements/ZG9jOjMyNjU4OTY0-introduction-to-elements).
 
 ## Contributing Workflow
 


### PR DESCRIPTION
This should fix #5753 reported by @ilmari.

fixes #5753