### PR TITLE
[pan-os] Normalize 9.0-XFR release name

### DIFF
--- a/products/pan-os.md
+++ b/products/pan-os.md
@@ -13,7 +13,7 @@ eolColumn: End-of-life Date
 auto:
   methods:
   # https://github.com/endoflife-date/release-data/blob/main/src/pan-os.py works great, but the latest.py script does not
-  # compute the latest version accurately, and the link is not updated too. So we better disable this for now. 
+  # compute the latest version accurately, and the link is not updated too. So we better disable this for now.
   # See https://github.com/endoflife-date/endoflife.date/issues/5775.
   #-   custom: pan-os
   -   release_table: https://www.paloaltonetworks.com/services/support/end-of-life-announcements/end-of-life-summary
@@ -77,7 +77,8 @@ releases:
     latestReleaseDate: 2024-05-22
     link: https://docs.paloaltonetworks.com/pan-os/9-1/pan-os-release-notes/pan-os-9-1-addressed-issues/pan-os-9-1-19-addressed-issues
 
--   releaseCycle: "9.0-XFR (VM-Series only)"
+-   releaseCycle: "9.0-xfr"
+    releaseLabel: "9.0-XFR (VM-Series only)"
     releaseDate: 2019-09-19
     eol: 2020-09-19
     latest: "9.0-XFR (VM-Series only)"


### PR DESCRIPTION
A release label was added so that it renders the same as the current https://endoflife.date/pan-os page.