### PR TITLE
[visionos] Update EOL for visionOS 1

### DIFF
--- a/products/visionos.md
+++ b/products/visionos.md
@@ -27,7 +27,7 @@ releases:
 -   releaseCycle: "1"
     releaseDate: 2024-01-31
     eoas: 2024-09-16
-    eol: false
+    eol: 2024-09-16
     latest: "1.3"
     latestReleaseDate: 2024-07-29
     link: https://support.apple.com/en-us/118202


### PR DESCRIPTION
Set date for EOL visionOS 1, no security updates since July and every device can upgrade to visionOS 2.