### PR TITLE
[oneplus] Normalize release cycles name

### DIFF
--- a/products/oneplus.md
+++ b/products/oneplus.md
@@ -22,7 +22,8 @@ customColumns:
 
 # Use Support/Spec pages from https://www.oneplus.com/global/support/spec pages for older phones
 releases:
--   releaseCycle: "13R"
+-   releaseCycle: "13r"
+    releaseLabel: "13R"
     releaseDate: 2025-01-07
     eoas: 2029-01-07 # approximation "4 major Android updates" https://community.oneplus.com/thread/1809805181760569353
     eol: 2031-01-07 # 6 years of security updates
@@ -36,7 +37,8 @@ releases:
     discontinued: false
     supportedOxygenOSVersions: 15
 
--   releaseCycle: "12R"
+-   releaseCycle: "12r"
+    releaseLabel: "12R"
     releaseDate: 2024-01-23 # https://community.oneplus.com/thread/1514801169317232648
     eoas: 2028-01-23 # approximation "4 major Android updates" https://community.oneplus.com/thread/1211291251581124608
     eol: 2029-01-23
@@ -50,7 +52,8 @@ releases:
     discontinued: false
     supportedOxygenOSVersions: 14 # https://oxygenupdater.com/article/396/
 
--   releaseCycle: "11R"
+-   releaseCycle: "11r"
+    releaseLabel: "11R"
     releaseDate: 2023-02-07 #https://oxygenupdater.com/article/379/
     eoas: 2027-02-07 # approximation "4 major Android updates" https://community.oneplus.com/thread/1211291251581124608
     eol: 2028-02-07
@@ -72,7 +75,7 @@ releases:
 
 OnePlus phones run OxygenOS, which is based on Android. It receives updates every two months.
 
-The OnePlus 13 & 13R supports [four major Android updates](https://community.oneplus.com/thread/1809805181760569353) and six years of security updates.  
+The OnePlus 13 & 13R supports [four major Android updates](https://community.oneplus.com/thread/1809805181760569353) and six years of security updates.
 OnePlus supports [four major Android updates](https://community.oneplus.com/thread/1211291251581124608) and five years of security updates on their flagship lineup (starting from OnePlus 11 onwards, including T & R series), [three major Android updates](https://community.oneplus.com/thread/1356800969827942405) and four years of security updates for the Nord series (starting from the Nord 3 onwards), [two major Android updates](https://community.oneplus.com/thread/1462181) and three years of security updates for the Nord CE series, and finally [one major Android updates](https://community.oneplus.com/thread/1462181) and three years of security updates for the Nord N series
 
 OxygenOS updates can be tracked at [Oxygen Updater](https://oxygenupdater.com/news/all/)


### PR DESCRIPTION
A release label was added so that it renders the same as the current https://endoflife.date/oneplus page.