### PR TITLE
[envoy] Fix rapidfort purl link

### DIFF
--- a/products/envoy.md
+++ b/products/envoy.md
@@ -17,6 +17,7 @@ identifiers:
 -   purl: pkg:docker/envoyproxy/envoy-alpine-debug
 -   purl: pkg:docker/envoyproxy/envoy-distroless
 -   purl: pkg:docker/bitnami/envoy
+-   purl: pkg:docker/rapidfort/envoy-official
 -   purl: pkg:docker/hashicorp/envoy-fips
 -   purl: pkg:docker/chainguard/envoy
 -   purl: pkg:github/envoyproxy/envoy

--- a/products/envoy.md
+++ b/products/envoy.md
@@ -17,7 +17,6 @@ identifiers:
 -   purl: pkg:docker/envoyproxy/envoy-alpine-debug
 -   purl: pkg:docker/envoyproxy/envoy-distroless
 -   purl: pkg:docker/bitnami/envoy
--   purl: pkg:docker/rapidfort/envoy
 -   purl: pkg:docker/hashicorp/envoy-fips
 -   purl: pkg:docker/chainguard/envoy
 -   purl: pkg:github/envoyproxy/envoy


### PR DESCRIPTION
rapidfort purl link was giving 404 and ~removed~ fixed  ( thanks to@captn3m0 )