### PR TITLE
Update supportedLinux for OpenZFS 2.1

### DIFF
--- a/products/openzfs.md
+++ b/products/openzfs.md
@@ -36,7 +36,7 @@ releases:
 
 -   releaseCycle: "2.1"
     lts: true
-    supportedLinux: "3.10 - 6.5"
+    supportedLinux: "3.10 - 6.7"
     supportedFreeBSD: "12.2-RELEASE+"
     releaseDate: 2021-07-02
     eol: false # still getting updates, estimation was 2023-07-02 releaseDate(x) plus 2 years


### PR DESCRIPTION
Update supportedLinux for OpenZFS 2.1, see
https://github.com/openzfs/zfs/releases/tag/zfs-2.1.15