### PR TITLE
[openssl] Automate EOL retrieval

### DIFF
--- a/products/openssl.md
+++ b/products/openssl.md
@@ -18,6 +18,14 @@ auto:
   methods:
   -   git: https://github.com/openssl/openssl.git
       regex: '^[o|O]pen[s|S][s|S][l|L][-|_](?P<major>\d+)[\.|_](?P<minor>\d+)[\.|_](?P<patch>\d+\w{0,2})?$'
+  -   release_table: https://openssl-library.org/source/index.html
+      selector: "table"
+      fields:
+        releaseCycle:
+          column: "Series"
+          regex: '^(?P<value>\d+\.\d+).*$'
+        #releaseDate: "Release" # release dates are wrong
+        eol: "End-of-Life"
 
 # EOL dates and LTS infos on https://www.openssl.org/policies/releasestrat.html
 releases:


### PR DESCRIPTION
Based on https://openssl-library.org/source/index.html. Note that releaseDate was ignore as it is wrong on that page: it is 11 Feb 2025 for all releases except 3.5.