### PR TITLE
[nokia] Normalize release cycles' name

### DIFF
--- a/products/nokia.md
+++ b/products/nokia.md
@@ -14,332 +14,398 @@ releaseColumn: false
 # * for C line: eol(x) = releaseDate(x) + 2 years
 # * for rest: eol(x) = releaseDate(x) + 3 years
 releases:
--   releaseCycle: "Nokia C210"
+-   releaseCycle: "c210"
+    releaseLabel: "Nokia C210"
     releaseDate: 2023-09-14
     eol: 2025-09-14 # estimated releaseDate(x) + 2 years
     link: https://www.nokia.com/phones/en_us/nokia-c-210
 
--   releaseCycle: "Nokia G310 5G"
+-   releaseCycle: "g310-5g"
+    releaseLabel: "Nokia G310 5G"
     releaseDate: 2023-08-24
     eol: 2026-08-24 # estimated releaseDate(x) + 3 years
     link: https://www.nokia.com/phones/en_us/nokia-g-310
 
--   releaseCycle: "Nokia G42 5G"
+-   releaseCycle: "g42-5g"
+    releaseLabel: "Nokia G42 5G"
     releaseDate: 2023-06-28
     eol: 2026-06-28 # Product page: 3 years of monthly security updates and 2 years of OS upgrades.
     link: https://www.nokia.com/phones/en_int/nokia-g-42
 
--   releaseCycle: "Nokia C300"
+-   releaseCycle: "c300"
+    releaseLabel: "Nokia C300"
     releaseDate: 2023-06-14
     eol: 2025-06-14 # estimated releaseDate(x) + 2 years
     link: https://www.nokia.com/phones/en_us/nokia-c-300
 
--   releaseCycle: "Nokia C110"
+-   releaseCycle: "c110"
+    releaseLabel: "Nokia C110"
     releaseDate: 2023-06-14
     eol: 2025-06-14 # estimated releaseDate(x) + 2 years
     link: https://www.nokia.com/phones/en_us/nokia-c-110
 
--   releaseCycle: "Nokia XR21"
+-   releaseCycle: "xr21"
+    releaseLabel: "Nokia XR21"
     releaseDate: 2023-05-24
     eol: 2027-05-24 # Product page: With 4 years of monthly security updates
     link: https://www.nokia.com/phones/en_int/nokia-xr-21
 
--   releaseCycle: "Nokia C32"
+-   releaseCycle: "c32"
+    releaseLabel: "Nokia C32"
     releaseDate: 2023-02-25
     eol: 2025-02-25
     link: https://www.nokia.com/phones/en_int/nokia-c-32
 
--   releaseCycle: "Nokia G22"
+-   releaseCycle: "g22"
+    releaseLabel: "Nokia G22"
     releaseDate: 2023-02-17
     eol: 2026-04-01
     link: https://www.nokia.com/phones/en_int/nokia-g-22
 
--   releaseCycle: "Nokia T21"
+-   releaseCycle: "t21"
+    releaseLabel: "Nokia T21"
     releaseDate: 2022-09-01
     eol: 2025-09-01 # Product page: 3 years of monthly security updates
     link: https://www.nokia.com/phones/en_int/nokia-t-21
 
--   releaseCycle: "Nokia X30 5G"
+-   releaseCycle: "x30-5g"
+    releaseLabel: "Nokia X30 5G"
     releaseDate: 2022-09-01
     eol: 2026-01-01
     link: https://www.nokia.com/phones/en_int/nokia-x-30
 
--   releaseCycle: "Nokia G60 5G"
+-   releaseCycle: "g60-5g"
+    releaseLabel: "Nokia G60 5G"
     releaseDate: 2022-08-05
     eol: 2025-12-01
     link: https://www.nokia.com/phones/en_int/nokia-g-60
 
--   releaseCycle: "Nokia C21"
+-   releaseCycle: "c21"
+    releaseLabel: "Nokia C21"
     releaseDate: 2022-05-03
     eol: 2024-06-01
     link: https://www.nokia.com/phones/en_int/nokia-c-21
 
