### PR TITLE
[godot] add 3.6

### DIFF
--- a/products/godot.md
+++ b/products/godot.md
@@ -28,6 +28,14 @@ auto:
 # Do not forget to remove the link after the first patch release.
 # For 3.x releases, they get deprecated on 3.x+1 release (both 3.5 and 3.6 are LTS)
 releases:
+-   releaseCycle: "3.6"
+    releaseDate: 2024-09-08
+    lts: true
+    eoas: false
+    eol: false
+    latest: "3.6.0"
+    latestReleaseDate: 2024-09-08
+
 -   releaseCycle: "4.3"
     releaseDate: 2024-08-15
     eoas: false
@@ -55,14 +63,6 @@ releases:
     eol: false
     latest: "4.0.4"
     latestReleaseDate: 2023-08-02
-
--   releaseCycle: "3.6"
-    releaseDate: 2024-09-08
-    lts: true
-    eoas: false
-    eol: false
-    latest: "3.6.0"
-    latestReleaseDate: 2024-09-08
 
 -   releaseCycle: "3.5"
     releaseDate: 2022-08-05

--- a/products/godot.md
+++ b/products/godot.md
@@ -26,7 +26,7 @@ auto:
       template: "{{version}}"
 
 # Do not forget to remove the link after the first patch release.
-# For 3.x releases, they get deprecated on 3.x+1 release
+# For 3.x releases, they get deprecated on 3.x+1 release (both 3.5 and 3.6 are LTS)
 releases:
 -   releaseCycle: "4.3"
     releaseDate: 2024-08-15
@@ -55,6 +55,14 @@ releases:
     eol: false
     latest: "4.0.4"
     latestReleaseDate: 2023-08-02
+
+-   releaseCycle: "3.6"
+    releaseDate: 2024-09-08
+    lts: true
+    eoas: false
+    eol: false
+    latest: "3.6.0"
+    latestReleaseDate: 2024-09-08
 
 -   releaseCycle: "3.5"
     releaseDate: 2022-08-05


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/d898cbf7-3595-4683-b37f-a0f493f546c9)

> The 3.6 release is still planned and should be the last stable branch of Godot 3.x. It will be a Long-Term Support (LTS) release, which we plan to support for as long as users still need it (due to missing features in Godot 4.x, or having published games which they need to keep updating for platform requirements).

