### PR TITLE
[nvidia-driver] Normalize release cycles' name

### DIFF
--- a/products/nvidia-driver.md
+++ b/products/nvidia-driver.md
@@ -21,15 +21,17 @@ eoasColumn: true
 # - releaseDate(x) + 1 year for NFB and PB releases
 # - releaseDate(x) + 3 years for LTS releases
 releases:
--   releaseCycle: "R570-Linux (PB)"
+-   releaseCycle: "r570-linux"
+    releaseLabel: "R570-Linux (PB)"
     releaseDate: 2025-01-27
     eoas: false # projected: 2026-01-27
     eol: false # projected: 2026-01-27
     latest: "570.133.20"
     latestReleaseDate: 2025-04-17
     link: https://docs.nvidia.com/datacenter/tesla/tesla-release-notes-570-133-20/
-          
--   releaseCycle: "R570-Windows (PB)"
+
+-   releaseCycle: "r570-windows"
+    releaseLabel: "R570-Windows (PB)"
     releaseDate: 2025-01-27
     eoas: false # projected: 2026-01-27
     eol: false # projected: 2026-01-27
@@ -37,7 +39,8 @@ releases:
     latestReleaseDate: 2025-04-17
     link: https://docs.nvidia.com/datacenter/tesla/tesla-release-notes-570-133-20/
 
--   releaseCycle: "R565-Linux (PB)"
+-   releaseCycle: "r565-linux"
+    releaseLabel: "R565-Linux (PB)"
     releaseDate: 2024-10-29
     eoas: 2025-10-01
     eol: 2025-10-01
@@ -45,7 +48,8 @@ releases:
     latestReleaseDate: 2024-10-29
     link: https://docs.nvidia.com/datacenter/tesla/tesla-release-notes-565-57-01/
 
--   releaseCycle: "R565-Windows (PB)"
+-   releaseCycle: "r565-windows"
+    releaseLabel: "R565-Windows (PB)"
     releaseDate: 2024-10-22
     eoas: 2025-10-01
     eol: 2025-10-01
@@ -53,7 +57,8 @@ releases:
     latestReleaseDate: 2024-10-22
     link: https://docs.nvidia.com/datacenter/tesla/tesla-release-notes-565-57-01/
 
--   releaseCycle: "R560-Linux (PB)"
+-   releaseCycle: "r560-linux"
+    releaseLabel: "R560-Linux (PB)"
     releaseDate: 2024-08-22
     eoas: true
     eol: 2025-08-01
@@ -61,7 +66,8 @@ releases:
     latestReleaseDate: 2024-08-21
     link: https://www.nvidia.com/Download/driverResults.aspx/230918/
 
--   releaseCycle: "R560-Windows (PB)"
+-   releaseCycle: "r560-windows"
+    releaseLabel: "R560-Windows (PB)"
     releaseDate: 2024-07-30
     eoas: true
     eol: 2025-07-01
@@ -69,7 +75,8 @@ releases:
     latestReleaseDate: 2024-07-30
     link: https://www.nvidia.com/Download/driverResults.aspx/230555/
 
--   releaseCycle: "R555-Linux (NFB)"
+-   releaseCycle: "r555-linux"
+    releaseLabel: "R555-Linux (NFB)"
     releaseDate: 2024-06-04
     eoas: true
     eol: 2025-06-01
@@ -77,7 +84,8 @@ releases:
     latestReleaseDate: 2024-07-01
     link: https://www.nvidia.com/Download/driverResults.aspx/228410/
 
--   releaseCycle: "R555-Windows (NFB)"
+-   releaseCycle: "r555-windows"
+    releaseLabel: "R555-Windows (NFB)"
     releaseDate: 2024-06-04
     eoas: true
     eol: 2025-06-01
@@ -85,7 +93,8 @@ releases:
     latestReleaseDate: 2024-06-04
     link: https://www.nvidia.com/download/driverResults.aspx/228179/
 
