### PR TITLE
[amazon-corretto] New EOL dates for Corretto 8 and 11

### DIFF
--- a/products/amazon-corretto.md
+++ b/products/amazon-corretto.md
@@ -143,7 +143,7 @@ releases:
 -   releaseCycle: "11"
     lts: true
     releaseDate: 2019-03-15
-    eol: 2027-10-31
+    eol: 2032-01-31
     latest: "11.0.24.8.1"
     latestReleaseDate: 2024-07-16
 

--- a/products/amazon-corretto.md
+++ b/products/amazon-corretto.md
@@ -151,7 +151,7 @@ releases:
 -   releaseCycle: "8"
     lts: true
     releaseDate: 2019-01-31
-    eol: 2026-07-31
+    eol: 2030-12-31
     latest: "8.422.05.1"
     latestReleaseDate: 2024-07-16
 


### PR DESCRIPTION
Amazon announced an Extension of EOL Dates for Amazon Corretto 8 and 11
https://aws.amazon.com/about-aws/whats-new/2024/10/extension-eol-dates-amazon-corretto-8-11/