### PR TITLE
[jboss] Update the version command for JBoss EAP

### DIFF
--- a/products/red-hat-jboss-eap.md
+++ b/products/red-hat-jboss-eap.md
@@ -8,7 +8,7 @@ alternate_urls:
 -   /jboss-eap
 -   /jboss
 -   /red-hat-jboss-eap
-versionCommand: $JBOSS_HOME/bin/version.sh
+versionCommand: $JBOSS_HOME/bin/standalone.sh --version
 releasePolicyLink: https://access.redhat.com/support/policy/updates/jboss_notes
 changelogTemplate: "https://access.redhat.com/documentation/en-us/red_hat_jboss_enterprise_application_platform/{{'__LATEST__'|split:'.'|slice:0,2|join:'.'}}"
 releaseDateColumn: true


### PR DESCRIPTION
The command "version.sh" (or .bat, .ps1) does not exist anymore. The following command can be used instead: `standalone.sh --version`:

```shell
root@5adc53445b5e:/opt/eap/bin# $JBOSS_HOME/bin/standalone.sh --version
=========================================================================

  JBoss Bootstrap Environment

  JBOSS_HOME: /opt/eap

  JAVA: /usr/lib/jdk/bin/java

  JAVA_OPTS:  -server -Xlog:gc*:file="/opt/eap/standalone/log/gc.log":time,uptimemillis:filecount=5,filesize=3M -Djdk.serialFilter="maxbytes=10485760;maxdepth=128;maxarray=100000;maxrefs=300000" -Xms1303m -Xmx1303m -XX:MetaspaceSize=96M -XX:MaxMetaspaceSize=256m -Djava.net.preferIPv4Stack=true -Djboss.modules.system.pkgs=org.jboss.byteman -Djava.awt.headless=true  --add-exports=java.base/sun.nio.ch=ALL-UNNAMED --add-exports=jdk.unsupported/sun.misc=ALL-UNNAMED --add-exports=jdk.unsupported/sun.reflect=ALL-UNNAMED --add-exports=java.desktop/sun.awt=ALL-UNNAMED --add-exports=java.naming/com.sun.jndi.ldap=ALL-UNNAMED --add-exports=java.naming/com.sun.jndi.url.ldap=ALL-UNNAMED --add-exports=java.naming/com.sun.jndi.url.ldaps=ALL-UNNAMED --add-opens=java.base/com.sun.net.ssl.internal.ssl=ALL-UNNAMED --add-opens=java.base/java.lang=ALL-UNNAMED --add-opens=java.base/java.lang.invoke=ALL-UNNAMED --add-opens=java.base/java.lang.reflect=ALL-UNNAMED --add-opens=java.base/java.io=ALL-UNNAMED --add-opens=java.base/java.security=ALL-UNNAMED --add-opens=java.base/java.util=ALL-UNNAMED --add-opens=java.base/java.util.concurrent=ALL-UNNAMED --add-opens=java.management/javax.management=ALL-UNNAMED --add-opens=java.naming/javax.naming=ALL-UNNAMED

=========================================================================

2024-10-18 19:16:30,486 INFO  [org.jboss.modules] (main) JBoss Modules version 1.12.3.Final-redhat-00001
JBoss EAP 7.4.19.GA (WildFly Core 15.0.39.Final-redhat-00001)
```