### PR TITLE
[firefox] Fix changelogTemplate

### DIFF
--- a/products/firefox.md
+++ b/products/firefox.md
@@ -6,7 +6,7 @@ iconSlug: firefoxbrowser
 permalink: /firefox
 versionCommand: firefox --version
 releasePolicyLink: https://www.mozilla.org/firefox/
-changelogTemplate: https://www.mozilla.org/firefox/__LATEST__/releasenotes/
+changelogTemplate: "https://www.mozilla.org/firefox/{{'__LATEST__' | drop_zero_patch}}/releasenotes/"
 LTSLabel: "<abbr title='Extended Support Release'>ESR</abbr>"
 releaseDateColumn: true
 


### PR DESCRIPTION
The link for the first version in a release does not mention the last `.0`, so links such as https://www.mozilla.org/firefox/135.0.0/releasenotes/ should be https://www.mozilla.org/firefox/135.0/releasenotes/.

Closes #6748.