### PR TITLE
[iphone] iOS 18 Supported devices

### DIFF
--- a/products/iphone.md
+++ b/products/iphone.md
@@ -57,7 +57,7 @@ releases:
     discontinued: false
     eol: false
     link: https://support.apple.com/kb/SP901
-    supportedIosVersions: 17
+    supportedIosVersions: 17 - 18
 
 -   releaseCycle: "15-plus"
     releaseLabel: "15 Plus"
@@ -65,7 +65,7 @@ releases:
     discontinued: false
     eol: false
     link: https://support.apple.com/kb/SP902
-    supportedIosVersions: 17
+    supportedIosVersions: 17 - 18
 
 -   releaseCycle: "15-pro"
     releaseLabel: "15 Pro"
@@ -73,7 +73,7 @@ releases:
     discontinued: false
     eol: false
     link: https://support.apple.com/kb/SP903
-    supportedIosVersions: 17
+    supportedIosVersions: 17 - 18
 
 -   releaseCycle: "15-pro-max"
     releaseLabel: "15 Pro Max"
@@ -81,7 +81,7 @@ releases:
     discontinued: false
     eol: false
     link: https://support.apple.com/kb/SP904
-    supportedIosVersions: 17
+    supportedIosVersions: 17 - 18
 
 -   releaseCycle: "14-plus"
     releaseLabel: "14 Plus"
@@ -89,7 +89,7 @@ releases:
     discontinued: false
     eol: false
     link: https://support.apple.com/kb/SP874
-    supportedIosVersions: 16 - 17
+    supportedIosVersions: 16 - 18
 
 -   releaseCycle: "14"
     releaseLabel: "14"
@@ -97,7 +97,7 @@ releases:
     discontinued: false
     eol: false
     link: https://support.apple.com/kb/SP873
-    supportedIosVersions: 16 - 17
+    supportedIosVersions: 16 - 18
 
 -   releaseCycle: "14-pro"
     releaseLabel: "14 Pro"
@@ -105,7 +105,7 @@ releases:
     discontinued: 2023-09-12
     eol: false
     link: https://support.apple.com/kb/SP875
-    supportedIosVersions: 16 - 17
+    supportedIosVersions: 16 - 18
 
 -   releaseCycle: "14-pro-max"
     releaseLabel: "14 Pro Max"
@@ -113,7 +113,7 @@ releases:
     discontinued: 2023-09-12
     eol: false
     link: https://support.apple.com/kb/SP876
-    supportedIosVersions: 16 - 17
+    supportedIosVersions: 16 - 18
 
 -   releaseCycle: "se-3"
     releaseLabel: "SE (3rd generation)"
@@ -121,7 +121,7 @@ releases:
     discontinued: false
     eol: false
     link: https://support.apple.com/kb/SP867
-    supportedIosVersions: 15 - 17
+    supportedIosVersions: 15 - 18
 
 -   releaseCycle: "13"
     releaseLabel: "13"
@@ -129,7 +129,7 @@ releases:
     discontinued: false
     eol: false
     link: https://support.apple.com/kb/SP851
-    supportedIosVersions: 15 - 17
+    supportedIosVersions: 15 - 18
 
 -   releaseCycle: "13-mini"
     releaseLabel: "13 Mini"
@@ -137,7 +137,7 @@ releases:
     discontinued: 2023-09-12
     eol: false
     link: https://support.apple.com/kb/SP847
-    supportedIosVersions: 15 - 17
+    supportedIosVersions: 15 - 18
 
 -   releaseCycle: "13-pro"
     releaseLabel: "13 Pro"
@@ -145,7 +145,7 @@ releases:
     discontinued: 2022-09-07
     eol: false
     link: https://support.apple.com/kb/SP852
-    supportedIosVersions: 15 - 17
+    supportedIosVersions: 15 - 18
 
 -   releaseCycle: "13-pro-max"
     releaseLabel: "13 Pro Max"
@@ -153,7 +153,7 @@ releases:
     discontinued: 2022-09-07
     eol: false
     link: https://support.apple.com/kb/SP848
