### PR TITLE
[pixel] add Android 15

### DIFF
--- a/products/pixel.md
+++ b/products/pixel.md
@@ -30,7 +30,7 @@ releases:
     eol: 2031-09-01 # at least
     discontinued: false
     link: https://en.wikipedia.org/wiki/Pixel_9_Pro_Fold
-    supportedAndroidVersions: 14 # https://www.gsmarena.com/google_pixel_9_pro_fold-13220.php
+    supportedAndroidVersions: 14 - 15 # https://www.gsmarena.com/google_pixel_9_pro_fold-13220.php
 
 -   releaseCycle: "9pro"
     releaseLabel: "Pixel 9 Pro"
@@ -39,7 +39,7 @@ releases:
     eol: 2031-09-01 # at least
     discontinued: false
     link: https://en.wikipedia.org/wiki/Pixel_9_Pro
-    supportedAndroidVersions: 14 # https://www.gsmarena.com/google_pixel_9_pro-13218.php
+    supportedAndroidVersions: 14 - 15 # https://www.gsmarena.com/google_pixel_9_pro-13218.php
 
 -   releaseCycle: "9proxl"
     releaseLabel: "Pixel 9 Pro XL"
@@ -48,7 +48,7 @@ releases:
     eol: 2031-08-01 # at least
     discontinued: false
     link: https://en.wikipedia.org/wiki/Pixel_9_Pro_XL
-    supportedAndroidVersions: 14 # https://www.gsmarena.com/google_pixel_9_pro_xl-13217.php
+    supportedAndroidVersions: 14 - 15 # https://www.gsmarena.com/google_pixel_9_pro_xl-13217.php
 
 -   releaseCycle: "9"
     releaseLabel: "Pixel 9"
@@ -57,7 +57,7 @@ releases:
     eol: 2031-08-01 # at least
     discontinued: false
     link: https://en.wikipedia.org/wiki/Pixel_9
-    supportedAndroidVersions: 14 # https://www.gsmarena.com/google_pixel_9_pro-13219.php
+    supportedAndroidVersions: 14 - 15 # https://www.gsmarena.com/google_pixel_9_pro-13219.php
 
 -   releaseCycle: "8a"
     releaseLabel: "Pixel 8a"
@@ -66,7 +66,7 @@ releases:
     eol: 2031-05-01 # at least
     discontinued: false
     link: https://en.wikipedia.org/wiki/Pixel_8a
-    supportedAndroidVersions: 14 # https://www.gsmarena.com/google_pixel_8a-12937.php
+    supportedAndroidVersions: 14 - 15 # https://www.gsmarena.com/google_pixel_8a-12937.php
     
 -   releaseCycle: "8pro"
     releaseLabel: "Pixel 8 Pro"
@@ -75,7 +75,7 @@ releases:
     eol: 2030-10-01 # at least
     discontinued: false
     link: https://en.wikipedia.org/wiki/Pixel_8_Pro
-    supportedAndroidVersions: 14 # https://www.gsmarena.com/google_pixel_8-12546.php
+    supportedAndroidVersions: 14 - 15 # https://www.gsmarena.com/google_pixel_8-12546.php
 
 -   releaseCycle: "8"
     releaseLabel: "Pixel 8"
@@ -84,7 +84,7 @@ releases:
     eol: 2030-10-01 # at least
     discontinued: false
     link: https://en.wikipedia.org/wiki/Pixel_8
-    supportedAndroidVersions: 14 # https://www.gsmarena.com/google_pixel_8-12546.php
+    supportedAndroidVersions: 14 - 15 # https://www.gsmarena.com/google_pixel_8-12546.php
 
 -   releaseCycle: "fold"
     releaseLabel: "Pixel Fold"
@@ -93,7 +93,7 @@ releases:
     eol: 2028-06-01  # at least
     discontinued: false
     link: https://en.wikipedia.org/wiki/Pixel_Fold
-    supportedAndroidVersions: 13 - 14 # https://www.gsmarena.com/google_pixel_fold-12265.php
+    supportedAndroidVersions: 13 - 15 # https://www.gsmarena.com/google_pixel_fold-12265.php
 
 -   releaseCycle: "tablet"
     releaseLabel: "Pixel Tablet"
