### PR TITLE
[meilisearch] add 1.12 and use `github_releases` instead of `tag`

### DIFF
--- a/products/meilisearch.md
+++ b/products/meilisearch.md
@@ -14,13 +14,19 @@ identifiers:
 
 auto:
   methods:
-  -   git: https://github.com/meilisearch/meilisearch.git
+  -   github_releases: meilisearch/meilisearch
 
 # eol(x) = releaseDate(x+1)
 releases:
+-   releaseCycle: "1.12"
+    releaseDate: 2024-12-23
+    eol: false
+    latest: "1.12.0"
+    latestReleaseDate: 2024-12-23
+
 -   releaseCycle: "1.11"
     releaseDate: 2024-10-21
-    eol: false
+    eol: 2024-12-23
     latest: "1.11.3"
     latestReleaseDate: 2024-11-14
 


### PR DESCRIPTION
- https://github.com/meilisearch/meilisearch/releases/tag/v1.12.0
- also update auto to pick up the right release date (instead of git tag date)