### PR TITLE
[spring-boot] Fix auto configuration

### DIFF
--- a/products/spring-boot.md
+++ b/products/spring-boot.md
@@ -47,7 +47,7 @@ auto:
           column: "Branch"
           regex: '^(?P<value>\d+\.\d+)\.x$'
         releaseDate: "Initial Release"
-        eol: "End of Support"
+        eol: "End of OSS Support"
         eoes: "End Enterprise Support *"
 
 releases:


### PR DESCRIPTION
'End of Support' column has been renamed to 'End of OSS Support' on https://spring.io/projects/spring-boot#support.