### PR TITLE
[cakephp] Add 5.1

### DIFF
--- a/products/cakephp.md
+++ b/products/cakephp.md
@@ -31,9 +31,9 @@ releases:
 -   releaseCycle: "5.1"
     codename: "Strawberry"
     releaseDate: 2024-09-13
-    supportedPhpVersions: 7.4+
-    eoas: 2025-09-09
-    eol: 2026-09-09
+    supportedPhpVersions: 8.1+
+    eoas: false
+    eol: false
     latest: "5.1.0"
     latestReleaseDate: 2024-09-13
 

--- a/products/cakephp.md
+++ b/products/cakephp.md
@@ -28,6 +28,15 @@ auto:
 # For a given major version, the last three minor versions have security support.
 # Do not forget to document the codename in the product's description when adding a new major version.
 releases:
+-   releaseCycle: "5.1"
+    codename: "Strawberry"
+    releaseDate: 2024-09-13
+    supportedPhpVersions: 7.4+
+    eoas: 2025-09-09
+    eol: 2026-09-09
+    latest: "5.1.0"
+    latestReleaseDate: 2024-09-13
+
 -   releaseCycle: "4.5"
     codename: "Strawberry"
     releaseDate: 2023-10-14


### PR DESCRIPTION
Released on [GitHub](https://github.com/cakephp/cakephp/releases)

The website is still showing 5.0 https://cakephp.org, waiting the update to see the codename for 5.1 