### PR TITLE
[LibreOffice] Add 25.2

### DIFF
--- a/products/libreoffice.md
+++ b/products/libreoffice.md
@@ -18,6 +18,12 @@ auto:
   -   custom: libreoffice
 
 releases:
+-   releaseCycle: "25.2"
+    releaseDate: 2025-02-06 # https://blog.documentfoundation.org/blog/2025/02/06/libreoffice-25-2/
+    eol: 2025-11-30
+    latest: "25.2.0"
+    latestReleaseDate: 2025-02-06
+
 -   releaseCycle: "24.8"
     releaseDate: 2024-07-09 # https://blog.documentfoundation.org/blog/2024/08/22/libreoffice-248/
     eol: 2025-06-12


### PR DESCRIPTION
EOL date from https://wiki.documentfoundation.org/ReleasePlan#25.2_release

https://blog.documentfoundation.org/blog/2025/02/06/libreoffice-25-2/