### PR TITLE
[grafana] add PURL for grafana

### DIFF
--- a/products/grafana.md
+++ b/products/grafana.md
@@ -10,6 +10,7 @@ eoasColumn: true
 
 identifiers:
 -   purl: pkg:github/grafana/grafana
+-   purl: pkg:golang/github.com/grafana/grafana
 
 auto:
   methods:


### PR DESCRIPTION
found in syft sbom

```
syft grafana/grafana:10.3.0 -o json | jq | grep purl | grep "grafana/grafana@v10.3.0"
 ✔ Loaded image                                                                                                                           grafana/grafana:10.3.0
 ✔ Parsed image                                                                          sha256:c69037a302def00b3ec9db91d34f5566ef13058bceaf6d04344b95d6f0a5e893
 ✔ Cataloged contents                                                                           8084f80798288d758e8ed1de656c72884fc80931fda89a1d58348335c1df6b13
   ├── ✔ Packages                        [410 packages]
   ├── ✔ File digests                    [1,090 files]
   ├── ✔ File metadata                   [1,090 locations]
   └── ✔ Executables                     [119 executables]
      "purl": "pkg:golang/github.com/grafana/grafana@v10.3.0",

```