### PR TITLE
[vault] EOL 1.16 and 1.17 from standard maintenance

### DIFF
--- a/products/hashicorp-vault.md
+++ b/products/hashicorp-vault.md
@@ -33,14 +33,14 @@ releases:
 
 -   releaseCycle: "1.17"
     releaseDate: 2024-06-10
-    eol: false
+    eol: 2024-10-09 # releaseDate(1.18)
     latest: "1.17.6"
     latestReleaseDate: 2024-09-24
 
 -   releaseCycle: "1.16"
     releaseDate: 2024-03-25
     lts: true
-    eol: false
+    eol: 2025-06-12 # releaseDate(1.17)
     eoes: 2026-03-15 # approximate = releaseDate(1.22)
     latest: "1.16.3"
     latestReleaseDate: 2024-05-29
@@ -93,9 +93,9 @@ releases:
 > provides a unified interface to any secret, while providing tight access control and recording a
 > detailed audit log.
 
-- **Generally Available (GA)** releases of active products are supported under standard maintenance approximately
-for a year. The standard support period and end of life policy covers "N−2" versions,
-which means, at any given time, HashiCorp maintains the current version ("N") and the two previous versions ("N−2").
+- **Generally Available (GA)** support of the latest minor release. [Community versions](https://github.com/hashicorp/vault/issues/28471#issuecomment-2393714603)
+end when the next release occurs. While the [Enterprise versions](https://support.hashicorp.com/hc/en-us/articles/360021185113-Support-Period-and-End-of-Life-EOL-Policy)
+have extended support.
 
 - [**Long-Term-Support (LTS)**](https://developer.hashicorp.com/vault/docs/enterprise/lts)
 releases offers extended maintenance through minor releases for select,
@@ -108,8 +108,9 @@ releases.
 
 ## Maintenance Levels
 
-- **Standard Maintenance** includes new features, bug fixes, and security patches.
-- **Extended Maintenance** (only availble for LTS releases for Vault Enterprise customers) only includes
+- **Standard Maintenance** includes new features, bug fixes, and security patches to the
+  latest minor version.
+- **Extended Maintenance** (only available for LTS releases for Vault Enterprise customers) only includes
   patches for bugs that may cause outages and critical vulnerabilities and exposures (CVEs).
 
 ## Versioning and Release Cadence


### PR DESCRIPTION
Per discussion [1], community support for a given release ends when the next release occurs. Now that 1.18 is out, it is the only supported community release until 1.19 takes over. This effectively means the community support is rolling release model.

This does not make any changes to the enterprise versions, releases, or support model.

[1] https://github.com/hashicorp/vault/issues/28471#issuecomment-2393714603