### PR TITLE
[keda] Correct 2.16 supported k8s versions

### DIFF
--- a/products/keda.md
+++ b/products/keda.md
@@ -23,7 +23,7 @@ releases:
 -   releaseCycle: "2.16"
     releaseDate: 2024-11-07
     eol: 2025-04-30 # estimated releaseDate(2.18)
-    supportedKubernetesVersions: 1.27 and higher
+    supportedKubernetesVersions: 1.29 - 1.31
     latest: "2.16.1"
     latestReleaseDate: 2024-12-24
 


### PR DESCRIPTION
As per https://keda.sh/docs/2.16/operate/cluster/