### PR TITLE
[new-product] Adds Caddy

### DIFF
--- a/products/caddy.md
+++ b/products/caddy.md
@@ -6,12 +6,11 @@ iconSlug: caddy
 permalink: /caddy
 versionCommand: caddy version
 releasePolicyLink: https://github.com/caddyserver/caddy?tab=security-ov-file
-changelogTemplate: https://github.com/caddyserver/caddy/releases/tag/__LATEST__
+changelogTemplate: https://github.com/caddyserver/caddy/releases/tag/v__LATEST__
 
 auto:
   methods:
   -   git: https://github.com/caddyserver/caddy.git
-      #regex: ^release-(?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)$
 
 # Supported versions : https://github.com/caddyserver/caddy
 

--- a/products/caddy.md
+++ b/products/caddy.md
@@ -1,0 +1,44 @@
+---
+title: caddy
+category: server-app
+tags: web-server
+iconSlug: caddy
+permalink: /caddy
+versionCommand: caddy version
+releasePolicyLink: https://github.com/caddyserver/caddy?tab=security-ov-file
+changelogTemplate: https://github.com/caddyserver/caddy/releases/tag/__LATEST__
+
+auto:
+  methods:
+  -   git: https://github.com/caddyserver/caddy.git
+      #regex: ^release-(?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)$
+
+# Supported versions : https://github.com/caddyserver/caddy
+
+releases:
+-   releaseCycle: "2"
+    releaseDate: 2020-05-05
+    eol: false
+    latest: "2.10.0"
+    latestReleaseDate: 2025-04-19
+
+-   releaseCycle: "1"
+    releaseDate: 2019-04-25
+    #https://caddy.community/t/caddy-version-1-end-of-life-date/7835/10
+    eol: 2020-07-01 
+    latest: "1.0.5"
+    latestReleaseDate: 2020-02-29
+
+-   releaseCycle: "0"
+    releaseDate: 2015-04-28
+    eol: true
+    latest: "0.11.5"
+    latestReleaseDate: 2019-03-05  
+
+---
+
+> [Caddy](https://caddyserver.com/) Fast and extensible multi-platform HTTP/1-2-3 web server with automatic HTTPS.
+
+## Security Policy
+
+The Caddy project would like to make sure that it stays on top of all practically-exploitable vulnerabilities.

--- a/products/caddy.md
+++ b/products/caddy.md
@@ -29,16 +29,9 @@ releases:
     latest: "1.0.5"
     latestReleaseDate: 2020-02-29
 
--   releaseCycle: "0"
-    releaseDate: 2015-04-28
-    eol: true
-    latest: "0.11.5"
-    latestReleaseDate: 2019-03-05  
-
 ---
 
-> [Caddy](https://caddyserver.com/) Fast and extensible multi-platform HTTP/1-2-3 web server with automatic HTTPS.
+> [Caddy](https://caddyserver.com/) is a fast and extensible multi-platform web
+> server with automatic HTTPS support.
 
-## Security Policy
-
-The Caddy project would like to make sure that it stays on top of all practically-exploitable vulnerabilities.
+Only the latest release is considered supported.


### PR DESCRIPTION
# :grey_question: About

[`caddy`](https://caddyserver.com/) is gaining a lot of traction these days (and I'm seriously thinking about switching to it). So I thought it would be useful to get it on `endoflife.date` like [`nginx`](https://endoflife.date/nginx) does.

I struggled a bit to get end of lifes dates.

I've chosen to stay simple and stick to major [supported versions ](https://github.com/caddyserver/caddy?tab=security-ov-file#supported-versions): 

- https://github.com/caddyserver/caddy/issues/3073#issuecomment-2817362717

| Version | Supported |
|     ---       |         ---        | 
| `2.latest ` |       ✔️        |
| [`1.x`](https://github.com/caddyserver/caddy/issues/3073#issuecomment-2817362717)          |      ❌         |
| `< 1.x`       |      ❌         |


:pray: Please let me know what you think about this first draft