### PR TITLE
Fix wrong EOL date for beats 8

### DIFF
--- a/products/beats.md
+++ b/products/beats.md
@@ -30,7 +30,7 @@ auto:
 releases:
 -   releaseCycle: "8"
     releaseDate: 2022-02-10
-    eol: false  # later of 2024-08-10 or 6 months after the release date of 9.0
+    eol: false  # later of 2024-08-10 or 18 months after the release date of 9.0
     latest: "8.15.0"
     latestReleaseDate: 2024-08-02
 

--- a/products/beats.md
+++ b/products/beats.md
@@ -30,7 +30,7 @@ auto:
 releases:
 -   releaseCycle: "8"
     releaseDate: 2022-02-10
-    eol: 2024-08-10 # later of 2024-08-10 or 6 months after the release date of 9.0
+    eol: false  # later of 2024-08-10 or 6 months after the release date of 9.0
     latest: "8.15.0"
     latestReleaseDate: 2024-08-02
 


### PR DESCRIPTION
The EOL date for beats 8 is the *later* of 2024-08-10 or 18 months after the release of 9. Having 2024-08-10 as the EOL date is making our process fail and suggests to use 7 since it shows as still supported. 