### PR TITLE
[Spring framework] Add commercial (HeroDevs) support for EOL versions.

### DIFF
--- a/_layouts/product.html
+++ b/_layouts/product.html
@@ -44,7 +44,6 @@ layout: default
       {% if page.eoasColumn %}<th>{{ page.eoasColumnLabel }}</th>{% assign colCount = colCount | plus:1 %}{% endif %}
       {% if page.eolColumn %}<th>{{ page.eolColumnLabel }}</th>{% assign colCount = colCount | plus:1 %}{% endif %}
       {% if page.eoesColumn %}<th>{{ page.eoesColumnLabel }}</th>{% assign colCount = colCount | plus:1 %}{% endif %}
-      {% if page.commercialProviderColumn %}<th>Commercial Support Provider</th>{% assign colCount = colCount | plus:1 %}{% endif %}
       {% for column in customColumnsBeforeLatest %}{% include custom-column-th.html column=column %}{% assign colCount = colCount | plus:1 %}{% endfor %}
       {% if page.releaseColumn %}<th>{{ page.releaseColumnLabel }}</th>{% assign colCount = colCount | plus:1 %}{% endif %}
       {% for column in customColumnsAfterLatest %}{% include custom-column-th.html column=column %}{% assign colCount = colCount | plus:1 %}{% endfor %}
@@ -130,14 +129,7 @@ layout: default
     </td>
     {% endif %}
 
-    {% if page.commercialProviderColumn %}
-    <td>
-      {% if r.commercialProviderColumn  %}
-        {{ r.commercialProviderColumn }}
-      {% endif %}
-    </td>
-    {% endif %}
-        {%- for column in customColumnsBeforeLatest %}
+    {%- for column in customColumnsBeforeLatest %}
     {% include custom-column-td.html release=r column=column %}
     {%- endfor %}
 
@@ -160,8 +152,8 @@ layout: default
   </tr>
 {% endfor %}
 {% assign can_be_hidden_releases_count = page.releases | where: 'can_be_hidden', true | size %}
-{% if can_be_hidden_releases_count > 0 %}
-  <tr id="show-more-row" class="d-none">
+{% if can_be_hidden_releases_count > 0 and page.omitHiddenReleaseButton != true %}
+<tr id="show-more-row" class="d-none">
     <td colspan="{{ colCount }}" class="text-center">
       <button id="show-hidden-releases-button" class="btn">
         Show more unmaintained releases

--- a/_layouts/product.html
+++ b/_layouts/product.html
@@ -44,6 +44,7 @@ layout: default
       {% if page.eoasColumn %}<th>{{ page.eoasColumnLabel }}</th>{% assign colCount = colCount | plus:1 %}{% endif %}
       {% if page.eolColumn %}<th>{{ page.eolColumnLabel }}</th>{% assign colCount = colCount | plus:1 %}{% endif %}
       {% if page.eoesColumn %}<th>{{ page.eoesColumnLabel }}</th>{% assign colCount = colCount | plus:1 %}{% endif %}
+      {% if page.commercialProviderColumn %}<th>Commercial Support Provider</th>{% assign colCount = colCount | plus:1 %}{% endif %}
       {% for column in customColumnsBeforeLatest %}{% include custom-column-th.html column=column %}{% assign colCount = colCount | plus:1 %}{% endfor %}
       {% if page.releaseColumn %}<th>{{ page.releaseColumnLabel }}</th>{% assign colCount = colCount | plus:1 %}{% endif %}
       {% for column in customColumnsAfterLatest %}{% include custom-column-th.html column=column %}{% assign colCount = colCount | plus:1 %}{% endfor %}
@@ -129,7 +130,14 @@ layout: default
     </td>
     {% endif %}
 
-    {%- for column in customColumnsBeforeLatest %}
+    {% if page.commercialProviderColumn %}
+    <td>
+      {% if r.commercialProviderColumn  %}
+        {{ r.commercialProviderColumn }}
+      {% endif %}
+    </td>
+    {% endif %}
+        {%- for column in customColumnsBeforeLatest %}
     {% include custom-column-td.html release=r column=column %}
     {%- endfor %}
 

--- a/_layouts/product.html
+++ b/_layouts/product.html
@@ -152,7 +152,7 @@ layout: default
   </tr>
 {% endfor %}
 {% assign can_be_hidden_releases_count = page.releases | where: 'can_be_hidden', true | size %}
-{% if can_be_hidden_releases_count > 0 and page.omitHiddenReleaseButton != true %}
+{% if can_be_hidden_releases_count > 0 and page.omitUnmaintainedReleasesButton != true %}
 <tr id="show-more-row" class="d-none">
     <td colspan="{{ colCount }}" class="text-center">
       <button id="show-hidden-releases-button" class="btn">

