### PR TITLE
[ghc] manual sync of EOL status

### DIFF
--- a/products/ghc.md
+++ b/products/ghc.md
@@ -21,6 +21,9 @@ auto:
   -   git: https://gitlab.haskell.org/ghc/ghc.git
       regex: ^ghc-(?P<major>\d+)[.](?P<minor>\d+)[.](?P<patch>\d+)-release$
       template: '{{major}}.{{minor}}.{{patch}}'
+  # this custom script parses GHC Status tables from the primary source (Gitlab Wiki),
+  # propagates the EOL signal, see https://github.com/endoflife-date/release-data/pull/395
+  #-   custom: ghc-wiki # TODO uncomment once merged into release-data
 
 releases:
 -   releaseCycle: "9.12"
@@ -54,14 +57,14 @@ releases:
 -   releaseCycle: "9.4"
     releaseDate: 2022-08-07
     eoas: true
-    eol: false
+    eol: true
     latest: "9.4.8"
     latestReleaseDate: 2023-11-10
 
 -   releaseCycle: "9.2"
     releaseDate: 2021-09-29
     eoas: true
-    eol: false
+    eol: true
     latest: "9.2.8"
     latestReleaseDate: 2023-05-26
     link: https://downloads.haskell.org/~ghc/__LATEST__/docs/html/users_guide/__LATEST__-notes.html


### PR DESCRIPTION
Hi,

GHC 9.12.2 was released a week ago; the `git tags` module has picked it up automatically — and that's great.

What **has not** happened automatically, is syncing of the **EOL column** (labelled "Recommended for use").

https://endoflife.date/ghc :

![image](https://github.com/user-attachments/assets/df3978c3-59a1-4606-857a-6c50c95f1f4f)

The primary source:

![image](https://github.com/user-attachments/assets/6e9ded80-9190-4dbd-8f20-03ab437befc7)

------------------

@marcwrobel @captn3m0 I dislike spending the time, both yours, and mine, on filing & reviewing this manually — but because https://github.com/endoflife-date/release-data/pull/395 has not been merged yet, this is the only way to propagate updates in the EOL column. git tags only cannot do it. 

Perhaps this PR provides better understanding on why https://github.com/endoflife-date/release-data/pull/395 was written 3 months ago.