### PR TITLE
[redmine] add 6.0

### DIFF
--- a/products/redmine.md
+++ b/products/redmine.md
@@ -19,6 +19,12 @@ auto:
 
 # eol releases announced in new versions blog posts
 releases:
+-   releaseCycle: "6.0"
+    releaseDate: 2024-11-10
+    eol: false
+    latest: "6.0.0"
+    latestReleaseDate: 2024-11-10
+
 -   releaseCycle: "5.1"
     releaseDate: 2023-10-31
     eol: false


### PR DESCRIPTION
- https://www.redmine.org/news/147

> With this release, Redmine 4.2.x became unsupported and Redmine [5.0.11](https://www.redmine.org/versions/200) is the latest version of Redmine 5.0-branch, after that it will receive only important security updates.