### PR TITLE
[gke] add 1.32 and update eol for 1.29/1.27

### DIFF
--- a/products/gke.md
+++ b/products/gke.md
@@ -57,8 +57,8 @@ releases:
 
 -   releaseCycle: "1.27"
     releaseDate: 2023-06-15
-    eoas: 2024-06-30
-    eol: 2024-08-31
+    eoas: 2024-07-31
+    eol: 2024-10-01
     latest: '1.27.16-gke.2387000'
     latestReleaseDate: 2025-02-11
 

--- a/products/gke.md
+++ b/products/gke.md
@@ -43,8 +43,8 @@ releases:
 
 -   releaseCycle: "1.29"
     releaseDate: 2024-01-26
-    eoas: 2025-01-31
-    eol: 2025-03-21
+    eoas: 2025-02-28
+    eol: 2025-04-12
     latest: '1.29.13-gke.1169000'
     latestReleaseDate: 2025-02-11
 

--- a/products/gke.md
+++ b/products/gke.md
@@ -20,6 +20,13 @@ auto:
 # eol: As per https://cloud.google.com/kubernetes-engine/docs/release-schedule
 # eoas:last-date-in-month(eol - 2months)
 releases:
+-   releaseCycle: "1.32"
+    releaseDate: 2025-02-11
+    eoas: 2026-02-28
+    eol: 2026-04-11
+    latest: '1.32.1-gke.1489001'
+    latestReleaseDate: 2025-02-11
+
 -   releaseCycle: "1.31"
     releaseDate: 2024-10-25
     eoas: 2025-09-30


### PR DESCRIPTION
https://cloud.google.com/kubernetes-engine/docs/release-schedule
<img width="940" alt="image" src="https://github.com/user-attachments/assets/40d1a801-3e80-4ed4-81f0-405824130dc3" />
