### PR TITLE
[gradle] Fix 8.13 latest release

### DIFF
--- a/products/gradle.md
+++ b/products/gradle.md
@@ -34,7 +34,7 @@ releases:
     testedAndroidVersions: 7.3 - 8.8
     eoas: false
     eol: false
-    latest: "8.13"
+    latest: "8.13.0"
     latestReleaseDate: 2025-02-25
 
 -   releaseCycle: "7"


### PR DESCRIPTION
The latest release for 8.13 is 8.13.0, as indicated by the corresponding tag: https://github.com/gradle/gradle/releases/tag/v8.13.0. This will also fix the latest release link.