### PR TITLE
[calico] Remove chainguard's dockerhub purl

### DIFF
--- a/products/calico.md
+++ b/products/calico.md
@@ -8,7 +8,6 @@ identifiers:
 -   repology: calico
 -   purl: pkg:github/projectcalico/calico
 -   purl: pkg:docker/calico/cni
--   purl: pkg:docker/chainguard/calico-cni
 -   cpe: cpe:/a:projectcalico:calico
 -   cpe: cpe:2.3:a:projectcalico:calico
 


### PR DESCRIPTION
Looks like they removed it from Docker Hub  just like airflow