### PR TITLE
[Quarkus] Add  Explaination of New Release Cadence

### DIFF
--- a/products/quarkus.md
+++ b/products/quarkus.md
@@ -298,6 +298,11 @@ The Quarkus team releases a `major.minor` version every 4 to 6 weeks, and a fix 
 the latest version every week in between. [Beginning with Quarkus 3.2](https://quarkus.io/blog/lts-releases/),
 a new LTS version is also published every 6 months.
 
+Quarkus releases an LTS (Long-Term Support) version every six months. LTS is designed for users who prioritize
+stability over new features.
+These versions are maintained for one year and receive critical bug and CVE fixes. An overlap period allows a smooth upgrade to the next LTS.
+A new LTS version will be released every six months. For each LTS, micro-releases will occur every two months (e.g., 3.20.1, 3.20.2).
+
 Non-LTS minor versions are supported with bug fixes and security updates [until the next minor version](https://github.com/quarkusio/quarkus/discussions/29161). LTS releases are supported for 12 months
 with critical bug fixes and security patches.
 


### PR DESCRIPTION
# :grey_question: About

Quarkus LTS strategy is changing a lot, I thought it may be useful to add some docs about it, thanks to the [following resource.](https://quarkus.io/blog/lts-cadence/)

# :bookmark: Resources

[Tweet:](https://x.com/QuarkusIO/status/1884196018096345165)

![image](https://github.com/user-attachments/assets/166a305a-f12c-490e-bec1-2ef61262e779)

![image](https://github.com/user-attachments/assets/d0ee09ac-e3a4-46cf-80d2-7f5655594bd3)