--   releaseCycle: "Nokia C21 Plus"
+-   releaseCycle: "c21-plus"
+    releaseLabel: "Nokia C21 Plus"
     releaseDate: 2022-04-29
     eol: 2024-06-01
     link: https://www.nokia.com/phones/en_int/nokia-c-21-plus
 
--   releaseCycle: "Nokia C2 2nd Edition"
+-   releaseCycle: "c2-2nd-edition"
+    releaseLabel: "Nokia C2 2nd Edition"
     releaseDate: 2022-04-19
     eol: 2024-05-01
     link: https://www.nokia.com/phones/en_int/nokia-c-2-2nd-edition
 
--   releaseCycle: "Nokia G11"
+-   releaseCycle: "g11"
+    releaseLabel: "Nokia G11"
     releaseDate: 2022-03-24
     eol: 2025-05-01
     link: https://www.nokia.com/phones/en_int/nokia-g-11
 
--   releaseCycle: "Nokia G21"
+-   releaseCycle: "g21"
+    releaseLabel: "Nokia G21"
     releaseDate: 2022-02-15
     eol: 2025-03-01
     link: https://www.nokia.com/phones/en_int/nokia-g-21
 
--   releaseCycle: "Nokia T20"
+-   releaseCycle: "t20"
+    releaseLabel: "Nokia T20"
     releaseDate: 2021-11-02
     eol: 2024-11-01
     link: https://www.nokia.com/phones/en_int/nokia-t-20
 
--   releaseCycle: "Nokia G50"
+-   releaseCycle: "g50"
+    releaseLabel: "Nokia G50"
     releaseDate: 2021-10-13
     eol: 2024-12-01
     link: https://www.nokia.com/phones/en_int/nokia-g-50
 
--   releaseCycle: "Nokia C30"
+-   releaseCycle: "c30"
+    releaseLabel: "Nokia C30"
     releaseDate: 2021-10-12
     eol: 2023-10-01
     link: https://www.nokia.com/phones/en_int/nokia-c-30
 
--   releaseCycle: "Nokia C1 2nd Edition"
+-   releaseCycle: "c1-2nd-edition"
+    releaseLabel: "Nokia C1 2nd Edition"
     releaseDate: 2021-08-27
     eol: 2023-09-01
     link: https://www.nokia.com/phones/en_int/nokia-c-1-2nd-edition
 
--   releaseCycle: "Nokia XR20"
+-   releaseCycle: "xr20"
+    releaseLabel: "Nokia XR20"
     releaseDate: 2021-08-04
     eol: 2025-11-01
     link: https://www.nokia.com/phones/en_int/nokia-xr-20
 
--   releaseCycle: "Nokia C10"
+-   releaseCycle: "c10"
+    releaseLabel: "Nokia C10"
     releaseDate: 2021-06-29
     eol: 2023-08-01
     link: https://www.nokia.com/phones/en_int/nokia-c-10
 
--   releaseCycle: "Nokia C01 Plus"
+-   releaseCycle: "c01-plus"
+    releaseLabel: "Nokia C01 Plus"
     releaseDate: 2021-06-28
     eol: 2023-08-01
     link: https://www.nokia.com/phones/en_int/nokia-c-01-plus
 
--   releaseCycle: "Nokia C20 Plus"
+-   releaseCycle: "c20-plus"
+    releaseLabel: "Nokia C20 Plus"
     releaseDate: 2021-06-16
     eol: 2023-09-01
     link: https://www.nokia.com/phones/en_in/nokia-c-20-plus
 
--   releaseCycle: "Nokia X10"
+-   releaseCycle: "x10"
+    releaseLabel: "Nokia X10"
     releaseDate: 2021-06-07
     eol: 2024-09-01
     link: https://www.nokia.com/phones/en_int/nokia-x-10
 
