### PR TITLE
[kibana] Fix 8 EOL

### DIFF
--- a/products/kibana.md
+++ b/products/kibana.md
@@ -20,7 +20,7 @@ auto:
 
 releases:
 -   releaseCycle: "8"
-    eol: 2024-08-10 # later of 2024-08-10 or 6 months after the release date of 9.0
+    eol: false # later of 2024-08-10 or 18 months after the release date of 9.0
     latest: "8.15.1"
     latestReleaseDate: 2024-09-02
     releaseDate: 2022-02-10

--- a/products/logstash.md
+++ b/products/logstash.md
@@ -20,7 +20,7 @@ auto:
 
 releases:
 -   releaseCycle: "8"
-    eol: false # later of 2024-08-10 or 6 months after the release date of 9.0
+    eol: false # later of 2024-08-10 or 18 months after the release date of 9.0
     latest: "8.15.1"
     latestReleaseDate: 2024-08-27
     releaseDate: 2022-02-10


### PR DESCRIPTION
Logstash 8 is not EOL, 9 was not released yet.

Also updated the comment to 18 instead of 6 months, as documented on https://www.elastic.co/support_policy.