### PR TITLE
[Laravel] prepare 12.x

### DIFF
--- a/products/laravel.md
+++ b/products/laravel.md
@@ -38,6 +38,15 @@ auto:
 
 # Do not forget to update the regex_exclude pattern below when a new major version is released.
 releases:
+
+-   releaseCycle: "12"
+    releaseDate: 2025-02-24
+    eoas: 2026-08-03
+    eol: 2027-02-24
+    supportedPhpVersions: '8.2 - 8.4'
+    latest: '12.0.0'
+    latestReleaseDate: 2025-02-24
+    
 -   releaseCycle: "11"
     releaseDate: 2024-03-12
     eoas: 2025-09-03

--- a/products/laravel.md
+++ b/products/laravel.md
@@ -41,7 +41,7 @@ releases:
 
 -   releaseCycle: "12"
     releaseDate: 2025-02-24
-    eoas: 2026-08-03
+    eoas: 2026-08-16
     eol: 2027-02-24
     supportedPhpVersions: '8.2 - 8.4'
     latest: '12.0.0'


### PR DESCRIPTION
Scheduled for February 24th, 2025.

https://laravel-news.com/laravel-12-release-date

EOL and EOS-Dates might need changes after that is updated
https://laravel.com/docs/master/releases#support-policy