### PR TITLE
[eurolinux] Update change log template

### DIFF
--- a/products/eurolinux.md
+++ b/products/eurolinux.md
@@ -5,7 +5,7 @@ tags: linux-distribution
 permalink: /eurolinux
 versionCommand: lsb_release --release
 releasePolicyLink: https://euro-linux.com/en/software/eurolinux/specification/
-changelogTemplate: https://euro-linux.com/en/software/eurolinux/specification/
+changelogTemplate: https://docs.euro-linux.com/release-notes/__LATEST__
 releaseDateColumn: true
 eoasColumn: true
 


### PR DESCRIPTION
Current link is broken

Replacing link with https://docs.euro-linux.com/release-notes