### PR TITLE
[ipad] Make release cycle names unique again

### DIFF
--- a/products/ipad.md
+++ b/products/ipad.md
@@ -110,7 +110,7 @@ releases:
     link: https://support.apple.com/kb/SP815
     supportedIpadOsVersions: 13, 14, 15, 16, 17, 18
 
--   releaseCycle: "pro-2"
+-   releaseCycle: "pro-2-11"
     releaseLabel: "iPad Pro 11-inch (2nd generation)"
     releaseDate: 2020-03-01
     discontinued: 2021-04-01
@@ -150,7 +150,7 @@ releases:
     link: https://support.apple.com/kb/SP785
     supportedIpadOsVersions: 12, 13, 14, 15, 16, 17, 18
 
--   releaseCycle: "pro-1"
+-   releaseCycle: "pro-1-11"
     releaseLabel: "iPad Pro 11-inch (1st generation)"
     releaseDate: 2018-11-01
     discontinued: 2020-03-01
@@ -166,7 +166,7 @@ releases:
     link: https://support.apple.com/kb/SP774
     supportedIpadOsVersions: 11, 12, 13, 14, 15, 16, 17
 
--   releaseCycle: "pro-1"
+-   releaseCycle: "pro-1-10"
     releaseLabel: "iPad Pro 10.5-inch (1st generation)"
     releaseDate: 2017-06-13
     discontinued: 2018-11-01
@@ -174,7 +174,7 @@ releases:
     link: https://support.apple.com/en-us/111927
     supportedIpadOsVersions: 9, 10, 11, 12, 13, 14, 15, 16, 17
 
--   releaseCycle: "pro-2"
+-   releaseCycle: "pro-2-12"
     releaseLabel: "iPad Pro 12.9-inch (2nd generation)"
     releaseDate: 2017-06-05
     discontinued: 2018-10-30
@@ -190,7 +190,7 @@ releases:
     link: https://support.apple.com/kb/SP751
     supportedIpadOsVersions: 10, 11, 12, 13, 14, 15, 16
 
--   releaseCycle: "pro-1"
+-   releaseCycle: "pro-1-9"
     releaseLabel: "iPad Pro 9.7-inch (1st generation)"
     releaseDate: 2016-03-21
     discontinued: 2017-06-05
@@ -198,7 +198,7 @@ releases:
     link: https://support.apple.com/en-us/111965
     supportedIpadOsVersions: 9, 10, 11, 12, 13, 14, 15, 16
 
--   releaseCycle: "pro-1"
+-   releaseCycle: "pro-1-12"
     releaseLabel: "iPad Pro 12.9-inch (1st generation)"
     releaseDate: 2015-11-11
     discontinued: 2017-06-05


### PR DESCRIPTION
This reverts changes introduced in #6789, which changed release cycles name and introduced duplicates.

Release cycle name should be unique so that each release cycle can be accessed from the API.