### PR TITLE
[ruby] move changelog to github

### DIFF
--- a/products/ruby.md
+++ b/products/ruby.md
@@ -104,6 +104,7 @@ releases:
     # Keep this pinned
     latest: "2.0.0p648"
     latestReleaseDate: 2015-12-16
+    link: null
 
 -   releaseCycle: "1.9.3"
     releaseDate: 2011-10-30
@@ -111,6 +112,7 @@ releases:
     # Keep this pinned
     latest: "1.9.3p551"
     latestReleaseDate: 2014-11-13
+    link: null
 
 ---
 

--- a/products/ruby.md
+++ b/products/ruby.md
@@ -5,7 +5,8 @@ iconSlug: ruby
 permalink: /ruby
 versionCommand: ruby --version
 releasePolicyLink: https://www.ruby-lang.org/en/downloads/branches/
-changelogTemplate: "https://rubychangelog.com/versions-all/#ruby-{{'__LATEST__'|replace:'.',''}}"
+changelogTemplate: https://github.com/ruby/ruby/releases/tag/v{{'__LATEST__'|replace:'.','_'}}
+# changelogTemplate: "https://rubychangelog.com/versions-all/#ruby-{{'__LATEST__'|replace:'.',''}}"   for archive purposes
 releaseDateColumn: true
 eolColumn: Support Status
 


### PR DESCRIPTION
Ruby start to use their website just for annoncement but changelog is always on github