### PR TITLE
[Python] remove interpreted phrase from description

### DIFF
--- a/products/python.md
+++ b/products/python.md
@@ -244,7 +244,7 @@ releases:
 
 ---
 
-> [Python](https://www.python.org/) is an interpreted, high-level, general-purpose programming
+> [Python](https://www.python.org/) is a high-level, general-purpose programming
 > language.
 
 The end-of-life is scheduled 5 years after the first release, but can be adjusted by the release


### PR DESCRIPTION
Python is not really an interpreted language and the default CPython implementation always compile the code in some form before execution, see [this article](https://eddieantonio.ca/blog/2023/10/25/python-is-a-compiled-language/) for more details.