### PR TITLE
[jboss-eap] Update to JBoss 8.0.4

### DIFF
--- a/products/red-hat-jboss-eap.md
+++ b/products/red-hat-jboss-eap.md
@@ -25,8 +25,8 @@ releases:
     eoas: 2028-02-05
     eol: 2031-02-05
     eoes: 2033-02-05
-    latest: "8.0.3.1"
-    latestReleaseDate: 2024-10-01
+    latest: "8.0.4"
+    latestReleaseDate: 2024-11-06
 
 -   releaseCycle: "7"
     releaseDate: 2016-05-01


### PR DESCRIPTION
Release notes (viewing requires a free RedHat account):

* JBoss 8.0.4: https://access.redhat.com/articles/7081324

The release notes information can be scraped with:

```
$ curl -s https://access.redhat.com/articles/7081324 | grep -A 4 "<h1 class=\"title\""
                              <h1 class="title">
                        JBoss Enterprise Application Platform 8.0 Update 4 Release Notes          </h1>

                                <div class="status-container">
              Updated <time class='moment_date' datetime='2024-11-06T00:58:57+00:00'>2024-11-06T00:58:57+00:00</time>               -
```