### PR TITLE
[symfony] Update Symfony 5.4 EOAS

### DIFF
--- a/products/symfony.md
+++ b/products/symfony.md
@@ -81,7 +81,7 @@ releases:
     lts: true
     releaseDate: 2021-11-29
     eoas: 2024-11-30
-    eol: 2025-11-30
+    eol: 2029-02-28
     latest: "5.4.45"
     latestReleaseDate: 2024-10-27
 


### PR DESCRIPTION
> As part of the sponsoring of Symfony 5.4 by Ibexa, we agreed to extend the security-only maintenance period until February 2029 (which matches the EOL of Ibexa's DXP 4.6 LTS).

ref: https://github.com/symfony/symfony/pull/58613