### PR TITLE
Schedule dependabot using a cron expression

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,12 +11,12 @@ updates:
     schedule:
       interval: "daily"
 
-  # This updates the _data/release-data submodule once a day
-  # which itself is updated twice a day.
+  # This updates the _data/release-data submodule.
   - package-ecosystem: "gitsubmodule"
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "cron"
+      cronjob: "every day at midnight"
 
   - package-ecosystem: "github-actions"
     directory: "/"


### PR DESCRIPTION
Up to now dependabot was triggered once a day, but only on week-days (see https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference#interval). This was not the best for endoflife.date as there are updates on weekends too.

Now that schedule.interval support cron expressions, we can use it to update the site even on weekends.

Closes #7261.