### PR TITLE
[vitess] Add 21 and use only major in releaseCycles

### DIFF
--- a/products/vitess.md
+++ b/products/vitess.md
@@ -18,50 +18,57 @@ identifiers:
 -   purl: pkg:docker/vitess/lite
 -   repology: vitess
 
+# eol(x) = releaseDate(x) + 1 year
 releases:
--   releaseCycle: "20.0"
+-   releaseCycle: "21"
+    releaseDate: 2024-06-27
+    eol: 2024-10-29
+    latest: "21.0.3"
+    latestReleaseDate: 2025-02-12
+
+-   releaseCycle: "20"
     releaseDate: 2024-06-27
     eol: 2025-06-27
     latest: "20.0.6"
     latestReleaseDate: 2025-02-12
 
--   releaseCycle: "19.0"
+-   releaseCycle: "19"
     releaseDate: 2024-03-06
     eol: 2025-03-06
     latest: "19.0.10"
     latestReleaseDate: 2025-02-12
 
--   releaseCycle: "18.0"
+-   releaseCycle: "18"
     releaseDate: 2023-11-06
     eol: 2024-11-07
     latest: "18.0.8"
     latestReleaseDate: 2024-11-06
 
--   releaseCycle: "17.0"
+-   releaseCycle: "17"
     releaseDate: 2023-06-27
     eol: 2024-06-27
     latest: "17.0.7"
     latestReleaseDate: 2024-05-08
 
--   releaseCycle: "16.0"
+-   releaseCycle: "16"
     releaseDate: 2023-02-28
     eol: 2024-02-28
     latest: "16.0.7"
     latestReleaseDate: 2023-12-20
 
--   releaseCycle: "15.0"
+-   releaseCycle: "15"
     releaseDate: 2022-10-25
     eol: 2023-10-25
     latest: "15.0.5"
     latestReleaseDate: 2023-10-03
 
--   releaseCycle: "14.0"
+-   releaseCycle: "14"
     releaseDate: 2022-06-28
     eol: 2023-06-28
     latest: "14.0.5"
     latestReleaseDate: 2023-03-30
 
--   releaseCycle: "13.0"
+-   releaseCycle: "13"
     releaseDate: 2022-02-22
     eol: 2023-02-22
     latest: "13.0.3"

--- a/products/vitess.md
+++ b/products/vitess.md
@@ -21,7 +21,7 @@ identifiers:
 # eol(x) = releaseDate(x) + 1 year
 releases:
 -   releaseCycle: "21"
-    releaseDate: 2024-06-27
+    releaseDate: 2024-10-29
     eol: 2024-10-29
     latest: "21.0.3"
     latestReleaseDate: 2025-02-12


### PR DESCRIPTION
See https://github.com/vitessio/vitess/releases/tag/v21.0.0.

As release cycles revolve around major version, also removed `.0` from all `releaseCycles`.