### PR TITLE
[ubuntu] LTS update

### DIFF
--- a/products/ubuntu.md
+++ b/products/ubuntu.md
@@ -46,8 +46,8 @@ releases:
     eoas: 2029-04-25
     eol: 2029-04-25
     eoes: 2036-04-25
-    latest: "24.04.1"
-    latestReleaseDate: 2024-08-29
+    latest: "24.04.2"
+    latestReleaseDate: 2025-02-21
 
 -   releaseCycle: "23.10"
     codename: "Mantic Minotaur"


### PR DESCRIPTION
[Ubuntu 24.04.2 LTS is now available to download, powered by Linux kernel 6.11](https://x.com/omgubuntu/status/1892607322557423822) : 

![image](https://github.com/user-attachments/assets/6c6dc36a-cb9d-4038-a7e1-bb98a3f97f22)