--- a/products/spring-framework.md
+++ b/products/spring-framework.md
@@ -11,7 +11,7 @@ changelogTemplate: https://github.com/spring-projects/spring-framework/releases/
 releaseDateColumn: true
 eolColumn: OSS support
 eoesColumn: Commercial Support
-commercialProviderColumn: true
+omitUnmaintainedReleasesButton: true
 
 auto:
   methods:
@@ -37,7 +37,6 @@ releases:
     releaseDate: 2023-11-16
     eol: 2025-08-31
     eoes: 2026-12-31
-    commercialProviderColumn: VMWare, HeroDevs
     latest: "6.1.14"
     latestReleaseDate: 2024-10-17
 
@@ -47,7 +46,6 @@ releases:
     releaseDate: 2022-11-16
     eol: 2024-08-31
     eoes: 2025-12-31
-    commercialProviderColumn: VMWare, HeroDevs
     latest: "6.0.23"
     latestReleaseDate: 2024-08-14
 
@@ -57,7 +55,6 @@ releases:
     releaseDate: 2020-10-27
     eol: 2024-08-31
     eoes: 2026-12-31
-    commercialProviderColumn: VMWare, HeroDevs
     lts: true
     latest: "5.3.39"
     latestReleaseDate: 2024-08-14
@@ -68,7 +65,6 @@ releases:
     releaseDate: 2019-09-30
     eol: 2021-12-31
     eoes: 2023-12-31
-    commercialProviderColumn: HeroDevs
     link: https://github.com/spring-projects/spring-framework/releases/tag/v__LATEST__.RELEASE
     latest: "5.2.25"
     latestReleaseDate: 2023-07-13
@@ -79,7 +75,6 @@ releases:
     releaseDate: 2018-09-21
     eol: 2020-12-31
     eoes: 2022-12-31
-    commercialProviderColumn: HeroDevs
     link: https://github.com/spring-projects/spring-framework/releases/tag/v__LATEST__.RELEASE
     latest: "5.1.20"
     latestReleaseDate: 2020-12-09
@@ -89,7 +84,6 @@ releases:
     supportedJakartaEEVersions: "N/A"
     releaseDate: 2017-09-28
     eol: 2020-12-31
-    commercialProviderColumn: HeroDevs
     link: https://github.com/spring-projects/spring-framework/releases/tag/v__LATEST__.RELEASE
     latest: "5.0.20"
     latestReleaseDate: 2020-12-09
@@ -99,7 +93,6 @@ releases:
     supportedJakartaEEVersions: "N/A"
     releaseDate: 2016-06-10
     eol: 2020-12-31
-    commercialProviderColumn: HeroDevs
     link: https://github.com/spring-projects/spring-framework/releases/tag/v__LATEST__.RELEASE
     latest: "4.3.30"
     latestReleaseDate: 2020-12-09
@@ -109,7 +102,6 @@ releases:
     supportedJakartaEEVersions: "N/A"
     releaseDate: 2012-12-13
     eol: 2016-12-31
-    commercialProviderColumn: (TODO - Two bots say no support)
     link: https://github.com/spring-projects/spring-framework/releases/tag/v__LATEST__.RELEASE
     latest: "3.2.18"
     latestReleaseDate: 2016-12-21
