### PR TITLE
[mautic] add 5.1

### DIFF
--- a/products/mautic.md
+++ b/products/mautic.md
@@ -36,17 +36,24 @@ identifiers:
 -   purl: pkg:github/mautic/mautic/
 
 releases:
--   releaseCycle: "5.0"
-    releaseDate: 2024-01-09
+-   releaseCycle: "5.1"
+    releaseDate: 2024-09-13
     eoas: false
     eol: false
+    latest: "5.1.1"
+    latestReleaseDate: 2024-09-18
+
+-   releaseCycle: "5.0"
+    releaseDate: 2024-01-09
+    eoas: 2024-09-13
+    eol: 2024-09-13
     latest: "5.0.4"
     latestReleaseDate: 2024-04-11
 
 -   releaseCycle: "4.4"
     releaseDate: 2022-06-27
-    eoas: 2024-01-09
-    eol: 2024-04-09
+    eoas: false
+    eol: false
     latest: "4.4.13"
     latestReleaseDate: 2024-09-18
 

--- a/products/mautic.md
+++ b/products/mautic.md
@@ -52,8 +52,8 @@ releases:
 
 -   releaseCycle: "4.4"
     releaseDate: 2022-06-27
-    eoas: false
-    eol: false
+    eoas: 2024-01-09
+    eol: 2024-04-09
     latest: "4.4.13"
     latestReleaseDate: 2024-09-18
 


### PR DESCRIPTION
- https://github.com/mautic/mautic/releases/tag/5.1.1

side note, now upstream has codename for each releasee since 5.1.0 (5.1.0 and 5.1.1 have different codename for releases)