### PR TITLE
[iPad] Update iPad Pro 1st & 2nd gen  and iPad Air 4th

### DIFF
--- a/products/ipad.md
+++ b/products/ipad.md
@@ -102,6 +102,14 @@ releases:
     link: https://support.apple.com/kb/SP822
     supportedIpadOsVersions: 14, 15, 16, 17, 18
 
+-   releaseCycle: "pro-2"
+    releaseLabel: "iPad Pro 11-inch (2nd generation)"
+    releaseDate: 2020-03-01
+    discontinued: 2021-04-01
+    eol: 2027-09-15 #3 years support expected for iPadOS 18
+    link: https://support.apple.com/en-us/118452
+    supportedIpadOsVersions: 10, 11, 12, 13, 14, 15, 16, 17, 18
+	
 -   releaseCycle: "pro-4"
     releaseLabel: "iPad Pro (4th generation)"
     releaseDate: 2020-03-25
@@ -142,6 +150,14 @@ releases:
     link: https://support.apple.com/kb/SP785
     supportedIpadOsVersions: 12, 13, 14, 15, 16, 17, 18
 
+-   releaseCycle: "pro-1"
+    releaseLabel: "iPad Pro 11-inch (1st generation)"
+    releaseDate: 2018-11-01
+    discontinued: 2020-03-01
+    eol: 2027-09-15 #3 years support expected for iPadOS 18
+    link: https://support.apple.com/en-us/111974
+    supportedIpadOsVersions: 9, 10, 11, 12, 13, 14, 15, 16, 17, 18
+
 -   releaseCycle: "6"
     releaseLabel: "iPad (6th generation)"
     releaseDate: 2018-03-27
@@ -150,14 +166,14 @@ releases:
     link: https://support.apple.com/kb/SP774
     supportedIpadOsVersions: 11, 12, 13, 14, 15, 16, 17
 
--   releaseCycle: "pro-2"
-    releaseLabel: "iPad Pro 11-inch (2nd generation)"
-    releaseDate: 2020-03-01
-    discontinued: 2021-04-01
-    eol: 2027-09-15 #3 years support expected for iPadOS 18
-    link: https://support.apple.com/en-us/118452
-    supportedIpadOsVersions: 10, 11, 12, 13, 14, 15, 16, 17, 18
-
+-   releaseCycle: "pro-1"
+    releaseLabel: "iPad Pro 10.5-inch (1st generation)"
+    releaseDate: 2017-06-13
+    discontinued: 2018-11-01
+    eol: 2026-09-17 #3 years support expected  for iPadOS 17
+    link: https://support.apple.com/en-us/111927
+    supportedIpadOsVersions: 9, 10, 11, 12, 13, 14, 15, 16, 17
+	
 -   releaseCycle: "pro-2"
     releaseLabel: "iPad Pro 12.9-inch (2nd generation)"
     releaseDate: 2017-06-05
@@ -181,22 +197,6 @@ releases:
     eol: 2024-09-16 #iPadOs 16 EOL 
     link: https://support.apple.com/en-us/111965
     supportedIpadOsVersions: 9, 10, 11, 12, 13, 14, 15, 16
-
--   releaseCycle: "pro-1"
-    releaseLabel: "iPad Pro 10.5-inch (1st generation)"
-    releaseDate: 2017-06-13
-    discontinued: 2018-11-01
-    eol: 2026-09-17 #3 years support expected  for iPadOS 17
-    link: https://support.apple.com/en-us/111927
-    supportedIpadOsVersions: 9, 10, 11, 12, 13, 14, 15, 16, 17
-
--   releaseCycle: "pro-1"
-    releaseLabel: "iPad Pro 11-inch (1st generation)"
-    releaseDate: 2018-11-01
-    discontinued: 2020-03-01
-    eol: 2027-09-15 #3 years support expected for iPadOS 18
-    link: https://support.apple.com/en-us/111974
-    supportedIpadOsVersions: 9, 10, 11, 12, 13, 14, 15, 16, 17, 18
 
 -   releaseCycle: "pro-1"
     releaseLabel: "iPad Pro 12.9-inch (1st generation)"

--- a/products/ipad.md
+++ b/products/ipad.md
@@ -90,9 +90,9 @@ releases:
     releaseLabel: "iPad Air (4th generation)"
     releaseDate: 2020-10-23
     discontinued: 2022-03-08
-    eol: false
+    eol: 2027-09-15 #3 years support expected
     link: https://support.apple.com/kb/SP828
-    supportedIpadOsVersions: 14, 15, 16, 17
+    supportedIpadOsVersions: 14, 15, 16, 17, 18
 
 -   releaseCycle: "8"
     releaseLabel: "iPad (8th generation)"
@@ -154,15 +154,15 @@ releases:
     releaseLabel: "iPad Pro 11-inch (2nd generation)"
     releaseDate: 2020-03-01
     discontinued: 2021-04-01
-    eol: 2027-09-15 #3 years support expected
+    eol: 2027-09-15 #3 years support expected for iPadOS 18
     link: https://support.apple.com/en-us/118452
     supportedIpadOsVersions: 10, 11, 12, 13, 14, 15, 16, 17, 18
 
-    releaseCycle: "pro-2"
+-   releaseCycle: "pro-2"
     releaseLabel: "iPad Pro 12.9-inch (2nd generation)"
     releaseDate: 2017-06-05
     discontinued: 2018-10-30
-    eol: 2026-09-17 #3 years support expected
+    eol: 2026-09-17 #3 years support expected for iPadOS 17
     link: https://support.apple.com/en-us/111964
     supportedIpadOsVersions: 10, 11, 12, 13, 14, 15, 16, 17
 
