### PR TITLE
[cakephp] Add 5.1

### DIFF
--- a/products/cakephp.md
+++ b/products/cakephp.md
@@ -28,6 +28,15 @@ auto:
 # For a given major version, the last three minor versions have security support.
 # Do not forget to document the codename in the product's description when adding a new major version.
 releases:
+-   releaseCycle: "5.1"
+    codename: ""
+    releaseDate: 2024-09-13
+    supportedPhpVersions: 8.1+
+    eoas: false
+    eol: false
+    latest: "5.1.0"
+    latestReleaseDate: 2024-09-13
+
 -   releaseCycle: "4.5"
     codename: "Strawberry"
     releaseDate: 2023-10-14

--- a/products/cakephp.md
+++ b/products/cakephp.md
@@ -29,7 +29,7 @@ auto:
 # Do not forget to document the codename in the product's description when adding a new major version.
 releases:
 -   releaseCycle: "5.1"
-    codename: ""
+    codename: "Chiffon"
     releaseDate: 2024-09-13
     supportedPhpVersions: 8.1+
     eoas: false

--- a/products/cakephp.md
+++ b/products/cakephp.md
@@ -26,7 +26,7 @@ auto:
 
 # support(X) = releaseDate(X+1) + 1 day
 # For a given major version, the last three minor versions have security support.
-# Do not forget to document the codename in the product's description when adding a new major version.
+# Do not forget to document the codename in the product's description when adding a new major version. (Codename only changes per major version release)
 releases:
 -   releaseCycle: "5.1"
     codename: "Chiffon"


### PR DESCRIPTION
Released on [GitHub](https://github.com/cakephp/cakephp/releases)

The website is still showing 5.0 https://cakephp.org/, waiting the update to see the codename for 5.1