### PR TITLE
[redhat-jboss-eap] Update to the latest for JBoss 7.4 and 8.0

### DIFF
--- a/products/red-hat-jboss-eap.md
+++ b/products/red-hat-jboss-eap.md
@@ -25,16 +25,16 @@ releases:
     eoas: 2028-02-05
     eol: 2031-02-05
     eoes: 2033-02-05
-    latest: "8.0.4"
-    latestReleaseDate: 2024-11-06
+    latest: "8.0.5.1"
+    latestReleaseDate: 2025-01-16
 
 -   releaseCycle: "7"
     releaseDate: 2016-05-01
     eoas: 2023-12-31
     eol: 2025-06-30
     eoes: 2026-11-30
-    latest: "7.4.19"
-    latestReleaseDate: 2024-10-14
+    latest: "7.4.21"
+    latestReleaseDate: 2025-02-18
 
 -   releaseCycle: "6"
     releaseDate: 2012-06-01


### PR DESCRIPTION
Release notes (viewing requires a free RedHat account):

JBoss 7.4.21: https://access.redhat.com/articles/7096742
JBoss 8.0.5.1: https://access.redhat.com/articles/7100137

The release notes version and date can be scraped with the following commands:

#### JBoss 7.4.21:

```shell
curl -s https://access.redhat.com/articles/7096742 | grep -A 4 "<h1 class=\"title\""
```

output:

```html
                              <h1 class="title">
                        JBoss Enterprise Application Platform 7.4 Update 21 Release Notes          </h1>

                                <div class="status-container">
              Updated <time class='moment_date' datetime='2025-02-18T13:18:51+00:00'>2025-02-18T13:18:51+00:00</time>               -
```

#### JBoss 8.0.5.1:

```shell
curl -s https://access.redhat.com/articles/7100137 | grep -A 4 "<h1 class=\"title\""
```

output:

```html
                              <h1 class="title">
                        JBoss Enterprise Application Platform 8.0 Update 5.1 Release Notes          </h1>

                                <div class="status-container">
              Updated <time class='moment_date' datetime='2025-01-16T14:15:24+00:00'>2025-01-16T14:15:24+00:00</time>               -```