### PR TITLE
[pan-gp]Update GlobalProtect to 6.2.6

### DIFF
--- a/products/pan-gp.md
+++ b/products/pan-gp.md
@@ -42,8 +42,8 @@ releases:
     releaseDate: 2023-05-23
     eol: 2025-12-31
     eoas: 2025-12-31
-    latest: "6.2.5-c788"
-    latestReleaseDate: 2024-10-14
+    latest: "6.2.6"
+    latestReleaseDate: 2024-11-12
     link: https://docs.paloaltonetworks.com/globalprotect/6-2/globalprotect-app-release-notes/globalprotect-addressed-issues
 
 -   releaseCycle: "6.1"


### PR DESCRIPTION
Updated GlobalProtect App to version 6.2.6.

Released 2024-11-12

Release Notes: https://docs.paloaltonetworks.com/globalprotect/6-2/globalprotect-app-release-notes/globalprotect-addressed-issues

