### PR TITLE
[godot] Fix changelogTemplate

### DIFF
--- a/products/godot.md
+++ b/products/godot.md
@@ -7,7 +7,7 @@ alternate_urls:
 -   /godotengine
 versionCommand: godot --version
 releasePolicyLink: https://docs.godotengine.org/en/latest/about/release_policy.html
-changelogTemplate: https://github.com/godotengine/godot/releases/tag/__LATEST__-stable
+changelogTemplate: "https://github.com/godotengine/godot/releases/tag/{{'__LATEST__'|drop_zero_patch}}-stable"
 eolColumn: Critical, Security and Platform support
 eoasColumn: true
 releaseDateColumn: true


### PR DESCRIPTION
First release don't have the `.0`, see https://github.com/godotengine/godot/releases/.