### PR TITLE
[Oneplus] Update  13 + 13R and minor changes

### DIFF
--- a/products/oneplus.md
+++ b/products/oneplus.md
@@ -32,7 +32,7 @@ releases:
 -   releaseCycle: "13"
     releaseDate: 2024-10-31
     eoas: 2028-10-31 # https://community.oneplus.com/thread/1809805181760569353
-    eol: 20230-10-31 # # See above but 6 years security updates
+    eol: 2030-10-31 # # See above but 6 years security updates
     discontinued: false
     supportedOxygenOSVersions: 15
 

--- a/products/oneplus.md
+++ b/products/oneplus.md
@@ -11,6 +11,7 @@ releaseLabel: "OnePlus __RELEASE_CYCLE__"
 releaseColumn: false
 activeSupportColumn: Active Major Updates
 discontinuedColumn: true
+eoasColumn: Android Updates
 eolColumn: Security Updates
 customColumns:
 -   property: supportedOxygenOSVersions
@@ -23,15 +24,15 @@ customColumns:
 releases:
 -   releaseCycle: "13R"
     releaseDate: 2025-01-07
-    eoas: 2029-01-07
-    eol: 2030-01-07
+    eoas: 2029-01-07 # Approximate based on 4 https://community.oneplus.com/thread/1809805181760569353 
+    eol: 2031-01-07 # See above but 6 years security updates
     discontinued: false
     supportedOxygenOSVersions: 15
 
 -   releaseCycle: "13"
     releaseDate: 2024-10-31
-    eoas: 2028-10-31
-    eol: 2029-10-31
+    eoas: 2028-10-31 # https://community.oneplus.com/thread/1809805181760569353
+    eol: 20230-10-31 # # See above but 6 years security updates
     discontinued: false
     supportedOxygenOSVersions: 15
 
@@ -39,7 +40,7 @@ releases:
     releaseDate: 2024-01-23 # https://community.oneplus.com/thread/1514801169317232648
     eoas: 2028-01-23 # approximation "4 major Android updates" https://community.oneplus.com/thread/1211291251581124608
     eol: 2029-01-23
-    discontinued: false
+    discontinued: true
     supportedOxygenOSVersions: 14 # https://oxygenupdater.com/article/401/
 
 -   releaseCycle: "12"
@@ -53,7 +54,7 @@ releases:
     releaseDate: 2023-02-07 #https://oxygenupdater.com/article/379/
     eoas: 2027-02-07 # approximation "4 major Android updates" https://community.oneplus.com/thread/1211291251581124608
     eol: 2028-02-07
-    discontinued: false
+    discontinued: true
     link: https://www.oneplus.in/11r
     supportedOxygenOSVersions: 13 - 14 # https://oxygenupdater.com/article/431/ https://community.oneplus.com/thread/1480591576202739713
 
@@ -61,7 +62,7 @@ releases:
     releaseDate: 2023-02-07 # https://oxygenupdater.com/article/379/
     eoas: 2027-02-07 # approximation "4 major Android updates" https://community.oneplus.com/thread/1211291251581124608
     eol: 2028-02-07
-    discontinued: false
+    discontinued: true
     link: https://service.oneplus.com/us/search/search-detail?id=2123192&articleIndex=2
     supportedOxygenOSVersions: 13 - 14 # https://oxygenupdater.com/article/426/ https://community.oneplus.com/thread/1465453057260126214
 
@@ -71,6 +72,7 @@ releases:
 
 OnePlus phones run OxygenOS, which is based on Android. It receives updates every two months.
 
