### PR TITLE
add various identifiers

### DIFF
--- a/products/amazon-cdk.md
+++ b/products/amazon-cdk.md
@@ -7,15 +7,17 @@ permalink: /amazon-cdk
 changelogTemplate: https://github.com/aws/aws-cdk/releases/tag/v__LATEST__
 releaseDateColumn: true
 
-auto:
-  methods:
-  -   git: https://github.com/aws/aws-cdk
-
 identifiers:
 -   repology: aws-cdk
 -   purl: pkg:npm/aws-cdk
 -   purl: pkg:golang/github.com/aws/aws-cdk-go
 -   purl: pkg:github/aws/aws-cdk-go
+-   cpe: cpe:/a:amazon:aws_cloud_development_kit
+-   cpe: cpe:2.3:a:amazon:aws_cloud_development_kit
+
+auto:
+  methods:
+  -   git: https://github.com/aws/aws-cdk
 
 releases:
 -   releaseCycle: "2"

--- a/products/amazon-corretto.md
+++ b/products/amazon-corretto.md
@@ -11,6 +11,10 @@ releasePolicyLink: https://aws.amazon.com/corretto/faqs/
 changelogTemplate: "https://github.com/corretto/corretto-{{'__LATEST__'|split:'.'|first}}/blob/release-__LATEST__/CHANGELOG.md"
 releaseDateColumn: true
 
+identifiers:
+-   cpe: cpe:/a:amazon:corretto
+-   cpe: cpe:2.3:a:amazon:corretto
+
 # There is one repository for each major release (except for 15 and 16).
 # Both tag and GitHub release dates are usually wrong, but GitHub release dates are closer to the correct date.
 auto:

--- a/products/android.md
+++ b/products/android.md
@@ -14,6 +14,10 @@ releaseColumn: false
 releaseDateColumn: true
 eolColumn: Security Support
 
+identifiers:
+-   cpe: cpe:/o:google:android
+-   cpe: cpe:2.3:o:google:android
+
 # EOL is the latest security patch date for "Old version" on https://en.wikipedia.org/wiki/Android_version_history.
 releases:
 -   releaseCycle: "15"

--- a/products/azure-devops.md
+++ b/products/azure-devops.md
@@ -11,6 +11,10 @@ releasePolicyLink: https://learn.microsoft.com/lifecycle/products/?terms=Azure%2
 eoasColumn: true
 releaseDateColumn: true
 
+identifiers:
+-   cpe: cpe:/o:microsoft:azure_devops_server
+-   cpe: cpe:2.3:o:microsoft:azure_devops_server
+
 releases:
 -   releaseCycle: "2022.2"
     releaseLabel: "2022 Update 2"

--- a/products/calico.md
+++ b/products/calico.md
@@ -14,6 +14,8 @@ identifiers:
 -   purl: pkg:docker/calico/cni
 -   purl: pkg:docker/chainguard/calico-cni
 -   repology: calico
+-   cpe: cpe:/a:projectcalico:calico
+-   cpe: cpe:2.3:a:projectcalico:calico
 
 # eol(x) = releaseDate(x+2)
 releases:


### PR DESCRIPTION
check #5352 
for api v1 #2080 :)

i have a question regarding the cpe for angular:

should i just add this cpe set ( cpe:/a:angular:angular and cpe:2.3:a:angular:angular ) or also this set ( cpe:/a:angularjs:angular and cpe:2.3:a:angularjs:angular )

and for angularjs i'll use this set ( cpe:/a:angularjs:angular.js and cpe:2.3:a:angularjs:angular.js ), is this correct?