### PR TITLE
[pan-gp]Updated GlobalProtect App from 6.3.1 to 6.3.1-c383

### DIFF
--- a/products/pan-gp.md
+++ b/products/pan-gp.md
@@ -34,8 +34,8 @@ releases:
     releaseDate: 2024-06-13
     eol: 2026-06-13
     eoas: 2026-06-13
-    latest: "6.3.1"
-    latestReleaseDate: 2024-09-11
+    latest: "6.3.1-c383"
+    latestReleaseDate: 2024-10-14
     link: https://docs.paloaltonetworks.com/globalprotect/6-3/globalprotect-app-release-notes/globalprotect-addressed-issues
 
 -   releaseCycle: "6.2"


### PR DESCRIPTION
Updated GlobalProtect App from 6.3.1 to 6.3.1-c383

Released: 2024-10-14

Release Notes: https://docs.paloaltonetworks.com/globalprotect/6-3/globalprotect-app-release-notes/globalprotect-addressed-issues