### PR TITLE
Improved grammar and clarity in Pop_os description

### DIFF
--- a/products/pop_os.md
+++ b/products/pop_os.md
@@ -75,6 +75,6 @@ releases:
 
 ---
 
->[Pop!_OS](https://pop.system76.com) is a free and open-source Linux distribution based on Ubuntu.
+>[Pop!_OS](https://pop.system76.com) is a free, and open-source Linux distribution based on Ubuntu.
 
-The release schedule of Pop!_OS is the same as Ubuntu, with new releases every six months in April and October. Long term support releases are made every two years, in April of even-numbered years. Each non-LTS release is supported for three months after the release of the next version, and LTS releases are supported for five years. However, after the release of Pop!_OS 22.04, System76 announced that they will be skipping the release of 22.10 to better focus their resources in the development of Cosmic DE based on Rust.
+The release schedule of Pop!_OS is the same as Ubuntu, with new releases every six months in April and October. Long term support(LTS) releases are made every two years, in April of even-numbered years. Each non-LTS release is supported for three months after the release of the next version, and LTS releases are supported for five years. However, after the release of Pop!_OS 22.04, System76 announced they would skip the 22.10 release to better focus their resources on developing the Cosmic DE based on Rust.


### PR DESCRIPTION
- Grammar Consistency:

"Pop!_OS is a free, open-source Linux distribution based on Ubuntu." (Add a comma for readability).

- Stylistic Improvement:

"Long-term support (LTS) releases are made every two years in April of even-numbered years." (Spell out "Long-term support" and add the abbreviation).

- Wording Clarification:

"System76 announced they would skip the 22.10 release to better focus their resources on developing the Cosmic DE based on Rust." (Use "would" for consistency and change "in the development of" to "on developing").