### PR TITLE
[drush] Document Drush's Drupal 6 version support

### DIFF
--- a/products/drush.md
+++ b/products/drush.md
@@ -76,7 +76,7 @@ releases:
     releaseDate: 2015-11-19
     eol: 2025-01-31
     supportedPhpVersions: "5.4.5+"
-    supportedDrupalVersions: "7 - 8"
+    supportedDrupalVersions: "6 - 8"
     latest: "8.5.0"
     latestReleaseDate: 2024-11-26
 
@@ -84,7 +84,7 @@ releases:
     releaseDate: 2015-05-20
     eol: 2017-07-31
     supportedPhpVersions: "5.3.0+"
-    supportedDrupalVersions: "7"
+    supportedDrupalVersions: "6 - 7"
     latest: "7.4.2"
     latestReleaseDate: 2022-03-25
 
@@ -92,7 +92,7 @@ releases:
     releaseDate: 2013-08-16
     eol: 2015-12-31
     supportedPhpVersions: "5.3.0+"
-    supportedDrupalVersions: "7"
+    supportedDrupalVersions: "6 - 7"
     latest: "6.7.0"
     latestReleaseDate: 2015-12-02
 
@@ -100,7 +100,7 @@ releases:
     releaseDate: 2012-03-23
     eol: 2015-05-31
     supportedPhpVersions: "5.2.0+"
-    supportedDrupalVersions: "7"
+    supportedDrupalVersions: "6 - 7"
     latest: "5.11.0"
     latestReleaseDate: 2014-05-22
 


### PR DESCRIPTION
this is relic from the past

documentation from that era https://github.com/drush-ops/drush/blob/a958430cb06b3626c68f528b47bad9c8f7f45bcf/docs/install.md