### PR TITLE
[react-native] 0.74.7 released and in the same time it 0.74.x became eol

### DIFF
--- a/products/react-native.md
+++ b/products/react-native.md
@@ -43,9 +43,9 @@ releases:
 -   releaseCycle: "0.74"
     releaseDate: 2024-04-23
     eoas: 2024-10-23
-    eol: false
-    latest: "0.74.6"
-    latestReleaseDate: 2024-10-02
+    eol: 2025-01-27
+    latest: "0.74.7"
+    latestReleaseDate: 2025-01-27
 
 -   releaseCycle: "0.73"
     releaseDate: 2023-12-07


### PR DESCRIPTION
React Native 0.74.x is now out of support
[react-native] 0.74.7 released and in the same time it 0.74.x became eol
https://github.com/facebook/react-native/releases/tag/v0.74.7