### PR TITLE
Various improvements to the JSON Schema and OpenAPI files

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -377,7 +377,7 @@ releases:
     # Use valid dates, and do not add quotes around dates.
     latestReleaseDate: 2022-01-23
 
-    # A link to the changelog for the latest release
+    # A link to the changelog for the latest release in this cycle
     # (optional, default = the URL generated from changelogTemplate if it is provided).
     # Use this if the link is not predictable (i.e. you can't use changelogTemplate),
     # or if the changelogTemplate generated link must be overridden.

--- a/assets/openapi.yml
+++ b/assets/openapi.yml
@@ -300,7 +300,7 @@ components:
             - string
             - 'null'
           minLength: 1
-          description: Link to changelog for the latest release, if available.
+          description: Link to changelog for the latest release in this cycle, or null if unavailable.
         lts:
           type:
             - string

--- a/assets/openapi.yml
+++ b/assets/openapi.yml
@@ -281,10 +281,10 @@ components:
           description: The release cycle which this release is part of.
         releaseDate:
           type: string
-          minLength: 10
-          description: Release date for the first release in this cycle.
           format: date
+          minLength: 10
           maxLength: 10
+          description: Release date for the first release in this cycle.
         eol:
           type:
             - string
@@ -297,14 +297,14 @@ components:
           description: Latest release in this cycle.
         link:
           type:
-          - string
-          - 'null'
+            - string
+            - 'null'
           minLength: 1
-          description: 'Link to changelog for the latest release, if available.'
+          description: Link to changelog for the latest release, if available.
         lts:
           type:
-            - boolean
             - string
+            - boolean
           description: Whether this release cycle has long-term-support (LTS), or the date it entered LTS status.
         support:
           type:
@@ -318,7 +318,7 @@ components:
           type:
             - string
             - boolean
-          description: Whether this cycle is now discontinued.
+          format: date
           minLength: 10
           maxLength: 10
-          format: date
+          description: Whether this cycle is now discontinued.

--- a/product-schema.json
+++ b/product-schema.json
@@ -438,24 +438,28 @@
           "$ref": "#/$defs/boolOrString"
         },
         "eol": {
-          "title": "EOL",
-          "description": "Date in the format `yyyy-mm-dd` or `false` if not available.",
+          "title": "End of Life (EOL)",
+          "description": "End of all support, including security support. Date in the `yyyy-mm-dd` format, or `false` if not determined.",
           "$ref": "#/$defs/boolOrDate"
         },
         "eoasColumn": {
-          "title": "Active support column",
+          "title": "End of active support (EOAS) column",
           "description": "Whether to show the end of active support column, or a custom name for it.",
           "$ref": "#/$defs/boolOrString"
         },
         "eoas": {
+          "title": "End of active support (EOAS)",
+          "description": "End of active support. Date in the `yyyy-mm-dd` format, or `false` if not determined.",
           "$ref": "#/$defs/boolOrDate"
         },
         "eoesColumn": {
-          "title": "Extended support column",
+          "title": "End of extended support column",
           "description": "Whether to show the end of extended support column, or a custom name for it.",
           "$ref": "#/$defs/boolOrString"
         },
         "eoes": {
+          "title": "End of extended support (EOES)",
+          "description": "End of extended support. Date in the `yyyy-mm-dd` format, or `false` if not determined.",
           "$ref": "#/$defs/boolOrDate"
         },
         "discontinuedColumn": {
@@ -465,7 +469,7 @@
         },
         "discontinued": {
           "title": "Discontinued",
-          "description": "Whether this cycle is now discontinued.",
+          "description": "Whether this cycle is now discontinued. Date in the `yyyy-mm-dd` format, or `false` if not determined.",
           "$ref": "#/$defs/boolOrDate"
         },
         "releaseDateColumn": {

--- a/product-schema.json
+++ b/product-schema.json
@@ -412,7 +412,7 @@
         },
         "link": {
           "title": "Link",
-          "description": "Link to changelog for the latest release.",
+          "description": "Link to changelog for the latest release in this cycle, or null if unavailable.",
           "oneOf": [
             {
               "type": "string",

--- a/product-schema.json
+++ b/product-schema.json
@@ -20,13 +20,13 @@
       "title": "Release policy link",
       "description": "URL to the product's release policy page.",
       "type": "string",
-      "pattern": "^https?://.+$"
+      "format": "uri"
     },
     "iconUrl": {
       "title": "Icon url",
       "description": "URL to the product icon.",
       "type": "string",
-      "format": "uri-template"
+      "format": "uri"
     },
     "category": {
       "title": "Category",
@@ -46,12 +46,12 @@
     },
     "permalink": {
       "title": "Permalink",
-      "description": "The URL to this product. Must start with a slash.",
+      "description": "The URL to this product within the endoflife.date website. Must start with a slash.",
       "examples": [
         "/foo",
         "/bar"
       ],
-      "$ref": "#/$defs/link"
+      "$ref": "#/$defs/slug"
     },
     "tags": {
       "title": "Tags",
@@ -64,10 +64,10 @@
     },
     "alternate_urls": {
       "title": "Alternate URLs",
-      "description": "Array of alternate urls for this product. Must start with a slash.",
+      "description": "Array of alternate urls for this product within the endoflife.date website. Must start with a slash.",
       "type": "array",
       "items": {
-        "$ref": "#/$defs/link"
+        "$ref": "#/$defs/slug"
       }
     },
     "auto": {
@@ -124,7 +124,7 @@
         }
       ]
     },
