### PR TITLE
[confluence] Add 9.3, use changelogTemplate instead of links

### DIFF
--- a/products/confluence.md
+++ b/products/confluence.md
@@ -7,6 +7,7 @@ permalink: /confluence
 alternate_urls:
 -   /atlassian-confluence
 releasePolicyLink: https://confluence.atlassian.com/enterprise/atlassian-enterprise-releases-948227420.html#LongTermSupportreleases-Policyanddetails
+changelogTemplate: https://confluence.atlassian.com/display/DOC/Confluence+__RELEASE_CYCLE__+Release+Notes
 eolColumn: Support
 releaseDateColumn: true
 
@@ -22,55 +23,54 @@ auto:
 # release date: https://www.atlassian.com/software/confluence/download-archives
 # lts/eol date: https://confluence.atlassian.com/support/atlassian-support-end-of-life-policy-201851003.html
 releases:
+-   releaseCycle: "9.3"
+    releaseDate: 2025-02-04
+    eol: 2027-02-04
+    latest: "9.3.1"
+    latestReleaseDate: 2025-02-03
+
 -   releaseCycle: "9.2"
     lts: true
     releaseDate: 2024-12-09
     eol: 2026-12-10
     latest: "9.2.1"
     latestReleaseDate: 2025-02-03
-    link: https://confluence.atlassian.com/doc/confluence-9-2-release-notes-1456345480.html
 
 -   releaseCycle: "9.1"
     releaseDate: 2024-10-03
     eol: 2026-10-03
     latest: "9.1.1"
     latestReleaseDate: 2024-11-04
-    link: https://confluence.atlassian.com/doc/confluence-9-1-release-notes-1431966396.html
 
 -   releaseCycle: "9.0"
     releaseDate: 2024-07-30
     eol: 2026-07-30
     latest: "9.0.3"
     latestReleaseDate: 2024-09-03
-    link: https://confluence.atlassian.com/doc/confluence-9-0-release-notes-1387867170.html
 
 -   releaseCycle: "8.9"
     releaseDate: 2024-04-01
     eol: 2026-04-02
     latest: "8.9.8"
     latestReleaseDate: 2024-11-04
-    link: https://confluence.atlassian.com/doc/confluence-8-9-release-notes-1384120473.html
 
 -   releaseCycle: "8.8"
     releaseDate: 2024-02-08
     eol: 2026-02-08
     latest: "8.8.1"
     latestReleaseDate: 2024-03-05
-    link: https://confluence.atlassian.com/doc/confluence-8-8-release-notes-1346045267.html
 
 -   releaseCycle: "8.7"
     releaseDate: 2023-12-05
     eol: 2025-12-06
     latest: "8.7.2"
     latestReleaseDate: 2024-01-16
-    link: https://confluence.atlassian.com/doc/confluence-8-7-release-notes-1318391277.html
 
 -   releaseCycle: "8.6"
     releaseDate: 2023-10-04
     eol: 2025-10-05
     latest: "8.6.2"
     latestReleaseDate: 2023-12-06
-    link: https://confluence.atlassian.com/doc/confluence-8-6-release-notes-1289421595.html
 
 -   releaseCycle: "8.5"
     lts: true
@@ -78,49 +78,42 @@ releases:
     eol: 2025-08-22
     latest: "8.5.19"
     latestReleaseDate: 2025-02-03
-    link: https://confluence.atlassian.com/doc/confluence-8-5-release-notes-1252010185.html
 
 -   releaseCycle: "8.4"
     releaseDate: 2023-07-05
     eol: 2025-07-06
     latest: "8.4.5"
     latestReleaseDate: 2023-12-06
-    link: https://confluence.atlassian.com/doc/confluence-8-4-release-notes-1251411547.html
 
 -   releaseCycle: "8.3"
     releaseDate: 2023-05-22
     eol: 2025-05-23
     latest: "8.3.4"
     latestReleaseDate: 2023-10-31
-    link: https://confluence.atlassian.com/doc/confluence-8-3-release-notes-1236928237.html
 
 -   releaseCycle: "8.2"
     releaseDate: 2023-03-28
     eol: 2025-03-29
     latest: "8.2.3"
     latestReleaseDate: 2023-05-16
