### PR TITLE
[log4j] adding purl identifier

### DIFF
--- a/products/log4j.md
+++ b/products/log4j.md
@@ -17,6 +17,7 @@ identifiers:
 -   cpe: cpe:/a:apache:log4j
 -   cpe: cpe:2.3:a:apache:log4j
 -   purl: pkg:maven/org.apache.logging.log4j/log4j-core
+-   purl: pkg:maven/log4j/log4j
 
 auto:
   methods:

--- a/products/log4j.md
+++ b/products/log4j.md
@@ -16,6 +16,7 @@ identifiers:
 -   repology: log4j
 -   cpe: cpe:/a:apache:log4j
 -   cpe: cpe:2.3:a:apache:log4j
+-   purl: pkg:maven/org.apache.logging.log4j/log4j-core
 
 auto:
   methods:


### PR DESCRIPTION

2.x https://mvnrepository.com/artifact/org.apache.logging.log4j/log4j-core
1.x https://mvnrepository.com/artifact/log4j/log4j

I think the cycles listed here can also be updated, since "2" doesnt seem like a valid cycle. I will create another ticket for that.