### PR TITLE
[lineageos] add LOS 22.1

### DIFF
--- a/products/lineageos.md
+++ b/products/lineageos.md
@@ -19,6 +19,13 @@ identifiers:
 -   cpe: cpe:2.3:o:lineageos:lineageos
 
 releases:
+# Changed back to minor versions due to changes in upstream development (Quarterly Platform Releases). Read Changelog 29 (LineageOS 22[.1]) for more information.
+-   releaseCycle: "22.1"
+    releaseDate: 2024-12-31
+    eol: false
+    link: https://lineageos.org/Changelog-29/
+    androidVersion: 15
+
 -   releaseCycle: "21"
     releaseDate: 2024-02-14
     eol: false
@@ -27,7 +34,7 @@ releases:
 
 -   releaseCycle: "20"
     releaseDate: 2022-12-31
-    eol: false
+    eol: true
     link: https://lineageos.org/Changelog-27/
     androidVersion: 13
 


### PR DESCRIPTION
self-explanatory. additionally marked lineageOS 20 as deprecated/EOL