### PR TITLE
Use /etc/os-release instead of lsb_release

### DIFF
--- a/products/eurolinux.md
+++ b/products/eurolinux.md
@@ -3,7 +3,7 @@ title: EuroLinux
 category: os
 tags: linux-distribution
 permalink: /eurolinux
-versionCommand: lsb_release --release
+versionCommand: cat /etc/os-release
 releasePolicyLink: https://euro-linux.com/en/software/eurolinux/specification/
 changelogTemplate: https://euro-linux.com/en/software/eurolinux/specification/
 releaseDateColumn: true

--- a/products/oracle-linux.md
+++ b/products/oracle-linux.md
@@ -6,7 +6,7 @@ iconSlug: oracle
 permalink: /oracle-linux
 alternate_urls:
 -   /oraclelinux
-versionCommand: lsb_release --release
+versionCommand: cat /etc/oracle-release # https://linux-audit.com/how-to-see-version-of-oracle-linux/
 releasePolicyLink: https://www.oracle.com/a/ocom/docs/elsp-lifetime-069338.pdf
 changelogTemplate: https://docs.oracle.com/en/operating-systems/oracle-linux/__RELEASE_CYCLE__/relnotes__LATEST__/
 releaseDateColumn: true

--- a/products/pop_os.md
+++ b/products/pop_os.md
@@ -7,7 +7,7 @@ permalink: /pop-os
 alternate_urls:
 -   /popos
 -   /pop_os
-versionCommand: lsb_release --release
+versionCommand: cat /etc/os-release
 releaseColumn: false
 releaseDateColumn: true
 eolColumn: General Support

--- a/products/ubuntu.md
+++ b/products/ubuntu.md
@@ -4,7 +4,7 @@ category: os
 tags: linux-distribution
 iconSlug: ubuntu
 permalink: /ubuntu
-versionCommand: lsb_release --release
+versionCommand: cat /etc/os-release
 releasePolicyLink: https://wiki.ubuntu.com/Releases
 releaseImage: https://github.com/endoflife-date/endoflife.date/assets/1423115/c1d812cd-9179-4ff6-9607-520dbf37fa3e
 


### PR DESCRIPTION
The /etc/os-release file is the standard. Any distribution based on systemd, including Red Hat Enterprise Linux, CentOS, Fedora, Gentoo, Debian, Mint, Ubuntu, and many others, is required to have that file. Distributions that don't use systemd may also have the file.