### PR TITLE
[red-hat-build-of-openjdk] Automate release level information retrieval

### DIFF
--- a/products/red-hat-build-of-openjdk.md
+++ b/products/red-hat-build-of-openjdk.md
@@ -40,6 +40,14 @@ identifiers:
     - purl: pkg:rpm/redhat/java-11-openjdk-devel
     - purl: pkg:rpm/redhat/java-11-openjdk-devel-debug
 
+auto:
+  methods:
+  -   redhat_lifecycles: Red Hat build of OpenJDK
+      regex: '^OpenJDK (?P<major>\d+).*$'
+      fields:
+        releaseDate: General availability
+        eol: Full support
+
 # EOL dates can be found on https://access.redhat.com/articles/1299013.
 releases:
 -   releaseCycle: "21"


### PR DESCRIPTION
Based on https://access.redhat.com/product-life-cycles/api/v1/products?name=Red%20Hat%20build%20of%20OpenJDK.