### PR TITLE
[logstash] mark 8.x active

### DIFF
--- a/products/logstash.md
+++ b/products/logstash.md
@@ -20,7 +20,7 @@ auto:
 
 releases:
 -   releaseCycle: "8"
-    eol: 2024-08-10 # later of 2024-08-10 or 6 months after the release date of 9.0
+    eol: false # later of 2024-08-10 or 6 months after the release date of 9.0
     latest: "8.15.0"
     latestReleaseDate: 2024-07-24
     releaseDate: 2022-02-10


### PR DESCRIPTION
- https://github.com/elastic/logstash/releases/tag/v8.15.1

![image](https://github.com/user-attachments/assets/b7b9c01a-2380-4f6f-9ed5-80180af19ca0)
