### PR TITLE
[tomcat] Set latestReleaseDate for 5.5 and 6.0

### DIFF
--- a/products/tomcat.md
+++ b/products/tomcat.md
@@ -17,6 +17,7 @@ auto:
   methods:
   -   maven: org.apache.tomcat/tomcat
 
+# EOL can be seen on https://tomcat.apache.org/whichversion.html
 releases:
 -   releaseCycle: "11.0"
     releaseDate: 2024-10-03
@@ -34,7 +35,7 @@ releases:
 
 -   releaseCycle: "10.0"
     releaseDate: 2020-12-03
-    eol: 2022-10-31
+    eol: 2022-10-31 # https://tomcat.apache.org/tomcat-10.0-eol.html
     minJavaVersion: 8
     latest: "10.0.27"
     latestReleaseDate: 2022-10-03
@@ -48,35 +49,35 @@ releases:
 
 -   releaseCycle: "8.5"
     releaseDate: 2016-03-17
-    eol: 2024-03-31
+    eol: 2024-03-31 # https://tomcat.apache.org/tomcat-85-eol.html
     minJavaVersion: 7
     latest: "8.5.100"
     latestReleaseDate: 2024-03-19
 
 -   releaseCycle: "8.0"
     releaseDate: 2014-01-29
-    eol: 2018-06-30
+    eol: 2018-06-30 # https://tomcat.apache.org/tomcat-80-eol.html
     minJavaVersion: 7
     latest: "8.0.53"
     latestReleaseDate: 2018-06-29
 
 -   releaseCycle: "7"
     releaseDate: 2013-01-10
-    eol: 2021-03-31
+    eol: 2021-03-31 # https://tomcat.apache.org/tomcat-70-eol.html
     minJavaVersion: 6
     latest: "7.0.109"
     latestReleaseDate: 2021-04-22
 
 -   releaseCycle: "6"
     releaseDate: 2006-10-21
-    eol: 2016-12-31
+    eol: 2016-12-31 # https://tomcat.apache.org/tomcat-60-eol.html
     minJavaVersion: 5
     latest: "6.0.53"
     latestReleaseDate: 2017-04-02
 
 -   releaseCycle: "5"
     releaseDate: 2003-09-06
-    eol: 2012-09-30
+    eol: 2012-10-10 # https://tomcat.apache.org/tomcat-55-eol.html
     minJavaVersion: 1.4
     latest: "5.5.36"
     latestReleaseDate: 2012-10-10

--- a/products/tomcat.md
+++ b/products/tomcat.md
@@ -72,15 +72,14 @@ releases:
     eol: 2016-12-31
     minJavaVersion: 5
     latest: "6.0.53"
+    latestReleaseDate: 2017-04-02
 
 -   releaseCycle: "5"
     releaseDate: 2003-09-06
     eol: 2012-09-30
     minJavaVersion: 1.4
     latest: "5.5.36"
-
-
-
+    latestReleaseDate: 2012-10-10
 
 ---
 

--- a/products/tomcat.md
+++ b/products/tomcat.md
@@ -77,7 +77,7 @@ releases:
 
 -   releaseCycle: "5"
     releaseDate: 2003-09-06
-    eol: 2012-10-10 # https://tomcat.apache.org/tomcat-55-eol.html
+    eol: 2012-09-30 # https://tomcat.apache.org/tomcat-55-eol.html
     minJavaVersion: 1.4
     latest: "5.5.36"
     latestReleaseDate: 2012-10-10


### PR DESCRIPTION
See https://lists.apache.org/thread/v6ht8ksp5l7vq82t7pv718sdm7qtldzs and https://tomcat.apache.org/tomcat-6.0-doc/changelog.html.

Note that even if those were released past EOL, this does not affect the official EOL date documented by Apache on https://tomcat.apache.org/whichversion.html.