### PR TITLE
[pan-gp]Updated GlobalProtect App from 6.2.7 to v6.2.8

### DIFF
--- a/products/pan-gp.md
+++ b/products/pan-gp.md
@@ -41,8 +41,8 @@ releases:
     releaseDate: 2023-05-23
     eol: 2026-12-31
     eoas: 2026-12-31
-    latest: "6.2.7"
-    latestReleaseDate: 2025-01-28
+    latest: "6.2.8"
+    latestReleaseDate: 2025-04-03
     link: https://docs.paloaltonetworks.com/globalprotect/6-2/globalprotect-app-release-notes/globalprotect-addressed-issues
 
 -   releaseCycle: "6.1"


### PR DESCRIPTION
Updated GlobalProtect App from 6.2.7 to v6.2.8

Released: 2025-04-03

Release Notes: https://docs.paloaltonetworks.com/globalprotect/6-2/globalprotect-app-release-notes/globalprotect-addressed-issues/globalprotect-app-6-2-8-windows-and-macos-addressed-issues
