### PR TITLE
[sourcegraph] migrated to private repo

### DIFF
--- a/products/sourcegraph.md
+++ b/products/sourcegraph.md
@@ -9,7 +9,6 @@ releaseDateColumn: true
 eolColumn: Support
 
 identifiers:
--   purl: pkg:github/sourcegraph/sourcegraph
 -   purl: pkg:docker/sourcegraph/sg
 
 auto:


### PR DESCRIPTION
It moved its source into a private repo and current purl giving 404