--   releaseCycle: "R550-Linux (PB)"
+-   releaseCycle: "r550-linux"
+    releaseLabel: "R550-Linux (PB)"
     releaseDate: 2024-02-23
     eoas: 2025-02-01
     eol: 2025-04-17
@@ -93,7 +102,8 @@ releases:
     latestReleaseDate: 2025-04-17
     link: https://docs.nvidia.com/datacenter/tesla/tesla-release-notes-550-163-01/
 
--   releaseCycle: "R550-Windows (PB)"
+-   releaseCycle: "r550-windows"
+    releaseLabel: "R550-Windows (PB)"
     releaseDate: 2024-02-22
     eoas: 2025-02-01
     eol: 2025-04-17
@@ -101,7 +111,8 @@ releases:
     latestReleaseDate: 2025-04-17
     link: https://docs.nvidia.com/datacenter/tesla/tesla-release-notes-550-163-01/
 
--   releaseCycle: "R545-Linux (NFB)"
+-   releaseCycle: "r545-linux"
+    releaseLabel: "R545-Linux (NFB)"
     releaseDate: 2023-10-31
     eoas: true
     eol: 2024-10-01
@@ -109,7 +120,8 @@ releases:
     latestReleaseDate: 2023-11-22
     link: https://www.nvidia.com/download/driverResults.aspx/216530/
 
--   releaseCycle: "R545-Windows (NFB)"
+-   releaseCycle: "r545-windows"
+    releaseLabel: "R545-Windows (NFB)"
     releaseDate: 2023-10-17
     eoas: true
     eol: 2024-10-01
@@ -117,7 +129,8 @@ releases:
     latestReleaseDate: 2023-10-31
     link: https://www.nvidia.com/Download/driverResults.aspx/216365/
 
--   releaseCycle: "R535-Linux"
+-   releaseCycle: "r535-linux"
+    releaseLabel: "R535-Linux"
     lts: true
     releaseDate: 2023-06-14
     eoas: 2024-06-01
@@ -126,7 +139,8 @@ releases:
     latestReleaseDate: 2025-04-17
     link: https://docs.nvidia.com/datacenter/tesla/tesla-release-notes-535-247-01/
 
--   releaseCycle: "R535-Windows"
+-   releaseCycle: "r535-windows"
+    releaseLabel: "R535-Windows"
     lts: true
     releaseDate: 2023-05-30
     eoas: 2024-06-01
@@ -135,7 +149,8 @@ releases:
     latestReleaseDate: 2025-04-17
     link: https://docs.nvidia.com/datacenter/tesla/tesla-release-notes-535-247-01/
 
--   releaseCycle: "R530-Linux (NFB)"
+-   releaseCycle: "r530-linux"
+    releaseLabel: "R530-Linux (NFB)"
     releaseDate: 2023-03-23
     eoas: true
     eol: 2023-06-24
@@ -143,7 +158,8 @@ releases:
     latestReleaseDate: 2023-03-23
     link: https://www.nvidia.com/Download/driverResults.aspx/200481/
 
--   releaseCycle: "R530-Windows (NFB)"
+-   releaseCycle: "r530-windows"
+    releaseLabel: "R530-Windows (NFB)"
     releaseDate: 2023-02-28
     eoas: true
     eol: 2023-06-24
@@ -151,7 +167,8 @@ releases:
     latestReleaseDate: 2023-05-02
     link: https://www.nvidia.com/Download/driverResults.aspx/204772/
 
--   releaseCycle: "R525-Windows (PB)"
+-   releaseCycle: "r525-windows"
+    releaseLabel: "R525-Windows (PB)"
     releaseDate: 2022-11-10
     eoas: 2023-12-01
     eol: 2023-12-01
@@ -159,7 +176,8 @@ releases:
     latestReleaseDate: 2023-10-31
     link: https://docs.nvidia.com/datacenter/tesla/tesla-release-notes-525-147-05/
 
