### PR TITLE
Make releaseDate and eol mandatory

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -317,9 +317,8 @@ releases:
     # It is also returned as-is in the API.
     codename: firebolt
 
-    # Date of the release (optional if releaseDateColumn is false, else mandatory).
-    # It should be removed if releaseDateColumn is false.
-    # Note that an approximate date is better than no date at all.
+    # Date of the release (mandatory).
+    # Note that an approximate date is OK if the exact date is not known.
     releaseDate: 2017-03-12
 
     # Whether this is a "LTS" release (optional, default = false).

--- a/_plugins/product-data-validator.rb
+++ b/_plugins/product-data-validator.rb
@@ -176,10 +176,10 @@ module EndOfLifeHooks
       error_if.is_not_a_string('releaseCycle')
       error_if.is_not_a_string('releaseLabel') if release.has_key?('releaseLabel')
       error_if.is_not_a_string('codename') if release.has_key?('codename')
-      error_if.is_not_a_date('releaseDate') if product.data['releaseDateColumn']
-      error_if.too_far_in_future('releaseDate') if product.data['releaseDateColumn']
+      error_if.is_not_a_date('releaseDate')
+      error_if.too_far_in_future('releaseDate')
       error_if.is_not_a_boolean_nor_a_date('eoas') if product.data['eoasColumn']
-      error_if.is_not_a_boolean_nor_a_date('eol') if product.data['eolColumn']
+      error_if.is_not_a_boolean_nor_a_date('eol')
       error_if.is_not_a_boolean_nor_a_date('discontinued') if product.data['discontinuedColumn']
       error_if.is_not_a_boolean_nor_a_date('eoes') if product.data['eoesColumn'] and release.has_key?('eoes')
       error_if.is_not_a_boolean_nor_a_date('lts') if release.has_key?('lts')
@@ -187,12 +187,12 @@ module EndOfLifeHooks
       error_if.is_not_a_date('latestReleaseDate') if product.data['releaseColumn'] and release.has_key?('latestReleaseDate')
       error_if.is_not_an_url('link') if release.has_key?('link') and release['link']
 
-      error_if.is_not_before('releaseDate', 'eoas') if product.data['releaseDateColumn'] and product.data['eoasColumn']
-      error_if.is_not_before('releaseDate', 'eol') if product.data['releaseDateColumn'] and product.data['eolColumn']
-      error_if.is_not_before('releaseDate', 'eoes') if product.data['releaseDateColumn'] and product.data['eoesColumn']
-      error_if.is_not_before('eoas', 'eol') if product.data['eoasColumn'] and product.data['eolColumn']
+      error_if.is_not_before('releaseDate', 'eoas') if product.data['eoasColumn']
+      error_if.is_not_before('releaseDate', 'eol')
+      error_if.is_not_before('releaseDate', 'eoes') if product.data['eoesColumn']
+      error_if.is_not_before('eoas', 'eol') if product.data['eoasColumn']
       error_if.is_not_before('eoas', 'eoes') if product.data['eoasColumn'] and product.data['eoesColumn']
-      error_if.is_not_before('eol', 'eoes') if product.data['eolColumn'] and product.data['eoesColumn']
+      error_if.is_not_before('eol', 'eoes') if product.data['eoesColumn']
     }
 
     Jekyll.logger.debug TOPIC, "Product '#{product.name}' successfully validated in #{(Time.now - start).round(3)} seconds."

--- a/products/alibaba-ack.md
+++ b/products/alibaba-ack.md
@@ -8,7 +8,6 @@ alternate_urls:
 -   /ack
 versionCommand: kubectl version
 releasePolicyLink: https://www.alibabacloud.com/help/en/ack/ack-managed-and-ack-dedicated/user-guide/support-for-kubernetes-versions
-releaseDateColumn: true
 releaseColumn: false
 eolColumn: End of Support
 

--- a/products/bitbucket.md
+++ b/products/bitbucket.md
@@ -8,9 +8,7 @@ alternate_urls:
 -   /atlassian-bitbucket
 releasePolicyLink: https://confluence.atlassian.com/enterprise/atlassian-enterprise-releases-948227420.html
 changelogTemplate: https://confluence.atlassian.com/display/BitbucketServer/Bitbucket+Data+Center+__RELEASE_CYCLE__+release+notes
-
 eolColumn: Support
-releaseDateColumn: true
 
 identifiers:
 -   cpe: cpe:/a:atlassian:bitbucket

--- a/products/raspberrypi.md
+++ b/products/raspberrypi.md
@@ -8,8 +8,7 @@ alternate_urls:
 -   /raspi
 -   /rpi
 releasePolicyLink: https://en.wikipedia.org/wiki/Raspberry_Pi#Model_comparison
