### PR TITLE
[spring-framework] Fix auto configuration

### DIFF
--- a/products/spring-framework.md
+++ b/products/spring-framework.md
@@ -25,7 +25,7 @@ auto:
           column: "Branch"
           regex: '^(?P<value>\d+\.\d+)\.x$'
         releaseDate: "Initial Release"
-        eol: "End of Support"
+        eol: "End of OSS Support"
         eoes: "End Enterprise Support *"
 
 # Supported Java/Jakarta EE versions available on https://github.com/spring-projects/spring-framework/wiki/Spring-Framework-Versions#jdk-version-range.


### PR DESCRIPTION
'End of Support' column has been renamed to 'End of OSS Support' on https://spring.io/projects/spring-framework#support.