### PR TITLE
[dotnetfx] Normalize 3.5 SP1 release cycle name

### DIFF
--- a/products/dotnetfx.md
+++ b/products/dotnetfx.md
@@ -73,7 +73,8 @@ releases:
     eol: 2016-01-12
     link: https://learn.microsoft.com/previous-versions/dotnet/netframework-4.0/ms171868(v=vs.100)
 
--   releaseCycle: "3.5 SP1"
+-   releaseCycle: "3.5-sp1"
+    releaseLabel: "3.5 SP1"
     releaseDate: 2007-11-19
     eol: 2029-01-09
     link: https://support.microsoft.com/en-us/topic/list-of-changes-and-fixed-issues-in-the-net-framework-3-5-service-pack-1-7e580459-9f9a-3f0d-ecb3-ee3ea374044f


### PR DESCRIPTION
A release label was added so that it renders the same on https://endoflife.date/dotnetfx.