-    supportedIosVersions: 15 - 17
+    supportedIosVersions: 15 - 18
 
 -   releaseCycle: "12-mini"
     releaseLabel: "12 Mini"
@@ -161,7 +161,7 @@ releases:
     discontinued: 2022-09-07
     eol: false
     link: https://support.apple.com/kb/SP829
-    supportedIosVersions: 14 - 17
+    supportedIosVersions: 14 - 18
 
 -   releaseCycle: "12-pro-max"
     releaseLabel: "12 Pro Max"
@@ -169,7 +169,7 @@ releases:
     discontinued: 2021-09-14
     eol: false
     link: https://support.apple.com/kb/SP832
-    supportedIosVersions: 14 - 17
+    supportedIosVersions: 14 - 18
 
 -   releaseCycle: "12"
     releaseLabel: "12"
@@ -177,7 +177,7 @@ releases:
     discontinued: 2023-09-12
     eol: false
     link: https://support.apple.com/kb/SP830
-    supportedIosVersions: 14 - 17
+    supportedIosVersions: 14 - 18
 
 -   releaseCycle: "12-pro"
     releaseLabel: "12 Pro"
@@ -185,7 +185,7 @@ releases:
     discontinued: 2021-09-14
     eol: false
     link: https://support.apple.com/kb/SP831
-    supportedIosVersions: 14 - 17
+    supportedIosVersions: 14 - 18
 
 -   releaseCycle: "se-2"
     releaseLabel: "SE (2nd generation)"
@@ -193,7 +193,7 @@ releases:
     discontinued: 2022-03-08
     eol: false
     link: https://support.apple.com/kb/SP820
-    supportedIosVersions: 13 - 17
+    supportedIosVersions: 13 - 18
 
 -   releaseCycle: "11"
     releaseLabel: "11"
@@ -201,7 +201,7 @@ releases:
     discontinued: 2022-09-07
     eol: false
     link: https://support.apple.com/kb/SP804
-    supportedIosVersions: 13 - 17
+    supportedIosVersions: 13 - 18
 
 -   releaseCycle: "11-pro"
     releaseLabel: "11 Pro"
@@ -209,7 +209,7 @@ releases:
     discontinued: 2020-10-13
     eol: false
     link: https://support.apple.com/kb/SP805
-    supportedIosVersions: 13 - 17
+    supportedIosVersions: 13 - 18
 
 -   releaseCycle: "11-pro-max"
     releaseLabel: "11 Pro Max"
@@ -217,7 +217,7 @@ releases:
     discontinued: 2020-10-13
     eol: false
     link: https://support.apple.com/kb/SP806
-    supportedIosVersions: 13 - 17
+    supportedIosVersions: 13 - 18
 
 -   releaseCycle: "xr"
     releaseLabel: "XR"
@@ -225,7 +225,7 @@ releases:
     discontinued: 2021-09-07
     eol: false
     link: https://support.apple.com/kb/SP781
-    supportedIosVersions: 12 - 17
+    supportedIosVersions: 12 - 18
 
 -   releaseCycle: "xs"
     releaseLabel: "XS"
@@ -233,7 +233,7 @@ releases:
     discontinued: 2019-09-10
     eol: false
     link: https://support.apple.com/kb/SP779
-    supportedIosVersions: 12 - 17
+    supportedIosVersions: 12 - 18
 
 -   releaseCycle: "xs-max"
     releaseLabel: "XS Max"
@@ -241,7 +241,7 @@ releases:
     discontinued: 2019-09-10
     eol: false
     link: https://support.apple.com/kb/SP780
-    supportedIosVersions: 12 - 17
+    supportedIosVersions: 12 - 18
 
 -   releaseCycle: "8"
     releaseLabel: "8"


### PR DESCRIPTION
iOS 18 released on September 16th, and is compatible with the following devices: https://support.apple.com/guide/iphone/iphone-models-compatible-with-ios-18-iphe3fa5df43/ios

Updated to reflect each iPhone that supports iOS 18.