@@ -178,31 +178,31 @@ releases:
     releaseLabel: "iPad Pro 9.7-inch (1st generation)"
     releaseDate: 2016-03-21
     discontinued: 2017-06-05
-    eol: 2025-10-23 #3 years support expected
+    eol: 2024-09-16 #iPadOs 16 EOL 
     link: https://support.apple.com/en-us/111965
     supportedIpadOsVersions: 9, 10, 11, 12, 13, 14, 15, 16
 
-    releaseCycle: "pro-1"
+-   releaseCycle: "pro-1"
     releaseLabel: "iPad Pro 10.5-inch (1st generation)"
     releaseDate: 2017-06-13
     discontinued: 2018-11-01
-    eol: 2026-09-17 #3 years support expected
+    eol: 2026-09-17 #3 years support expected  for iPadOS 17
     link: https://support.apple.com/en-us/111927
     supportedIpadOsVersions: 9, 10, 11, 12, 13, 14, 15, 16, 17
 
-    releaseCycle: "pro-1"
+-   releaseCycle: "pro-1"
     releaseLabel: "iPad Pro 11-inch (1st generation)"
     releaseDate: 2018-11-01
     discontinued: 2020-03-01
-    eol: 2027-09-15 #3 years support expected
+    eol: 2027-09-15 #3 years support expected for iPadOS 18
     link: https://support.apple.com/en-us/111974
     supportedIpadOsVersions: 9, 10, 11, 12, 13, 14, 15, 16, 17, 18
 
-    releaseCycle: "pro-1"
+-   releaseCycle: "pro-1"
     releaseLabel: "iPad Pro 12.9-inch (1st generation)"
     releaseDate: 2015-11-11
     discontinued: 2017-06-05
-    eol: 2025-10-23 #3 years support expected
+    eol: 2024-09-16 #iPadOs 16 EOL 
     link: https://support.apple.com/en-us/112024
     supportedIpadOsVersions: 9, 10, 11, 12, 13, 14, 15, 16
 

--- a/products/ipad.md
+++ b/products/ipad.md
@@ -109,7 +109,7 @@ releases:
     eol: 2027-09-15 #3 years support expected for iPadOS 18
     link: https://support.apple.com/en-us/118452
     supportedIpadOsVersions: 10, 11, 12, 13, 14, 15, 16, 17, 18
-	
+
 -   releaseCycle: "pro-4"
     releaseLabel: "iPad Pro (4th generation)"
     releaseDate: 2020-03-25

--- a/products/ipad.md
+++ b/products/ipad.md
@@ -102,14 +102,6 @@ releases:
     link: https://support.apple.com/kb/SP822
     supportedIpadOsVersions: 14, 15, 16, 17, 18
 
--   releaseCycle: "pro-2"
-    releaseLabel: "iPad Pro 11-inch (2nd generation)"
-    releaseDate: 2020-03-01
-    discontinued: 2021-04-01
-    eol: 2027-09-15 #3 years support expected for iPadOS 18
-    link: https://support.apple.com/en-us/118452
-    supportedIpadOsVersions: 10, 11, 12, 13, 14, 15, 16, 17, 18
-
 -   releaseCycle: "pro-4"
     releaseLabel: "iPad Pro (4th generation)"
     releaseDate: 2020-03-25
@@ -117,6 +109,14 @@ releases:
     eol: false
     link: https://support.apple.com/kb/SP815
     supportedIpadOsVersions: 13, 14, 15, 16, 17, 18
+
+-   releaseCycle: "pro-2"
+    releaseLabel: "iPad Pro 11-inch (2nd generation)"
+    releaseDate: 2020-03-01
+    discontinued: 2021-04-01
+    eol: 2027-09-15 #3 years support expected for iPadOS 18
+    link: https://support.apple.com/en-us/118452
+    supportedIpadOsVersions: 10, 11, 12, 13, 14, 15, 16, 17, 18
 
 -   releaseCycle: "7"
     releaseLabel: "iPad (7th generation)"

--- a/products/ipad.md
+++ b/products/ipad.md
@@ -150,7 +150,7 @@ releases:
     link: https://support.apple.com/kb/SP774
     supportedIpadOsVersions: 11, 12, 13, 14, 15, 16, 17
 
--   releaseCycle: "pro-2-11"
+-   releaseCycle: "pro-2"
     releaseLabel: "iPad Pro 11-inch (2nd generation)"
     releaseDate: 2020-03-01
     discontinued: 2021-04-01
@@ -174,7 +174,7 @@ releases:
     link: https://support.apple.com/kb/SP751
     supportedIpadOsVersions: 10, 11, 12, 13, 14, 15, 16
 
--   releaseCycle: "pro-1-9"
+-   releaseCycle: "pro-1"
     releaseLabel: "iPad Pro 9.7-inch (1st generation)"
     releaseDate: 2016-03-21
     discontinued: 2017-06-05

--- a/products/ipad.md
+++ b/products/ipad.md
@@ -173,7 +173,7 @@ releases:
     eol: 2026-09-17 #3 years support expected  for iPadOS 17
     link: https://support.apple.com/en-us/111927
     supportedIpadOsVersions: 9, 10, 11, 12, 13, 14, 15, 16, 17
-	
+
 -   releaseCycle: "pro-2"
     releaseLabel: "iPad Pro 12.9-inch (2nd generation)"
     releaseDate: 2017-06-05


### PR DESCRIPTION
adding '-' at he beginning of the line to let the mdel appear in web site
 take into account iPadOS 16 EOL on 2024-09-16
According Apple web site, iPad Air 4th supports iPadOS18