### PR TITLE
[Quarkus] New release cycle 3.18 added

### DIFF
--- a/products/quarkus.md
+++ b/products/quarkus.md
@@ -34,21 +34,18 @@ auto:
 # - eoes(x) = false if listed on https://access.redhat.com/products/quarkus
 releases:
 -   releaseCycle: "3.18"
-    lts: false
     releaseDate: 2025-01-30
     eol: false
     latest: "3.18.1"
     latestReleaseDate: 2025-01-30
 
 -   releaseCycle: "3.17"
-    lts: false
     releaseDate: 2024-11-27
     eol: 2025-01-30
     latest: "3.17.8"
     latestReleaseDate: 2025-01-22
 
 -   releaseCycle: "3.16"
-    lts: false
     releaseDate: 2024-10-30
     eol: 2024-11-28
     latest: "3.16.4"

--- a/products/quarkus.md
+++ b/products/quarkus.md
@@ -33,10 +33,17 @@ auto:
 # - eol(x) = releaseDate(x)+1y for LTS
 # - eoes(x) = false if listed on https://access.redhat.com/products/quarkus
 releases:
+-   releaseCycle: "3.18"
+    lts: false
+    releaseDate: 2025-01-30
+    eol: false
+    latest: "3.18.1"
+    latestReleaseDate: 2025-01-30
+
 -   releaseCycle: "3.17"
     lts: false
     releaseDate: 2024-11-27
-    eol: false
+    eol: 2025-01-30
     latest: "3.17.8"
     latestReleaseDate: 2025-01-22
 


### PR DESCRIPTION
[first feature release for 2025: Quarkus 3.18](https://quarkus.io/blog/quarkus-3-18-1-released/) : 

![image](https://github.com/user-attachments/assets/54fe4ea3-007b-4dc0-9b10-e842ed694d16)
