### PR TITLE
Update raspberrypi.md

### DIFF
--- a/products/raspberrypi.md
+++ b/products/raspberrypi.md
@@ -18,28 +18,28 @@ releases:
     releaseLabel: "5" # Is just called "Raspberry Pi 5", without "Model B"
     # https://www.raspberrypi.com/news/raspberry-pi-5-available-now/
     releaseDate: 2023-10-23
-    discontinued: 2035-01-01
+    discontinued: 2036-01-01
     link: https://www.raspberrypi.com/products/raspberry-pi-5/
 
 -   releaseCycle: "CM4S"
     releaseLabel: Compute Module 4S
     # https://www.jeffgeerling.com/blog/2022/new-raspberry-pi-compute-module-4s
     releaseDate: 2022-04-04
-    discontinued: 2031-01-01
+    discontinued: 2034-01-01
     link: https://www.raspberrypi.com/products/compute-module-4s/
 
 -   releaseCycle: "zero-2-w"
     releaseLabel: "Zero 2 W"
     # https://www.raspberrypi.com/news/new-raspberry-pi-zero-2-w-2/
     releaseDate: 2021-10-28
-    discontinued: 2028-01-01
+    discontinued: 2030-01-01
     link: https://www.raspberrypi.com/products/raspberry-pi-zero-2-w/
 
 -   releaseCycle: "pico"
     releaseLabel: Pico
     # https://www.raspberrypi.com/news/raspberry-pi-silicon-pico-now-on-sale/
     releaseDate: 2021-01-21
-    discontinued: 2028-01-01
+    discontinued: 2036-01-01
     link: https://www.raspberrypi.com/products/raspberry-pi-pico/
 
 -   releaseCycle: "4-400"
@@ -54,7 +54,7 @@ releases:
     # https://www.raspberrypi.com/news/raspberry-pi-compute-module-4/
     releaseDate: 2020-10-19
     # https://www.raspberrypi.com/products/compute-module-4/?variant=raspberry-pi-cm4001000
-    discontinued: 2031-01-01
+    discontinued: 2034-01-01
     link: https://www.raspberrypi.com/products/compute-module-4/
 
 -   releaseCycle: "4-b"
@@ -62,7 +62,7 @@ releases:
     # https://www.raspberrypi.com/news/raspberry-pi-4-on-sale-now-from-35/
     releaseDate: 2019-06-24
     # https://www.raspberrypi.com/products/raspberry-pi-4-model-b/specifications/
-    discontinued: 2031-01-01
+    discontinued: 2034-01-01
     link: https://www.raspberrypi.com/products/raspberry-pi-4-model-b/
 
 -   releaseCycle: "CM3+"
@@ -70,7 +70,7 @@ releases:
     # https://www.raspberrypi.com/news/compute-module-3-on-sale-now-from-25/
     releaseDate: 2019-01-28
     # https://www.raspberrypi.com/products/compute-module-3-plus/
-    discontinued: 2028-01-01
+    discontinued: 2030-01-01
     link: https://www.raspberrypi.com/products/compute-module-3-plus/
 
 -   releaseCycle: "3-a+"
@@ -78,7 +78,7 @@ releases:
     # https://www.raspberrypi.com/news/new-product-raspberry-pi-3-model-a/
     releaseDate: 2018-11-15
     # https://www.raspberrypi.com/products/raspberry-pi-3-model-a-plus/
-    discontinued: 2028-01-01
+    discontinued: 2030-01-01
     link: https://www.raspberrypi.com/products/raspberry-pi-3-model-a-plus/
 
 -   releaseCycle: "3-b+"
@@ -86,7 +86,7 @@ releases:
     # https://www.raspberrypi.com/news/raspberry-pi-3-model-bplus-sale-now-35/
     releaseDate: 2018-03-14
     # https://www.raspberrypi.com/products/raspberry-pi-3-model-b-plus/
-    discontinued: 2028-01-01
+    discontinued: 2030-01-01
     link: https://www.raspberrypi.com/products/raspberry-pi-3-model-b-plus/
 
     # There is also https://www.raspberrypi.com/news/zero-wh/, but no associated product page, so
@@ -95,7 +95,7 @@ releases:
     releaseLabel: "Zero W/WH"
     # https://www.raspberrypi.com/news/raspberry-pi-zero-w-joins-family/
     releaseDate: 2017-02-28
-    discontinued: 2026-01-01
+    discontinued: 2030-01-01
     link: https://www.raspberrypi.com/products/raspberry-pi-zero-w/
 
 -   releaseCycle: "CM3"
@@ -118,7 +118,7 @@ releases:
     releaseLabel: "Zero"
     # https://www.raspberrypi.com/news/raspberry-pi-zero/
     releaseDate: 2015-11-26
-    discontinued: 2026-01-01
+    discontinued: 2030-01-01
     link: https://www.raspberrypi.com/products/raspberry-pi-zero/
 
 -   releaseCycle: "2-b"
@@ -132,14 +132,14 @@ releases:
     releaseLabel: "1 Model A+"
     # https://www.raspberrypi.com/news/raspberry-pi-model-a-plus-on-sale/
     releaseDate: 2014-11-10
-    discontinued: 2026-01-01
+    discontinued: 2030-01-01
     link: https://www.raspberrypi.com/products/raspberry-pi-1-model-a-plus/
 
 -   releaseCycle: "1-b+"
     releaseLabel: "1 Model B+"
     # https://www.raspberrypi.com/news/introducing-raspberry-pi-model-b-plus/
     releaseDate: 2014-07-14
-    discontinued: 2026-01-01
+    discontinued: 2030-01-01
     link: https://www.raspberrypi.com/products/raspberry-pi-1-model-b-plus/
 
 -   releaseCycle: "CM1"


### PR DESCRIPTION
Updated end of life dates for all Raspberry Pi products as of September 12 2024.