### PR TITLE
[apache-spark] Update 3.5  as LTS release, 3.4 as EoL

### DIFF
--- a/products/apache-spark.md
+++ b/products/apache-spark.md
@@ -27,13 +27,13 @@ auto:
 releases:
 -   releaseCycle: "3.5"
     releaseDate: 2023-09-09
-    eol: 2025-03-09 # estimated
+    eol: 2026-04-12 # https://github.com/apache/spark-website/commit/f06babdb98c4d97163c405622b2cc06c9d3c5797
     latest: "3.5.4"
     latestReleaseDate: 2024-12-17
 
 -   releaseCycle: "3.4"
     releaseDate: 2023-04-07
-    eol: false # estimated
+    eol: true # 3.4.4 announced as last 3.4.x release in https://lists.apache.org/thread/hfpgp3mz0lq6w9ysqv92zkygwn8bmcpk
     latest: "3.4.4"
     latestReleaseDate: 2024-10-21
 


### PR DESCRIPTION
Apache Spark 3.5 has been made an LTS release branch and will receive support until 2026-04-12, see https://github.com/apache/spark-website/commit/f06babdb98c4d97163c405622b2cc06c9d3c5797

Apache Spark 3.4.4 when released was noted as an EOL release, no more releases will be made on the 3.4 branch, see the 3.4.4 release announcement https://lists.apache.org/thread/hfpgp3mz0lq6w9ysqv92zkygwn8bmcpk