### PR TITLE
[apache-couchdb] Update links

### DIFF
--- a/products/apache-couchdb.md
+++ b/products/apache-couchdb.md
@@ -6,8 +6,8 @@ iconSlug: apachecouchdb
 permalink: /apache-couchdb
 alternate_urls:
 -   /couchdb
-releasePolicyLink: https://docs.couchdb.org/en/latest/cve/index.html#security-issues-cves
-changelogTemplate: "https://docs.couchdb.org/en/stable/whatsnew/{{'__LATEST__'|split:'.'|slice:':2'|join:'.'}}.html#version-{{'__LATEST__'|replace:'.','-'}}"
+releasePolicyLink: https://docs.couchdb.org/en/stable/cve/index.html
+changelogTemplate: https://docs.couchdb.org/en/stable/whatsnew/__RELEASE_CYCLE__.html
 versionCommand: curl http://localhost:5984/_config/vendor/version
 releaseDateColumn: true
 


### PR DESCRIPTION
`https://docs.couchdb.org/en/latest/xxx` links are no longer valid, see https://github.com/endoflife-date/endoflife.date/actions/runs/12728803068/job/35479821915.