### PR TITLE
[graalvm] update 17,21,23 and update lts status for jdk17 and jdk21

### DIFF
--- a/products/graalvm.md
+++ b/products/graalvm.md
@@ -53,7 +53,7 @@ releases:
     lts: true
     releaseLabel: "JDK 17"
     releaseDate: 2023-06-13
-    eol: false # java 17 is LTS, oracle extended support until September 2029
+    eol: 2029-09-30 # java 17 is LTS, oracle extended support until September 2029
     latest: "jdk-17.0.9"
     latestReleaseDate: 2025-01-21
 

--- a/products/graalvm.md
+++ b/products/graalvm.md
@@ -38,7 +38,7 @@ releases:
     lts: true
     releaseLabel: "JDK 21"
     releaseDate: 2023-09-19
-    eol: false # java 21 is LTS, oracle extended support until September 2031
+    eol: 2031-09-30 # java 21 is LTS, oracle extended support until September 2031
     latest: "jdk-21.0.6"
     latestReleaseDate: 2025-01-21
 

--- a/products/graalvm.md
+++ b/products/graalvm.md
@@ -24,8 +24,8 @@ releases:
     releaseLabel: "JDK 23"
     releaseDate: 2024-09-17
     eol: 2025-03-18
-    latest: "jdk-23.0.1"
-    latestReleaseDate: 2024-10-15
+    latest: "jdk-23.0.2"
+    latestReleaseDate: 2025-01-21
 
 -   releaseCycle: "jdk-22"
     releaseLabel: "JDK 22"
@@ -35,11 +35,12 @@ releases:
     latestReleaseDate: 2024-04-16
 
 -   releaseCycle: "jdk-21"
+    lts: true
     releaseLabel: "JDK 21"
     releaseDate: 2023-09-19
-    eol: 2024-03-19
-    latest: "jdk-21.0.2"
-    latestReleaseDate: 2024-01-16
+    eol: false # java 21 is LTS, oracle extended support until September 2031
+    latest: "jdk-21.0.6"
+    latestReleaseDate: 2025-01-21
 
 -   releaseCycle: "jdk-20"
     releaseLabel: "JDK 20"
@@ -49,16 +50,16 @@ releases:
     latestReleaseDate: 2023-07-25
 
 -   releaseCycle: "jdk-17"
+    lts: true
     releaseLabel: "JDK 17"
     releaseDate: 2023-06-13
-    eol: 2023-10-24
+    eol: false # java 17 is LTS, oracle extended support until September 2029
     latest: "jdk-17.0.9"
-    latestReleaseDate: 2023-10-24
+    latestReleaseDate: 2025-01-21
 
 -   releaseCycle: "22.3"
     releaseDate: 2022-10-25
     eol: 2023-10-25
-    lts: true
     latest: "22.3.3"
     latestReleaseDate: 2023-07-25
 


### PR DESCRIPTION
- they only announced jdk 23 update, https://www.graalvm.org/release-notes/JDK_23/, but added other releases in the release table
- also updated the jdk17 and jdk21 lts designation as they are both lts releases. 

<img width="723" alt="image" src="https://github.com/user-attachments/assets/c267a506-e875-4796-a3b4-98ab6e2b0e86" />
