### PR TITLE
[kuma] Disable custom auto method

### DIFF
--- a/products/kuma.md
+++ b/products/kuma.md
@@ -12,7 +12,7 @@ eolColumn: Support
 auto:
   methods:
   -   git: https://github.com/kumahq/kuma.git
-  -   custom: kuma
+#  -   custom: kuma # disabled, versions has been messed up in https://github.com/kumahq/kuma/commit/87e225ecb794f7c0d9d5c0bf9a2ef2c33f7acbd0
 
 # EOL dates can be found on https://github.com/kumahq/kuma/blob/master/versions.yml
 releases:


### PR DESCRIPTION
Versions has been messed up in https://github.com/kumahq/kuma/commit/87e225ecb794f7c0d9d5c0bf9a2ef2c33f7acbd0, and it prevents automation to run properly (see https://app.netlify.com/sites/endoflife-date/deploys/67577c5000e89600089611b9).