### PR TITLE
Eurolinux EOL

### DIFF
--- a/products/eurolinux.md
+++ b/products/eurolinux.md
@@ -22,14 +22,14 @@ releases:
 -   releaseCycle: "9"
     releaseDate: 2022-06-14
     eoas: 2032-05-31
-    eol: 2024-10-23
+    eol: 2024-11-03
     latest: "9.4"
     latestReleaseDate: 2024-05-10
 
 -   releaseCycle: "8"
     releaseDate: 2021-07-12
     eoas: 2029-03-01
-    eol: 2024-10-23
+    eol: 2024-11-03
     latest: "8.10"
     latestReleaseDate: 2024-05-27
 

--- a/products/eurolinux.md
+++ b/products/eurolinux.md
@@ -48,17 +48,12 @@ releases:
     latestReleaseDate: 2018-07-25
 
 ---
+
+> [EuroLinux](https://euro-linux.com) was a Polish Enterprise Linux distribution
+> that maintained compatibility with RHEL and CentOS.
+
 {: .warning }
-> The last packages for EuroLinux distribution were released on 23rd October 2024. The EuroLinux team advises and supports migration to Rocky Linux using [linked](https://docs.euro-linux.com/HowTo/migrate_to_rocky_linux/) instructions.
-> The EuroLinux project is evolving into a comprehensive support service for Linux systems. As of 2024-11-03, the EuroLinux distribution will reach End Of Life status. 
+> The EuroLinux distribution reached End-Of-Life in October 2024. The EuroLinux team
+> [advises and supports migration to Rocky Linux](https://docs.euro-linux.com/HowTo/migrate_to_rocky_linux/).
 
-> [EuroLinux](https://euro-linux.com) is a Polish Enterprise Linux distribution that has been in
-> development since 2013. EuroLinux guarantees its compatibility with RHEL and CentOS. It is
-> available in two versions: paid and free, with the paid version providing additional technical
-> support cover.
-
-EuroLinux releases regular updates within 1 business day from RHEL. Each release, like RHEL, comes
-with a 10-year lifecycle.
-
-The table above showcases Standard Support dates. EuroLinux 6 paid Extended Support ends at
-July 31, 2024
+The EuroLinux project has now evolved into a comprehensive support service for Linux systems.

--- a/products/eurolinux.md
+++ b/products/eurolinux.md
@@ -21,14 +21,14 @@ auto:
 releases:
 -   releaseCycle: "9"
     releaseDate: 2022-06-14
-    eoas: 2032-05-31
+    eoas: 2024-10-23
     eol: 2024-11-03
     latest: "9.4"
     latestReleaseDate: 2024-05-10
 
 -   releaseCycle: "8"
     releaseDate: 2021-07-12
-    eoas: 2029-03-01
+    eoas: 2024-10-23
     eol: 2024-11-03
     latest: "8.10"
     latestReleaseDate: 2024-05-27

--- a/products/eurolinux.md
+++ b/products/eurolinux.md
@@ -22,14 +22,14 @@ releases:
 -   releaseCycle: "9"
     releaseDate: 2022-06-14
     eoas: 2032-05-31
-    eol: 2032-06-30
+    eol: 2024-10-23
     latest: "9.4"
     latestReleaseDate: 2024-05-10
 
 -   releaseCycle: "8"
     releaseDate: 2021-07-12
     eoas: 2029-03-01
-    eol: 2029-06-30
+    eol: 2024-10-23
     latest: "8.10"
     latestReleaseDate: 2024-05-27
 

--- a/products/eurolinux.md
+++ b/products/eurolinux.md
@@ -48,6 +48,9 @@ releases:
     latestReleaseDate: 2018-07-25
 
 ---
+{: .warning }
+> The last packages for EuroLinux distribution were released on 23rd October 2024. The EuroLinux team advises and supports migration to Rocky Linux using [linked](https://docs.euro-linux.com/HowTo/migrate_to_rocky_linux/) instructions.
+> The EuroLinux project is evolving into a comprehensive support service for Linux systems. As of 2024-11-03, the EuroLinux distribution will reach End Of Life status. 
 
 > [EuroLinux](https://euro-linux.com) is a Polish Enterprise Linux distribution that has been in
 > development since 2013. EuroLinux guarantees its compatibility with RHEL and CentOS. It is


### PR DESCRIPTION
https://docs.euro-linux.com/
https://community.centminmod.com/threads/eurolinux-shutting-down.26815

> The last packages for EuroLinux distribution were released on 23rd October 2024. The EuroLinux team advises and supports migration to Rocky Linux using [linked instructions](https://docs.euro-linux.com/HowTo/migrate_to_rocky_linux/). For technical support services check [this page](https://euro-linux.com/en/software/technical-support/).