--   releaseCycle: "R525-Linux (PB)"
+-   releaseCycle: "r525-linux"
+    releaseLabel: "R525-Linux (PB)"
     releaseDate: 2022-11-10
     eoas: 2023-12-01
     eol: 2023-12-01
@@ -167,7 +185,8 @@ releases:
     latestReleaseDate: 2023-10-31
     link: https://docs.nvidia.com/datacenter/tesla/tesla-release-notes-525-147-05/
 
--   releaseCycle: "R520-Linux (NFB)"
+-   releaseCycle: "r520-linux"
+    releaseLabel: "R520-Linux (NFB)"
     releaseDate: 2022-10-12
     eoas: true
     eol: 2023-10-01
@@ -175,7 +194,8 @@ releases:
     latestReleaseDate: 2022-10-12
     link: https://www.nvidia.com/download/driverResults.aspx/193764/
 
--   releaseCycle: "R515-Windows (PB)"
+-   releaseCycle: "r515-windows"
+    releaseLabel: "R515-Windows (PB)"
     releaseDate: 2022-05-11
     eoas: 2023-05-01
     eol: 2023-05-01
@@ -183,7 +203,8 @@ releases:
     latestReleaseDate: 2023-03-30
     link: https://docs.nvidia.com/datacenter/tesla/tesla-release-notes-515-105-01/
 
--   releaseCycle: "R515-Linux (PB)"
+-   releaseCycle: "r515-linux"
+    releaseLabel: "R515-Linux (PB)"
     releaseDate: 2022-05-11
     eoas: 2023-05-01
     eol: 2023-05-01
@@ -191,7 +212,8 @@ releases:
     latestReleaseDate: 2023-03-30
     link: https://www.nvidia.com/download/driverResults.aspx/202059/
 
--   releaseCycle: "R510-Windows (PB)"
+-   releaseCycle: "r510-windows"
+    releaseLabel: "R510-Windows (PB)"
     releaseDate: 2022-01-14
     eoas: 2023-01-01
     eol: 2023-01-01
@@ -199,7 +221,8 @@ releases:
     latestReleaseDate: 2022-12-20
     link: https://www.nvidia.com/download/driverResults.aspx/197675/
 
--   releaseCycle: "R510-Linux (PB)"
+-   releaseCycle: "r510-linux"
+    releaseLabel: "R510-Linux (PB)"
     releaseDate: 2022-01-14
     eoas: 2023-01-01
     eol: 2023-01-01
@@ -207,7 +230,8 @@ releases:
     latestReleaseDate: 2022-11-22
     link: https://www.nvidia.com/download/driverResults.aspx/194569/
 
--   releaseCycle: "R495-Linux (NFB)"
+-   releaseCycle: "r495-linux"
+    releaseLabel: "R495-Linux (NFB)"
     releaseDate: 2021-10-26
     eoas: true
     eol: 2022-10-12
@@ -215,7 +239,8 @@ releases:
     latestReleaseDate: 2021-12-13
     link: https://www.nvidia.com/Download/driverResults.aspx/184248/
 
--   releaseCycle: "R495-Windows (NFB)"
+-   releaseCycle: "r495-windows"
+    releaseLabel: "R495-Windows (NFB)"
     releaseDate: 2021-10-12
     eoas: true
     eol: 2022-01-14
@@ -223,7 +248,8 @@ releases:
     latestReleaseDate: 2021-12-20
     link: https://www.nvidia.com/Download/driverResults.aspx/184717/
 
--   releaseCycle: "R470-Linux"
+-   releaseCycle: "r470-linux"
+    releaseLabel: "R470-Linux"
     lts: true
     releaseDate: 2021-07-19
     eoas: 2021-10-26
