### PR TITLE
[pixel] Split entries containing mutiple models

### DIFF
--- a/products/pixel.md
+++ b/products/pixel.md
@@ -247,7 +247,7 @@ releases:
     link: https://en.wikipedia.org/wiki/Pixel_3
     supportedAndroidVersions: 9 - 12 # https://www.gsmarena.com/google_pixel_3-9256.php
 
--   releaseCycle: "2"
+-   releaseCycle: "2xl"
     releaseLabel: "Pixel 2 XL"
     releaseDate: 2017-10-17
     eoas: 2020-10-05

--- a/products/pixel.md
+++ b/products/pixel.md
@@ -193,8 +193,17 @@ releases:
     link: https://en.wikipedia.org/wiki/Pixel_4a
     supportedAndroidVersions: 10 - 13 # https://www.gsmarena.com/google_pixel_4a-10123.php
 
+-   releaseCycle: "4xl"
+    releaseLabel: "Pixel 4 XL"
+    releaseDate: 2019-10-24
+    eoas: 2022-10-05
+    eol: 2022-10-05 # TP1A.221005.002.B2
+    discontinued: 2020-08-06
+    link: https://en.wikipedia.org/wiki/Pixel_4
+    supportedAndroidVersions: 10 - 13 # https://www.gsmarena.com/google_pixel_4_xl-9895.php
+
 -   releaseCycle: "4"
-    releaseLabel: "Pixel 4 / XL"
+    releaseLabel: "Pixel 4"
     releaseDate: 2019-10-24
     eoas: 2022-10-05
     eol: 2022-10-05 # TP1A.221005.002.B2
@@ -202,18 +211,36 @@ releases:
     link: https://en.wikipedia.org/wiki/Pixel_4
     supportedAndroidVersions: 10 - 13 # https://www.gsmarena.com/google_pixel_4-9896.php
 
+-   releaseCycle: "3axl"
+    releaseLabel: "Pixel 3a XL"
+    releaseDate: 2019-05-15
+    eoas: 2022-05-05
+    eol: 2022-05-05 # SP2A.220505.008
+    discontinued: 2020-07-01
+    link: https://en.wikipedia.org/wiki/Pixel_3a
+    supportedAndroidVersions: 9 - 12.1 # https://www.gsmarena.com/google_pixel_3a_xl-9690.php
+
 -   releaseCycle: "3a"
-    releaseLabel: "Pixel 3a / XL"
-    releaseDate: 2019-05-07
+    releaseLabel: "Pixel 3a"
+    releaseDate: 2019-05-15
     eoas: 2022-05-05
     eol: 2022-05-05 # SP2A.220505.008
     discontinued: 2020-07-01
     link: https://en.wikipedia.org/wiki/Pixel_3a
     supportedAndroidVersions: 9 - 12.1 # https://www.gsmarena.com/google_pixel_3a-9408.php
 
+-   releaseCycle: "3xl"
+    releaseLabel: "Pixel 3 XL"
+    releaseDate: 2018-10-18
+    eoas: 2021-10-05
+    eol: 2021-10-05 # SP1A.210812.016.C2
+    discontinued: 2020-03-31
+    link: https://en.wikipedia.org/wiki/Pixel_3
+    supportedAndroidVersions: 9 - 12 # https://www.gsmarena.com/google_pixel_3_xl-9257.php
+
 -   releaseCycle: "3"
-    releaseLabel: "Pixel 3 / XL"
-    releaseDate: 2018-10-09
+    releaseLabel: "Pixel 3"
+    releaseDate: 2018-10-18
     eoas: 2021-10-05
     eol: 2021-10-05 # SP1A.210812.016.C2
     discontinued: 2020-03-31
@@ -221,22 +248,40 @@ releases:
     supportedAndroidVersions: 9 - 12 # https://www.gsmarena.com/google_pixel_3-9256.php
 
 -   releaseCycle: "2"
+    releaseLabel: "Pixel 2 XL"
+    releaseDate: 2017-10-17
+    eoas: 2020-10-05
+    eol: 2020-10-05 # RP1A.201005.004.A1
+    discontinued: 2019-04-01
+    link: https://en.wikipedia.org/wiki/Pixel_2
+    supportedAndroidVersions: 8 - 11 # https://www.gsmarena.com/google_pixel_2_xl-8720.php
+
+-   releaseCycle: "2"
     releaseLabel: "Pixel 2 / XL"
-    releaseDate: 2017-10-19
+    releaseDate: 2017-10-17
     eoas: 2020-10-05
     eol: 2020-10-05 # RP1A.201005.004.A1
     discontinued: 2019-04-01
     link: https://en.wikipedia.org/wiki/Pixel_2
     supportedAndroidVersions: 8 - 11 # https://www.gsmarena.com/google_pixel_2-8733.php
 
--   releaseCycle: "1"
-    releaseLabel: "Pixel / Pixel XL"
+-   releaseCycle: "1xl"
+    releaseLabel: "Pixel XL"
     releaseDate: 2016-10-20
     eoas: 2019-10-06
     eol: 2019-10-06 # QP1A.191005.007.A3
     discontinued: 2018-04-11
     link: https://en.wikipedia.org/wiki/Pixel_(1st_generation)
     supportedAndroidVersions: 7.1 - 10 # https://www.gsmarena.com/google_pixel_xl-8345.php
+
+-   releaseCycle: "1"
+    releaseLabel: "Pixel"
+    releaseDate: 2016-10-20
+    eoas: 2019-10-06
+    eol: 2019-10-06 # QP1A.191005.007.A3
+    discontinued: 2018-04-11
+    link: https://en.wikipedia.org/wiki/Pixel_(1st_generation)
+    supportedAndroidVersions: 7.1 - 10 # https://www.gsmarena.com/google_pixel-8346.php
 
 ---
 

--- a/products/pixel.md
+++ b/products/pixel.md
@@ -257,7 +257,7 @@ releases:
     supportedAndroidVersions: 8 - 11 # https://www.gsmarena.com/google_pixel_2_xl-8720.php
 
 -   releaseCycle: "2"
-    releaseLabel: "Pixel 2 / XL"
+    releaseLabel: "Pixel 2"
     releaseDate: 2017-10-17
     eoas: 2020-10-05
     eol: 2020-10-05 # RP1A.201005.004.A1


### PR DESCRIPTION
As done in #3791, each models should have its own entry because it makes maintenance easier and makes URL more stable / convenient for API.

Closes #4294.