### PR TITLE
[jira] Mark 10.3 as LTS

### DIFF
--- a/products/jira.md
+++ b/products/jira.md
@@ -28,6 +28,7 @@ releases:
 -   releaseCycle: "10.3"
     releaseDate: 2024-12-05
     eol: 2026-12-05
+    lts: true
     latest: "10.3.2"
     latestReleaseDate: 2025-01-08
     link: https://confluence.atlassian.com/jirasoftware/jira-software-10-3-x-release-notes-1472790887.html


### PR DESCRIPTION
Hey,

Jira 10.3 is a LTS release:
https://confluence.atlassian.com/jirasoftware/jira-software-10-3-x-release-notes-1472790887.html

Best,
Felix