+The OnePlus 13 & 13R supports [five major Android updates](https://community.oneplus.com/thread/1809805181760569353) and 6 years of security updates.  
 OnePlus supports [four major Android updates](https://community.oneplus.com/thread/1211291251581124608) and five years of security updates on their flagship lineup (starting from OnePlus 11 onwards, including T & R series), [three major Android updates](https://community.oneplus.com/thread/1356800969827942405) and four years of security updates for the Nord series (starting from the Nord 3 onwards), [two major Android updates](https://community.oneplus.com/thread/1462181) and three years of security updates for the Nord CE series, and finally [one major Android updates](https://community.oneplus.com/thread/1462181) and three years of security updates for the Nord N series
 
 OxygenOS updates can be tracked at [Oxygen Updater](https://oxygenupdater.com/news/all/)

--- a/products/oneplus.md
+++ b/products/oneplus.md
@@ -54,7 +54,7 @@ releases:
     releaseDate: 2023-02-07 #https://oxygenupdater.com/article/379/
     eoas: 2027-02-07 # approximation "4 major Android updates" https://community.oneplus.com/thread/1211291251581124608
     eol: 2028-02-07
-    discontinued: true
+    discontinued: false
     link: https://www.oneplus.in/11r
     supportedOxygenOSVersions: 13 - 14 # https://oxygenupdater.com/article/431/ https://community.oneplus.com/thread/1480591576202739713
 

--- a/products/oneplus.md
+++ b/products/oneplus.md
@@ -31,8 +31,8 @@ releases:
 
 -   releaseCycle: "13"
     releaseDate: 2024-10-31
-    eoas: 2028-10-31 # https://community.oneplus.com/thread/1809805181760569353
-    eol: 2030-10-31 # See above but 6 years security updates
+    eoas: 2028-10-31 # approximation "4 major Android updates" https://community.oneplus.com/thread/1809805181760569353
+    eol: 2030-10-31 # 6 years of security updates
     discontinued: false
     supportedOxygenOSVersions: 15
 

--- a/products/oneplus.md
+++ b/products/oneplus.md
@@ -40,7 +40,7 @@ releases:
     releaseDate: 2024-01-23 # https://community.oneplus.com/thread/1514801169317232648
     eoas: 2028-01-23 # approximation "4 major Android updates" https://community.oneplus.com/thread/1211291251581124608
     eol: 2029-01-23
-    discontinued: true
+    discontinued: false
     supportedOxygenOSVersions: 14 # https://oxygenupdater.com/article/401/
 
 -   releaseCycle: "12"

--- a/products/oneplus.md
+++ b/products/oneplus.md
@@ -72,7 +72,7 @@ releases:
 
 OnePlus phones run OxygenOS, which is based on Android. It receives updates every two months.
 
-The OnePlus 13 & 13R supports [five major Android updates](https://community.oneplus.com/thread/1809805181760569353) and 6 years of security updates.  
+The OnePlus 13 & 13R supports [four major Android updates](https://community.oneplus.com/thread/1809805181760569353) and six years of security updates.  
 OnePlus supports [four major Android updates](https://community.oneplus.com/thread/1211291251581124608) and five years of security updates on their flagship lineup (starting from OnePlus 11 onwards, including T & R series), [three major Android updates](https://community.oneplus.com/thread/1356800969827942405) and four years of security updates for the Nord series (starting from the Nord 3 onwards), [two major Android updates](https://community.oneplus.com/thread/1462181) and three years of security updates for the Nord CE series, and finally [one major Android updates](https://community.oneplus.com/thread/1462181) and three years of security updates for the Nord N series
 
 OxygenOS updates can be tracked at [Oxygen Updater](https://oxygenupdater.com/news/all/)

--- a/products/oneplus.md
+++ b/products/oneplus.md
@@ -24,8 +24,8 @@ customColumns:
 releases:
 -   releaseCycle: "13R"
     releaseDate: 2025-01-07
-    eoas: 2029-01-07 # Approximate based on 4 https://community.oneplus.com/thread/1809805181760569353 
-    eol: 2031-01-07 # See above but 6 years security updates
+    eoas: 2029-01-07 # approximation "4 major Android updates" https://community.oneplus.com/thread/1809805181760569353
+    eol: 2031-01-07 # 6 years of security updates
     discontinued: false
     supportedOxygenOSVersions: 15
 

--- a/products/oneplus.md
+++ b/products/oneplus.md
@@ -32,7 +32,7 @@ releases:
 -   releaseCycle: "13"
     releaseDate: 2024-10-31
     eoas: 2028-10-31 # https://community.oneplus.com/thread/1809805181760569353
-    eol: 2030-10-31 # # See above but 6 years security updates
+    eol: 2030-10-31 # See above but 6 years security updates
     discontinued: false
     supportedOxygenOSVersions: 15
 

--- a/products/oneplus.md
+++ b/products/oneplus.md
@@ -62,7 +62,7 @@ releases:
     releaseDate: 2023-02-07 # https://oxygenupdater.com/article/379/
     eoas: 2027-02-07 # approximation "4 major Android updates" https://community.oneplus.com/thread/1211291251581124608
     eol: 2028-02-07
-    discontinued: true
+    discontinued: false
     link: https://service.oneplus.com/us/search/search-detail?id=2123192&articleIndex=2
     supportedOxygenOSVersions: 13 - 14 # https://oxygenupdater.com/article/426/ https://community.oneplus.com/thread/1465453057260126214
 


### PR DESCRIPTION
Made some changes to the oneplus file.  

- Changed the eoasColumn to Android Updates  
- Added Oneplus 13 and 13R dates with a source (Dates are still approx though).  
- Discontinued some of the older phones - I don't have a discontinue date at this time.  
- Added a little footer text regarding oneplus new 4+6 years update policy.