### PR TITLE
[aws-glue] Add 5.0

### DIFF
--- a/products/amazon-glue.md
+++ b/products/amazon-glue.md
@@ -10,6 +10,15 @@ releaseColumn: false
 # Versions taken from https://docs.aws.amazon.com/glue/latest/dg/release-notes.html
 # EOL dates from https://docs.aws.amazon.com/glue/latest/dg/glue-version-support-policy.html.
 releases:
+
+-   releaseCycle: "5.0"
+    releaseLabel: "5.0"
+    releaseDate: 2024-12-03
+    eol: false
+    pythonVersion: "3.11"
+    sparkVersion: "3.5 "
+    link: https://aws.amazon.com/about-aws/whats-new/2024/12/aws-glue-5-0/
+
 -   releaseCycle: "4.0"
     releaseLabel: "4.0"
     releaseDate: 2022-11-28

--- a/products/amazon-glue.md
+++ b/products/amazon-glue.md
@@ -10,7 +10,6 @@ releaseColumn: false
 # Versions taken from https://docs.aws.amazon.com/glue/latest/dg/release-notes.html
 # EOL dates from https://docs.aws.amazon.com/glue/latest/dg/glue-version-support-policy.html.
 releases:
-
 -   releaseCycle: "5.0"
     releaseLabel: "5.0"
     releaseDate: 2024-12-03

--- a/products/amazon-glue.md
+++ b/products/amazon-glue.md
@@ -15,7 +15,7 @@ releases:
     releaseDate: 2024-12-03
     eol: false
     pythonVersion: "3.11"
-    sparkVersion: "3.5 "
+    sparkVersion: "3.5"
     link: https://aws.amazon.com/about-aws/whats-new/2024/12/aws-glue-5-0/
 
 -   releaseCycle: "4.0"

--- a/products/amazon-glue.md
+++ b/products/amazon-glue.md
@@ -81,7 +81,7 @@ Jobs running on deprecated versions of AWS Glue are not eligible for technical s
 patches or any other updates. AWS Glue will also not honor SLAs when jobs are run on deprecated
 versions.
 
-## [Compatibility matrix](https://docs.aws.amazon.com/glue/latest/dg/release-notes.html)
+## [Compatibility Matrix](https://docs.aws.amazon.com/glue/latest/dg/release-notes.html)
 
 {% include table.html
 labels="Glue version,Python version,Spark version"


### PR DESCRIPTION
Version 5.0 was released December 3rd, 2024 ([source](https://aws.amazon.com/about-aws/whats-new/2024/12/aws-glue-5-0/))

Python and Spark versions for Glue 5.0 can be found [here](https://docs.aws.amazon.com/glue/latest/dg/release-notes.html).

Additionally fixes casing in the Compatibility Matrix title