### PR TITLE
[openssl] Add 3.4 eol date

### DIFF
--- a/products/openssl.md
+++ b/products/openssl.md
@@ -24,7 +24,7 @@ auto:
 releases:
 -   releaseCycle: "3.4"
     releaseDate: 2024-10-22
-    eol: 2026-10-22
+    eol: 2026-10-22 # documented on https://openssl-library.org/source/
     latest: "3.4.1"
     latestReleaseDate: 2025-02-11
 

--- a/products/openssl.md
+++ b/products/openssl.md
@@ -24,7 +24,7 @@ auto:
 releases:
 -   releaseCycle: "3.4"
     releaseDate: 2024-10-22
-    eol: false
+    eol: 2026-10-22
     latest: "3.4.1"
     latestReleaseDate: 2025-02-11
 


### PR DESCRIPTION
OpenSSL 3.4 series have an EOL date set as well, as shown in https://openssl-library.org/source/.

> Note: The latest stable version is the 3.4 series supported until 22nd October 2026. Also available is the 3.3 series supported until 9th April 2026, the 3.2 series supported until 23rd November 2025, the 3.1 series supported until 14th March 2025, and the 3.0 series which is a Long Term Support (LTS) version and is supported until 7th September 2026. All older versions (including 1.1.1, 1.1.0, 1.0.2, 1.0.0 and 0.9.8) are now out of support and should not be used. Users of these older versions are encouraged to upgrade to 3.4 as soon as possible. Extended support for 1.1.1 and 1.0.2 to gain access to security fixes for those versions is [available](https://openssl-corporation.org/support/).
