### PR TITLE
[fedora] Fix releaseDate for F37 and F39

### DIFF
--- a/products/fedora.md
+++ b/products/fedora.md
@@ -34,7 +34,7 @@ releases:
     latestReleaseDate: 2024-04-23
 
 -   releaseCycle: "39"
-    releaseDate: 2023-10-24
+    releaseDate: 2023-11-07
     eol: 2024-11-26
     latest: "39"
     latestReleaseDate: 2023-11-07
@@ -46,7 +46,7 @@ releases:
     latestReleaseDate: 2023-04-18
 
 -   releaseCycle: "37"
-    releaseDate: 2022-10-25
+    releaseDate: 2022-11-15
     eol: 2023-12-05
     latest: "37"
     latestReleaseDate: 2022-11-15


### PR DESCRIPTION
Those dates were the "final target date 1" from the internal release schedules. There are multiple targets and they are not expected to be met or to be publicated as release dates. Now all the releaseDate and latestReleaseDate values here match and I also have a script which cross checked them with other data sources like wikidata and some wikipedia tables and diagrams.