### PR TITLE
[samsungmobile] Mark various devices as EOL

### DIFF
--- a/products/samsungmobile.md
+++ b/products/samsungmobile.md
@@ -741,14 +741,14 @@ releases:
 
 -   releaseCycle: "Galaxy Watch3"
     releaseDate: 2020-08-06
-    eoas: false
-    eol: false
+    eoas: true
+    eol: true
     link: https://doc.samsungmobile.com/sm-r850/btu/doc.html
 
 -   releaseCycle: "Galaxy A01 Core"
     releaseDate: 2020-08-06
     eoas: true
-    eol: false
+    eol: true
     link: https://doc.samsungmobile.com/SM-A013F/SEK/doc.html
 
 -   releaseCycle: "Galaxy Tab S7+"
@@ -759,32 +759,32 @@ releases:
 
 -   releaseCycle: "Galaxy M01 Core"
     releaseDate: 2020-07-29
-    eoas: false
-    eol: false
+    eoas: true
+    eol: true
     link: https://doc.samsungmobile.com/SM-M013F/INS/doc.html
 
 -   releaseCycle: "Galaxy M01s"
     releaseDate: 2020-07-16
-    eoas: false
-    eol: false
+    eoas: true
+    eol: true
     link: https://doc.samsungmobile.com/SM-M017F/INS/doc.html
 
 -   releaseCycle: "Galaxy A71 5G UW"
     releaseDate: 2020-07-16
-    eoas: false
-    eol: false
+    eoas: true
+    eol: true
     link: https://doc.samsungmobile.com/SM-A716V/CCT/doc.html
 
 -   releaseCycle: "Galaxy A21"
     releaseDate: 2020-06-26
-    eoas: false
-    eol: false # Quarterly
+    eoas: true
+    eol: true
     link: https://doc.samsungmobile.com/sm-a215u/usc/doc.html
 
 -   releaseCycle: "Galaxy A71 5G"
     releaseDate: 2020-06-15
-    eoas: false
-    eol: false
+    eoas: true
+    eol: true
     link: https://doc.samsungmobile.com/sm-a716u/spr/doc.html
 
 -   releaseCycle: "Galaxy S20 5G UW" # Verizon only
@@ -795,14 +795,14 @@ releases:
 
 -   releaseCycle: "Galaxy A21s"
     releaseDate: 2020-06-02
-    eoas: false
-    eol: false # Quarterly
+    eoas: true
+    eol: true
     link: https://doc.samsungmobile.com/SM-A217F/XEF/doc.html
 
 -   releaseCycle: "Galaxy M01"
     releaseDate: 2020-06-02
-    eoas: false
-    eol: false
+    eoas: true
+    eol: true
     link: https://doc.samsungmobile.com/SM-M015G/INS/doc.html
 
 -   releaseCycle: "Galaxy A Quantum"
@@ -819,26 +819,26 @@ releases:
 
 -   releaseCycle: "Galaxy A11"
     releaseDate: 2020-05-15
-    eoas: false
-    eol: false # Quarterly
+    eoas: true
+    eol: true
     link: https://doc.samsungmobile.com/SM-A115F/XSG/doc.html
 
 -   releaseCycle: "Galaxy M11"
     releaseDate: 2020-05-04
-    eoas: false
-    eol: false
+    eoas: true
+    eol: true
     link: https://doc.samsungmobile.com/SM-M115F/INS/doc.html
 
 -   releaseCycle: "Galaxy A31"
     releaseDate: 2020-04-27
-    eoas: false
-    eol: false # Quarterly
+    eoas: true
+    eol: true
     link: https://doc.samsungmobile.com/SM-A315F/MID/doc.html
 
 -   releaseCycle: "Galaxy J2 Core (2020)"
     releaseDate: 2020-04-27
     eoas: true # Android 8.1 Oreo (Go edition) is not supported anymore
-    eol: false
+    eol: true
     link: https://doc.samsungmobile.com/SM-J260FU/SER/doc.html
 
 -   releaseCycle: "Galaxy Xcover FieldPro"
@@ -861,8 +861,8 @@ releases:
 
 -   releaseCycle: "Galaxy A41"
     releaseDate: 2020-03-18
-    eoas: false
-    eol: false # Quarterly
+    eoas: true
+    eol: true
     link: https://doc.samsungmobile.com/SM-A415F/TMH/doc.html
 
 -   releaseCycle: "Galaxy S20 Ultra"
@@ -903,38 +903,38 @@ releases:
 
 -   releaseCycle: "Galaxy M31"
     releaseDate: 2020-03-05
-    eoas: false
-    eol: false
+    eoas: true
+    eol: true
     link: https://doc.samsungmobile.com/sm-m315f/ins/doc.html
 
 -   releaseCycle: "Galaxy Z Flip"
     releaseDate: 2020-02-14
-    eoas: false
-    eol: false
+    eoas: true
+    eol: true
     link: https://doc.samsungmobile.com/SM-F700F/XEH/doc.html
 
 -   releaseCycle: "Galaxy Tab S6 5G"
     releaseDate: 2020-01-30
-    eoas: false
-    eol: false
+    eoas: true
+    eol: true
     link: https://doc.samsungmobile.com/sm-t866n/koo/doc.html
 
 -   releaseCycle: "Galaxy A71"
     releaseDate: 2020-01-17
-    eoas: false
-    eol: false
+    eoas: true
+    eol: true
     link: https://doc.samsungmobile.com/sm-a715f/ins/doc.html
 
 -   releaseCycle: "Galaxy S10 Lite"
     releaseDate: 2020-01-03
-    eoas: false
-    eol: false
+    eoas: true
+    eol: true
     link: https://doc.samsungmobile.com/sm-g770f/phe/doc.html
 
 -   releaseCycle: "Galaxy Note10 Lite"
     releaseDate: 2020-01-03
-    eoas: false
-    eol: false
+    eoas: true
+    eol: true
     link: https://doc.samsungmobile.com/sm-n770f/xef/doc.html
 
 -   releaseCycle: "Galaxy XCover Pro" # Unclear release date.
@@ -945,14 +945,14 @@ releases:
 
 -   releaseCycle: "Galaxy A51"
     releaseDate: 2019-12-27
-    eoas: false
-    eol: false
+    eoas: true
+    eol: true
     link: https://doc.samsungmobile.com/SM-A515F/XEF/doc.html
 
 -   releaseCycle: "Galaxy A01"
     releaseDate: 2019-12-18
-    eoas: false
-    eol: false # Quarterly
+    eoas: true
+    eol: true
     link: https://doc.samsungmobile.com/SM-A015F/THL/doc.html
 
 -   releaseCycle: "Galaxy Fold 5G"


### PR DESCRIPTION
These are over 4 years old and no longer listed on the security updates page.