### PR TITLE
[red-hat-openshift] Update changelogTemplate

### DIFF
--- a/products/red-hat-openshift.md
+++ b/products/red-hat-openshift.md
@@ -10,7 +10,7 @@ alternate_urls:
 versionCommand: oc version
 releasePolicyLink: https://access.redhat.com/support/policy/updates/openshift
 releaseImage: https://access.redhat.com/sites/default/files/styles/XL%20-%20Extra%20Large/public/images/ocp_lifecycle_eus_v4_0.png
-changelogTemplate: https://docs.openshift.com/container-platform/__RELEASE_CYCLE__/release_notes/ocp-{{"__RELEASE_CYCLE__"| replace:'.','-'}}-release-notes.html
+changelogTemplate: https://docs.redhat.com/en/documentation/openshift_container_platform/__RELEASE_CYCLE__/html/release_notes/ocp-{{"__RELEASE_CYCLE__"| replace:'.','-'}}-release-notes
 eoasColumn: Full Support
 eolColumn: Maintenance Support
 eoesColumn: Extended Update Support


### PR DESCRIPTION
https://docs.openshift.com/container-platform/4.18/release_notes/ocp-4-18-release-notes.html
> Starting on March 12, 2025, OpenShift docs will only be available at docs.redhat.com. From that time on, docs.openshift.com links will automatically redirect to their locations on docs.redhat.com.