### PR TITLE
[amazon-linux] fix dates for Amazon Linux 2023

### DIFF
--- a/products/amazon-linux.md
+++ b/products/amazon-linux.md
@@ -27,8 +27,8 @@ auto:
 releases:
 -   releaseCycle: '2023'
     releaseDate: 2023-03-01
-    eoas: 2025-03-15
-    eol: 2028-03-15
+    eoas: 2027-06-30
+    eol: 2029-06-30
     latest: "2023.6.20250107.0"
     latestReleaseDate: 2025-01-11
     link: https://aws.amazon.com/about-aws/whats-new/2023/03/amazon-linux-2023/


### PR DESCRIPTION
Per https://docs.aws.amazon.com/linux/al2023/ug/release-cadence.html, the dates are:

**End of Active Support:** 2027-06-30
**End of Life:** 2029-06-30