### PR TITLE
[pan-gp]Updated GlobalProtect App from 6.2.6 to 6.2.6-c857

### DIFF
--- a/products/pan-gp.md
+++ b/products/pan-gp.md
@@ -42,8 +42,8 @@ releases:
     releaseDate: 2023-05-23
     eol: 2025-12-31
     eoas: 2025-12-31
-    latest: "6.2.6"
-    latestReleaseDate: 2024-11-12
+    latest: "6.2.6-c857"
+    latestReleaseDate: 2025-01-16
     link: https://docs.paloaltonetworks.com/globalprotect/6-2/globalprotect-app-release-notes/globalprotect-addressed-issues
 
 -   releaseCycle: "6.1"


### PR DESCRIPTION
Updated GlobalProtect App from 6.2.6 to 6.2.6-c857


Released: 2025-01-16

Release Notes: https://docs.paloaltonetworks.com/globalprotect/6-2/globalprotect-app-release-notes/globalprotect-addressed-issues