### PR TITLE
[iphone] Add iPhone 16 series

### DIFF
--- a/products/iphone.md
+++ b/products/iphone.md
@@ -24,7 +24,7 @@ releases:
     releaseDate: 2024-09-20
     discontinued: false
     eol: false
-    link: https://support.apple.com/kb/SP901
+    link: https://support.apple.com/en-us/121029
     supportedIosVersions: 18
 
 -   releaseCycle: "16-plus"
@@ -32,7 +32,7 @@ releases:
     releaseDate: 2024-09-20
     discontinued: false
     eol: false
-    link: https://support.apple.com/kb/SP902
+    link: https://support.apple.com/en-us/121030
     supportedIosVersions: 18
 
 -   releaseCycle: "16-pro"
@@ -40,7 +40,7 @@ releases:
     releaseDate: 2024-09-20
     discontinued: false
     eol: false
-    link: https://support.apple.com/kb/SP903
+    link: https://support.apple.com/en-us/121031
     supportedIosVersions: 18
 
 -   releaseCycle: "16-pro-max"
@@ -48,7 +48,7 @@ releases:
     releaseDate: 2024-09-20
     discontinued: false
     eol: false
-    link: https://support.apple.com/kb/SP904
+    link: https://support.apple.com/en-us/121032
     supportedIosVersions: 18
 
 -   releaseCycle: "15"

--- a/products/iphone.md
+++ b/products/iphone.md
@@ -21,7 +21,7 @@ customColumns:
 releases:
 -   releaseCycle: "16"
     releaseLabel: "16"
-    releaseDate: 2023-09-16
+    releaseDate: 2023-09-20
     discontinued: false
     eol: false
     link: https://support.apple.com/kb/SP901
@@ -29,7 +29,7 @@ releases:
 
 -   releaseCycle: "16-plus"
     releaseLabel: "16 Plus"
-    releaseDate: 2023-09-16
+    releaseDate: 2023-09-20
     discontinued: false
     eol: false
     link: https://support.apple.com/kb/SP902
@@ -37,7 +37,7 @@ releases:
 
 -   releaseCycle: "16-pro"
     releaseLabel: "16 Pro"
-    releaseDate: 2024-09-16
+    releaseDate: 2024-09-20
     discontinued: false
     eol: false
     link: https://support.apple.com/kb/SP903
@@ -45,7 +45,7 @@ releases:
 
 -   releaseCycle: "16-pro-max"
     releaseLabel: "16 Pro Max"
-    releaseDate: 2024-09-16
+    releaseDate: 2024-09-20
     discontinued: false
     eol: false
     link: https://support.apple.com/kb/SP904

--- a/products/iphone.md
+++ b/products/iphone.md
@@ -21,7 +21,7 @@ customColumns:
 releases:
 -   releaseCycle: "16"
     releaseLabel: "16"
-    releaseDate: 2023-09-20
+    releaseDate: 2024-09-20
     discontinued: false
     eol: false
     link: https://support.apple.com/kb/SP901
@@ -29,7 +29,7 @@ releases:
 
 -   releaseCycle: "16-plus"
     releaseLabel: "16 Plus"
-    releaseDate: 2023-09-20
+    releaseDate: 2024-09-20
     discontinued: false
     eol: false
     link: https://support.apple.com/kb/SP902

--- a/products/iphone.md
+++ b/products/iphone.md
@@ -19,6 +19,38 @@ customColumns:
 # All links can be found on https://support.apple.com/en-us/HT201296.
 # All supported iOS versions can be found on https://en.wikipedia.org/wiki/List_of_iPhone_models#Release_dates.
 releases:
+-   releaseCycle: "16"
+    releaseLabel: "16"
+    releaseDate: 2023-09-16
+    discontinued: false
+    eol: false
+    link: https://support.apple.com/kb/SP901
+    supportedIosVersions: 18
+
+-   releaseCycle: "16-plus"
+    releaseLabel: "16 Plus"
+    releaseDate: 2023-09-16
+    discontinued: false
+    eol: false
+    link: https://support.apple.com/kb/SP902
+    supportedIosVersions: 18
+
+-   releaseCycle: "16-pro"
+    releaseLabel: "16 Pro"
+    releaseDate: 2024-09-16
+    discontinued: false
+    eol: false
+    link: https://support.apple.com/kb/SP903
+    supportedIosVersions: 18
+
+-   releaseCycle: "16-pro-max"
+    releaseLabel: "16 Pro Max"
+    releaseDate: 2024-09-16
+    discontinued: false
+    eol: false
+    link: https://support.apple.com/kb/SP904
+    supportedIosVersions: 18
+
 -   releaseCycle: "15"
     releaseLabel: "15"
     releaseDate: 2023-09-22


### PR DESCRIPTION
iPhone 16 series is planed to be released September 20

https://www.apple.com/newsroom/2024/09/apple-debuts-iphone-16-pro-and-iphone-16-pro-max/#:~:text=and%20desert%20titanium.-,iPhone%2016%20Pro%20and%20iPhone%2016%20Pro%20Max%20will%20be,availability%20beginning%20Friday%2C%20September%2020.