### PR TITLE
[redis] Redis 8 with new license released

### DIFF
--- a/products/redis.md
+++ b/products/redis.md
@@ -108,8 +108,11 @@ major security issues are committed and released as patches:
 - The previous minor version of the latest stable release.
 - The previous stable major release.
 
-Starting from 7.4, Redis will be dual-licensed under the
-[RSALv2 and SSPLv1](https://redis.com/blog/redis-adopts-dual-source-available-licensing/) licenses.
-7.2 is the last release under the old 3-BSD license.
+Open Source Redis releases are subject to the following licenses:
+
+- Version 7.2.x and prior releases are subject to BSDv3. 
+- Versions 7.4.x to 7.8.x are subject to your choice of RSALv2 or SSPLv1; and
+- Version 8.0.x and subsequent releases are subject to the tri-license RSALv2/SSPLv1/AGPLv3 at your option.
+
 
 [Security Overview](https://github.com/redis/redis/security) with the actual list of supported versions and advisories.

--- a/products/redis.md
+++ b/products/redis.md
@@ -38,6 +38,13 @@ auto:
 # - eoas(x) = release(x+1)
 # - eol(x) = release(x+3)
 releases:
+-   releaseCycle: "8.0"
+    releaseDate: 2025-05-01
+    eoas: false
+    eol: false
+    latest: '8.0.0'
+    latestReleaseDate: 2025-05-01
+
 -   releaseCycle: "7.4"
     releaseDate: 2024-07-29
     eoas: false

--- a/products/redis.md
+++ b/products/redis.md
@@ -39,23 +39,23 @@ auto:
 # - eol(x) = release(x+3)
 releases:
 -   releaseCycle: "8.0"
-    releaseDate: 2025-05-01
+    releaseDate: 2025-05-03
     eoas: false
     eol: false
     latest: '8.0.0'
-    latestReleaseDate: 2025-05-01
+    latestReleaseDate: 2025-05-03
 
 -   releaseCycle: "7.4"
     releaseDate: 2024-07-29
     eoas: false
-    eol: 2026-11-30
+    eol: 2025-05-03
     latest: '7.4.3'
     latestReleaseDate: 2025-04-23
 
 -   releaseCycle: "7.2"
     releaseDate: 2023-08-15
     eoas: 2024-07-29
-    eol: 2026-02-28
+    eol: 2025-05-03
     latest: '7.2.8'
     latestReleaseDate: 2025-04-23
 


### PR DESCRIPTION
See https://redis.io/blog/agplv3/.

Closes #7408.
