### PR TITLE
[ghc] Fix old releases link

### DIFF
--- a/products/ghc.md
+++ b/products/ghc.md
@@ -24,97 +24,104 @@ auto:
       template: '{{major}}.{{minor}}.{{patch}}'
 
 releases:
-
 -   releaseCycle: "9.12"
     releaseDate: 2024-12-16
-    latest: "9.12.1"
     eoas: false
     eol: false
-
+    latest: "9.12.1"
     latestReleaseDate: 2024-12-16
+
 -   releaseCycle: "9.10"
     releaseDate: 2024-05-10
-    latest: "9.10.1"
     eoas: false
     eol: false
-
+    latest: "9.10.1"
     latestReleaseDate: 2024-05-10
+
 -   releaseCycle: "9.8"
     releaseDate: 2023-10-09
-    latest: "9.8.4"
-    latestReleaseDate: 2024-11-29
     eoas: true
     eol: false
+    latest: "9.8.4"
+    latestReleaseDate: 2024-11-29
 
 -   releaseCycle: "9.6"
     releaseDate: 2023-03-10
-    latest: "9.6.6"
-    latestReleaseDate: 2024-07-01
     eoas: false
     eol: false
+    latest: "9.6.6"
+    latestReleaseDate: 2024-07-01
 
 -   releaseCycle: "9.4"
     releaseDate: 2022-08-07
-    latest: "9.4.8"
-    latestReleaseDate: 2023-11-10
     eoas: true
     eol: false
+    latest: "9.4.8"
+    latestReleaseDate: 2023-11-10
 
 -   releaseCycle: "9.2"
     releaseDate: 2021-09-29
-    latest: "9.2.8"
-    latestReleaseDate: 2023-05-26
     eoas: true
     eol: false
+    latest: "9.2.8"
+    latestReleaseDate: 2023-05-26
+    link: https://downloads.haskell.org/~ghc/__LATEST__/docs/html/users_guide/__LATEST__-notes.html
 
 -   releaseCycle: "9.0"
     releaseDate: 2021-02-03
-    latest: "9.0.2"
-    latestReleaseDate: 2021-12-26
     eoas: true
     eol: true
+    latest: "9.0.2"
+    latestReleaseDate: 2021-12-26
+    link: https://downloads.haskell.org/~ghc/9.0.2/docs/html/users_guide/9.0.2-notes.html
 
 -   releaseCycle: "8.10"
     releaseDate: 2020-03-22
-    latest: "8.10.7"
-    latestReleaseDate: 2021-08-27
     eoas: true
     eol: true
+    latest: "8.10.7"
+    latestReleaseDate: 2021-08-27
+    link: https://downloads.haskell.org/~ghc/8.10.7/docs/html/users_guide/8.10.7-notes.html
 
 -   releaseCycle: "8.8"
     releaseDate: 2019-08-25
-    latest: "8.8.4"
-    latestReleaseDate: 2020-07-15
     eoas: true
     eol: true
+    latest: "8.8.4"
+    latestReleaseDate: 2020-07-15
+    link: https://downloads.haskell.org/~ghc/8.8.4/docs/html/users_guide/8.8.4-notes.html
 
 -   releaseCycle: "8.6"
     releaseDate: 2018-09-21
-    latest: "8.6.5"
-    latestReleaseDate: 2019-04-22
     eoas: true
     eol: true
+    latest: "8.6.5"
+    latestReleaseDate: 2019-04-22
+    link: https://downloads.haskell.org/~ghc/8.6.5/docs/html/users_guide/8.6.5-notes.html
 
 -   releaseCycle: "8.4"
     releaseDate: 2018-03-08
-    latest: "8.4.4"
-    latestReleaseDate: 2018-10-13
     eoas: true
     eol: true
+    latest: "8.4.4"
+    latestReleaseDate: 2018-10-13
+    link: https://downloads.haskell.org/~ghc/8.4.4/docs/html/users_guide/8.4.4-notes.html
 
 -   releaseCycle: "8.2"
     releaseDate: 2017-07-21
-    latest: "8.2.2"
-    latestReleaseDate: 2017-11-21
     eoas: true
     eol: true
+    latest: "8.2.2"
+    latestReleaseDate: 2017-11-21
+    link: https://downloads.haskell.org/~ghc/8.2.2/docs/html/users_guide/8.2.2-notes.html
 
 -   releaseCycle: "8.0"
     releaseDate: 2016-05-17
-    latest: "8.0.2"
-    latestReleaseDate: 2017-01-04
     eoas: true
     eol: true
+    latest: "8.0.2"
+    latestReleaseDate: 2017-01-04
+    link: https://downloads.haskell.org/~ghc/8.0.2/docs/html/users_guide/8.0.2-notes.html
 
 ---
 


### PR DESCRIPTION
Currently generated link returns a 404, see https://github.com/endoflife-date/endoflife.date/actions/runs/12728803068/job/35479821915.