### PR TITLE
[ios] Mark 16 and 17 as EOL

### DIFF
--- a/products/ios.md
+++ b/products/ios.md
@@ -30,7 +30,7 @@ releases:
 -   releaseCycle: "17"
     releaseDate: 2023-09-18
     eoas: 2024-09-16
-    eol: false
+    eol: 2024-11-19
     latest: "17.7.2"
     latestReleaseDate: 2024-11-19
     link: https://support.apple.com/en-us/118723
@@ -38,7 +38,7 @@ releases:
 -   releaseCycle: "16"
     releaseDate: 2022-09-12
     eoas: 2023-09-18
-    eol: false
+    eol: 2024-08-07
     latest: "16.7.10"
     latestReleaseDate: 2024-08-07
     link: https://support.apple.com/HT213407
@@ -141,5 +141,8 @@ Major versions of iOS are released annually. Apple significantly extended the cy
 iOS-supported devices over the years. Usually, only the latest iOS release is supported by Apple.
 Starting with iOS 15, Apple started to support [2 major versions of iOS](https://www.zdnet.com/article/still-running-ios-14-on-your-iphone-apple-brings-support-to-an-end/),
 for a short period of time.
+
+Apple has ocassionally backported critical security fixes to [much older iOS versions](https://9to5mac.com/2021/03/26/apple-releases-ios-14-4-2-and-ios-12-5-2-with-security-bug-fixes/)
+but such fixes are not guaranteed. As of now, only iOS 18 appears to be receiving security fixes, as iOS 17 is missing fixes published in iOS 18.2.
 
 Support information for iPhone devices are available at [/iphone](/iphone).


### PR DESCRIPTION
Unfortunate, but doesn't look like backports are happening currently - there are unpatched security issues in iOS17 (and likely 16?).

Backports will likely happen in the future, but we can't predict them in the absence of clear guidance from Apple, so we have to mark these as unsupported.

See discussion on #6444.