### PR TITLE
Update supportedLinux for OpenZFS 2.2

### DIFF
--- a/products/openzfs.md
+++ b/products/openzfs.md
@@ -27,7 +27,7 @@ auto:
 # supportedLinux / supportedFreeBSD is available at the top of each release note and evolve even in minor versions.
 releases:
 -   releaseCycle: "2.2"
-    supportedLinux: "3.10 - 6.8"
+    supportedLinux: "4.18 - 6.10"
     supportedFreeBSD: "12.2-RELEASE+"
     releaseDate: 2023-10-12
     eol: false # releaseDate(2.3)


### PR DESCRIPTION
Update supportedlinux, see https://github.com/openzfs/zfs/releases/tag/zfs-2.2.6