### PR TITLE
[intel-processors] Normalize release cycles name

### DIFF
--- a/products/intel-processors.md
+++ b/products/intel-processors.md
@@ -9,186 +9,211 @@ eolColumn: Active Support
 discontinuedColumn: true
 
 releases:
--   releaseCycle: "Raptor Lake"
+-   releaseCycle: "raptor-lake"
+    releaseLabel: "Raptor Lake"
     releaseDate: 2022-10-20
     discontinued: false
     eol: false
     link: https://ark.intel.com/content/www/us/en/ark/products/codename/215599/products-formerly-raptor-lake.html
 
--   releaseCycle: "Alder Lake"
+-   releaseCycle: "alder-lake"
+    releaseLabel: "Alder Lake"
     releaseDate: 2021-11-04
     discontinued: false
     eol: false
     link: https://ark.intel.com/content/www/us/en/ark/products/codename/147470/products-formerly-alder-lake.html
 
--   releaseCycle: "Rocket Lake"
+-   releaseCycle: "rocket-lake"
+    releaseLabel: "Rocket Lake"
     releaseDate: 2021-03-30
     discontinued: false
     eol: false
     link: https://ark.intel.com/content/www/us/en/ark/products/codename/192985/products-formerly-rocket-lake.html
 
--   releaseCycle: "Jasper Lake"
+-   releaseCycle: "jasper-lake"
+    releaseLabel: "Jasper Lake"
     releaseDate: 2021-01-11
     discontinued: false
     eol: false
     link: https://ark.intel.com/content/www/us/en/ark/products/codename/128823/products-formerly-jasper-lake.html
 
--   releaseCycle: "Elkhart Lake"
+-   releaseCycle: "elkhart-lake"
+    releaseLabel: "Elkhart Lake"
     releaseDate: 2020-09-23
     discontinued: false
     eol: false
     link: https://ark.intel.com/content/www/us/en/ark/products/codename/128825/products-formerly-elkhart-lake.html
 
--   releaseCycle: "Tiger Lake"
+-   releaseCycle: "tiger-lake"
+    releaseLabel: "Tiger Lake"
     releaseDate: 2020-09-02
     discontinued: false
     eol: false
     link: https://ark.intel.com/content/www/us/en/ark/products/codename/88759/products-formerly-tiger-lake.html
 
--   releaseCycle: "Lakefield"
+-   releaseCycle: "lakefield"
+    releaseLabel: "Lakefield"
     releaseDate: 2020-06-19
     discontinued: true
     eol: false
     link: https://ark.intel.com/content/www/us/en/ark/products/codename/81657/products-formerly-lakefield.html
 
--   releaseCycle: "Ice Lake"
+-   releaseCycle: "ice-lake"
+    releaseLabel: "Ice Lake"
     releaseDate: 2019-09-01
     discontinued: false
     eol: false
     link: https://ark.intel.com/content/www/us/en/ark/products/codename/74979/products-formerly-ice-lake.html
 
--   releaseCycle: "Comet Lake"
+-   releaseCycle: "comet-lake"
+    releaseLabel: "Comet Lake"
     releaseDate: 2019-08-21
     discontinued: false
     eol: false
     link: https://ark.intel.com/content/www/us/en/ark/products/codename/90354/products-formerly-comet-lake.html
 
--   releaseCycle: "Cannon Lake"
+-   releaseCycle: "cannon-lake"
+    releaseLabel: "Cannon Lake"
     releaseDate: 2018-05-01
     discontinued: 2020-02-28
     eol: 2021-09-30
     link: null
 
--   releaseCycle: "Gemini Lake"
+-   releaseCycle: "gemini-lake"
+    releaseLabel: "Gemini Lake"
     releaseDate: 2017-12-11
     discontinued: true
     eol: false
     link: https://ark.intel.com/content/www/us/en/ark/products/codename/83915/products-formerly-gemini-lake.html
 
--   releaseCycle: "Coffee Lake"
+-   releaseCycle: "coffee-lake"
+    releaseLabel: "Coffee Lake"
     releaseDate: 2017-10-05
     discontinued: 2021-12-24
     eol: false
     link: https://ark.intel.com/content/www/us/en/ark/products/codename/97787/products-formerly-coffee-lake.html
 
--   releaseCycle: "Apollo Lake"
+-   releaseCycle: "apollo-lake"
+    releaseLabel: "Apollo Lake"
     releaseDate: 2016-08-30
     discontinued: false # TODO: This is likely incorrect, but I am assuming it is under production due to this CPU being launched semi recently and having its status say not discontinued: https://ark.intel.com/content/www/us/en/ark/products/195253/intel-pentium-processor-n4200e-2m-cache-up-to-2-50-ghz.html
     eol: 2023-06-30
     link: https://ark.intel.com/content/www/us/en/ark/products/codename/80644/products-formerly-apollo-lake.html
 
--   releaseCycle: "Kaby Lake"
+-   releaseCycle: "kaby-lake"
+    releaseLabel: "Kaby Lake"
     releaseDate: 2015-08-30
     discontinued: 2020-10-09
     eol: false
     link: https://ark.intel.com/content/www/us/en/ark/products/codename/82879/products-formerly-kaby-lake.html
 
--   releaseCycle: "Skylake"
+-   releaseCycle: "skylake"
+    releaseLabel: "Skylake"
     releaseDate: 2015-08-05
     discontinued: 2019-03-04
     eol: 2022-09-30
     link: https://ark.intel.com/content/www/us/en/ark/products/codename/37572/products-formerly-skylake.html
 
