### PR TITLE
[samsungmobile] update links

### DIFF
--- a/products/samsungmobile.md
+++ b/products/samsungmobile.md
@@ -35,7 +35,7 @@ releases:
     releaseDate: 2024-03-11
     eoas: 2028-03-11 # "four generations of OS upgrades" (https://news.samsung.com/uk/galaxy-a55-5g-and-galaxy-a35-5g-awesome-innovations-and-security-engineered-for-everyone)
     eol: 2029-03-11 # "five years of security updates"
-    link: https://doc.samsungmobile.com/SM-A356U/TMB/doc.html
+    link: https://doc.samsungmobile.com/SM-A356E/NPB/doc.html
 
 -   releaseCycle: "Galaxy S24 Ultra"
     releaseDate: 2024-01-24
@@ -545,7 +545,7 @@ releases:
     releaseDate: 2021-03-12
     eoas: false
     eol: false
-    link: https://doc.samsungmobile.com/SM-G525N/KOO/doc.html
+    link: https://doc.samsungmobile.com/SM-G525F/XNZ/doc.html
 
 -   releaseCycle: "Galaxy M62"
     releaseDate: 2021-03-03


### PR DESCRIPTION
change link for 'xcover 5' and galaxy A35'
new links do not refer the exact same model ID (xcover : SM-G525N ->SM-G525F and galaxy A35 : SM-A356U - >SM-A356E)  new link include much more languages (and include all languages from previous link)