### PR TITLE
[cert-manager] Remove purl link which gives 404

### DIFF
--- a/products/cert-manager.md
+++ b/products/cert-manager.md
@@ -14,7 +14,6 @@ eolColumn: Support
 
 identifiers:
 -   repology: cert-manager
--   purl: pkg:docker/cert-manager/cert-manager
 
 auto:
   methods:


### PR DESCRIPTION
Remove not working purl