--   releaseCycle: "Braswell"
+-   releaseCycle: "braswell"
+    releaseLabel: "Braswell"
     releaseDate: 2015-03-01
     discontinued: true
     eol: 2022-06-30
     link: https://ark.intel.com/content/www/us/en/ark/products/codename/66094/products-formerly-braswell.html
 
 -   releaseCycle: "broadwell"
-    releaseLabel: Broadwell
+    releaseLabel: "Broadwell"
     releaseDate: 2014-10-27
     discontinued: 2018-11-01
     eol: 2021-06-30
     link: https://ark.intel.com/content/www/us/en/ark/products/codename/38530/products-formerly-broadwell.html
 
--   releaseCycle: "broadwell_xeon"
-    releaseLabel: Broadwell (Xeon E7v4/E7v4)
+-   releaseCycle: "broadwell-xeon"
+    releaseLabel: "Broadwell (Xeon E7v4/E7v4)"
     releaseDate: 2014-10-27
     discontinued: 2018-11-01
     eol: 2022-06-30
     link: null
 
--   releaseCycle: "Broadwell DE"
+-   releaseCycle: "broadwell-de"
+    releaseLabel: "Broadwell DE"
     releaseDate: 2014-10-27
     discontinued: 2018-11-01
     eol: 2022-12-31
     link: null
 
--   releaseCycle: "Devil's Canyon"
+-   releaseCycle: "devils-canyon"
+    releaseLabel: "Devil's Canyon"
     releaseDate: 2014-06-02
     discontinued: 2017-07-14
     eol: 2021-06-30
     link: https://ark.intel.com/content/www/us/en/ark/products/codename/81246/products-formerly-devils-canyon.html
 
--   releaseCycle: "Bay Trail"
+-   releaseCycle: "bay-trail"
+    releaseLabel: "Bay Trail"
     releaseDate: 2013-09-11
     discontinued: true
     eol: 2021-06-30
     link: https://ark.intel.com/content/www/us/en/ark/products/codename/55844/products-formerly-bay-trail.html
 
--   releaseCycle: "Avoton"
+-   releaseCycle: "avoton"
+    releaseLabel: "Avoton"
     releaseDate: 2013-07-01 # Not accurate, date of start of quarter 3 of 2013
     discontinued: true
     eol: 2021-06-30
     link: https://ark.intel.com/content/www/us/en/ark/products/codename/54859/products-formerly-avoton.html
 
--   releaseCycle: haswell
+-   releaseCycle: "haswell"
     releaseLabel: "Haswell"
     releaseDate: 2013-06-04
     discontinued: true
     eol: 2021-06-30
     link: https://ark.intel.com/content/www/us/en/ark/products/codename/42174/products-formerly-haswell.html
 
--   releaseCycle: haswell_xeon
-    releaseLabel: Haswell (Xeon E5v3/E7v3)
+-   releaseCycle: "haswell-xeon"
+    releaseLabel: "Haswell (Xeon E5v3/E7v3)"
     releaseDate: 2013-06-04
     discontinued: true
     eol: 2021-12-31
     link: null
 
--   releaseCycle: "Crystal Well"
+-   releaseCycle: "crystal-well"
+    releaseLabel: "Crystal Well"
     releaseDate: 2013-06-02
     discontinued: true
     eol: 2021-06-30
     link: https://ark.intel.com/content/www/us/en/ark/products/codename/51802/products-formerly-crystal-well.html
 
--   releaseCycle: "Briarwood"
+-   releaseCycle: "briarwood"
+    releaseLabel: "Briarwood"
     releaseDate: 2013-04-01 # Not accurate, date of start of quarter 3 of 2013
     discontinued: true
     eol: 2021-06-30
     link: null
 
--   releaseCycle: "Cherry Trail"
+-   releaseCycle: "cherry-trail"
+    releaseLabel: "Cherry Trail"
     releaseDate: 2013-03-02
     discontinued: true
     eol: 2022-06-30
     link: https://ark.intel.com/content/www/us/en/ark/products/codename/46629/products-formerly-cherry-trail.html
 
--   releaseCycle: "Centerton"
+-   releaseCycle: "centerton"
+    releaseLabel: "Centerton"
     releaseDate: 2012-12-11
     discontinued: true
     eol: 2021-06-30
     link: https://ark.intel.com/content/www/us/en/ark/products/codename/60105/products-formerly-centerton.html
 
--   releaseCycle: "Ivy Bridge"
+-   releaseCycle: "ivy-bridge"
+    releaseLabel: "Ivy Bridge"
     releaseDate: 2012-04-29
     discontinued: 2015-06-05
     eol: 2019-12-31
     link: https://ark.intel.com/content/www/us/en/ark/products/codename/29902/products-formerly-ivy-bridge.html
 
--   releaseCycle: ivy_bridge_xeon
-    releaseLabel: Ivy Bridge (Xeon E5v2/E7v2)
+-   releaseCycle: "ivy-bridge-xeon"
+    releaseLabel: "Ivy Bridge (Xeon E5v2/E7v2)"
     releaseDate: 2012-04-29
     discontinued: 2015-06-05
     eol: 2020-06-30
@@ -218,3 +243,4 @@ your CPU belongs on:
 - FreeBSD/OpenBSD: `sysctl -n hw.model`
 
 Then check product classification on https://ark.intel.com/.
+


### PR DESCRIPTION
A release label was added so that it renders the same as the current https://endoflife.date/intel-processors page.