### PR TITLE
[ios] update version info

### DIFF
--- a/products/ios.md
+++ b/products/ios.md
@@ -23,8 +23,8 @@ releases:
     releaseDate: 2024-09-16
     eoas: false
     eol: false
-    latest: "18.2"
-    latestReleaseDate: 2024-12-11
+    latest: "18.2.1"
+    latestReleaseDate: 2025-01-06
     link: https://support.apple.com/en-us/121161
 
 -   releaseCycle: "17"


### PR DESCRIPTION
i guess we can update the information even if this update does not include security update because column name is 'lastest' and not 'security latest' up to you