### PR TITLE
[watchos] Update eoas for watchos 10 and eol for watchos 9

### DIFF
--- a/products/watchos.md
+++ b/products/watchos.md
@@ -97,3 +97,6 @@ releases:
 > Watches. It is based on iOS, and introduced in 2015.
 
 Major versions of watchOS are released annually, with the previous major version losing support.
+
+Apple publishes a [Compatibility Table](https://support.apple.com/118490) for supported combinations
+of iPhone, iOS, watchOS.

--- a/products/watchos.md
+++ b/products/watchos.md
@@ -43,7 +43,7 @@ releases:
 -   releaseCycle: "9"
     releaseDate: 2022-09-12
     eoas: 2023-09-18
-    eol: false
+    eol: 2023-09-22
     latestReleaseDate: 2023-09-21
     latest: '9.6.3'
 

--- a/products/watchos.md
+++ b/products/watchos.md
@@ -35,7 +35,7 @@ releases:
 
 -   releaseCycle: "10"
     releaseDate: 2023-09-18
-    eoas: false
+    eoas: 2024-09-16
     eol: false
     latest: '10.6.1'
     latestReleaseDate: 2024-08-19


### PR DESCRIPTION
With a new major version released previos is losing active support.
Watchos has almost one year without updates and is 2 major releases behind, so probably is not receiving new security updates. 

https://en.wikipedia.org/wiki/WatchOS in wikipedia it is obsolete

