### PR TITLE
[react] Remove .0 for releaseCycle 19

### DIFF
--- a/products/react.md
+++ b/products/react.md
@@ -19,7 +19,7 @@ auto:
   -   npm: react
 
 releases:
--   releaseCycle: "19.0"
+-   releaseCycle: "19"
     releaseDate: 2024-12-05
     eoas: false
     eol: false


### PR DESCRIPTION
We only track major versions as releaseCycles

From discussion in #6680