### PR TITLE
[yarn] Remove nonexisting yarnpkg/cli purl

### DIFF
--- a/products/yarn.md
+++ b/products/yarn.md
@@ -11,7 +11,6 @@ identifiers:
 -   purl: pkg:github/yarnpkg/berry
 -   purl: pkg:github/yarnpkg/yarn
 -   purl: pkg:npm/yarn
--   purl: pkg:npm/yarnpkg/cli
 -   repology: yarn
 -   cpe: cpe:2.3:a:yarnpkg:yarn
 -   cpe: cpe:/a:yarnpkg:yarn


### PR DESCRIPTION
This one was giving 404