### PR TITLE
Make sass silent for deprecation warnings

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -17,6 +17,12 @@ plugins:
   - jekyll-last-modified-at
   - jemoji
 
+# This part is to silent sass deprecating warnings
+# remove after they fix it 
+# https://github.com/just-the-docs/just-the-docs/pull/1548
+# and https://github.com/jekyll/jekyll/issues/9686
+sass:
+  quiet_deps: true
 
 # just-the-docs settings, see https://just-the-docs.com/
 theme: just-the-docs


### PR DESCRIPTION
We will remove it after https://github.com/just-the-docs/just-the-docs/pull/1548 merged. and https://github.com/jekyll/jekyll/issues/9686 fixed completely