-discontinuedColumn: true
-eolColumn: false
+eolColumn: Discontinued
 releaseColumn: false
 
 releases:
@@ -17,49 +16,49 @@ releases:
     releaseLabel: "500"
     # https://www.raspberrypi.com/news/raspberry-pi-500-and-raspberry-pi-monitor-on-sale-now/
     releaseDate: 2024-12-09
-    discontinued: 2034-01-01
+    eol: 2034-01-01
     link: https://www.raspberrypi.com/products/raspberry-pi-500/
 
 -   releaseCycle: "CM5"
     releaseLabel: Compute Module 5
     # https://www.raspberrypi.com/news/compute-module-5-on-sale-now/
     releaseDate: 2024-11-27
-    discontinued: 2036-01-01
+    eol: 2036-01-01
     link: https://www.raspberrypi.com/products/compute-module-5
 
 -   releaseCycle: "5"
     releaseLabel: "5" # Is just called "Raspberry Pi 5", without "Model B"
     # https://www.raspberrypi.com/news/raspberry-pi-5-available-now/
     releaseDate: 2023-10-23
-    discontinued: 2036-01-01
+    eol: 2036-01-01
     link: https://www.raspberrypi.com/products/raspberry-pi-5/
 
 -   releaseCycle: "CM4S"
     releaseLabel: Compute Module 4S
     # https://www.jeffgeerling.com/blog/2022/new-raspberry-pi-compute-module-4s
     releaseDate: 2022-04-04
-    discontinued: 2034-01-01
+    eol: 2034-01-01
     link: https://www.raspberrypi.com/products/compute-module-4s/
 
 -   releaseCycle: "zero-2-w"
     releaseLabel: "Zero 2 W"
     # https://www.raspberrypi.com/news/new-raspberry-pi-zero-2-w-2/
     releaseDate: 2021-10-28
-    discontinued: 2030-01-01
+    eol: 2030-01-01
     link: https://www.raspberrypi.com/products/raspberry-pi-zero-2-w/
 
 -   releaseCycle: "pico"
     releaseLabel: Pico
     # https://www.raspberrypi.com/news/raspberry-pi-silicon-pico-now-on-sale/
     releaseDate: 2021-01-21
-    discontinued: 2036-01-01
+    eol: 2036-01-01
     link: https://www.raspberrypi.com/products/raspberry-pi-pico/
 
 -   releaseCycle: "4-400"
     releaseLabel: "400"
     # https://www.raspberrypi.com/news/raspberry-pi-400-the-70-desktop-pc/
     releaseDate: 2020-11-02
-    discontinued: 2028-01-01
+    eol: 2028-01-01
     link: https://www.raspberrypi.com/products/raspberry-pi-400-unit/
 
 -   releaseCycle: "CM4"
@@ -67,7 +66,7 @@ releases:
     # https://www.raspberrypi.com/news/raspberry-pi-compute-module-4/
     releaseDate: 2020-10-19
     # https://www.raspberrypi.com/products/compute-module-4/?variant=raspberry-pi-cm4001000
-    discontinued: 2034-01-01
+    eol: 2034-01-01
     link: https://www.raspberrypi.com/products/compute-module-4/
 
 -   releaseCycle: "4-b"
@@ -75,7 +74,7 @@ releases:
     # https://www.raspberrypi.com/news/raspberry-pi-4-on-sale-now-from-35/
     releaseDate: 2019-06-24
     # https://www.raspberrypi.com/products/raspberry-pi-4-model-b/specifications/
-    discontinued: 2034-01-01
+    eol: 2034-01-01
     link: https://www.raspberrypi.com/products/raspberry-pi-4-model-b/
 
 -   releaseCycle: "CM3+"
@@ -83,7 +82,7 @@ releases:
     # https://www.raspberrypi.com/news/compute-module-3-on-sale-now-from-25/
     releaseDate: 2019-01-28
     # https://www.raspberrypi.com/products/compute-module-3-plus/
-    discontinued: 2028-01-01
+    eol: 2028-01-01
     link: https://www.raspberrypi.com/products/compute-module-3-plus/
 
 -   releaseCycle: "3-a+"
@@ -91,7 +90,7 @@ releases:
     # https://www.raspberrypi.com/news/new-product-raspberry-pi-3-model-a/
     releaseDate: 2018-11-15
     # https://www.raspberrypi.com/products/raspberry-pi-3-model-a-plus/
-    discontinued: 2030-01-01
+    eol: 2030-01-01
     link: https://www.raspberrypi.com/products/raspberry-pi-3-model-a-plus/
 
 -   releaseCycle: "3-b+"
