### PR TITLE
[rust] add 1.86

### DIFF
--- a/products/rust.md
+++ b/products/rust.md
@@ -21,6 +21,12 @@ identifiers:
 
 # eol(x) = releaseDate(x+1)
 releases:
+-   releaseCycle: "1.86"
+    releaseDate: 2025-04-03
+    eol: false
+    latest: "1.86.0"
+    latestReleaseDate: 2025-04-03
+
 -   releaseCycle: "1.85"
     releaseDate: 2025-02-20
     eol: false

--- a/products/rust.md
+++ b/products/rust.md
@@ -29,7 +29,7 @@ releases:
 
 -   releaseCycle: "1.85"
     releaseDate: 2025-02-20
-    eol: false
+    eol: 2025-04-03
     latest: "1.85.1"
     latestReleaseDate: 2025-03-18
 


### PR DESCRIPTION
Rust 1.86 released
https://github.com/rust-lang/rust/releases/tag/1.86.0