### PR TITLE
[wagtail] Extend LTS period to 18 months

### DIFF
--- a/products/wagtail.md
+++ b/products/wagtail.md
@@ -32,8 +32,8 @@ releases:
 -   releaseCycle: "6.3"
     lts: true
     releaseDate: 2024-11-01
-    eoas: 2026-02-03
-    eol: 2026-02-03
+    eoas: 2026-05-01
+    eol: 2026-05-01
     latest: "6.3.2"
     latestReleaseDate: 2025-01-02
 
@@ -61,8 +61,8 @@ releases:
 -   releaseCycle: "5.2"
     lts: true
     releaseDate: 2023-11-01
-    eoas: 2025-02-03
-    eol: 2025-02-03
+    eoas: 2025-05-01
+    eol: 2025-05-01
     latest: "5.2.7"
     latestReleaseDate: 2024-11-01
 
@@ -191,8 +191,8 @@ releases:
 Minor/Feature releases of Wagtail are released every three months. A feature release will usually
 stop receiving patch release updates when the next feature release comes out. LTS releases receive
 fixes for security and data-loss related issues. Typically, an LTS release will happen once every
-four feature releases and receive updates for five feature releases, giving a support period of
-fifteen months with a three-month overlap. LTS releases will ensure compatibility with at least
+four feature releases and receive updates for six feature releases, giving a support period of
+eighteen months with a six-month overlap. LTS releases will ensure compatibility with at least
 one [Django LTS release](https://www.djangoproject.com/download/#supported-versions).
 
 The Wagtail team provides [official security support](https://docs.wagtail.org/en/stable/contributing/security.html#supported-versions) for:


### PR DESCRIPTION
As per https://github.com/wagtail/wagtail/wiki/Release-schedule Wagtail is extending the support period for LTS releases from 15 to 18 months, giving a 6 month overlap.