### PR TITLE
[jenkins] Add 2.492 LTS

### DIFF
--- a/products/jenkins.md
+++ b/products/jenkins.md
@@ -37,10 +37,17 @@ releases:
     latest: "2.497"
     latestReleaseDate: 2025-02-11
 
+-   releaseCycle: "2.492"
+    releaseDate: 2025-01-07
+    lts: 2025-02-05
+    eol: false
+    latest: "2.492.1"
+    latestReleaseDate: 2025-02-05
+
 -   releaseCycle: "2.479"
     releaseDate: 2024-09-27
     lts: 2024-10-30
-    eol: false
+    eol: 2025-02-05
     latest: "2.479.3"
     latestReleaseDate: 2025-01-08
 


### PR DESCRIPTION
See [Upgrading to Jenkins LTS 2.492.x](https://www.jenkins.io/doc/upgrade-guide/2.492/)