### PR TITLE
[amazon-linux] Fix EOL date

### DIFF
--- a/products/amazon-linux.md
+++ b/products/amazon-linux.md
@@ -35,8 +35,8 @@ releases:
 
 -   releaseCycle: '2'
     releaseDate: 2018-06-26
-    eoas: 2025-06-30
-    eol: 2025-06-30
+    eoas: 2026-06-30
+    eol: 2026-06-30
     latest: "2.0.20241113.1"
     latestReleaseDate: 2024-11-16
     link: https://aws.amazon.com/about-aws/whats-new/2018/06/announcing-amazon-linux-2-with-long-term-support/

--- a/products/amazon-linux.md
+++ b/products/amazon-linux.md
@@ -184,7 +184,7 @@ details.
 ## Amazon Linux 2
 
 [Amazon Linux 2][al2] will provide _security updates and bug fixes for all packages in core until
-June 30, 2025_. User-space Application Binary Interface (ABI) compatibility is guaranteed for
+June 30, 2026_[^2]. User-space Application Binary Interface (ABI) compatibility is guaranteed for
 [specific packages][al2-faq]. It only seems to receive critical bug fixes and security patches.
 
 ## Amazon Linux 2023
@@ -238,3 +238,4 @@ Amazon Provides security advisories for all versions on the Amazon Linux Securit
 [al2023-sec-rss]: https://alas.aws.amazon.com/AL2023/alas.rss
 
 [^1]: It was announced as Amazon Linux 2022, and renamed to Amazon Linux 2023.
+[^2]: Amazon Linux 2 has had its LTS EOL extended multiple times from the originally scheduled date of June 2023.


### PR DESCRIPTION
source: https://aws.amazon.com/amazon-linux-2/faqs/

Q. When will support for Amazon Linux 2 end?
Amazon Linux 2 end of support date (End of Life, or EOL) will be on 2026-06-30.