### PR TITLE
[fairphone] Update EOL for 3, 3+

### DIFF
--- a/products/fairphone.md
+++ b/products/fairphone.md
@@ -41,8 +41,8 @@ releases:
     supportedAndroidVersions: 10 - 13
     releaseDate: 2020-09-30
     discontinued: 2022-11-01
-    eoas: true
-    eol: 2025-09-30
+    eoas: 2024-09-30
+    eol: 2026-09-30
     link: https://support.fairphone.com/hc/articles/360048139032
 
 -   releaseCycle: "3"
@@ -50,8 +50,8 @@ releases:
     supportedAndroidVersions: 10 - 13
     releaseDate: 2019-09-30
     discontinued: 2021-09-01
-    eoas: true
-    eol: 2024-09-30
+    eoas: 2024-09-30
+    eol: 2026-09-30
     link: https://support.fairphone.com/hc/articles/360048139032
 
 -   releaseCycle: "2"


### PR DESCRIPTION
Closes #6588. Quoting the support team:

> The software and security updates for both models are expected to be provided for 5 years from the original launch date of the Fairphone 3 in August 2019. This means software support is expected to last until August 2024, and security updates will be provided until mid-2026.
> 
> So, in short, the Fairphone 3+ follows the same support schedule as the Fairphone 3. The support end date is not extended by the Fairphone 3+'s release.

Thanks @hdep

I also set the EOAS ("Active Major Updates") date as the 5 year deadline.