### PR TITLE
Update apache-airflow to 2.10.1

### DIFF
--- a/products/apache-airflow.md
+++ b/products/apache-airflow.md
@@ -44,8 +44,8 @@ releases:
     releaseDate: 2020-12-17
     eoas: false
     eol: false
-    latest: "2.10.0"
-    latestReleaseDate: 2024-08-15
+    latest: "2.10.1"
+    latestReleaseDate: 2024-09-05
 
 -   releaseCycle: "1.10"
     releaseDate: 2018-08-27


### PR DESCRIPTION
Cf [Airflow 2.10.1 (2024-09-05)](https://airflow.apache.org/docs/apache-airflow/2.10.1/release_notes.html#id288)

Not sure this PR is really useful or if the automation will do it in the next days :thinking: 

[Tweet](https://x.com/ApacheAirflow/status/1832038571030511965)

![image](https://github.com/user-attachments/assets/be840f12-bcee-4736-be6f-05f97b9f42b4)
