### PR TITLE
[pan-gp]Updated GlobalProtect App to version 6.0.11

### DIFF
--- a/products/pan-gp.md
+++ b/products/pan-gp.md
@@ -58,8 +58,8 @@ releases:
     releaseDate: 2022-02-22
     eol: 2025-12-31
     eoas: 2025-12-31
-    latest: "6.0.10-c826"
-    latestReleaseDate: 2024-11-04
+    latest: "6.0.11"
+    latestReleaseDate: 2024-11-25
     link: https://docs.paloaltonetworks.com/globalprotect/6-0/globalprotect-app-release-notes/globalprotect-addressed-issues
 
 -   releaseCycle: "5.3"


### PR DESCRIPTION
Updated GlobalProtect App from version 6.0.10-c826 to version 6.0.11

Released: 2024-11-25

Release Notes: https://docs.paloaltonetworks.com/globalprotect/6-0/globalprotect-app-release-notes/globalprotect-addressed-issues