--   releaseCycle: "Nokia C20"
+-   releaseCycle: "c20"
+    releaseLabel: "Nokia C20"
     releaseDate: 2021-06-06
     eol: 2023-06-01
     link: https://www.nokia.com/phones/en_int/nokia-c-20
 
--   releaseCycle: "Nokia G20"
+-   releaseCycle: "g20"
+    releaseLabel: "Nokia G20"
     releaseDate: 2021-05-17
     eol: 2024-07-01
     link: https://www.nokia.com/phones/en_int/nokia-g-20
 
--   releaseCycle: "Nokia X20"
+-   releaseCycle: "x20"
+    releaseLabel: "Nokia X20"
     releaseDate: 2021-05-12
     eol: 2024-07-01
     link: https://www.nokia.com/phones/en_int/nokia-x-20
 
--   releaseCycle: "Nokia G10"
+-   releaseCycle: "g10"
+    releaseLabel: "Nokia G10"
     releaseDate: 2021-04-26
     eol: 2024-07-01
     link: https://www.nokia.com/phones/en_int/nokia-g-10
 
--   releaseCycle: "Nokia 1.4"
+-   releaseCycle: "1.4"
+    releaseLabel: "Nokia 1.4"
     releaseDate: 2021-02-03
     eol: 2024-04-01
     link: https://www.nokia.com/phones/en_int/nokia-1-4
 
--   releaseCycle: "Nokia C1 Plus"
+-   releaseCycle: "c1-plus"
+    releaseLabel: "Nokia C1 Plus"
     releaseDate: 2021-01-29
     eol: 2023-01-01
     link: https://www.nokia.com/phones/en_int/nokia-c-1-plus
 
--   releaseCycle: "Nokia 5.4"
+-   releaseCycle: "5.4"
+    releaseLabel: "Nokia 5.4"
     releaseDate: 2020-12-25
     eol: 2024-01-01
     link: https://www.nokia.com/phones/en_int/nokia-5-4
 
--   releaseCycle: "Nokia 3.4"
+-   releaseCycle: "3.4"
+    releaseLabel: "Nokia 3.4"
     releaseDate: 2020-10-26
     eol: 2023-11-01
     link: https://www.nokia.com/phones/en_int/nokia-3-4
 
--   releaseCycle: "Nokia 2.4"
+-   releaseCycle: "2.4"
+    releaseLabel: "Nokia 2.4"
     releaseDate: 2020-09-30
     eol: 2023-10-01
     link: https://www.nokia.com/phones/en_int/nokia-2-4
 
--   releaseCycle: "Nokia 8.3 5G"
+-   releaseCycle: "8.3-5g"
+    releaseLabel: "Nokia 8.3 5G"
     releaseDate: 2020-09-15
     eol: 2023-11-01
     link: https://www.nokia.com/phones/en_us/nokia-8-3-5g
 
--   releaseCycle: "Nokia C3"
+-   releaseCycle: "c3"
+    releaseLabel: "Nokia C3"
     releaseDate: 2020-08-13
     eol: 2022-11-01
     link: https://www.nokia.com/phones/en_int/nokia-c-3
 
--   releaseCycle: "Nokia 1.3"
+-   releaseCycle: "1.3"
+    releaseLabel: "Nokia 1.3"
     releaseDate: 2020-04-02
     eol: 2023-06-01
     link: https://www.nokia.com/phones/en_int/nokia-1-3
 
--   releaseCycle: "Nokia 5.3"
+-   releaseCycle: "5.3"
+    releaseLabel: "Nokia 5.3"
     releaseDate: 2020-04-02
     eol: 2023-06-01
     link: https://www.nokia.com/phones/en_int/nokia-5-3
 
--   releaseCycle: "Nokia C2"
+-   releaseCycle: "c2"
+    releaseLabel: "Nokia C2"
     releaseDate: 2020-03-22
     eol: 2022-02-01
     link: https://www.nokia.com/phones/en_int/nokia-c-2
 
