### PR TITLE
[mssqlserver] Update 2017 Azure Connect pack

### DIFF
--- a/products/mssqlserver.md
+++ b/products/mssqlserver.md
@@ -105,9 +105,9 @@ releases:
     eol: 2027-10-12
     latestGdr: "14.0.2070.1"
     latestGdrLink: https://support.microsoft.com/help/5046857
-    latest: "14.0.3485.1 CU31+GDR"
-    latestReleaseDate: 2024-11-14
-    # CU31 link: https://learn.microsoft.com/troubleshoot/sql/releases/sqlserver-2017/cumulativeupdate31
+    latest: "14.0.3490.10 Azure Connect Pack"
+    latestReleaseDate: 2025-03-06
+    # Azure Connect Pack link: https://learn.microsoft.com/en-us/troubleshoot/sql/releases/sqlserver-2017/azureconnect
     link: https://support.microsoft.com/help/5046858 # GDR for CU31
 
 -   releaseCycle: "13.0-sp1"

--- a/products/mssqlserver.md
+++ b/products/mssqlserver.md
@@ -107,7 +107,7 @@ releases:
     latestGdrLink: https://support.microsoft.com/help/5046857
     latest: "14.0.3490.10 Azure Connect Pack"
     latestReleaseDate: 2025-03-06
-    # Azure Connect Pack link: https://learn.microsoft.com/en-us/troubleshoot/sql/releases/sqlserver-2017/azureconnect
+    # Azure Connect Pack link: https://learn.microsoft.com/troubleshoot/sql/releases/sqlserver-2017/azureconnect
     link: https://support.microsoft.com/help/5046858 # GDR for CU31
 
 -   releaseCycle: "13.0-sp1"


### PR DESCRIPTION
A new feature pack was released for Microsoft SQL Server 2017 which bumps the latest version to `14.0.3490.10`.

Release Notes: [https://learn.microsoft.com/en-us/troubleshoot/sql/releases/sqlserver-2017/azureconnect](https://learn.microsoft.com/en-us/troubleshoot/sql/releases/sqlserver-2017/azureconnect)