### PR TITLE
[FairPhone] Add Android 14 to supported Android List for FP5

### DIFF
--- a/products/fairphone.md
+++ b/products/fairphone.md
@@ -20,7 +20,7 @@ customColumns:
 releases:
 -   releaseCycle: "5"
     releaseLabel: "Fairphone 5"
-    supportedAndroidVersions: "13"
+    supportedAndroidVersions: "13 - 14"
     releaseDate: 2023-09-14
     discontinued: false
     eoas: false

--- a/products/fairphone.md
+++ b/products/fairphone.md
@@ -20,7 +20,7 @@ customColumns:
 releases:
 -   releaseCycle: "5"
     releaseLabel: "Fairphone 5"
-    supportedAndroidVersions: "13 - 14"
+    supportedAndroidVersions: "13 - 14" # https://support.fairphone.com/hc/en-us/articles/18682800465169-Fairphone-5-OS-Release-Notes
     releaseDate: 2023-09-14
     discontinued: false
     eoas: false


### PR DESCRIPTION
Android 14 was released for the FP5 in Mid 2024