### PR TITLE
Update Oracle Solaris 11.4 extended support life & documentation link

### DIFF
--- a/products/oracle-solaris.md
+++ b/products/oracle-solaris.md
@@ -24,8 +24,8 @@ releases:
 -   releaseCycle: "11.4"
     releaseDate: 2018-08-28
     eol: 2031-11-01
-    eoes: 2034-11-01
-    link: https://docs.oracle.com/cd/E37838_01/index.html
+    eoes: 2037-11-01
+    link: https://docs.oracle.com/en/operating-systems/solaris/oracle-solaris/
 
 -   releaseCycle: "11.3"
     releaseDate: 2015-10-26


### PR DESCRIPTION
Oracle has extended the extended support period for Oracle Solaris 11.4 until November 2037, as per
https://www.oracle.com/us/assets/lifetime-support-hardware-301321.pdf

Also the previously listed link for Solaris 11.4 docs now redirects to https://docs.oracle.com/en/operating-systems/solaris/oracle-solaris/