### PR TITLE
[redis] update eol for 6.2

### DIFF
--- a/products/redis.md
+++ b/products/redis.md
@@ -62,7 +62,7 @@ releases:
 -   releaseCycle: "6.2"
     releaseDate: 2021-02-22
     eoas: 2022-04-27
-    eol: 2025-05-31
+    eol: 2025-04-23
     latest: '6.2.18'
     latestReleaseDate: 2025-04-23
 

--- a/products/redis.md
+++ b/products/redis.md
@@ -62,7 +62,7 @@ releases:
 -   releaseCycle: "6.2"
     releaseDate: 2021-02-22
     eoas: 2022-04-27
-    eol: 2025-02-28
+    eol: 2025-05-31
     latest: '6.2.18'
     latestReleaseDate: 2025-04-23
 


### PR DESCRIPTION
There is a security patch release today, https://github.com/redis/redis/releases/tag/6.2.18. Updating eol for 6.2 to the end of next month.

- relates to https://github.com/redis/docs/issues/1459