### PR TITLE
[grafana-loki] Add  3.4.x series and eol 3.3.x

### DIFF
--- a/products/grafana-loki.md
+++ b/products/grafana-loki.md
@@ -23,11 +23,17 @@ identifiers:
 
 # eol(x) = releaseDate(x+1)
 releases:
+-   releaseCycle: "3.4"
+    releaseDate: 2025-02-12
+    eol: false
+    latest: "3.4.2"
+    latestReleaseDate: 2025-02-14
+
 -   releaseCycle: "3.3"
     releaseDate: 2024-11-19
-    eol: false
+    eol: 2025-02-13
     latest: "3.3.3"
-    latestReleaseDate: 2025-02-12
+    latestReleaseDate: 2025-02-13
 
 -   releaseCycle: "3.2"
     releaseDate: 2024-09-18


### PR DESCRIPTION
3.4.x is latest now and I think grafana only supports the latest loki so this commit updates the same. This marks 3.3 to be eol as I don't expect more releases on 3.3.x tags.