### PR TITLE
[rabbitmq] add 4.1, eol 4.0

### DIFF
--- a/products/rabbitmq.md
+++ b/products/rabbitmq.md
@@ -25,9 +25,16 @@ auto:
       -   '^rabbitmq_v(?P<major>[1-9]\d*)_(?P<minor>\d+)_(?P<patch>\d+)$' # oldest versions
 
 releases:
+-   releaseCycle: "4.1"
+    releaseDate: 2025-04-15
+    eol: false # releaseDate(4.2)
+    eoes: false
+    latest: "4.1.0"
+    latestReleaseDate: 2025-04-15
+
 -   releaseCycle: "4.0"
     releaseDate: 2024-09-18
-    eol: false # releaseDate(4.1)
+    eol: 2025-04-15
     eoes: 2027-09-29
     latest: "4.0.9"
     latestReleaseDate: 2025-04-14


### PR DESCRIPTION
note, commercial end of service no longer exists in the release table

<img width="1029" alt="image" src="https://github.com/user-attachments/assets/97ba1c61-3de5-4d69-9362-1311a58cba89" />


https://web.archive.org/web/20250417014229/https://www.rabbitmq.com/release-information

