### PR TITLE
[linux] Add eol date for 6.13.x and update versioninfos

### DIFF
--- a/products/linuxkernel.md
+++ b/products/linuxkernel.md
@@ -30,21 +30,21 @@ releases:
 -   releaseCycle: "6.14"
     releaseDate: 2025-03-24
     eol: false # when its eol date announced we need to fix this
-    latest: "6.14.2"
-    latestReleaseDate: 2025-04-10
+    latest: "6.14.3"
+    latestReleaseDate: 2025-04-20
 
 -   releaseCycle: "6.13"
     releaseDate: 2025-01-19
-    eol: false # when its eol date announced we need to fix this
-    latest: "6.13.11"
-    latestReleaseDate: 2025-04-10
+    eol: 2025-04-20 # when its eol date announced we need to fix this
+    latest: "6.13.12"
+    latestReleaseDate: 2025-04-20
 
 -   releaseCycle: "6.12"
     lts: true
     releaseDate: 2024-11-17
     eol: 2026-12-31
-    latest: "6.12.23"
-    latestReleaseDate: 2025-04-10
+    latest: "6.12.24"
+    latestReleaseDate: 2025-04-20
 
 -   releaseCycle: "6.11"
     releaseDate: 2024-09-15


### PR DESCRIPTION
Add eol date for 6.13
update versions for 6.14 , 6.13, 6.12