### PR TITLE
[jboss] Update JBoss to versions 8.0.3.1 and 7.4.19

### DIFF
--- a/products/red-hat-jboss-eap.md
+++ b/products/red-hat-jboss-eap.md
@@ -25,16 +25,16 @@ releases:
     eoas: 2028-02-05
     eol: 2031-02-05
     eoes: 2033-02-05
-    latest: "8.0.3"
-    latestReleaseDate: 2024-08-15
+    latest: "8.0.3.1"
+    latestReleaseDate: 2024-10-01
 
 -   releaseCycle: "7"
     releaseDate: 2016-05-01
     eoas: 2023-12-31
     eol: 2025-06-30
     eoes: 2026-11-30
-    latest: "7.4.18"
-    latestReleaseDate: 2024-08-08
+    latest: "7.4.19"
+    latestReleaseDate: 2024-10-14
 
 -   releaseCycle: "6"
     releaseDate: 2012-06-01


### PR DESCRIPTION
Release notes (viewing requires a free RedHat account):

* JBoss 7.4.19: https://access.redhat.com/articles/7081937
* JBoss 8.0.3.1: https://access.redhat.com/articles/7089667

The release notes information can be scraped with:

JBoss 7.4.19:

```shell
$ curl -s https://access.redhat.com/articles/7081937 | grep -A 4 "<h1 class=\"title\""
                              <h1 class="title">
                        JBoss Enterprise Application Platform 7.4 Update 19 Release Notes          </h1>

                                <div class="status-container">
              Updated <time class='moment_date' datetime='2024-10-14T19:46:09+00:00'>2024-10-14T19:46:09+00:00</time>
```

JBoss 8.0.3.1:

```shell
$ curl -s https://access.redhat.com/articles/7089667 | grep -A 4 "<h1 class=\"title\""
                              <h1 class="title">
                        JBoss Enterprise Application Platform 8.0 Update 3.1 Release Notes          </h1>

                                <div class="status-container">
              Updated <time class='moment_date' datetime='2024-10-01T17:02:50+00:00'>2024-10-01T17:02:50+00:00</time>
```