### PR TITLE
[python] 3.8 is EOL

### DIFF
--- a/products/python.md
+++ b/products/python.md
@@ -162,7 +162,7 @@ releases:
 -   releaseCycle: "3.8"
     releaseDate: 2019-10-14
     eoas: 2021-05-03
-    eol: 2024-10-31
+    eol: 2024-10-07
     latest: "3.8.20"
     latestReleaseDate: 2024-09-06
 


### PR DESCRIPTION
* https://devguide.python.org/versions/
* https://github.com/python/devguide/pull/1430
* https://peps.python.org/pep-0569/
* https://github.com/python/peps/commit/ada0f55a8e29c11cc72b3f234558fade2ff5708e