### PR TITLE
[amazon-cdk] Fix purl link for golang

### DIFF
--- a/products/amazon-cdk.md
+++ b/products/amazon-cdk.md
@@ -9,7 +9,7 @@ changelogTemplate: https://github.com/aws/aws-cdk/releases/tag/v__LATEST__
 identifiers:
 -   repology: aws-cdk
 -   purl: pkg:npm/aws-cdk
--   purl: pkg:golang/github.com/aws/aws-cdk-go
+-   purl: pkg:golang/github.com/aws/aws-cdk-go/awscdk/v2
 -   purl: pkg:github/aws/aws-cdk-go
 -   cpe: cpe:/a:amazon:aws_cloud_development_kit
 -   cpe: cpe:2.3:a:amazon:aws_cloud_development_kit


### PR DESCRIPTION
It has missing `awscdk/v2` part of url