### PR TITLE
Clarify meaning of the discontinued column

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -50,7 +50,7 @@ title: Timeturner
 # - app: end-user applications
 # - lang: programming languages
 # - framework: application libraries, SDKs, frameworks...
-# - device: physical devices
+# - device: physical, hardware devices
 # - service: managed service offerings (SaaS/PaaS...)
 # - server-app: applications usually installed on the server-side
 category: os
@@ -151,8 +151,7 @@ releaseColumn: Latest
 releaseDateColumn: Released
 
 # Whether the "Discontinued" column should be displayed (optional, default = false).
-# Set to true if you're tracking a device. This usually means the device is no longer available for
-# sale or is no longer being manufactured.
+# Set this to true for physical, hardware devices (as opposed to software projects).
 # The value of this property can be set to any string to override the default column label.
 discontinuedColumn: Discontinued
 
@@ -360,6 +359,9 @@ releases:
     eoes: 2020-01-01
 
     # Discontinuation date (mandatory if discontinuedColumn is true, else MUST NOT be set).
+    # This is typically used for physical, hardware devices (as opposed to software projects),
+    # to indicate when the device is no longer available for sale or is no longer being manufactured.
+    # In contrast, the `eol` property indicates the end of support service for the device version.
     # This can be either a date (must be valid and not quoted)
     # or a boolean value (when the date is not known or has not been decided yet).
     # - When a date is used, this is the date where the release cycle is discontinued.

--- a/assets/openapi.yml
+++ b/assets/openapi.yml
@@ -321,4 +321,4 @@ components:
           format: date
           minLength: 10
           maxLength: 10
-          description: Whether this cycle is now discontinued.
+          description: Whether this device version is no longer in production.

--- a/product-schema.json
+++ b/product-schema.json
@@ -469,7 +469,7 @@
         },
         "discontinued": {
           "title": "Discontinued",
-          "description": "Whether this cycle is now discontinued. Date in the `yyyy-mm-dd` format, or `false` if not determined.",
+          "description": "Whether this device version is no longer in production. Date in the `yyyy-mm-dd` format, or `false` if not determined.",
           "$ref": "#/$defs/boolOrDate"
         },
         "releaseDateColumn": {

--- a/products/apache-cassandra.md
+++ b/products/apache-cassandra.md
@@ -43,14 +43,12 @@ releases:
     releaseDate: 2017-06-23
     eol: 2024-09-05 # releaseDate(5.0)
     latest: "3.11.19"
-    discontinued: true
     latestReleaseDate: 2025-02-07
 
 -   releaseCycle: "3.0"
     releaseDate: 2015-11-09
     eol: 2024-09-05
     latest: "3.0.32"
-    discontinued: true
     latestReleaseDate: 2025-02-07
 
 ---

--- a/products/steamos.md
+++ b/products/steamos.md
@@ -6,7 +6,6 @@ iconSlug: steam
 permalink: /steamos
 eolColumn: Support
 releaseColumn: false
-discontinuedColumn: true
 
 identifiers:
 -   cpe: cpe:/o:valvesoftware:steamos
@@ -17,19 +16,16 @@ releases:
     codename: holo
     releaseDate: 2022-03-01
     eol: false
-    discontinued: false
 
 -   releaseCycle: "2"
     codename: brewmaster
     releaseDate: 2015-11-01
     eol: 2019-06-30
-    discontinued: true
 
 -   releaseCycle: "1"
     codename: alchemist
     releaseDate: 2013-12-01
     eol: 2015-11-02
-    discontinued: true
 
 ---
 

--- a/products/wordpress.md
+++ b/products/wordpress.md
@@ -8,7 +8,6 @@ versionCommand: wp core version
 releasePolicyLink: https://codex.wordpress.org/Supported_Versions
 changelogTemplate: "https://wordpress.org/documentation/wordpress-version/version-{{'__LATEST__'|drop_zero_patch|replace:'.','-'}}/"
 releaseColumn: true
-discontinuedColumn: false
 eolColumn: Support
 customColumns:
 -   property: supportedPHPVersions


### PR DESCRIPTION
This PR follows up from the discussion at https://github.com/endoflife-date/endoflife.date/discussions/6643.

These changes clarify the wording in various places, and remove the column from non-hardware pages which were using them as synonymous to "eol".
