### PR TITLE
jekyll.md: update version used by GitHub Pages

### DIFF
--- a/products/jekyll.md
+++ b/products/jekyll.md
@@ -68,7 +68,7 @@ releases:
 Jekyll follows [Semantic Versioning](https://semver.org/). It does not have a fixed release policy,
 nor a clearly defined support policy. Nevertheless, limited bug fixes and security updates are
 always applied to [the version used by GitHub Pages](https://pages.github.com/versions/) (Currently
-`3.9.x`).
+`3.10.x`).
 
 ## [Ruby Compatibility](https://jekyllrb.com/docs/installation/)
 


### PR DESCRIPTION
[GitHub Pages now uses Jekyll 3.10.x](https://pages.github.com/versions/). See release [v232](https://github.com/github/pages-gem/releases/tag/v232), from Aug 2024, which includes the Jekyll bump to v3.10, from PR [pages-gem#919](https://github.com/github/pages-gem/pull/919).