### PR TITLE
[sourcegraph] Fix github repository link

### DIFF
--- a/products/sourcegraph.md
+++ b/products/sourcegraph.md
@@ -14,7 +14,7 @@ identifiers:
 
 auto:
   methods:
-  -   git: https://github.com/sourcegraph/sourcegraph.git
+  -   git: https://github.com/sourcegraph/sourcegraph-public-snapshot.git
 
 # eol(x) = releaseDate(x+1)
 releases:


### PR DESCRIPTION
https://github.com/sourcegraph/sourcegraph is not available anymore, switch to https://github.com/sourcegraph/sourcegraph-public-snapshot.