@@ -124,8 +116,42 @@ See [Spring Boot Milestones page](https://github.com/spring-projects/spring-fram
 for upcoming releases and [Spring Boot Support page](https://spring.io/projects/spring-framework#support)
 for more details about support roadmap.
 
-Extended support is available from
-[VMWare](https://tanzu.vmware.com/content/blog/vmware-spring-runtime-extended-support) and [HeroDevs](https://www.herodevs.com/support/spring-nes).
+Commercial support is available from
+[VMWare](https://tanzu.vmware.com/content/blog/vmware-spring-runtime-extended-support) and [HeroDevs NES](https://www.herodevs.com/support/spring-nes).
+
+<table class="lifecycle">
+    <thead>
+        <tr>
+            <th style="width: 100pt;">Version</th>
+            <th style="width: 220pt;">VMWare</th>
+            <th style="width: 220pt;">HeroDevs</th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr>
+            <td>6.1</td>
+            <td class="bg-green-000">Ends on 31 Dec 2026</td>
+            <td class="bg-green-000">Ends on 31 Dec 2028</td>
+        </tr>
+        <tr>
+            <td>6.0</td>
+            <td class="bg-green-000">Ends on 31 Dec 2026</td>
+            <td class="bg-green-000">Ends on 31 Dec 2027</td>
+        </tr>
+        <tr>
+            <td>5.3</td>
+            <td class="bg-green-000">Ends on 31 Dec 2026</td>
+            <td class="bg-green-000">Ends on 31 Dec 2036</td>
+        </tr>
+        <tr>
+            <td>4.3</td>
+            <td class="bg-red-000">Ended 31 Dec 2022</td>
+            <td class="bg-green-000">Ends on 31 Dec 2036</td>
+        </tr>
+    </tbody>
+</table>
+
+
 
 ## [JDK/Jakarta EE Compatibility](https://github.com/spring-projects/spring-framework/wiki/Spring-Framework-Versions#jdk-version-range)
 

--- a/products/spring-framework.md
+++ b/products/spring-framework.md
@@ -1,7 +1,7 @@
 ---
 title: Spring Framework
 category: framework
-tags: java-runtime vmware
+tags: java-runtime vmware herodevs
 iconSlug: spring
 permalink: /spring-framework
 alternate_urls:
@@ -36,7 +36,7 @@ releases:
     supportedJakartaEEVersions: "9 - 10"
     releaseDate: 2023-11-16
     eol: 2025-08-31
-    eoes: 2026-12-31
+    eoes: 2028-12-31
     latest: "6.1.14"
     latestReleaseDate: 2024-10-17
 
@@ -45,7 +45,7 @@ releases:
     supportedJakartaEEVersions: "9 - 10"
     releaseDate: 2022-11-16
     eol: 2024-08-31
-    eoes: 2025-12-31
+    eoes: 2027-12-31
     latest: "6.0.23"
     latestReleaseDate: 2024-08-14
 
@@ -54,7 +54,7 @@ releases:
     supportedJakartaEEVersions: "7 - 8"
     releaseDate: 2020-10-27
     eol: 2024-08-31
-    eoes: 2026-12-31
+    eoes: 2036-12-31
     lts: true
     latest: "5.3.39"
     latestReleaseDate: 2024-08-14
@@ -93,6 +93,7 @@ releases:
     supportedJakartaEEVersions: "N/A"
     releaseDate: 2016-06-10
     eol: 2020-12-31
+    eoes: 2036-12-31
     link: https://github.com/spring-projects/spring-framework/releases/tag/v__LATEST__.RELEASE
     latest: "4.3.30"
     latestReleaseDate: 2020-12-09

--- a/products/spring-framework.md
+++ b/products/spring-framework.md
@@ -115,8 +115,8 @@ See [Spring Boot Milestones page](https://github.com/spring-projects/spring-fram
 for upcoming releases and [Spring Boot Support page](https://spring.io/projects/spring-framework#support)
 for more details about support roadmap.
 
-Extended support is available
-[from VMWare](https://tanzu.vmware.com/content/blog/vmware-spring-runtime-extended-support).
+Extended support is available from
+[VMWare](https://tanzu.vmware.com/content/blog/vmware-spring-runtime-extended-support) and [HeroDevs](https://www.herodevs.com/support/spring-nes).
 
 ## [JDK/Jakarta EE Compatibility](https://github.com/spring-projects/spring-framework/wiki/Spring-Framework-Versions#jdk-version-range)
 

--- a/products/spring-framework.md
+++ b/products/spring-framework.md
@@ -11,6 +11,7 @@ changelogTemplate: https://github.com/spring-projects/spring-framework/releases/
 releaseDateColumn: true
 eolColumn: OSS support
 eoesColumn: Commercial Support
+commercialProviderColumn: true
 
 auto:
   methods:
@@ -36,6 +37,7 @@ releases:
     releaseDate: 2023-11-16
     eol: 2025-08-31
     eoes: 2026-12-31
+    commercialProviderColumn: VMWare, HeroDevs
     latest: "6.1.14"
     latestReleaseDate: 2024-10-17
 
@@ -45,6 +47,7 @@ releases:
     releaseDate: 2022-11-16
     eol: 2024-08-31
     eoes: 2025-12-31
+    commercialProviderColumn: VMWare, HeroDevs
     latest: "6.0.23"
     latestReleaseDate: 2024-08-14
 
@@ -54,6 +57,7 @@ releases:
     releaseDate: 2020-10-27
     eol: 2024-08-31
     eoes: 2026-12-31
+    commercialProviderColumn: VMWare, HeroDevs
     lts: true
     latest: "5.3.39"
     latestReleaseDate: 2024-08-14
@@ -64,6 +68,7 @@ releases:
     releaseDate: 2019-09-30
     eol: 2021-12-31
     eoes: 2023-12-31
+    commercialProviderColumn: HeroDevs
     link: https://github.com/spring-projects/spring-framework/releases/tag/v__LATEST__.RELEASE
     latest: "5.2.25"
     latestReleaseDate: 2023-07-13
@@ -74,6 +79,7 @@ releases:
     releaseDate: 2018-09-21
     eol: 2020-12-31
     eoes: 2022-12-31
+    commercialProviderColumn: HeroDevs
     link: https://github.com/spring-projects/spring-framework/releases/tag/v__LATEST__.RELEASE
     latest: "5.1.20"
     latestReleaseDate: 2020-12-09
@@ -83,6 +89,7 @@ releases:
     supportedJakartaEEVersions: "N/A"
     releaseDate: 2017-09-28
     eol: 2020-12-31
+    commercialProviderColumn: HeroDevs
     link: https://github.com/spring-projects/spring-framework/releases/tag/v__LATEST__.RELEASE
     latest: "5.0.20"
     latestReleaseDate: 2020-12-09
@@ -92,6 +99,7 @@ releases:
     supportedJakartaEEVersions: "N/A"
     releaseDate: 2016-06-10
     eol: 2020-12-31
+    commercialProviderColumn: HeroDevs
     link: https://github.com/spring-projects/spring-framework/releases/tag/v__LATEST__.RELEASE
     latest: "4.3.30"
     latestReleaseDate: 2020-12-09
@@ -101,6 +109,7 @@ releases:
     supportedJakartaEEVersions: "N/A"
     releaseDate: 2012-12-13
     eol: 2016-12-31
+    commercialProviderColumn: (TODO - Two bots say no support)
     link: https://github.com/spring-projects/spring-framework/releases/tag/v__LATEST__.RELEASE
     latest: "3.2.18"
     latestReleaseDate: 2016-12-21

--- a/products/spring-framework.md
+++ b/products/spring-framework.md
@@ -84,6 +84,7 @@ releases:
     supportedJakartaEEVersions: "N/A"
     releaseDate: 2017-09-28
     eol: 2020-12-31
+    eoes: 2020-12-31
     link: https://github.com/spring-projects/spring-framework/releases/tag/v__LATEST__.RELEASE
     latest: "5.0.20"
     latestReleaseDate: 2020-12-09
@@ -113,8 +114,8 @@ releases:
 > programming and configuration model for modern Java-based enterprise applications - on any kind of
 > deployment platform.
 
-See [Spring Boot Milestones page](https://github.com/spring-projects/spring-framework/milestones)
-for upcoming releases and [Spring Boot Support page](https://spring.io/projects/spring-framework#support)
+See [Spring Framework Milestones page](https://github.com/spring-projects/spring-framework/milestones)
+for upcoming releases and [Spring Framework Support page](https://spring.io/projects/spring-framework#support)
 for more details about support roadmap.
 
 Commercial support is available from
@@ -131,28 +132,26 @@ Commercial support is available from
     <tbody>
         <tr>
             <td>6.1</td>
-            <td class="bg-green-000">Ends on 31 Dec 2026</td>
-            <td class="bg-green-000">Ends on 31 Dec 2028</td>
+            <td class="bg-green-000"><a href="https://blogs.vmware.com/tanzu">Ends on 31 Dec 2026</a></td>
+            <td class="bg-green-000"><a href="https://www.herodevs.com/support/spring-nes">Ends on 31 Dec 2028</a></td>
         </tr>
         <tr>
             <td>6.0</td>
-            <td class="bg-green-000">Ends on 31 Dec 2026</td>
-            <td class="bg-green-000">Ends on 31 Dec 2027</td>
+            <td class="bg-green-000"><a href="https://blogs.vmware.com/tanzu">Ends on 31 Dec 2026</a></td>
+            <td class="bg-green-000"><a href="https://www.herodevs.com/support/spring-nes">Ends on 31 Dec 2027</a></td>
         </tr>
         <tr>
             <td>5.3</td>
-            <td class="bg-green-000">Ends on 31 Dec 2026</td>
-            <td class="bg-green-000">Ends on 31 Dec 2036</td>
+            <td class="bg-green-000"><a href="https://blogs.vmware.com/tanzu">Ends on 31 Dec 2026</a></td>
+            <td class="bg-green-000"><a href="https://www.herodevs.com/support/spring-nes">Ends on 31 Dec 2036</a></td>
         </tr>
         <tr>
             <td>4.3</td>
-            <td class="bg-red-000">Ended 31 Dec 2022</td>
-            <td class="bg-green-000">Ends on 31 Dec 2036</td>
+            <td class="bg-red-000"><a href="https://blogs.vmware.com/tanzu">Ended 31 Dec 2022</a></td>
+            <td class="bg-green-000"><a href="https://www.herodevs.com/support/spring-nes">Ends on 31 Dec 2036</a></td>
         </tr>
     </tbody>
 </table>
-
-
 
 ## [JDK/Jakarta EE Compatibility](https://github.com/spring-projects/spring-framework/wiki/Spring-Framework-Versions#jdk-version-range)
 


### PR DESCRIPTION
In this PR:

- added a table letting users know the end of support for each vendor
- added HeroDevs to list of providers below the table
- omitted the Show Unmaintained Releases button since unmaintained versions are now a concern for users.