### PR TITLE
docs: Add text allowing vendor tags.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -73,6 +73,7 @@ category: os
 # - must be added for one of the following reasons :
 #   - set a product family such as linux-distribution, web-browser, mobile-phone or web-server,
 #   - set a product vendor such as adobe, amazon or apache,
+#   - set a third-party extended support partner, or
 #   - set a runtime dependency such as java-runtime, javascript-runtime or php-runtime.
 tags: amazon linux-distribution
 


### PR DESCRIPTION
Allow support vendors to have tags.

From issue: https://github.com/endoflife-date/endoflife.date/issues/6504

This is the real first PR, @marcwrobel ; ignore previous one.