### PR TITLE
[firefox] add 134

### DIFF
--- a/products/firefox.md
+++ b/products/firefox.md
@@ -26,9 +26,15 @@ auto:
 # For LTS version, eol(x) = releaseDate of the next major after the corresponding version last minor LTS on https://wiki.mozilla.org/Release_Management/Calendar, if available.
 # Next ESR/LTS is not yet planned.
 releases:
+-   releaseCycle: "134"
+    releaseDate: 2025-01-07
+    eol: false
+    latest: "134.0.0"
+    latestReleaseDate: 2025-01-07
+
 -   releaseCycle: "133"
     releaseDate: 2024-11-26
-    eol: false
+    eol: 2025-01-07
     latest: "133.0.3"
     latestReleaseDate: 2024-12-10
 

--- a/products/firefox.md
+++ b/products/firefox.md
@@ -23,7 +23,7 @@ auto:
   -   custom: firefox
 
 # For non-LTS versions, eol(x) = releaseDate(x+1)
-# For LTS version, eol(x) = releaseDate of the next major after the corresponding version last minor LTS on https://wiki.mozilla.org/Release_Management/Calendar, if available.
+# For LTS version, eol(x) = releaseDate of the next major after the corresponding version last minor LTS on https://whattrainisitnow.com/calendar/, if available.
 # Next ESR/LTS is not yet planned.
 releases:
 -   releaseCycle: "134"
@@ -65,7 +65,7 @@ releases:
 -   releaseCycle: "128"
     lts: true
     releaseDate: 2024-07-09
-    eol: 2025-09-16 # estimated release day for 140.3 on https://wiki.mozilla.org/Release_Management/Calendar
+    eol: 2025-09-16 # estimated release day for 140.3 on https://whattrainisitnow.com/calendar/
     latest: "128.6.0"
     latestReleaseDate: 2025-01-07
 
@@ -144,7 +144,7 @@ releases:
 -   releaseCycle: "115"
     lts: true
     releaseDate: 2023-07-04
-    eol: 2024-10-01 # estimated release day for 131 on https://wiki.mozilla.org/Release_Management/Calendar
+    eol: 2024-10-01 # estimated release day for 131 on https://whattrainisitnow.com/calendar/
     latest: "115.12.0"
     latestReleaseDate: 2024-06-11
 
@@ -261,7 +261,7 @@ releases:
   organizations like universities and businesses that need to set up and maintain Firefox on a large
   scale. Firefox ESR does not come with the latest features, but it has the latest security and
   stability fixes. Usually these branches are supported for a year,
-  [with a planned release calendar for new ESR branches.](https://wiki.mozilla.org/Release_Management/Calendar)
+  [with a planned release calendar for new ESR branches.](https://whattrainisitnow.com/calendar/)
   For more information you should review the [release cycle documentation.](https://support.mozilla.org/kb/firefox-esr-release-cycle)
 
 ## Firefox also has three testing channels:


### PR DESCRIPTION
- https://web.archive.org/web/20241217173803/https://whattrainisitnow.com/release/?version=134


```
$ curl -I https://wiki.mozilla.org/Release_Management/Calendar
HTTP/2 302
date: Tue, 14 Jan 2025 16:27:03 GMT
server: Apache/2.4.62 (Debian)
x-powered-by: PHP/8.1.31
x-content-type-options: nosniff
vary: Accept-Encoding,Cookie
expires: Thu, 01 Jan 1970 00:00:00 GMT
cache-control: private, must-revalidate, max-age=0
location: https://whattrainisitnow.com/calendar?rdfrom=https%3A%2F%2Fwiki.mozilla.org%2Findex.php%3Ftitle%3DRelease_Management%2FCalendar%26redirect%3Dno
x-request-id: 7b17710b49adf79a6199fb2a
content-type: text/html; charset=UTF-8
via: 1.1 google
alt-svc: h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
```