### PR TITLE
Add new PHP pURLs

### DIFF
--- a/products/php.md
+++ b/products/php.md
@@ -11,6 +11,9 @@ eoasColumn: true
 identifiers:
 -   purl: pkg:deb/ubuntu/php
 -   purl: pkg:deb/debian/php
+-   purl: pkg:generic/php
+-   purl: pkg:generic/php-cli
+-   purl: pkg:generic/php-fpm
 -   repology: php
 -   cpe: cpe:2.3:a:php:php
 -   cpe: cpe:/a:php:php


### PR DESCRIPTION
The changes add support for containers using custom PHP binary, like the official https://hub.docker.com/_/php. Certain container will only use CLI or FPM build, but the EOL detection should be all the same.