--   releaseCycle: "Nokia 2.3"
+-   releaseCycle: "2.3"
+    releaseLabel: "Nokia 2.3"
     releaseDate: 2019-12-19
     eol: 2022-12-01
     link: https://www.nokia.com/phones/en_int/nokia-2-3
 
--   releaseCycle: "Nokia C1"
+-   releaseCycle: "c1"
+    releaseLabel: "Nokia C1"
     releaseDate: 2019-12-11
     eol: 2021-12-01
     link: https://www.nokia.com/phones/en_int/nokia-c-1
 
--   releaseCycle: "Nokia 6.2"
+-   releaseCycle: "6.2"
+    releaseLabel: "Nokia 6.2"
     releaseDate: 2019-10-17
     eol: 2022-10-01
     link: https://www.nokia.com/phones/en_int/nokia-6-2
 
--   releaseCycle: "Nokia 7.2"
+-   releaseCycle: "7.2"
+    releaseLabel: "Nokia 7.2"
     releaseDate: 2019-09-23
     eol: 2022-09-01
     link: https://www.nokia.com/phones/en_int/nokia-7-2
 
--   releaseCycle: "Nokia 2.2"
+-   releaseCycle: "2.2"
+    releaseLabel: "Nokia 2.2"
     releaseDate: 2019-06-11
     eol: 2022-05-01
     link: https://www.nokia.com/phones/en_int/nokia-2-2
 
--   releaseCycle: "Nokia 3.2"
+-   releaseCycle: "3.2"
+    releaseLabel: "Nokia 3.2"
     releaseDate: 2019-05-22
     eol: 2022-04-01
     link: https://www.nokia.com/phones/en_int/nokia-3-2
 
--   releaseCycle: "Nokia 4.2"
+-   releaseCycle: "4.2"
+    releaseLabel: "Nokia 4.2"
     releaseDate: 2019-05-07
     eol: 2022-04-01
     link: https://www.nokia.com/phones/en_int/nokia-4-2
 
--   releaseCycle: "Nokia X71"
+-   releaseCycle: "x71"
+    releaseLabel: "Nokia X71"
     releaseDate: 2019-04-17
     eol: 2019-05-01
     link: https://www.nokia.com/phones/zh_tw/nokia-x71
 
--   releaseCycle: "Nokia 9 Pureview"
+-   releaseCycle: "9-pureview"
+    releaseLabel: "Nokia 9 Pureview"
     releaseDate: 2019-03-13
     eol: 2022-03-01
     link: https://www.nokia.com/phones/en_int/nokia-9-pureview
 
--   releaseCycle: "Nokia 1 Plus"
+-   releaseCycle: "1-plus"
+    releaseLabel: "Nokia 1 Plus"
     releaseDate: 2019-02-24
     eol: 2022-02-01
     link: https://www.nokia.com/phones/en_int/nokia-1-plus
 
--   releaseCycle: "Nokia 5.1 Plus"
+-   releaseCycle: "5.1-plus"
+    releaseLabel: "Nokia 5.1 Plus"
     releaseDate: 2018-12-05
     eol: 2021-10-01
     link: https://www.nokia.com/phones/en_int/nokia-5-plus
 
--   releaseCycle: "Nokia 8.1"
+-   releaseCycle: "8.1"
+    releaseLabel: "Nokia 8.1"
     releaseDate: 2018-12-05
     eol: 2021-12-01
     link: https://www.nokia.com/phones/en_int/nokia-8-1
 
--   releaseCycle: "Nokia 7.1"
+-   releaseCycle: "7.1"
+    releaseLabel: "Nokia 7.1"
     releaseDate: 2018-10-28
     eol: 2021-11-01
     link: https://www.nokia.com/phones/en_int/nokia-7-1
 
--   releaseCycle: "Nokia 6.1 Plus"
+-   releaseCycle: "6.1-plus"
+    releaseLabel: "Nokia 6.1 Plus"
     releaseDate: 2018-08-21
     eol: 2021-08-01
     link: https://www.nokia.com/phones/en_int/nokia-6-plus
 
