### PR TITLE
[windows] Add 10 22H2 ESU

### DIFF
--- a/products/windows.md
+++ b/products/windows.md
@@ -387,7 +387,7 @@ releases:
 [Windows 8.1 update information](https://support.microsoft.com/topic/windows-8-1-and-windows-server-2012-r2-update-history-47d81dd2-6804-b6ae-4112-20089467c7a6)
 [Windows 7 update information](https://support.microsoft.com/topic/windows-7-sp1-and-windows-server-2008-r2-sp1-update-history-720c2590-fd58-26ba-16cc-6d8f3b547599)
 [Windows Lifecycle FAQ](https://learn.microsoft.com/lifecycle/faq/windows)
-[Windows ESU information](https://learn.microsoft.com/en-us/windows/whats-new/extended-security-updates)
+[Extended Security Updates (ESU) program for Windows 10](https://learn.microsoft.com/en-us/windows/whats-new/extended-security-updates)
 
 Beginning with Windows 10, version 21H2, feature updates for Windows 10 release are released
 annually, in the second half of the calendar year.

--- a/products/windows.md
+++ b/products/windows.md
@@ -7,6 +7,7 @@ versionCommand: winver
 releasePolicyLink: https://learn.microsoft.com/lifecycle/products/?terms=Windows
 eoasColumn: true
 releaseDateColumn: true
+eoesColumn: Extended Security Updates
 
 identifiers:
 -   cpe: cpe:2.3:o:microsoft:windows
@@ -63,21 +64,12 @@ releases:
     latest: 10.0.22631
     link: https://learn.microsoft.com/windows/release-health/windows11-release-information
 
-    # This cycle includes 10 22H2 (E) and commercial Pro from (W)
--   releaseCycle: "10-22h2-esu"
-    releaseLabel: "10 22H2 ESU"
-    releaseDate: 2022-10-18
-    eoas: 2025-10-14
-    eol: 2028-10-10
-    latest: 10.0.19045
-    link: https://learn.microsoft.com/en-us/windows/whats-new/extended-security-updates
-
-    # This cycle includes 10 22H2 (W) for non-commercial Pro
 -   releaseCycle: "10-22h2"
     releaseLabel: "10 22H2"
     releaseDate: 2022-10-18
     eoas: 2025-10-14
     eol: 2025-10-14
+    eoes: 2028-10-10
     latest: 10.0.19045
     link: https://learn.microsoft.com/windows/release-health/release-information
 
@@ -388,7 +380,6 @@ releases:
 | ---- | ---------------------------------------------------------- |
 | (E)  | Enterprise, Education and IoT Enterprise editions          |
 | (W)  | Home, Pro, Pro Education and Pro for Workstations editions |
-| ESU  | Extended Security Updates program                          |
 | LTS  | Long-Term Servicing Channel/Branch                         |
 
 [Windows 11 release information](https://learn.microsoft.com/windows/release-health/windows11-release-information)
@@ -396,6 +387,7 @@ releases:
 [Windows 8.1 update information](https://support.microsoft.com/topic/windows-8-1-and-windows-server-2012-r2-update-history-47d81dd2-6804-b6ae-4112-20089467c7a6)
 [Windows 7 update information](https://support.microsoft.com/topic/windows-7-sp1-and-windows-server-2008-r2-sp1-update-history-720c2590-fd58-26ba-16cc-6d8f3b547599)
 [Windows Lifecycle FAQ](https://learn.microsoft.com/lifecycle/faq/windows)
+[Windows ESU information](https://learn.microsoft.com/en-us/windows/whats-new/extended-security-updates)
 
 Beginning with Windows 10, version 21H2, feature updates for Windows 10 release are released
 annually, in the second half of the calendar year.

--- a/products/windows.md
+++ b/products/windows.md
@@ -63,6 +63,16 @@ releases:
     latest: 10.0.22631
     link: https://learn.microsoft.com/windows/release-health/windows11-release-information
 
+    # This cycle includes 10 22H2 (E) and commercial Pro from (W)
+-   releaseCycle: "10-22h2-esu"
+    releaseLabel: "10 22H2 ESU"
+    releaseDate: 2022-10-18
+    eoas: 2025-10-14
+    eol: 2028-10-10
+    latest: 10.0.19045
+    link: https://learn.microsoft.com/en-us/windows/whats-new/extended-security-updates
+
+    # This cycle includes 10 22H2 (W) for non-commercial Pro
 -   releaseCycle: "10-22h2"
     releaseLabel: "10 22H2"
     releaseDate: 2022-10-18
@@ -378,6 +388,7 @@ releases:
 | ---- | ---------------------------------------------------------- |
 | (E)  | Enterprise, Education and IoT Enterprise editions          |
 | (W)  | Home, Pro, Pro Education and Pro for Workstations editions |
+| ESU  | Extended Security Updates program                          |
 | LTS  | Long-Term Servicing Channel/Branch                         |
 
 [Windows 11 release information](https://learn.microsoft.com/windows/release-health/windows11-release-information)


### PR DESCRIPTION
This came up during https://github.com/dotnet/core/pull/9647#issuecomment-2550731035 and is based on the following information:
* https://learn.microsoft.com/en-us/lifecycle/faq/extended-security-updates
* https://learn.microsoft.com/en-us/windows/whats-new/extended-security-updates
* https://learn.microsoft.com/en-us/windows/whats-new/whats-new-windows-10-version-22h2

According to Microsoft, `The editions that qualify for the Windows 10 ESU include Enterprise, Education, and Pro in Commercial use` which is a subset of the current `(W)` + (most probably all of) `(E)` where I'm not fully sure if IoT is included or not given the special handling in IoT having a `21H2 LTS` with support until 2032 without need for ESU being paid.

So I kept it just as `ESU` flag with the information retrievable by Microsoft.

/CC @BiNZGi for review