### PR TITLE
Schedule dependabot using a real cron expression

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,7 +16,7 @@ updates:
     directory: "/"
     schedule:
       interval: "cron"
-      cronjob: "every day at midnight"
+      cronjob: "0 8 * * *" # every day at 8am UTC
 
   - package-ecosystem: "github-actions"
     directory: "/"


### PR DESCRIPTION
"every day at midnight" should have worked according to https://github.com/endoflife-date/endoflife.date/issues/7261#issuecomment-2830576656, but [it did not](https://github.com/endoflife-date/endoflife.date/network/updates/11777156/jobs).

Try using a "real" cron expression.