### PR TITLE
[new-product] Add greenlight

### DIFF
--- a/products/greenlight.md
+++ b/products/greenlight.md
@@ -4,6 +4,7 @@ category: server-app
 iconSlug: bigbluebutton
 permalink: /greenlight
 releasePolicyLink: https://github.com/bigbluebutton/greenlight/security
+releaseDateColumn: true
 
 auto:
   methods:
@@ -12,11 +13,15 @@ auto:
 releases:
 -   releaseCycle: "3"
     eol: false
-    latest: "3.4.1"
+    latest: "3.5.0"
+    releaseDate: 2023-02-16
+    latestReleaseDate: 2025-02-19
 
 -   releaseCycle: "2"
     eol: true
     latest: "2.14.10"
+    releaseDate: 2018-09-14
+    latestReleaseDate: 2024-05-03
 
 -   releaseCycle: "1"
     eol: true

--- a/products/greenlight.md
+++ b/products/greenlight.md
@@ -1,0 +1,20 @@
+---
+title: Greenlight
+category: server-app
+iconSlug: bigbluebutton
+permalink: /greenlight
+releasePolicyLink: https://github.com/bigbluebutton/greenlight/security
+releases:
+-   releaseCycle: "3"
+    eol: false
+    latest: "3.4.1"
+-   releaseCycle: "2"
+    eol: true
+    latest: "2.14.10"
+-   releaseCycle: "1"
+    eol: true
+    latest: "1.0"
+
+---
+
+> [Greenlight](https://docs.bigbluebutton.org/greenlight/v3/install/) is an open-source web user interface for BigBlueButton.

--- a/products/greenlight.md
+++ b/products/greenlight.md
@@ -23,10 +23,6 @@ releases:
     releaseDate: 2018-09-14
     latestReleaseDate: 2024-05-03
 
--   releaseCycle: "1"
-    eol: true
-    latest: "1.0"
-
 ---
 
 > [Greenlight](https://docs.bigbluebutton.org/greenlight/v3/install/) is an open-source web user interface for BigBlueButton.

--- a/products/greenlight.md
+++ b/products/greenlight.md
@@ -9,6 +9,7 @@ releaseDateColumn: true
 auto:
   methods:
   -   git: https://github.com/bigbluebutton/greenlight.git
+      regex: '^release-(?P<major>\d+)\.(?P<minor>\d+)(\.(?P<patch>\d+))?$'
 
 # EOL dates can be found in SECURITY.md history (https://github.com/bigbluebutton/greenlight/commits/master/SECURITY.md)
 releases:

--- a/products/greenlight.md
+++ b/products/greenlight.md
@@ -5,6 +5,10 @@ iconSlug: bigbluebutton
 permalink: /greenlight
 releasePolicyLink: https://github.com/bigbluebutton/greenlight/security
 
+auto:
+  methods:
+  -   git: https://github.com/bigbluebutton/greenlight.git
+
 releases:
 -   releaseCycle: "3"
     eol: false

--- a/products/greenlight.md
+++ b/products/greenlight.md
@@ -3,6 +3,7 @@ title: Greenlight
 category: server-app
 iconSlug: bigbluebutton
 permalink: /greenlight
+changelogTemplate: https://github.com/bigbluebutton/greenlight/releases/tag/release-__LATEST__
 releaseDateColumn: true
 
 auto:

--- a/products/greenlight.md
+++ b/products/greenlight.md
@@ -3,7 +3,6 @@ title: Greenlight
 category: server-app
 iconSlug: bigbluebutton
 permalink: /greenlight
-releasePolicyLink: https://github.com/bigbluebutton/greenlight/security
 releaseDateColumn: true
 
 auto:
@@ -26,3 +25,5 @@ releases:
 ---
 
 > [Greenlight](https://docs.bigbluebutton.org/greenlight/v3/install/) is an open-source web user interface for BigBlueButton.
+
+Greenlight supported versions are documented on <https://github.com/bigbluebutton/greenlight/security>.

--- a/products/greenlight.md
+++ b/products/greenlight.md
@@ -4,13 +4,16 @@ category: server-app
 iconSlug: bigbluebutton
 permalink: /greenlight
 releasePolicyLink: https://github.com/bigbluebutton/greenlight/security
+
 releases:
 -   releaseCycle: "3"
     eol: false
     latest: "3.4.1"
+
 -   releaseCycle: "2"
     eol: true
     latest: "2.14.10"
+
 -   releaseCycle: "1"
     eol: true
     latest: "1.0"

--- a/products/greenlight.md
+++ b/products/greenlight.md
@@ -10,21 +10,23 @@ auto:
   methods:
   -   git: https://github.com/bigbluebutton/greenlight.git
 
+# EOL dates can be found in SECURITY.md history (https://github.com/bigbluebutton/greenlight/commits/master/SECURITY.md)
 releases:
 -   releaseCycle: "3"
+    releaseDate: 2023-02-16
     eol: false
     latest: "3.5.0"
-    releaseDate: 2023-02-16
     latestReleaseDate: 2025-02-19
 
 -   releaseCycle: "2"
-    eol: true
-    latest: "2.14.10"
     releaseDate: 2018-09-14
+    eol: 2023-09-11 # https://github.com/bigbluebutton/greenlight/commit/f739387a304b7d8f8d28b5cf5d96e801f7f60546
+    latest: "2.14.10"
     latestReleaseDate: 2024-05-03
 
 ---
 
-> [Greenlight](https://docs.bigbluebutton.org/greenlight/v3/install/) is an open-source web user interface for BigBlueButton.
+> [Greenlight](https://docs.bigbluebutton.org/greenlight/v3/install/) is an open-source web user interface for
+> BigBlueButton.
 
 Greenlight supported versions are documented on <https://github.com/bigbluebutton/greenlight/security>.


### PR DESCRIPTION
Followup to https://github.com/endoflife-date/endoflife.date/pull/6091

I could not find an exact latest release for the 1.x branch, the Git repository does not have any tags for this branch.