### PR TITLE
[gstreamer] Add 1.26

### DIFF
--- a/products/gstreamer.md
+++ b/products/gstreamer.md
@@ -21,6 +21,12 @@ auto:
       regex: '^(?P<major>[1-9]\d*)\.(?P<minor>([1-9]\d*)?[02468])\.?(?P<patch>\d+)?$'
 
 releases:
+-   releaseCycle: "1.26"
+    releaseDate: 2025-03-11
+    eol: false
+    latest: "1.26.0"
+    latestReleaseDate: 2025-03-11
+
 -   releaseCycle: "1.24"
     releaseDate: 2024-03-04
     eol: false
@@ -29,7 +35,7 @@ releases:
 
 -   releaseCycle: "1.22"
     releaseDate: 2023-01-23
-    eol: false
+    eol: true
     latest: "1.22.12"
     latestReleaseDate: 2024-04-29
 


### PR DESCRIPTION
See https://gstreamer.freedesktop.org/releases/1.26/.

Also deprecate 1.22 : there was no version in more than a year.