### PR TITLE
[ipados] Update EOL ipadOS 16

### DIFF
--- a/products/ipados.md
+++ b/products/ipados.md
@@ -37,7 +37,7 @@ releases:
 -   releaseCycle: "16"
     releaseDate: 2022-10-24
     eoas: 2023-09-18
-    eol: false
+    eol: 2024-09-16
     latest: '16.7.10'
     latestReleaseDate: 2024-08-07
     link: https://developer.apple.com/documentation/ios-ipados-release-notes/ipados-16-release-notes


### PR DESCRIPTION
iOS 16 reached EOL, and ipadOS 16 is not receiving security updates since August.