### PR TITLE
[mattermost] Add 10.6

### DIFF
--- a/products/mattermost.md
+++ b/products/mattermost.md
@@ -28,6 +28,12 @@ identifiers:
 
 # releaseDate and eol see: https://docs.mattermost.com/about/mattermost-server-releases.html
 releases:
+-   releaseCycle: "10.6"
+    releaseDate: 2025-03-16
+    eol: 2025-06-15
+    latest: '10.6.1'
+    latestReleaseDate: 2025-03-16
+
 -   releaseCycle: "10.5"
     releaseDate: 2025-02-16
     lts: true


### PR DESCRIPTION
The official release date is on 16/03 according to https://docs.mattermost.com/about/mattermost-server-releases.html, while the 10.6.1 release date was released on 14/03. So I forced 10.6.1 release date to 16/03 to align with the release date.