### PR TITLE
[visionos] Update visionos eoas

### DIFF
--- a/products/visionos.md
+++ b/products/visionos.md
@@ -26,7 +26,7 @@ releases:
 
 -   releaseCycle: "1"
     releaseDate: 2024-01-31
-    eoas: false
+    eoas: 2024-09-16
     eol: false
     latest: "1.3"
     latestReleaseDate: 2024-07-29


### PR DESCRIPTION
Last version was on July, 4 months without any update for visionOS 1, apple currently is focused on visionOS 2, all vision pro can update to visionOS 2.