### PR TITLE
[macos] Set eol for macos 12

### DIFF
--- a/products/macos.md
+++ b/products/macos.md
@@ -44,7 +44,7 @@ releases:
 -   releaseCycle: "12"
     codename: "Monterey"
     releaseDate: 2021-10-25
-    eol: false
+    eol: true
     latest: '12.7.6'
     latestReleaseDate: 2024-07-29
     link: https://support.apple.com/HT212585


### PR DESCRIPTION
According to wikipedia Monterey is unsupported.
https://en.wikipedia.org/wiki/MacOS_Monterey

Other forums are expecting EOL is after October, November.

Considering apple is supporting 3 latest versions, yes, but apple is not providing exact date so maybe we wait a little more to be sure.

@elliotwutingfeng is also suggesting set eol..