### PR TITLE
[pan-os]Update PAN-OS version(s)

### DIFF
--- a/products/pan-os.md
+++ b/products/pan-os.md
@@ -53,9 +53,9 @@ releases:
 -   releaseCycle: "10.2"
     releaseDate: 2022-02-27
     eol: 2026-02-28
-    latest: "10.2.13-h1"
-    latestReleaseDate: 2024-12-20
-    link: https://docs.paloaltonetworks.com/pan-os/10-2/pan-os-release-notes/pan-os-10-2-13-known-and-addressed-issues/pan-os-10-2-13-h1-addressed-issues
+    latest: "10.2.13-h2"
+    latestReleaseDate: 2024-12-27
+    link: https://docs.paloaltonetworks.com/pan-os/10-2/pan-os-release-notes/pan-os-10-2-13-known-and-addressed-issues/pan-os-10-2-13-h2-addressed-issues
 
 -   releaseCycle: "10.1"
     releaseDate: 2021-05-31


### PR DESCRIPTION
[panos] This PR updates the PAN-OS versions, Release dates and the Release Notes url.

Updated Pan-OS Version:  10.2.13-h2 

Released:                2024-12-27 

Release Notes:           https://docs.paloaltonetworks.com/pan-os/10-2/pan-os-release-notes/pan-os-10-2-13-known-and-addressed-issues/pan-os-10-2-13-h2-addressed-issues
