### PR TITLE
[laravel] add PHP 8.4 support to Laravel versions 10 & 11

### DIFF
--- a/products/laravel.md
+++ b/products/laravel.md
@@ -42,7 +42,7 @@ releases:
     releaseDate: 2024-03-12
     eoas: 2025-09-03
     eol: 2026-03-12
-    supportedPhpVersions: '8.2 - 8.3'
+    supportedPhpVersions: '8.2 - 8.4'
     latest: '11.34.2'
     latestReleaseDate: 2024-11-27
 
@@ -50,7 +50,7 @@ releases:
     releaseDate: 2023-02-14
     eoas: 2024-08-06
     eol: 2025-02-04
-    supportedPhpVersions: '8.1 - 8.3'
+    supportedPhpVersions: '8.1 - 8.4'
     latest: '10.48.25'
     latestReleaseDate: 2024-11-26
 


### PR DESCRIPTION
PHP 8.4 is supported since v10 according to the release notes: https://laravel.com/docs/11.x/releases