### PR TITLE
[dotnet] Fix regex to ignore RC releases

### DIFF
--- a/products/dotnet.md
+++ b/products/dotnet.md
@@ -49,7 +49,7 @@ auto:
       fields:
         releaseCycle:
           column: "Version"
-          regex: '^.NET( Core)? (?P<value>\d+(\.\d+)?).*$'
+          regex: '^.NET( Core)? (?P<value>\d+(\.\d+)?)$'
         eol: "End of support"
 
 releases:


### PR DESCRIPTION
https://dotnet.microsoft.com/en-us/platform/support/policy/dotnet-core

added a new table with EOL dates for some RC releases, which changed the EOL date of 9 to EOL(9RC1) < releaseDate (9),
which causes some validation issues.