### PR TITLE
[ghc] manual sync EOAS column for 9.6

### DIFF
--- a/products/ghc.md
+++ b/products/ghc.md
@@ -49,7 +49,7 @@ releases:
 
 -   releaseCycle: "9.6"
     releaseDate: 2023-03-10
-    eoas: false
+    eoas: true
     eol: false
     latest: "9.6.7"
     latestReleaseDate: 2025-03-24


### PR DESCRIPTION
This is another manual sync, necessary because https://github.com/endoflife-date/release-data/pull/395 is not merged.

2 days ago, the upstream has released 9.6.7, and changed 9.6 series to "no further releases planned":

![image](https://github.com/user-attachments/assets/e7a8b652-3237-4760-865a-6a7190e5947e)

This makes the table on https://endoflife.date/ghc outdated:

![image](https://github.com/user-attachments/assets/cb2db639-81fe-4eb5-952c-8f99f7033ade)

The `auto` script proposed for addition in https://github.com/endoflife-date/release-data/pull/395 — would've fixed this autonomously. @marcwrobel can it be merged?