### PR TITLE
[sourcegraph] Update changelog template

### DIFF
--- a/products/sourcegraph.md
+++ b/products/sourcegraph.md
@@ -4,7 +4,7 @@ category: server-app
 tags: java-runtime
 permalink: /sourcegraph
 releasePolicyLink: https://handbook.sourcegraph.com/departments/engineering/dev/process/releases/
-changelogTemplate: https://github.com/sourcegraph/sourcegraph/releases/tag/v__LATEST__
+changelogTemplate: https://github.com/sourcegraph/sourcegraph-public-snapshot/releases/tag/v__LATEST__
 releaseDateColumn: true
 eolColumn: Support
 


### PR DESCRIPTION
Sourcegraph transitioned to a private monorepo. This repository, sourcegraph/sourcegraph-public-snapshot is a publicly available copy of the sourcegraph/sourcegraph repository as it was just before the migration.

https://github.com/sourcegraph/sourcegraph-public-snapshot