### PR TITLE
[hashicorp-vault] Fix EOL date for  1.16

### DIFF
--- a/products/hashicorp-vault.md
+++ b/products/hashicorp-vault.md
@@ -40,7 +40,7 @@ releases:
 -   releaseCycle: "1.16"
     releaseDate: 2024-03-25
     lts: true
-    eol: 2025-06-12 # releaseDate(1.17)
+    eol: 2024-06-10 # releaseDate(1.17)
     eoes: 2026-03-15 # approximate = releaseDate(1.22)
     latest: "1.16.3"
     latestReleaseDate: 2024-05-29


### PR DESCRIPTION
Reading the c[omment left as the evidence on the endoflife vault page](https://github.com/hashicorp/vault/issues/28471#issuecomment-2393714603), it states "Community support for a given CE release generally ends when the next major release happens" and specifically for 1.16 "1.16 was released quite some time ago, and is receiving such extended Enterprise support because it's an Enterprise LTS version."   1.16 should have EOL date set to 1.17 release date. [ie 10 Jun 2024](https://endoflife.date/hashicorp-vault#:~:text=6%20months%20ago-,(10%20Jun%202024),-Ended%202%20months)