### PR TITLE
[SteamOS] (Re)Add proper EOL date for SteamOS 1.0

### DIFF
--- a/products/steamos.md
+++ b/products/steamos.md
@@ -28,7 +28,7 @@ releases:
 -   releaseCycle: "1"
     codename: alchemist
     releaseDate: 2013-12-01
-    eol: true
+    eol: 2015-11-02
     discontinued: true
 
 ---


### PR DESCRIPTION
The EOL date for SteamOS 1.0 was added in PR #4843, thanks to the [review suggestion](https://github.com/endoflife-date/endoflife.date/pull/4843#discussion_r1527534571) by @captn3m0.
However, there was a typo in the date, which was entered as 20**11**-11-02 instead of 20**15**-11-02, which is what's indicated in the source at https://steamcommunity.com/groups/steamuniverse/discussions/1/496880203078572666.
This led it to be removed as erroneous (because 2011 is before the `releaseDate` of that release cycle) in commit [972faf7e8](https://github.com/endoflife-date/endoflife.date/pull/6678/commits/972faf7e8337679e6b6c84eed491d5ea675a39e3) from PR #6687 (cc @marcwrobel).

This PR restores the EOL date, this time without the typo :)