@@ -232,7 +258,8 @@ releases:
     latestReleaseDate: 2024-06-04
     link: https://docs.nvidia.com/datacenter/tesla/tesla-release-notes-470-256-02/
 
--   releaseCycle: "R470-Windows"
+-   releaseCycle: "r470-windows"
+    releaseLabel: "R470-Windows"
     lts: true
     releaseDate: 2021-06-22
     eoas: 2021-09-20
@@ -241,7 +268,8 @@ releases:
     latestReleaseDate: 2024-07-09
     link: https://docs.nvidia.com/datacenter/tesla/tesla-release-notes-475-14/
 
--   releaseCycle: "R460-Linux (PB)"
+-   releaseCycle: "r460-linux"
+    releaseLabel: "R460-Linux (PB)"
     releaseDate: 2021-01-07
     eoas: 2021-07-19
     eol: 2022-01-01
@@ -249,7 +277,8 @@ releases:
     latestReleaseDate: 2021-10-26
     link: https://docs.nvidia.com/datacenter/tesla/tesla-release-notes-460-106-00/
 
--   releaseCycle: "R460-Windows (PB)"
+-   releaseCycle: "r460-windows"
+    releaseLabel: "R460-Windows (PB)"
     releaseDate: 2020-12-15
     eoas: 2021-06-23
     eol: 2022-01-01
@@ -257,7 +286,8 @@ releases:
     latestReleaseDate: 2021-10-26
     link: https://docs.nvidia.com/datacenter/tesla/tesla-release-notes-460-106-00/
 
--   releaseCycle: "R450-Windows"
+-   releaseCycle: "r450-windows"
+    releaseLabel: "R450-Windows"
     lts: true
     releaseDate: 2020-06-24
     eoas: 2020-12-15
@@ -266,7 +296,8 @@ releases:
     latestReleaseDate: 2023-06-26
     link: https://docs.nvidia.com/datacenter/tesla/tesla-release-notes-450-248-02/
 
--   releaseCycle: "R450-Linux"
+-   releaseCycle: "r450-linux"
+    releaseLabel: "R450-Linux"
     lts: true
     releaseDate: 2020-06-24
     eoas: 2020-10-07
@@ -275,7 +306,8 @@ releases:
     latestReleaseDate: 2023-06-26
     link: https://docs.nvidia.com/datacenter/tesla/tesla-release-notes-450-248-02/
 
--   releaseCycle: "R418-Windows"
+-   releaseCycle: "r418-windows"
+    releaseLabel: "R418-Windows"
     lts: true
     releaseDate: 2019-02-04
     eoas: 2019-04-23
@@ -284,7 +316,8 @@ releases:
     latestReleaseDate: 2021-04-20
     link: https://docs.nvidia.com/datacenter/tesla/tesla-release-notes-418-19702/
 
--   releaseCycle: "R418-Linux"
+-   releaseCycle: "r418-linux"
+    releaseLabel: "R418-Linux"
     lts: true
     releaseDate: 2019-01-30
     eoas: 2019-03-20
@@ -293,7 +326,8 @@ releases:
     latestReleaseDate: 2021-04-19
     link: https://docs.nvidia.com/datacenter/tesla/tesla-release-notes-418-19702/
 
--   releaseCycle: "R390-Windows"
+-   releaseCycle: "r390-windows"
+    releaseLabel: "R390-Windows"
     lts: true
     releaseDate: 2018-01-08
     eoas: 2018-07-31
@@ -302,7 +336,8 @@ releases:
     latestReleaseDate: 2021-10-26
     link: https://www.nvidia.com/download/driverResults.aspx/181267/
 
--   releaseCycle: "R390-Linux"
+-   releaseCycle: "r390-linux"
+    releaseLabel: "R390-Linux"
     lts: true
     releaseDate: 2018-01-04
     eoas: 2018-03-10


### PR DESCRIPTION
Release labels were added so that it renders the same as the current https://endoflife.date/nvidia-driver page.