### PR TITLE
[mattermost] fix wrong esr release months

### DIFF
--- a/products/mattermost.md
+++ b/products/mattermost.md
@@ -279,6 +279,6 @@ Mattermost backports high-severity or high-impact security fixes to the previous
 releases and to supported [extended support releases (ESR)](https://docs.mattermost.com/upgrade/extended-support-release.html).
 A new ESR release is made when a significant number of new features and improvements have been added
 to the product, and have had sufficient time to stabilize. A new ESR is released twice a year in
-January and July. ESR releases are supported for nine months.
+February and August. ESR releases are supported for nine months.
 
 Announcements are published on the [Mattermost Announcements Mailing List](https://eepurl.com/dCKn2P).


### PR DESCRIPTION
Change esr release months, because they changed from January to February and from July to August (see https://docs.mattermost.com/about/release-policy.html#extended-support-releases)