### PR TITLE
[bazel] Remove chainguard's purl for dockerhub

### DIFF
--- a/products/bazel.md
+++ b/products/bazel.md
@@ -13,7 +13,6 @@ eoasColumn: true
 identifiers:
 -   repology: bazel
 -   purl: pkg:github/bazelbuild/bazel
--   purl: pkg:docker/chainguard/bazel
 -   purl: pkg:oci/bazel?repository_url=cgr.dev/chainguard
 -   cpe: cpe:/a:google:bazel
 -   cpe: cpe:2.3:a:google:bazel


### PR DESCRIPTION
Same like others , looks like docker. removed some of purls for their dockerhub