### PR TITLE
[forgejo] Remove git tag

### DIFF
--- a/products/forgejo.md
+++ b/products/forgejo.md
@@ -1,7 +1,6 @@
 ---
 title: Forgejo
 category: server-app
-tags: git
 iconSlug: forgejo
 permalink: /forgejo
 versionCommand: forgejo --version


### PR DESCRIPTION
Forgejo is the only product to use it, so this tag is not that useful.