### PR TITLE
Support date for Pixel 6, 7 and Fold devices extended

### DIFF
--- a/products/pixel.md
+++ b/products/pixel.md
@@ -256,5 +256,3 @@ seven years, offering full support until October 2030.
 In December 2024, Google updated the information page for software updates to extend the support 
 period for all Pixel 6 and Pixel 7 phones, as well as the Pixel Fold, to five years of both software
 and security updates.
-
-The end date for guaranteed Android version updates is indicated in the 'Active Support' column.

--- a/products/pixel.md
+++ b/products/pixel.md
@@ -89,7 +89,7 @@ releases:
 -   releaseCycle: "fold"
     releaseLabel: "Pixel Fold"
     releaseDate: 2023-06-28
-    eoas: 2026-06-01  # at least
+    eoas: 2028-06-01  # at least
     eol: 2028-06-01  # at least
     discontinued: false
     link: https://en.wikipedia.org/wiki/Pixel_Fold
@@ -107,7 +107,7 @@ releases:
 -   releaseCycle: "7a"
     releaseLabel: "Pixel 7a"
     releaseDate: 2023-05-10
-    eoas: 2026-05-01 # at least
+    eoas: 2028-05-01 # at least
     eol: 2028-05-01 # at least
     discontinued: false
     link: https://en.wikipedia.org/wiki/Pixel_7a
@@ -116,7 +116,7 @@ releases:
 -   releaseCycle: "7pro"
     releaseLabel: "Pixel 7 Pro"
     releaseDate: 2022-10-13
-    eoas: 2025-10-01 # at least
+    eoas: 2027-10-01 # at least
     eol: 2027-10-01 # at least
     discontinued: false
     link: https://en.wikipedia.org/wiki/Pixel_7_Pro
@@ -125,7 +125,7 @@ releases:
 -   releaseCycle: "7"
     releaseLabel: "Pixel 7"
     releaseDate: 2022-10-13
-    eoas: 2025-10-01 # at least
+    eoas: 2027-10-01 # at least
     eol: 2027-10-01 # at least
     discontinued: false
     link: https://en.wikipedia.org/wiki/Pixel_7
@@ -134,7 +134,7 @@ releases:
 -   releaseCycle: "6a"
     releaseLabel: "Pixel 6a"
     releaseDate: 2022-07-28
-    eoas: 2025-07-01 # at least
+    eoas: 2027-07-01 # at least
     eol: 2027-07-01 # at least
     discontinued: false
     link: https://en.wikipedia.org/wiki/Pixel_6a
@@ -143,7 +143,7 @@ releases:
 -   releaseCycle: "6pro"
     releaseLabel: "Pixel 6 Pro"
     releaseDate: 2021-10-28
-    eoas: 2024-10-01 # at least
+    eoas: 2026-10-01 # at least
     eol: 2026-10-01 # at least
     discontinued: 2022-10-06
     link: https://en.wikipedia.org/wiki/Pixel_6_Pro
@@ -152,7 +152,7 @@ releases:
 -   releaseCycle: "6"
     releaseLabel: "Pixel 6"
     releaseDate: 2021-10-28
-    eoas: 2024-10-01 # at least
+    eoas: 2026-10-01 # at least
     eol: 2026-10-01 # at least
     discontinued: 2022-10-06
     link: https://en.wikipedia.org/wiki/Pixel_6

--- a/products/pixel.md
+++ b/products/pixel.md
@@ -253,4 +253,8 @@ In October 2023, it was
 Pixel 8 and Pixel 8 Pro will guarantee both Android version updates and security updates for
 seven years, offering full support until October 2030.
 
+In December 2024, Google updated the information page for software updates to extend the support 
+period for all Pixel 6 and Pixel 7 phones, as well as the Pixel Fold, to five years of both software
+and security updates.
+
 The end date for guaranteed Android version updates is indicated in the 'Active Support' column.


### PR DESCRIPTION
The support length for the Pixel 6, 7 and Fold series has been extended to five years of both software and security updates.

https://support.google.com/pixelphone/answer/4457705