### PR TITLE
[apache-flink] Add 2.0 and clarify support policy

### DIFF
--- a/products/apache-flink.md
+++ b/products/apache-flink.md
@@ -23,7 +23,14 @@ auto:
       regex: '^release-(?P<version>[\d\.]+)$'
       template: '{{version}}'
 
+# eol(x) = releaseDate(x+3)
 releases:
+-   releaseCycle: "2.0"
+    releaseDate: 2025-03-24
+    eol: false
+    latest: "2.0.0"
+    latestReleaseDate: 2025-03-24
+
 -   releaseCycle: "1.20"
     releaseDate: 2024-08-01
     eol: false
@@ -38,13 +45,13 @@ releases:
 
 -   releaseCycle: "1.18"
     releaseDate: 2023-10-24
-    eol: false
+    eol: 2025-03-24
     latest: "1.18.1"
     latestReleaseDate: 2024-01-16
 
 -   releaseCycle: "1.17"
     releaseDate: 2023-03-23
-    eol: false
+    eol: 2024-08-01
     latest: "1.17.2"
     latestReleaseDate: 2023-11-27
 
@@ -54,8 +61,8 @@ releases:
 > framework designed for processing large-scale data streams in real-time with
 > high throughput and low latency.
 
-Apache Flink maintains match releases for multiple versions. Backports seem to be
-maintained for the latest 3 releases.
+Apache Flink support policy is not defined. Given 3 releases [are listed on the download page](https://flink.apache.org/downloads/),
+backports seem to be maintained for the last 3 releases.
 
 ## [Java Compatibility](https://nightlies.apache.org/flink/flink-docs-release-1.19/docs/deployment/java_compatibility/)
 


### PR DESCRIPTION
See https://flink.apache.org/2025/03/24/apache-flink-2.0.0-a-new-era-of-real-time-data-processing/.