-    "link": {
+    "slug": {
       "type": "string",
       "pattern": "^/"
     },
@@ -182,7 +182,8 @@
         "link": {
           "title": "Link",
           "description": "A link that gives more information about what the custom column contains.",
-          "type": "string"
+          "type": "string",
+          "format": "uri-template"
         }
       },
       "required": [
@@ -405,7 +406,7 @@
           "oneOf": [
             {
               "type": "string",
-              "pattern": "[^ ]+"
+              "format": "uri"
             },
             {
               "type": "null"

--- a/product-schema.json
+++ b/product-schema.json
@@ -124,6 +124,16 @@
         }
       ]
     },
+    "boolOrString": {
+      "oneOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "boolean"
+        }
+      ]
+    },
     "slug": {
       "type": "string",
       "pattern": "^/"
@@ -420,19 +430,12 @@
         },
         "eolColumn": {
           "title": "EOL column",
-          "description": "Name of the EOL column or `false` to disable the column.",
+          "description": "Whether to show the EOL column, or a custom name for it.",
           "examples": [
             "General Support",
             false
           ],
-          "oneOf": [
-            {
-              "const": false
-            },
-            {
-              "type": "string"
-            }
-          ]
+          "$ref": "#/$defs/boolOrString"
         },
         "eol": {
           "title": "EOL",
@@ -441,24 +444,24 @@
         },
         "eoasColumn": {
           "title": "Active support column",
-          "description": "Name of the active support column or `false` to disable the column.",
-          "type": "boolean"
+          "description": "Whether to show the end of active support column, or a custom name for it.",
+          "$ref": "#/$defs/boolOrString"
         },
         "eoas": {
           "$ref": "#/$defs/boolOrDate"
         },
         "eoesColumn": {
           "title": "Extended support column",
-          "description": "Name of the extended support column or `false` to disable the column.",
-          "type": "boolean"
+          "description": "Whether to show the end of extended support column, or a custom name for it.",
+          "$ref": "#/$defs/boolOrString"
         },
         "eoes": {
           "$ref": "#/$defs/boolOrDate"
         },
         "discontinuedColumn": {
           "title": "Discontinued column",
-          "description": "Name of the discontinued column or `false` to disable the column.",
-          "type": "boolean"
+          "description": "Whether to show the discontinued column, or a custom name for it.",
+          "$ref": "#/$defs/boolOrString"
         },
         "discontinued": {
           "title": "Discontinued",
@@ -467,8 +470,8 @@
         },
         "releaseDateColumn": {
           "title": "Release date column",
-          "description": "Name of the release date column or `false` to disable the column.",
-          "type": "boolean"
+          "description": "Whether to show the release date column, or a custom name for it.",
+          "$ref": "#/$defs/boolOrString"
         },
         "releaseDate": {
           "title": "Release date",
@@ -477,8 +480,8 @@
         },
         "releaseColumn": {
           "title": "Release column",
-          "description": "Name of the release column or `false` to disable the column.",
-          "type": "boolean"
+          "description": "Whether to show the release column, or a custom name for it.",
+          "$ref": "#/$defs/boolOrString"
         },
         "latest": {
           "title": "Latest release",

--- a/product-schema.json
+++ b/product-schema.json
@@ -494,14 +494,14 @@
       "allOf": [
         {
           "if": {
+            "required": [
+              "eolColumn"
+            ],
             "properties": {
               "eolColumn": {
                 "type": "string"
               }
-            },
-            "required": [
-              "eolColumn"
-            ]
+            }
           },
           "then": {
             "required": [
@@ -511,14 +511,14 @@
         },
         {
           "if": {
+            "required": [
+              "eoasColumn"
+            ],
             "properties": {
               "eoasColumn": {
                 "type": "string"
               }
-            },
-            "required": [
-              "eoasColumn"
-            ]
+            }
           },
           "then": {
             "required": [
@@ -528,14 +528,14 @@
         },
         {
           "if": {
+            "required": [
+              "eoesColumn"
+            ],
             "properties": {
               "eoesColumn": {
                 "type": "string"
               }
-            },
-            "required": [
-              "eoesColumn"
-            ]
+            }
           },
           "then": {
             "required": [
@@ -545,14 +545,14 @@
         },
         {
           "if": {
+            "required": [
+              "discontinuedColumn"
+            ],
             "properties": {
               "discontinuedColumn": {
                 "type": "string"
               }
-            },
-            "required": [
-              "discontinuedColumn"
-            ]
+            }
           },
           "then": {
             "required": [
@@ -562,14 +562,14 @@
         },
         {
           "if": {
+            "required": [
+              "releaseDateColumn"
+            ],
             "properties": {
               "releaseDateColumn": {
                 "type": "string"
               }
-            },
-            "required": [
-              "releaseDateColumn"
-            ]
+            }
           },
           "then": {
             "required": [
@@ -579,14 +579,14 @@
         },
         {
           "if": {
+            "required": [
+              "releaseColumn"
+            ],
             "properties": {
               "releaseColumn": {
                 "type": "string"
               }
-            },
-            "required": [
-              "releaseColumn"
-            ]
+            }
           },
           "then": {
             "required": [

--- a/product-schema.json
+++ b/product-schema.json
@@ -476,7 +476,8 @@
         "releaseDate": {
           "title": "Release date",
           "description": "Release date for the first release in this cycle.",
-          "$ref": "#/$defs/boolOrDate"
+          "type": "string",
+          "format": "date"
         },
         "releaseColumn": {
           "title": "Release column",


### PR DESCRIPTION
This PR contains several commits that address consistency and correctness issues in the JSON Schema and the OpenAPI definition.
It's probably a good idea to review the diffs for each commit separately, so that what's being changed is clearer.

- Reorder if-then conditions in JSON Schema, for improved readability
- Normalize field order and formatting of OpenAPI definition
- Normalize specification of relative links (slugs) and absolute links (URIs) in the JSON Schema
- Normalize description and format of *Column fields in JSON Schema
- Fix format of releaseDate field in JSON Schema
- Normalize titles and descriptions of end-of-* fields in JSON Schema
- Sync descriptions of the link field between the JSON Schema and OpenAPI definition
