### PR TITLE
[new product] add svelte

### DIFF
--- a/products/svelte.md
+++ b/products/svelte.md
@@ -1,0 +1,87 @@
+---
+title: Svelte
+category: framework
+tags: javascript-runtime
+iconSlug: svelte
+permalink: /svelte
+versionCommand: npm list svelte  
+eoasColumn: undefined
+eoesColumn: undefined
+releaseDateColumn: true
+releasePolicyLink: undefined
+changelogTemplate: https://github.com/sveltejs/svelte/releases/tag/v__LATEST__
+
+auto:
+  methods:
+  -   npm: svelte
+
+identifiers:
+-   purl: pkg:npm/svelte
+-   purl: pkg:github/sveltejs/svelte
+
+releases:
+-   releaseCycle: "5.1"
+    releaseDate: 2024-10-23
+    eoas: false
+    eol: false
+    latest: "5.1.13"
+    latestReleaseDate: 2024-11-08
+
+-   releaseCycle: "5.0"
+    releaseDate: 2024-10-19
+    eoas: 2024-10-23
+    eol: 2024-10-23
+    latest: "5.0.5"
+    latestReleaseDate: 2024-10-21
+
+-   releaseCycle: "4.2"
+    releaseDate: 2023-08-11
+    eoas: 2024-10-19
+    eol: 2024-10-19
+    latest: "4.2.19"
+    latestReleaseDate: 2024-08-23
+
+-   releaseCycle: "4.1"
+    releaseDate: 2023-07-19
+    eoas: 2023-08-11
+    eol: 2023-08-11
+    latest: "4.1.2"
+    latestReleaseDate: 2023-07-31
+
+-   releaseCycle: "4.0"
+    releaseDate: 2023-06-22
+    eoas: 2023-07-19
+    eol: 2023-07-19
+    latest: "4.0.5"
+    latestReleaseDate: 2023-07-06
+
+-   releaseCycle: "3"
+    releaseDate: 2019-04-21
+    eoas: 2023-06-22
+    eol: 2023-06-22
+    latest: "3.59.2"
+    latestReleaseDate: 2023-06-20
+
+-   releaseCycle: "2"
+    releaseDate: 2018-04-19
+    eoas: 2019-04-21
+    eol: 2019-04-21
+    latest: "2.16.1"
+    latestReleaseDate: 2019-02-08
+
+-   releaseCycle: "1"
+    releaseDate: 2016-11-29
+    eoas: 2018-04-19
+    eol: 2018-04-19
+    latest: "1.64.1"
+    latestReleaseDate: 2018-04-18
+
+---
+
+> [Svelte](https://svelte.dev/) a UI framework that uses a compiler to let you write
+> breathtakingly concise components that do minimal work in the browser, using languages you already
+> know — HTML, CSS and JavaScript.
+Svelte has not made any official announcement regarding the updates. Yet, it appears that each new
+major/minor deprecates the previous version since no new minor/patch is released for it afterwards.
+Minor and patch updates are made regularly.
+There is no known extended support.

--- a/products/svelte.md
+++ b/products/svelte.md
@@ -5,10 +5,9 @@ tags: javascript-runtime
 iconSlug: svelte
 permalink: /svelte
 versionCommand: npm list svelte  
-eoasColumn: undefined
-eoesColumn: undefined
+eoasColumn: true
+eoesColumn: false
 releaseDateColumn: true
-releasePolicyLink: undefined
 changelogTemplate: https://github.com/sveltejs/svelte/releases/tag/v__LATEST__
 
 auto:


### PR DESCRIPTION
Add end of life version history for Svelte JS framework.
I have expended the EOL history for minors of v4 and v5 since they are recent and few in number, but not for v1/2/3 since they are older and very numerous.