### PR TITLE
[api-platform] Make 3.3.x eol instead of 3.4.x

### DIFF
--- a/products/api-platform.md
+++ b/products/api-platform.md
@@ -32,14 +32,14 @@ releases:
 -   releaseCycle: "3.4"
     releaseDate: 2024-09-18
     eoas: 2024-09-18
-    eol: 2025-02-28
+    eol: false
     latest: "3.4.16"
     latestReleaseDate: 2025-01-17
 
 -   releaseCycle: "3.3"
     releaseDate: 2024-04-29
     eoas: 2024-09-18
-    eol: false
+    eol: 2025-02-28
     latest: "3.3.15"
     latestReleaseDate: 2025-01-17
 

--- a/products/api-platform.md
+++ b/products/api-platform.md
@@ -13,7 +13,7 @@ auto:
   -   git: https://github.com/api-platform/core.git
 
 # eoas(x) = releaseDate(x+1)
-# eol(x) = releaseDate(x+2)
+# eol(x) = releaseDate(x+3)
 releases:
 -   releaseCycle: "4.1"
     releaseDate: 2025-02-28


### PR DESCRIPTION
`Releases older than the latest three are not maintained.` And latest 3 are 4.1 4.0 3.4