### PR TITLE
[nutanix] Update end of active support & end of life definitions and dates

### DIFF
--- a/products/nutanix-aos.md
+++ b/products/nutanix-aos.md
@@ -6,7 +6,8 @@ iconSlug: nutanix
 permalink: /nutanix-aos
 versionCommand: ncli cluster version
 releasePolicyLink: "https://www.nutanix.com/support-services/product-support/support-policies-and-faqs"
-eoasColumn: true
+eoasColumn: End of Maintenance
+eolColumn: End of Support Life
 
 auto:
   methods:

--- a/products/nutanix-files.md
+++ b/products/nutanix-files.md
@@ -30,7 +30,7 @@ releases:
 -   releaseCycle: "4.4"
     releaseDate: 2023-09-13
     eoas: 2024-08-31
-    eol: 2025-09-30
+    eol: 2025-05-31
     latest: "4.4.0.3"
 
     latestReleaseDate: 2024-03-26

--- a/products/nutanix-files.md
+++ b/products/nutanix-files.md
@@ -5,7 +5,8 @@ tags: nutanix
 iconSlug: nutanix
 permalink: /nutanix-files
 releasePolicyLink: "https://www.nutanix.com/support-services/product-support/support-policies-and-faqs"
-eoasColumn: true
+eoasColumn: End of Maintenance
+eolColumn: End of Support Life
 
 auto:
   methods:

--- a/products/nutanix-prism.md
+++ b/products/nutanix-prism.md
@@ -21,15 +21,15 @@ auto:
 releases:
 -   releaseCycle: "pc.2024.3"
     releaseDate: 2024-12-05
-    eoas: false # not yet announced on https://portal.nutanix.com/page/documents/eol/list?type=pc
-    eol: false # not yet announced on https://portal.nutanix.com/page/documents/eol/list?type=pc
+    eoas: 2026-03-31
+    eol: 2026-12-31
     latest: "pc.2024.3.1"
     latestReleaseDate: 2025-03-19
 
 -   releaseCycle: "pc.2024.2"
     releaseDate: 2024-09-17
-    eoas: 2026-03-31
-    eol: 2026-12-31
+    eoas: 2026-01-31
+    eol: 2026-10-31
     latest: "pc.2024.2.0.5"
     latestReleaseDate: 2025-03-11
 
@@ -42,8 +42,8 @@ releases:
 
 -   releaseCycle: "pc.2023.4"
     releaseDate: 2023-08-28
-    eoas: 2024-07-31
-    eol: 2024-10-31
+    eoas: 2024-10-31
+    eol: 2025-06-30
     latest: "pc.2023.4.0.5"
     latestReleaseDate: 2024-11-20
 
@@ -70,7 +70,7 @@ releases:
 
 -   releaseCycle: "pc.2022.6"
     releaseDate: 2022-08-03
-    eoas: 2024-06-30
+    eoas: 2024-08-31
     eol: 2025-06-30
     latest: "pc.2022.6.0.11"
     latestReleaseDate: 2024-06-05

--- a/products/nutanix-prism.md
+++ b/products/nutanix-prism.md
@@ -10,7 +10,8 @@ alternate_urls:
 -   /prismcentral
 versionCommand: ncli cluster version
 releasePolicyLink: "https://www.nutanix.com/support-services/product-support/support-policies-and-faqs"
-eoasColumn: true
+eoasColumn: End of Maintenance
+eolColumn: End of Support Life
 
 auto:
   methods:


### PR DESCRIPTION
According to Nutanix Support Policy (https://www.nutanix.com/support-services/product-support/support-policies-and-faqs) and End of Support Life Information (https://portal.nutanix.com/page/documents/eol/list?type=aos), security patches are not provided once a product version reaches end of maintenance. Update the end of active support and end of life definitions for Nutanix products to reflect this.