### PR TITLE
[quarkus] Mark 3.20 LTS as RHBQ

### DIFF
--- a/products/quarkus.md
+++ b/products/quarkus.md
@@ -42,6 +42,7 @@ releases:
     lts: true
     releaseDate: 2025-03-26
     eol: 2026-03-28
+    eoes: false
     latest: "3.20.0"
     latestReleaseDate: 2025-03-26
 


### PR DESCRIPTION
RHBQ 3.20 was released today: https://access.redhat.com/errata/RHEA-2025:4162