### PR TITLE
[ios] Update links ios 18 and 17

### DIFF
--- a/products/ios.md
+++ b/products/ios.md
@@ -25,7 +25,7 @@ releases:
     eol: false
     latest: "18.0.0"
     latestReleaseDate: 2024-09-16
-    link: https://developer.apple.com/documentation/ios-ipados-release-notes/ios-ipados-18-release-notes
+    link: https://support.apple.com/en-us/121161
 
 -   releaseCycle: "17"
     releaseDate: 2023-09-18

--- a/products/ios.md
+++ b/products/ios.md
@@ -33,7 +33,7 @@ releases:
     eol: false
     latest: "17.7"
     latestReleaseDate: 2024-09-16
-    link: https://developer.apple.com/documentation/ios-ipados-release-notes/ios-ipados-17-release-notes
+    link: https://support.apple.com/en-us/118723
 
 -   releaseCycle: "16"
     releaseDate: 2022-09-12


### PR DESCRIPTION
From ios 5 to ios 16 link is redirecting to https://support.apple.com/, currently ios 17 and 18 are redirecting to https://developer.apple.com/documentation.

With this change all versions are redirecting to support.apple.com