### PR TITLE
[pan-gp]Updated GlobalProtect from 6.0.10 to 6.0.10-c823

### DIFF
--- a/products/pan-gp.md
+++ b/products/pan-gp.md
@@ -58,8 +58,8 @@ releases:
     releaseDate: 2022-02-22
     eol: 2025-12-31
     eoas: 2025-12-31
-    latest: "6.0.10"
-    latestReleaseDate: 2024-05-15
+    latest: "6.0.10-c823"
+    latestReleaseDate: 2024-10-22
     link: https://docs.paloaltonetworks.com/globalprotect/6-0/globalprotect-app-release-notes/globalprotect-addressed-issues
 
 -   releaseCycle: "5.3"


### PR DESCRIPTION
Updated GlobalProtect from 6.0.10 to 6.0.10-c823

Released: 2024-10-22

Release Notes: https://docs.paloaltonetworks.com/globalprotect/6-0/globalprotect-app-release-notes/globalprotect-addressed-issues