--   releaseCycle: "Nokia 2.1"
+-   releaseCycle: "2.1"
+    releaseLabel: "Nokia 2.1"
     releaseDate: 2018-08-01
     eol: 2021-08-01
     link: https://www.nokia.com/phones/en_int/nokia-2-1
 
--   releaseCycle: "Nokia 5.1"
+-   releaseCycle: "5.1"
+    releaseLabel: "Nokia 5.1"
     releaseDate: 2018-08-01
     eol: 2021-08-01
     link: https://www.nokia.com/phones/en_int/nokia-5-1
 
--   releaseCycle: "Nokia 6.1"
+-   releaseCycle: "6.1"
+    releaseLabel: "Nokia 6.1"
     releaseDate: 2018-05-06
     eol: 2021-04-01
     link: https://www.nokia.com/phones/en_int/nokia-6-1
 
--   releaseCycle: "Nokia 3.1"
+-   releaseCycle: "3.1"
+    releaseLabel: "Nokia 3.1"
     releaseDate: 2018-05-01
     eol: 2021-07-01
     link: https://www.nokia.com/phones/en_int/nokia-3-1
 
--   releaseCycle: "Nokia 7 Plus"
+-   releaseCycle: "7-plus"
+    releaseLabel: "Nokia 7 Plus"
     releaseDate: 2018-04-30
     eol: 2021-04-01
     link: https://www.nokia.com/phones/en_int/nokia-7-plus
 
--   releaseCycle: "Nokia 8 Sirocco"
+-   releaseCycle: "8-sirocco"
+    releaseLabel: "Nokia 8 Sirocco"
     releaseDate: 2018-04-23
     eol: 2021-05-01
     link: https://www.nokia.com/phones/en_int/nokia-8-sirocco
 
--   releaseCycle: "Nokia 1"
+-   releaseCycle: "1"
+    releaseLabel: "Nokia 1"
     releaseDate: 2018-04-01
     eol: 2021-04-01
     link: https://www.nokia.com/phones/en_int/nokia-1-0
 
--   releaseCycle: "Nokia 3.1 Plus"
+-   releaseCycle: "3.1-plus"
+    releaseLabel: "Nokia 3.1 Plus"
     releaseDate: 2018-04-01
     eol: 2021-10-01
     link: https://www.nokia.com/phones/en_int/nokia-3-plus
 
--   releaseCycle: "Nokia 2"
+-   releaseCycle: "2"
+    releaseLabel: "Nokia 2"
     releaseDate: 2017-11-01
     eol: 2019-11-01
     link: https://www.nokia.com/phones/en_int/nokia-2-0
 
--   releaseCycle: "Nokia 8"
+-   releaseCycle: "8"
+    releaseLabel: "Nokia 8"
     releaseDate: 2017-09-07
     eol: 2020-10-01
     link: https://www.nokia.com/phones/en_int/nokia-8-0
 
--   releaseCycle: "Nokia 5"
+-   releaseCycle: "5"
+    releaseLabel: "Nokia 5"
     releaseDate: 2017-07-17
     eol: 2020-10-01
     link: https://www.nokia.com/phones/en_int/nokia-5-0
 
--   releaseCycle: "Nokia 3"
+-   releaseCycle: "3"
+    releaseLabel: "Nokia 3"
     releaseDate: 2017-06-17
     eol: 2020-09-01
     link: https://www.nokia.com/phones/en_int/nokia-3-0
 
--   releaseCycle: "Nokia 6"
+-   releaseCycle: "6"
+    releaseLabel: "Nokia 6"
     releaseDate: 2017-01-19
     eol: 2020-10-01
     link: https://www.hmd.com/en_int/support/nokia-6-user-guide/


### PR DESCRIPTION
Release labels were added so that it renders the same as the current https://endoflife.date/nokia page.