### PR TITLE
[pan-pg]Updated GlobalProtect App to 6.2.5-c788

### DIFF
--- a/products/pan-gp.md
+++ b/products/pan-gp.md
@@ -42,8 +42,8 @@ releases:
     releaseDate: 2023-05-23
     eol: 2025-12-31
     eoas: 2025-05-23
-    latest: "6.2.4"
-    latestReleaseDate: 2024-07-15
+    latest: "6.2.5-c788"
+    latestReleaseDate: 2024-10-14
     link: https://docs.paloaltonetworks.com/globalprotect/6-2/globalprotect-app-release-notes/globalprotect-addressed-issues
 
 -   releaseCycle: "6.1"


### PR DESCRIPTION
GlobalProtect App from 6.2.4 to 6.2.5-c788.

Released: 2024-10-14

Release Notes: https://docs.paloaltonetworks.com/globalprotect/6-2/globalprotect-app-release-notes/globalprotect-addressed-issues