### PR TITLE
[kotlin] Fix release date for  2.1 series

### DIFF
--- a/products/kotlin.md
+++ b/products/kotlin.md
@@ -22,7 +22,7 @@ auto:
 # EOL(N) = MAX(latestReleaseDate(N), releaseDate(N+1))
 releases:
 -   releaseCycle: "2.1"
-    releaseDate: 2024-11-27
+    releaseDate: 2024-10-10
     eol: false
     latest: "2.1.0"
     latestReleaseDate: 2024-10-10


### PR DESCRIPTION
It was not matching with 2.1.0's release date