### PR TITLE
[ros] Change category from 'os' to 'framework' for ROS and ROS 2

### DIFF
--- a/products/ros-2.md
+++ b/products/ros-2.md
@@ -1,6 +1,6 @@
 ---
 title: ROS 2
-category: os
+category: framework
 iconSlug: ros
 permalink: /ros-2
 alternate_urls:

--- a/products/ros.md
+++ b/products/ros.md
@@ -1,6 +1,6 @@
 ---
 title: ROS
-category: os
+category: framework
 iconSlug: ros
 permalink: /ros
 versionCommand: rosversion -d


### PR DESCRIPTION
Hi @marcwrobel, thanks for maintaining this awesome project!

This PR suggests changing the category of `ROS` and `ROS 2` from `os` to `framework`.

Although ROS is called an "Operating System," it's actually middleware. Also, each ROS distribution is tied to a specific Ubuntu release.
Given the current categories, I think `framework` would be a better fit.

Reference: https://wiki.debian.org/DebianScience/Robotics/ROS