### PR TITLE
[watchOS] Add 11.2

### DIFF
--- a/products/watchos.md
+++ b/products/watchos.md
@@ -29,8 +29,8 @@ releases:
     releaseDate: 2024-09-16
     eoas: false
     eol: false
-    latest: '11.1'
-    latestReleaseDate: 2024-10-28
+    latest: '11.2'
+    latestReleaseDate: 2024-12-11
     link: https://support.apple.com/en-us/121163
 
 -   releaseCycle: "10"


### PR DESCRIPTION
watchOS 11.2 released today.

See https://support.apple.com/en-us/100100 and https://support.apple.com/en-us/121843.

Note https://support.apple.com/en-us/121163 still lists latest update for watchOS as 11.1