### PR TITLE
Bump packageurl-ruby to recent version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -30,4 +30,4 @@ gem 'icalendar', '~> 2.10'
 gem "open-uri", "~> 0.5"
 
 # Used in purl-to-url to parse PURLs
-gem "packageurl-ruby", "~> 0.1.0"
+gem "packageurl-ruby", "~> 0.2.0"


### PR DESCRIPTION
    Use correct require statement in docs
    Bump activesupport from 6.1.4.1 to 7.0.4.3
    Update ruby version to 3.4.2
    Fix parsing errors