### PR TITLE
[docker] Fix release notes URL

### DIFF
--- a/products/docker-engine.md
+++ b/products/docker-engine.md
@@ -5,7 +5,8 @@ iconSlug: docker
 permalink: /docker-engine
 versionCommand: docker version --format '{{.Server.Version}}'
 releasePolicyLink: https://github.com/moby/moby/blob/master/project/BRANCHES-AND-TAGS.md
-changelogTemplate: "https://docs.docker.com/engine/release-notes/__RELEASE_CYCLE__/"
+changelogTemplate: |
+  https://docs.docker.com/engine/release-notes/{% assign MajorReleaseCycle = "__RELEASE_CYCLE__" | split:"." |first| plus:0 %}{% if MajorReleaseCycle >= 27 %}{{MajorReleaseCycle}}{%else%}__RELEASE_CYCLE__{%endif%}/#{{"__LATEST__"|replace:".",""}}
 releaseDateColumn: true
 
 identifiers:


### PR DESCRIPTION
Closes #6226 

Fixes all but the really old links, which have an extra `-ce` on the anchor refs.