@@ -102,7 +102,7 @@ releases:
     eol: 2028-06-01 # at least
     discontinued: false
     link: https://en.wikipedia.org/wiki/Pixel_Tablet
-    supportedAndroidVersions: 13 - 14 # https://www.gsmarena.com/google_pixel_tablet-11905.php
+    supportedAndroidVersions: 13 - 15 # https://www.gsmarena.com/google_pixel_tablet-11905.php
 
 -   releaseCycle: "7a"
     releaseLabel: "Pixel 7a"
@@ -111,7 +111,7 @@ releases:
     eol: 2028-05-01 # at least
     discontinued: false
     link: https://en.wikipedia.org/wiki/Pixel_7a
-    supportedAndroidVersions: 13 - 14 # https://www.gsmarena.com/google_pixel_7a-12170.php
+    supportedAndroidVersions: 13 - 15 # https://www.gsmarena.com/google_pixel_7a-12170.php
 
 -   releaseCycle: "7pro"
     releaseLabel: "Pixel 7 Pro"
@@ -120,7 +120,7 @@ releases:
     eol: 2027-10-01 # at least
     discontinued: false
     link: https://en.wikipedia.org/wiki/Pixel_7_Pro
-    supportedAndroidVersions: 13 - 14 # https://www.gsmarena.com/google_pixel_7_pro-11908.php
+    supportedAndroidVersions: 13 - 15 # https://www.gsmarena.com/google_pixel_7_pro-11908.php
 
 -   releaseCycle: "7"
     releaseLabel: "Pixel 7"
@@ -129,7 +129,7 @@ releases:
     eol: 2027-10-01 # at least
     discontinued: false
     link: https://en.wikipedia.org/wiki/Pixel_7
-    supportedAndroidVersions: 13 - 14 # https://www.gsmarena.com/google_pixel_7-11903.php
+    supportedAndroidVersions: 13 - 15 # https://www.gsmarena.com/google_pixel_7-11903.php
 
 -   releaseCycle: "6a"
     releaseLabel: "Pixel 6a"
@@ -138,7 +138,7 @@ releases:
     eol: 2027-07-01 # at least
     discontinued: false
     link: https://en.wikipedia.org/wiki/Pixel_6a
-    supportedAndroidVersions: 12 - 14 # https://www.gsmarena.com/google_pixel_6a-11229.php
+    supportedAndroidVersions: 12 - 15 # https://www.gsmarena.com/google_pixel_6a-11229.php
 
 -   releaseCycle: "6pro"
     releaseLabel: "Pixel 6 Pro"
@@ -147,7 +147,7 @@ releases:
     eol: 2026-10-01 # at least
     discontinued: 2022-10-06
     link: https://en.wikipedia.org/wiki/Pixel_6_Pro
-    supportedAndroidVersions: 12 - 14 # https://www.gsmarena.com/google_pixel_6_pro-10918.php
+    supportedAndroidVersions: 12 - 15 # https://www.gsmarena.com/google_pixel_6_pro-10918.php
 
 -   releaseCycle: "6"
     releaseLabel: "Pixel 6"
@@ -156,7 +156,7 @@ releases:
     eol: 2026-10-01 # at least
     discontinued: 2022-10-06
     link: https://en.wikipedia.org/wiki/Pixel_6
-    supportedAndroidVersions: 12 - 14 # https://www.gsmarena.com/google_pixel_6-11037.php
+    supportedAndroidVersions: 12 - 15 # https://www.gsmarena.com/google_pixel_6-11037.php
 
 -   releaseCycle: "5a"
     releaseLabel: "Pixel 5a"


### PR DESCRIPTION
As in the title. Update for devices where Android 15 is available. Based on [this official website](https://developers.google.com/android/images) where flash images can be downloaded from.

Surprisingly, but a nice gesture from Google, is that 6-series devices have been updated even though technically they've been end-of-life for 2 weeks on the day of release.