### PR TITLE
[aws-lambda] Add .NET 9

### DIFF
--- a/products/aws-lambda.md
+++ b/products/aws-lambda.md
@@ -17,6 +17,13 @@ auto:
 # The custom script will only detect new releases and update support and eol dates based on dates found on https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html.
 # The release dates must be retrieved from announcements blog post on https://aws.amazon.com/blogs/compute/category/compute/aws-lambda/.
 releases:
+-   releaseCycle: "dotnet9"
+    releaseLabel: ".NET 9 (container only)"
+    releaseDate: 2024-12-09
+    eoas: false
+    eol: false
+    link: https://github.com/aws/aws-lambda-dotnet/blob/master/CHANGELOG.md#release-2024-12-09
+
 -   releaseCycle: "nodejs22.x"
     releaseLabel: Node.js 22
     releaseDate: 2024-11-22


### PR DESCRIPTION
There was no announcement on https://aws.amazon.com/new/, but could find https://github.com/aws/aws-lambda-dotnet/blob/master/CHANGELOG.md#release-2024-12-09.