### PR TITLE
[Neo4j] 5.26 became LTS

### DIFF
--- a/products/neo4j.md
+++ b/products/neo4j.md
@@ -47,6 +47,7 @@ releases:
 -   releaseCycle: "5.26"
     releaseDate: 2024-12-06
     eol: false # releaseDate(5.27)
+    lts: true
     latest: "5.26.1"
     latestReleaseDate: 2025-01-08
     link: https://neo4j.com/release-notes/database/neo4j-5/


### PR DESCRIPTION
[🎊 The release of Neo4j 5.26 as our Long-Term Support (LTS) has arrived!](https://x.com/neo4j/status/1883513242225442827) (Take a look at these details and migrate to Neo4j 5.26 LTS! [https://bit.ly/4hp93pk](https://t.co/6eCuJbRctA)): 

![image](https://github.com/user-attachments/assets/cbd406cd-e043-4c8d-a218-1c0ae294f01a)

