### PR TITLE
Update EOL policy for Kibana, Logstash and Elastic Beats

### DIFF
--- a/products/beats.md
+++ b/products/beats.md
@@ -64,7 +64,7 @@ other products in the Elastic Stack (Elasticsearch, Logstash, Kibana...).
 
 Elastic Stack product releases follow [Semantic Versioning](https://semver.org/). Elastic provides
 maintenance for each major release series for the longest of 30 months after the GA date of the
-major release or 6 months after the GA date of the subsequent major release.
+major release or 18 months after the GA date of the subsequent major release.
 
 End of life dates for Beats can be found on the [Elastic product EOL dates page](https://www.elastic.co/support/eol).
 Support for various operating systems can also be found on the [Elastic support matrix page](https://www.elastic.co/support/matrix).

--- a/products/kibana.md
+++ b/products/kibana.md
@@ -48,7 +48,7 @@ other products in the Elastic Stack (Elasticsearch, Logstash, Beats...).
 
 Elastic Stack product releases follow [Semantic Versioning](https://semver.org/). Elastic provides
 maintenance for each major release series for the longest of 30 months after the GA date of the
-major release or 6 months after the GA date of the subsequent major release.
+major release or 18 months after the GA date of the subsequent major release.
 
 End of life dates for Kibana can be found on the [Elastic product EOL dates page](https://www.elastic.co/support/eol).
 Support for various operating systems can also be found on the [Elastic support matrix page](https://www.elastic.co/support/matrix).

--- a/products/logstash.md
+++ b/products/logstash.md
@@ -48,7 +48,7 @@ other products in the Elastic Stack (Elasticsearch, Kibana, Beats...).
 
 Elastic Stack product releases follow [Semantic Versioning](https://semver.org/). Elastic provides
 maintenance for each major release series for the longest of 30 months after the GA date of the
-major release or 6 months after the GA date of the subsequent major release.
+major release or 18 months after the GA date of the subsequent major release.
 
 End of life dates for Logstash can be found on the [Elastic product EOL dates page](https://www.elastic.co/support/eol).
 Support for various operating systems can also be found on the [Elastic support matrix page](https://www.elastic.co/support/matrix).


### PR DESCRIPTION
Per https://www.elastic.co/support/eol and https://www.elastic.co/support_policy, these products will be maintained for the longer of (i) 30 months after the general availability ("GA") date of the major release (e.g., 8.0.0) or (ii) 18 months after the GA date of the subsequent major release (e.g., 9.0.0).

Update the description of these products to reflect the same.

Closes #5401 