@@ -99,7 +98,7 @@ releases:
     # https://www.raspberrypi.com/news/raspberry-pi-3-model-bplus-sale-now-35/
     releaseDate: 2018-03-14
     # https://www.raspberrypi.com/products/raspberry-pi-3-model-b-plus/
-    discontinued: 2030-01-01
+    eol: 2030-01-01
     link: https://www.raspberrypi.com/products/raspberry-pi-3-model-b-plus/
 
     # There is also https://www.raspberrypi.com/news/zero-wh/, but no associated product page, so
@@ -108,7 +107,7 @@ releases:
     releaseLabel: "Zero W/WH"
     # https://www.raspberrypi.com/news/raspberry-pi-zero-w-joins-family/
     releaseDate: 2017-02-28
-    discontinued: 2030-01-01
+    eol: 2030-01-01
     link: https://www.raspberrypi.com/products/raspberry-pi-zero-w/
 
 -   releaseCycle: "CM3"
@@ -116,7 +115,7 @@ releases:
     # https://www.raspberrypi.com/news/compute-module-3-launch/
     releaseDate: 2017-01-16
     # https://www.raspberrypi.com/products/compute-module-3/
-    discontinued: 2028-01-01
+    eol: 2028-01-01
     link: https://www.raspberrypi.com/products/compute-module-3/
 
 -   releaseCycle: "3-b"
@@ -124,42 +123,42 @@ releases:
     # https://www.raspberrypi.com/news/raspberry-pi-3-on-sale/
     releaseDate: 2016-02-29
     # https://www.raspberrypi.com/products/raspberry-pi-3-model-b/
-    discontinued: 2028-01-01
+    eol: 2028-01-01
     link: https://www.raspberrypi.com/products/raspberry-pi-3-model-b/
 
 -   releaseCycle: "zero"
     releaseLabel: "Zero"
     # https://www.raspberrypi.com/news/raspberry-pi-zero/
     releaseDate: 2015-11-26
-    discontinued: 2030-01-01
+    eol: 2030-01-01
     link: https://www.raspberrypi.com/products/raspberry-pi-zero/
 
 -   releaseCycle: "2-b"
     releaseLabel: "2 Model B"
     # https://www.raspberrypi.com/news/raspberry-pi-2-on-sale/
     releaseDate: 2015-02-02
-    discontinued: 2026-01-01
+    eol: 2026-01-01
     link: https://www.raspberrypi.com/products/raspberry-pi-2-model-b/
 
 -   releaseCycle: "1-a+"
     releaseLabel: "1 Model A+"
     # https://www.raspberrypi.com/news/raspberry-pi-model-a-plus-on-sale/
     releaseDate: 2014-11-10
-    discontinued: 2030-01-01
+    eol: 2030-01-01
     link: https://www.raspberrypi.com/products/raspberry-pi-1-model-a-plus/
 
 -   releaseCycle: "1-b+"
     releaseLabel: "1 Model B+"
     # https://www.raspberrypi.com/news/introducing-raspberry-pi-model-b-plus/
     releaseDate: 2014-07-14
-    discontinued: 2030-01-01
+    eol: 2030-01-01
     link: https://www.raspberrypi.com/products/raspberry-pi-1-model-b-plus/
 
 -   releaseCycle: "CM1"
     releaseLabel: Compute Module 1
     # https://www.raspberrypi.org/raspberry-pi-compute-module-new-product/
     releaseDate: 2014-04-07
-    discontinued: 2026-01-01
+    eol: 2026-01-01
     link: https://www.raspberrypi.com/products/compute-module-1/
 
 -   releaseCycle: "1-a"
@@ -167,14 +166,14 @@ releases:
     # https://www.raspberrypi.com/news/model-a-now-for-sale-in-europe-buy-one-today/
     releaseDate: 2013-02-04
     # replaced by 1a+ -  https://www.raspberrypi.com/products/raspberry-pi-1-model-a-plus/
-    discontinued: 2014-11-10
+    eol: 2014-11-10
     link: https://www.raspberrypi.com/news/model-a-now-for-sale-in-europe-buy-one-today/
 
 -   releaseCycle: "1-b"
     releaseLabel: "1 Model B"
     releaseDate: 2012-03-01
     # replaced by 1b+ - https://www.raspberrypi.com/products/raspberry-pi-1-model-b-plus/
-    discontinued: 2014-07-14
+    eol: 2014-07-14
     link: https://www.raspberrypi.com/news/the-raspberry-pi-launch/
 
 ---


### PR DESCRIPTION
It's better if those are always provided, especially when using the API. And this was already the case for the vast majority of the products.

The Raspberry PI page were using the discontinued column without the EOL column, updated the product to replace discontinued by EOL. This is a breaking change for API users.