### PR TITLE
[watchos] EOL watchOS 10

### DIFF
--- a/products/watchos.md
+++ b/products/watchos.md
@@ -36,7 +36,7 @@ releases:
 -   releaseCycle: "10"
     releaseDate: 2023-09-18
     eoas: 2024-09-16
-    eol: false
+    eol: 2024-09-16
     latest: '10.6.1'
     latestReleaseDate: 2024-08-19
 


### PR DESCRIPTION
watchOS 10 is not receiving security updates since August 2024