-    link: https://confluence.atlassian.com/doc/confluence-8-2-release-notes-1216971744.html
 
 -   releaseCycle: "8.1"
     releaseDate: 2023-02-13
     eol: 2025-02-14
     latest: "8.1.4"
     latestReleaseDate: 2023-04-05
-    link: https://confluence.atlassian.com/doc/confluence-8-1-release-notes-1206791873.html
 
 -   releaseCycle: "8.0"
     releaseDate: 2022-11-28
     eol: 2024-11-29
     latest: "8.0.4"
     latestReleaseDate: 2023-02-13
-    link: https://confluence.atlassian.com/doc/confluence-8-0-release-notes-1127254402.html
 
 -   releaseCycle: "7.20"
     releaseDate: 2022-10-03
     eol: 2024-10-04
     latest: "7.20.3"
     latestReleaseDate: 2022-12-13
-    link: https://confluence.atlassian.com/doc/confluence-7-20-release-notes-1142251039.html
 
 -   releaseCycle: "7.19"
     lts: true
@@ -128,42 +121,36 @@ releases:
     eol: 2024-12-13
     latest: "7.19.30"
     latestReleaseDate: 2024-12-02
-    link: https://confluence.atlassian.com/doc/confluence-7-19-release-notes-1141976784.html
 
 -   releaseCycle: "7.18"
     releaseDate: 2022-05-28
     eol: 2024-05-30
     latest: "7.18.3"
     latestReleaseDate: 2022-07-11
-    link: https://confluence.atlassian.com/doc/confluence-7-18-release-notes-1115677302.html
 
 -   releaseCycle: "7.17"
     releaseDate: 2022-03-20
     eol: 2024-03-22
     latest: "7.17.5"
     latestReleaseDate: 2022-06-21
-    link: https://confluence.atlassian.com/doc/confluence-7-17-release-notes-1108683391.html
 
 -   releaseCycle: "7.16"
     releaseDate: 2022-01-30
     eol: 2024-01-31
     latest: "7.16.5"
     latestReleaseDate: 2022-07-05
-    link: https://confluence.atlassian.com/doc/confluence-7-16-release-notes-1087527591.html
 
 -   releaseCycle: "7.15"
     releaseDate: 2021-11-22
     eol: 2023-11-24
     latest: "7.15.3"
     latestReleaseDate: 2022-06-23
-    link: https://confluence.atlassian.com/doc/confluence-7-16-release-notes-1087527591.html
 
 -   releaseCycle: "7.14"
     releaseDate: 2021-10-10
     eol: 2023-10-12
     latest: "7.14.4"
     latestReleaseDate: 2022-06-23
-    link: https://confluence.atlassian.com/doc/confluence-7-14-release-notes-1063176411.html
 
 -   releaseCycle: "7.13"
     lts: true
@@ -171,7 +158,6 @@ releases:
     eol: 2023-08-17
     latest: "7.13.20"
     latestReleaseDate: 2023-08-02
-    link: https://confluence.atlassian.com/doc/confluence-7-13-release-notes-1044114085.html
 
 -   releaseCycle: "7.4"
     lts: true
@@ -179,7 +165,6 @@ releases:
     eol: 2022-04-21
     latest: "7.4.18"
     latestReleaseDate: 2022-07-04
-    link: https://confluence.atlassian.com/doc/confluence-7-4-release-notes-994312218.html
 
 -   releaseCycle: "6.13"
     lts: true
@@ -187,7 +172,6 @@ releases:
     eol: 2020-12-04
     latest: "6.13.23"
     latestReleaseDate: 2021-08-23
-    link: https://confluence.atlassian.com/doc/confluence-6-13-release-notes-959288785.html
 
 -   releaseCycle: "6.6"
     lts: true
@@ -195,7 +179,6 @@ releases:
     eol: 2019-12-12
     latest: "6.6.17"
     latestReleaseDate: 2019-11-07
-    link: https://confluence.atlassian.com/doc/confluence-6-6-release-notes-940116151.html
 
 ---
 

--- a/products/confluence.md
+++ b/products/confluence.md
@@ -27,7 +27,7 @@ releases:
     releaseDate: 2025-02-04
     eol: 2027-02-04
     latest: "9.3.1"
-    latestReleaseDate: 2025-02-03
+    latestReleaseDate: 2025-02-04
 
 -   releaseCycle: "9.2"
     lts: true


### PR DESCRIPTION
https://confluence.atlassian.com/display/DOC/Confluence+9.3+Release+Notes