### PR TITLE
[samsungmobile] Normalize release cycles' name

### DIFF
--- a/products/samsungmobile.md
+++ b/products/samsungmobile.md
@@ -18,2648 +18,3088 @@ eolColumn: Security Updates
 # 2. search on Google with the query : "<model_number> site:doc.samsungmobile.com",
 # 3. choose a page (preferably in english).
 releases:
-
--   releaseCycle: "Galaxy S25 Ultra"
+-   releaseCycle: "galaxy-s25-ultra"
+    releaseLabel: "Galaxy S25 Ultra"
     releaseDate: 2025-02-03
     eoas: 2032-02-03 # "seven generations of OS upgrades" (https://news.samsung.com/global/samsung-galaxy-s25-series-sets-the-standard-of-ai-phone-as-a-true-ai-companion)
     eol: 2032-02-03 # "seven years of security updates"
     link: https://doc.samsungmobile.com/SM-S938B/INS/doc.html
 
--   releaseCycle: "Galaxy S25+"
+-   releaseCycle: "galaxy-s25-plus"
+    releaseLabel: "Galaxy S25+"
     releaseDate: 2025-02-03
     eoas: 2032-02-03 # "seven generations of OS upgrades" (https://news.samsung.com/global/samsung-galaxy-s25-series-sets-the-standard-of-ai-phone-as-a-true-ai-companion)
     eol: 2032-02-03 # "seven years of security updates"
     link: https://doc.samsungmobile.com/SM-S936B/INS/doc.html
 
--   releaseCycle: "Galaxy S25"
+-   releaseCycle: "galaxy-s25"
+    releaseLabel: "Galaxy S25"
     releaseDate: 2025-02-03
     eoas: 2032-02-03 # "seven generations of OS upgrades" (https://news.samsung.com/global/samsung-galaxy-s25-series-sets-the-standard-of-ai-phone-as-a-true-ai-companion)
     eol: 2032-02-03 # "seven years of security updates"
     link: https://doc.samsungmobile.com/SM-S931B/INS/doc.html
 
--   releaseCycle: "Galaxy A16"
+-   releaseCycle: "galaxy-a16"
+    releaseLabel: "Galaxy A16"
     releaseDate: 2024-11-20
     eoas: 2030-11-20 # "6 generations of OS updates" (https://news.samsung.com/uk/samsung-introduces-the-galaxy-a16-series-featuring-two-new-devices)
     eol: 2030-11-20 # "6 years of security updates"
     link: https://doc.samsungmobile.com/SM-A165F/XFA/doc.html
 
--   releaseCycle: "Galaxy A16 5G"
+-   releaseCycle: "galaxy-a16-5g"
+    releaseLabel: "Galaxy A16 5G"
     releaseDate: 2024-10-25
     eoas: 2030-10-25 # "6 generations of OS updates" (https://news.samsung.com/uk/samsung-introduces-the-galaxy-a16-series-featuring-two-new-devices)
     eol: 2030-10-25 # "6 years of security updates"
     link: https://doc.samsungmobile.com/SM-A166B/EUX/doc.html
 
--   releaseCycle: "Galaxy S24 FE"
+-   releaseCycle: "galaxy-s24-fe"
+    releaseLabel: "Galaxy S24 FE"
     releaseDate: 2024-09-26
     eoas: 2031-09-26 # "seven generations of OS upgrades" (https://news.samsung.com/us/galaxy-s24-series-expands-with-s24-fe-a-premium-experience-that-makes-full-galaxy-ai-capabilities-attainable-for-more-users/)
     eol: 2031-09-26 # "seven years of security updates"
     link: https://doc.samsungmobile.com/sm-s721u/tmb/doc.html
 
--   releaseCycle: "Galaxy A55 5G"
+-   releaseCycle: "galaxy-a55-5g"
+    releaseLabel: "Galaxy A55 5G"
     releaseDate: 2024-03-11
     eoas: 2028-03-11 # "four generations of OS upgrades" (https://news.samsung.com/uk/galaxy-a55-5g-and-galaxy-a35-5g-awesome-innovations-and-security-engineered-for-everyone)
     eol: 2029-03-11 # "five years of security updates"
     link: https://doc.samsungmobile.com/sm-a556e/ins/doc.html
 
--   releaseCycle: "Galaxy A35 5G"
+-   releaseCycle: "galaxy-a35-5g"
+    releaseLabel: "Galaxy A35 5G"
     releaseDate: 2024-03-11
     eoas: 2028-03-11 # "four generations of OS upgrades" (https://news.samsung.com/uk/galaxy-a55-5g-and-galaxy-a35-5g-awesome-innovations-and-security-engineered-for-everyone)
     eol: 2029-03-11 # "five years of security updates"
     link: https://doc.samsungmobile.com/SM-A356E/NPB/doc.html
 
--   releaseCycle: "Galaxy S24 Ultra"
+-   releaseCycle: "galaxy-s24-ultra"
+    releaseLabel: "Galaxy S24 Ultra"
     releaseDate: 2024-01-24
     eoas: 2031-01-24 # "seven generations of OS upgrades" (https://news.samsung.com/global/enter-the-new-era-of-mobile-ai-with-samsung-galaxy-s24-series)
     eol: 2031-01-24 # "seven years of security updates"
     link: https://doc.samsungmobile.com/SM-S928U1/XAA/doc.html
 
--   releaseCycle: "Galaxy S24+"
+-   releaseCycle: "galaxy-s24-plus"
+    releaseLabel: "Galaxy S24+"
     releaseDate: 2024-01-24
     eoas: 2031-01-24 # "seven generations of OS upgrades" (https://news.samsung.com/global/enter-the-new-era-of-mobile-ai-with-samsung-galaxy-s24-series)
     eol: 2031-01-24 # "seven years of security updates"
     link: https://doc.samsungmobile.com/SM-S926U1/XAA/doc.html
 
--   releaseCycle: "Galaxy S24"
+-   releaseCycle: "galaxy-s24"
+    releaseLabel: "Galaxy S24"
     releaseDate: 2024-01-24
     eoas: 2031-01-24 # "seven generations of OS upgrades" (https://news.samsung.com/global/enter-the-new-era-of-mobile-ai-with-samsung-galaxy-s24-series)
     eol: 2031-01-24 # "seven years of security updates"
     link: https://doc.samsungmobile.com/SM-S921U1/XAA/doc.html
 
--   releaseCycle: "Galaxy XCover7"
+-   releaseCycle: "galaxy-xcover7"
+    releaseLabel: "Galaxy XCover7"
     releaseDate: 2024-01-10
     eoas: 2030-01-10 #  "ANDROID 21 supported"
     eol: 2031-01-01  # "ANDROID 21 supported"
     link: https://doc.samsungmobile.com/sm-g556b/eux/doc.html
-    
--   releaseCycle: "Galaxy A25 5G"
+
+-   releaseCycle: "galaxy-a25-5g"
+    releaseLabel: "Galaxy A25 5G"
     releaseDate: 2023-12-11
     eoas: 2027-12-11 # "4 generations of OS upgrades" (https://news.samsung.com/in/samsung-galaxy-a25-5g-galaxy-a15-5g-with-awesome-camera-and-new-editing-features-launched-in-india)
     eol: 2028-12-11 # "5 years of security updates"
     link: https://doc.samsungmobile.com/SM-A256E/CHT/doc.html
 
--   releaseCycle: "Galaxy A15 5G"
+-   releaseCycle: "galaxy-a15-5g"
+    releaseLabel: "Galaxy A15 5G"
     releaseDate: 2023-12-11
     eoas: 2027-12-11 # "4 generations of OS upgrades" (https://news.samsung.com/in/samsung-galaxy-a25-5g-galaxy-a15-5g-with-awesome-camera-and-new-editing-features-launched-in-india)
     eol: 2028-12-11 # "5 years of security updates"
     link: https://doc.samsungmobile.com/SM-A156B/EUX/doc.html
 
--   releaseCycle: "Galaxy A15"
+-   releaseCycle: "galaxy-a15"
+    releaseLabel: "Galaxy A15"
     releaseDate: 2023-12-11
     eoas: 2027-12-11 # "4 generations of OS upgrades" (https://news.samsung.com/in/samsung-galaxy-a25-5g-galaxy-a15-5g-with-awesome-camera-and-new-editing-features-launched-in-india)
     eol: 2028-12-11 # "5 years of security updates"
     link: https://doc.samsungmobile.com/SM-A155F/EUX/doc.html
 
--   releaseCycle: "Galaxy Tab S9 FE"
+-   releaseCycle: "galaxy-tab-s9-fe"
+    releaseLabel: "Galaxy Tab S9 FE"
     releaseDate: 2023-10-16
     eoas: false
     eol: false
     link: https://doc.samsungmobile.com/SM-X510/ZTO/doc.html
 
--   releaseCycle: "Galaxy Tab S9 FE+"
+-   releaseCycle: "galaxy-tab-s9-fe-plus"
+    releaseLabel: "Galaxy Tab S9 FE+"
     releaseDate: 2023-10-16
     eoas: false
     eol: false
     link: https://doc.samsungmobile.com/SM-X610/ZTO/doc.html
 
--   releaseCycle: "Galaxy S23 FE"
+-   releaseCycle: "galaxy-s23-fe"
+    releaseLabel: "Galaxy S23 FE"
     releaseDate: 2023-10-05
     eoas: false
     eol: 2028-10-05 # "five years of security updates" (https://security.samsungmobile.com/securityPost.smsb)
     link: https://doc.samsungmobile.com/SM-S711B/INS/doc.html
 
--   releaseCycle: "Galaxy Tab S9"
+-   releaseCycle: "galaxy-tab-s9"
+    releaseLabel: "Galaxy Tab S9"
     releaseDate: 2023-08-11
     eoas: false
     eol: false
     link: https://doc.samsungmobile.com/sm-x710/eux/doc.html
 
--   releaseCycle: "Galaxy Tab S9+ 5G"
+-   releaseCycle: "galaxy-tab-s9-plus-5g"
+    releaseLabel: "Galaxy Tab S9+ 5G"
     releaseDate: 2023-08-11
     eoas: false
     eol: false
     link: https://doc.samsungmobile.com/SM-X816B/INS/doc.html
 
--   releaseCycle: "Galaxy Tab S9 Ultra"
+-   releaseCycle: "galaxy-tab-s9-ultra"
+    releaseLabel: "Galaxy Tab S9 Ultra"
     releaseDate: 2023-08-11
     eoas: false
     eol: false
     link: https://doc.samsungmobile.com/SM-X910/XJP/doc.html
 
--   releaseCycle: "Galaxy A24"
+-   releaseCycle: "galaxy-a24"
+    releaseLabel: "Galaxy A24"
     releaseDate: 2023-05-05
     eoas: false # "four generations of OS upgrades"
     eol: 2028-05-05 #five years of security updates" (https://news.samsung.com/my/your-galaxy-a24-is-worth-more-in-resale-or-trade-in-value-heres-why)
     link: https://doc.samsungmobile.com/sm-a245f/pak/doc.html
 
--   releaseCycle: "Galaxy A54 5G"
+-   releaseCycle: "galaxy-a54-5g"
+    releaseLabel: "Galaxy A54 5G"
     releaseDate: 2023-03-24
     eoas: false # "four generations of OS upgrades"
     eol: 2028-03-24 # "five years of security updates" (https://news.samsung.com/global/the-samsung-galaxy-a54-5g-and-galaxy-a34-5g-awesome-experiences-for-all)
     link: https://doc.samsungmobile.com/SM-A546U/TMB/doc.html
 
--   releaseCycle: "Galaxy A34 5G"
+-   releaseCycle: "galaxy-a34-5g"
+    releaseLabel: "Galaxy A34 5G"
     releaseDate: 2023-03-24
     eoas: false # "four generations of OS upgrades"
     eol: 2028-03-24 # "five years of security updates" (https://news.samsung.com/global/the-samsung-galaxy-a54-5g-and-galaxy-a34-5g-awesome-experiences-for-all)
     link: https://doc.samsungmobile.com/SM-A346E/INS/doc.html
 
--   releaseCycle: "Galaxy S23 Ultra"
+-   releaseCycle: "galaxy-s23-ultra"
+    releaseLabel: "Galaxy S23 Ultra"
     releaseDate: 2023-02-17
     eoas: false
     eol: 2028-02-17 # "five years of security updates" (https://security.samsungmobile.com/securityPost.smsb)
     link: https://doc.samsungmobile.com/SM-S918B/EUX/doc.html
 
--   releaseCycle: "Galaxy S23+"
+-   releaseCycle: "galaxy-s23-plus"
+    releaseLabel: "Galaxy S23+"
     releaseDate: 2023-02-17
     eoas: false
     eol: 2028-02-17 # "five years of security updates" (https://security.samsungmobile.com/securityPost.smsb)
     link: https://doc.samsungmobile.com/SM-S916B/EUX/doc.html
 
--   releaseCycle: "Galaxy S23"
+-   releaseCycle: "galaxy-s23"
+    releaseLabel: "Galaxy S23"
     releaseDate: 2023-02-17
     eoas: false
     eol: 2028-02-17 # "five years of security updates" (https://security.samsungmobile.com/securityPost.smsb)
     link: https://doc.samsungmobile.com/SM-S911B/EUX/doc.html
 
--   releaseCycle: "Galaxy A14 5G"
+-   releaseCycle: "galaxy-a14-5g"
+    releaseLabel: "Galaxy A14 5G"
     releaseDate: 2023-01-12
     eoas: false
     eol: false
     link: https://doc.samsungmobile.com/SM-A146B/INS/doc.html
 
--   releaseCycle: "Galaxy F04"
+-   releaseCycle: "galaxy-f04"
+    releaseLabel: "Galaxy F04"
     releaseDate: 2023-01-12
     eoas: false
     eol: false
     link: null
 
--   releaseCycle: "Galaxy M04"
+-   releaseCycle: "galaxy-m04"
+    releaseLabel: "Galaxy M04"
     releaseDate: 2022-12-16
     eoas: false
     eol: false
     link: https://doc.samsungmobile.com/SM-M045F/INS/doc.html
 
--   releaseCycle: "Galaxy Tab A7 10.4 (2022)"
+-   releaseCycle: "galaxy-tab-a7-10.4-2022"
+    releaseLabel: "Galaxy Tab A7 10.4 (2022)"
     releaseDate: 2022-11-21
     eoas: false
     eol: false
     link: https://doc.samsungmobile.com/SM-T509/ITV/doc.html
 
--   releaseCycle: "Galaxy A04e"
+-   releaseCycle: "galaxy-a04e"
+    releaseLabel: "Galaxy A04e"
     releaseDate: 2022-11-07
     eoas: false
     eol: false
     link: https://doc.samsungmobile.com/SM-A042F/XXV/doc.html
 
--   releaseCycle: "Galaxy A04"
+-   releaseCycle: "galaxy-a04"
+    releaseLabel: "Galaxy A04"
     releaseDate: 2022-10-10
     eoas: false
     eol: false
     link: https://doc.samsungmobile.com/SM-A045F/XXV/doc.html
 
--   releaseCycle: "Galaxy A04s"
+-   releaseCycle: "galaxy-a04s"
+    releaseLabel: "Galaxy A04s"
     releaseDate: 2022-09-22
     eoas: false
     eol: false
     link: https://doc.samsungmobile.com/SM-A047F/XXV/doc.html
 
--   releaseCycle: "Galaxy Tab Active4 Pro"
+-   releaseCycle: "galaxy-tab-active4-pro"
+    releaseLabel: "Galaxy Tab Active4 Pro"
     releaseDate: 2022-09-13
     eoas: false
     eol: false
     link: https://doc.samsungmobile.com/SM-T636B/XSA/doc.html
 
--   releaseCycle: "Galaxy A23 5G"
+-   releaseCycle: "galaxy-a23-5g"
+    releaseLabel: "Galaxy A23 5G"
     releaseDate: 2022-09-02
     eoas: false
     eol: false
     link: https://doc.samsungmobile.com/SM-A236U/DSA/doc.html
 
--   releaseCycle: "Galaxy Watch5 Pro"
+-   releaseCycle: "galaxy-watch5-pro"
+    releaseLabel: "Galaxy Watch5 Pro"
     releaseDate: 2022-08-26
     eoas: false
     eol: false
     link: https://doc.samsungmobile.com/SM-R925F/ITV/doc.html
 
--   releaseCycle: "Galaxy Watch5"
+-   releaseCycle: "galaxy-watch5"
+    releaseLabel: "Galaxy Watch5"
     releaseDate: 2022-08-26
     eoas: false
     eol: false
     link: https://doc.samsungmobile.com/SM-R905F/BTU/doc.html
 
--   releaseCycle: "Galaxy Z Fold4"
+-   releaseCycle: "galaxy-z-fold4"
+    releaseLabel: "Galaxy Z Fold4"
     releaseDate: 2022-08-25
     eoas: false
     eol: false
     link: https://doc.samsungmobile.com/SM-F936U1/TMB/doc.html
 
--   releaseCycle: "Galaxy Z Flip4"
+-   releaseCycle: "galaxy-z-flip4"
+    releaseLabel: "Galaxy Z Flip4"
     releaseDate: 2022-08-25
     eoas: false
     eol: false
     link: https://doc.samsungmobile.com/SM-F721U1/XAR/doc.html
 
--   releaseCycle: "Galaxy M13 5G"
+-   releaseCycle: "galaxy-m13-5g"
+    releaseLabel: "Galaxy M13 5G"
     releaseDate: 2022-07-23
     eoas: false
     eol: false
     link: https://doc.samsungmobile.com/SM-M136B/INS/doc.html
 
--   releaseCycle: "Galaxy M13 (India)"
+-   releaseCycle: "galaxy-m13-india"
+    releaseLabel: "Galaxy M13 (India)"
     releaseDate: 2022-07-23
     eoas: false
     eol: false
     link: https://doc.samsungmobile.com/SM-M135FU/INS/doc.html
 
--   releaseCycle: "Galaxy Xcover6 Pro"
+-   releaseCycle: "galaxy-xcover6-pro"
+    releaseLabel: "Galaxy Xcover6 Pro"
     releaseDate: 2022-07-13
     eoas: false
     eol: false
     link: https://doc.samsungmobile.com/SM-G736B/XSA/doc.html
 
--   releaseCycle: "Galaxy A13 (SM-A137)"
+-   releaseCycle: "galaxy-a13-sm-a137"
+    releaseLabel: "Galaxy A13 (SM-A137)"
     releaseDate: 2022-07-01 # Approximate to the month and year.
     eoas: false
     eol: false
     link: https://doc.samsungmobile.com/SM-A137F/SFR/doc.html
 
--   releaseCycle: "Galaxy M13"
+-   releaseCycle: "galaxy-m13"
+    releaseLabel: "Galaxy M13"
     releaseDate: 2022-07-01
     eoas: false
     eol: false
     link: https://doc.samsungmobile.com/SM-M135F/EUX/doc.html
 
--   releaseCycle: "Galaxy F13"
+-   releaseCycle: "galaxy-f13"
+    releaseLabel: "Galaxy F13"
     releaseDate: 2022-06-29
     eoas: false
     eol: false
     link: https://doc.samsungmobile.com/SM-E135F/INS/doc.html
 
--   releaseCycle: "Galaxy Tab S6 Lite (2022)"
+-   releaseCycle: "galaxy-tab-s6-lite-2022"
+    releaseLabel: "Galaxy Tab S6 Lite (2022)"
     releaseDate: 2022-05-23
     eoas: false
     eol: false
     link: https://doc.samsungmobile.com/SM-P619/ATO/doc.html
 
--   releaseCycle: "Galaxy Tab S8 Ultra"
+-   releaseCycle: "galaxy-tab-s8-ultra"
+    releaseLabel: "Galaxy Tab S8 Ultra"
     releaseDate: 2022-04-30
     eoas: false
     eol: false
     link: https://doc.samsungmobile.com/SM-X906B/XXV/doc.html
 
--   releaseCycle: "Galaxy M53"
+-   releaseCycle: "galaxy-m53"
+    releaseLabel: "Galaxy M53"
     releaseDate: 2022-04-22
     eoas: false
     eol: false
     link: https://doc.samsungmobile.com/SM-M536B/SER/doc.html
 
--   releaseCycle: "Galaxy A73 5G"
+-   releaseCycle: "galaxy-a73-5g"
+    releaseLabel: "Galaxy A73 5G"
     releaseDate: 2022-04-22
     eoas: false
     eol: false
     link: https://doc.samsungmobile.com/SM-A736B/XSA/doc.html
 
--   releaseCycle: "Galaxy Tab S8+"
+-   releaseCycle: "galaxy-tab-s8-plus"
+    releaseLabel: "Galaxy Tab S8+"
     releaseDate: 2022-04-14
     eoas: false
     eol: false
     link: https://doc.samsungmobile.com/SM-X806B/XXV/doc.html
 
--   releaseCycle: "Galaxy M33"
+-   releaseCycle: "galaxy-m33"
+    releaseLabel: "Galaxy M33"
     releaseDate: 2022-04-08
     eoas: false
     eol: false
     link: https://doc.samsungmobile.com/SM-M336BU/INS/doc.html
 
--   releaseCycle: "Galaxy M23"
+-   releaseCycle: "galaxy-m23"
+    releaseLabel: "Galaxy M23"
     releaseDate: 2022-04-08
     eoas: false
     eol: false
     link: https://doc.samsungmobile.com/SM-M236B/XXV/doc.html
 
--   releaseCycle: "Galaxy S20 FE 2022" # South Korea only
+-   releaseCycle: "galaxy-s20-fe-2022"
+    releaseLabel: "Galaxy S20 FE 2022" # South Korea only
     releaseDate: 2022-04-01
     eoas: false
     eol: 2026-03-31 # Samsung provides a 5th year security support for S20
     link: https://doc.samsungmobile.com/sm-g781b/xeo/doc.html
 
--   releaseCycle: "Galaxy A53 5G"
+-   releaseCycle: "galaxy-a53-5g"
+    releaseLabel: "Galaxy A53 5G"
     releaseDate: 2022-04-01
     eoas: false
     eol: false
     link: https://doc.samsungmobile.com/SM-A536B/EUX/doc.html
 
--   releaseCycle: "Galaxy A33 5G"
+-   releaseCycle: "galaxy-a33-5g"
+    releaseLabel: "Galaxy A33 5G"
     releaseDate: 2022-04-01
     eoas: false
     eol: false
     link: https://doc.samsungmobile.com/sm-a336e/ins/doc.html
 
--   releaseCycle: "Galaxy A23"
+-   releaseCycle: "galaxy-a23"
+    releaseLabel: "Galaxy A23"
     releaseDate: 2022-03-25
     eoas: false
     eol: false
     link: https://doc.samsungmobile.com/SM-A235M/PET/doc.html
 
--   releaseCycle: "Galaxy A13"
+-   releaseCycle: "galaxy-a13"
+    releaseLabel: "Galaxy A13"
     releaseDate: 2022-03-23
     eoas: false
     eol: false
     link: https://doc.samsungmobile.com/SM-A135M/PET/doc.html
 
--   releaseCycle: "Galaxy Tab S8"
+-   releaseCycle: "galaxy-tab-s8"
+    releaseLabel: "Galaxy Tab S8"
     releaseDate: 2022-03-22
     eoas: false
     eol: false
     link: https://doc.samsungmobile.com/SM-X706B/SER/doc.html
 
--   releaseCycle: "Galaxy F23"
+-   releaseCycle: "galaxy-f23"
+    releaseLabel: "Galaxy F23"
     releaseDate: 2022-03-16
     eoas: false
     eol: false
     link: https://doc.samsungmobile.com/SM-E236B/INS/doc.html
 
--   releaseCycle: "Galaxy S22 Ultra 5G"
+-   releaseCycle: "galaxy-s22-ultra-5g"
+    releaseLabel: "Galaxy S22 Ultra 5G"
     releaseDate: 2022-02-25
     eoas: false
     eol: 2027-02-25 # "five years of security updates" (https://security.samsungmobile.com/securityPost.smsb)
     link: https://doc.samsungmobile.com/SM-S908E/VAU/doc.html
 
--   releaseCycle: "Galaxy S22+ 5G"
+-   releaseCycle: "galaxy-s22-plus-5g"
+    releaseLabel: "Galaxy S22+ 5G"
     releaseDate: 2022-02-25
     eoas: false
     eol: 2027-02-25 # "five years of security updates" (https://security.samsungmobile.com/securityPost.smsb)
     link: https://doc.samsungmobile.com/SM-S906E/XXV/doc.html
 
--   releaseCycle: "Galaxy S22 5G"
+-   releaseCycle: "galaxy-s22-5g"
+    releaseLabel: "Galaxy S22 5G"
     releaseDate: 2022-02-25
     eoas: false
     eol: 2027-02-25 # "five years of security updates" (https://security.samsungmobile.com/securityPost.smsb)
     link: https://doc.samsungmobile.com/SM-S901E/XXV/doc.html
 
--   releaseCycle: "Galaxy A03"
+-   releaseCycle: "galaxy-a03"
+    releaseLabel: "Galaxy A03"
     releaseDate: 2022-01-21
     eoas: false
     eol: false
     link: https://doc.samsungmobile.com/SM-A035G/BTU/doc.html
 
--   releaseCycle: "Galaxy Tab A8 10.5 (2021)"
+-   releaseCycle: "galaxy-tab-a8-10.5-2021"
+    releaseLabel: "Galaxy Tab A8 10.5 (2021)"
     releaseDate: 2022-01-17
     eoas: false
     eol: false
     link: https://doc.samsungmobile.com/SM-X205/INS/doc.html
 
--   releaseCycle: "Galaxy S21 FE 5G"
+-   releaseCycle: "galaxy-s21-fe-5g"
+    releaseLabel: "Galaxy S21 FE 5G"
     releaseDate: 2022-01-07
     eoas: false
     eol: 2027-01-07 # "five years of security updates" (https://security.samsungmobile.com/securityPost.smsb)
     link: https://doc.samsungmobile.com/SM-G990B2/SER/doc.html
 
--   releaseCycle: "Galaxy A03 Core"
+-   releaseCycle: "galaxy-a03-core"
+    releaseLabel: "Galaxy A03 Core"
     releaseDate: 2021-12-06
     eoas: false
     eol: false
     link: https://doc.samsungmobile.com/SM-A032M/PET/doc.html
 
--   releaseCycle: "Galaxy A13 5G"
+-   releaseCycle: "galaxy-a13-5g"
+    releaseLabel: "Galaxy A13 5G"
     releaseDate: 2021-12-03
     eoas: false
     eol: false
     link: https://doc.samsungmobile.com/SM-A136U/USC/doc.html
 
--   releaseCycle: "Galaxy F42 5G"
+-   releaseCycle: "galaxy-f42-5g"
+    releaseLabel: "Galaxy F42 5G"
     releaseDate: 2021-10-03
     eoas: false
     eol: false
     link: https://doc.samsungmobile.com/sm-e426b/ins/doc.html
 
--   releaseCycle: "Galaxy M52 5G"
+-   releaseCycle: "galaxy-m52-5g"
+    releaseLabel: "Galaxy M52 5G"
     releaseDate: 2021-10-03
     eoas: false
     eol: false
     link: https://doc.samsungmobile.com/SM-M526BR/ITV/doc.html
 
--   releaseCycle: "Galaxy M22"
+-   releaseCycle: "galaxy-m22"
+    releaseLabel: "Galaxy M22"
     releaseDate: 2021-09-14 # Unclear date, defaulting to announcement date
     eoas: false
     eol: false
     link: https://doc.samsungmobile.com/sm-m225fv/zto/doc.html
 
--   releaseCycle: "Galaxy M32 5G"
+-   releaseCycle: "galaxy-m32-5g"
+    releaseLabel: "Galaxy M32 5G"
     releaseDate: 2021-09-02
     eoas: false
     eol: false
     link: https://doc.samsungmobile.com/SM-M326B/INS/doc.html
 
--   releaseCycle: "Galaxy A52s 5G"
+-   releaseCycle: "galaxy-a52s-5g"
+    releaseLabel: "Galaxy A52s 5G"
     releaseDate: 2021-09-01
     eoas: false
     eol: false
     link: https://doc.samsungmobile.com/SM-A528B/BTU/doc.html
 
--   releaseCycle: "Galaxy Z Fold3 5G"
+-   releaseCycle: "galaxy-z-fold3-5g"
+    releaseLabel: "Galaxy Z Fold3 5G"
     releaseDate: 2021-08-27
     eoas: false
     eol: false
     link: https://doc.samsungmobile.com/SM-F926B/SER/doc.html
 
--   releaseCycle: "Galaxy Z Flip3 5G"
+-   releaseCycle: "galaxy-z-flip3-5g"
+    releaseLabel: "Galaxy Z Flip3 5G"
     releaseDate: 2021-08-27
     eoas: false
     eol: false
     link: https://doc.samsungmobile.com/SM-F711B/SER/doc.html
 
--   releaseCycle: "Galaxy Watch4 Classic"
+-   releaseCycle: "galaxy-watch4-classic"
+    releaseLabel: "Galaxy Watch4 Classic"
     releaseDate: 2021-08-27
     eoas: false
     eol: false
     link: https://doc.samsungmobile.com/SM-R890/XAA/doc.html
 
--   releaseCycle: "Galaxy Watch4"
+-   releaseCycle: "galaxy-watch4"
+    releaseLabel: "Galaxy Watch4"
     releaseDate: 2021-08-27
     eoas: false
     eol: false
     link: https://doc.samsungmobile.com/SM-R870/XAA/doc.html
 
--   releaseCycle: "Galaxy A03s"
+-   releaseCycle: "galaxy-a03s"
+    releaseLabel: "Galaxy A03s"
     releaseDate: 2021-08-18
     eoas: false
     eol: false
     link: https://doc.samsungmobile.com/SM-A037F/INS/doc.html
 
--   releaseCycle: "Galaxy A12 (India)"
+-   releaseCycle: "galaxy-a12-india"
+    releaseLabel: "Galaxy A12 (India)"
     releaseDate: 2021-08-12
     eoas: false
     eol: false
     link: https://doc.samsungmobile.com/SM-A127F/INS/doc.html
 
--   releaseCycle: "Galaxy A12 Nacho"
+-   releaseCycle: "galaxy-a12-nacho"
+    releaseLabel: "Galaxy A12 Nacho"
     releaseDate: 2021-08-09
     eoas: false
     eol: false
     link: https://doc.samsungmobile.com/SM-A127F/ITV/doc.html
 
--   releaseCycle: "Galaxy M21 2021"
+-   releaseCycle: "galaxy-m21-2021"
+    releaseLabel: "Galaxy M21 2021"
     releaseDate: 2021-07-26
     eoas: false
     eol: false
     link: https://doc.samsungmobile.com/sm-m215f/ins/doc.html
 
--   releaseCycle: "Galaxy F22"
+-   releaseCycle: "galaxy-f22"
+    releaseLabel: "Galaxy F22"
     releaseDate: 2021-07-13
     eoas: false
     eol: false
     link: https://doc.samsungmobile.com/SM-E225F/INS/doc.html
 
--   releaseCycle: "Galaxy M32"
+-   releaseCycle: "galaxy-m32"
+    releaseLabel: "Galaxy M32"
     releaseDate: 2021-06-28
     eoas: false
     eol: false
     link: https://doc.samsungmobile.com/sm-m325f/ins/doc.html
 
--   releaseCycle: "Galaxy A22 5G"
+-   releaseCycle: "galaxy-a22-5g"
+    releaseLabel: "Galaxy A22 5G"
     releaseDate: 2021-06-24
     eoas: false
     eol: false
     link: https://doc.samsungmobile.com/SM-A226B/XEH/doc.html
 
--   releaseCycle: "Galaxy A22"
+-   releaseCycle: "galaxy-a22"
+    releaseLabel: "Galaxy A22"
     releaseDate: 2021-06-03
     eoas: false
     eol: false
     link: https://doc.samsungmobile.com/SM-A225F/TUR/doc.html
 
--   releaseCycle: "Galaxy F52 5G"
+-   releaseCycle: "galaxy-f52-5g"
+    releaseLabel: "Galaxy F52 5G"
     releaseDate: 2021-06-01
     eoas: false
     eol: false
     link: https://doc.samsungmobile.com/SM-E5260/CHC/doc.html
 
--   releaseCycle: "Galaxy Tab A7 Lite"
+-   releaseCycle: "galaxy-tab-a7-lite"
+    releaseLabel: "Galaxy Tab A7 Lite"
     releaseDate: 2021-05-27
     eoas: false
     eol: false
     link: https://doc.samsungmobile.com/SM-T220/CHN/doc.html
 
--   releaseCycle: "Galaxy Tab S7 FE"
+-   releaseCycle: "galaxy-tab-s7-fe"
+    releaseLabel: "Galaxy Tab S7 FE"
     releaseDate: 2021-05-25
     eoas: false
     eol: false
     link: https://doc.samsungmobile.com/SM-T730/KOO/doc.html
 
--   releaseCycle: "Galaxy A82 5G"
+-   releaseCycle: "galaxy-a82-5g"
+    releaseLabel: "Galaxy A82 5G"
     releaseDate: 2021-05-05
     eoas: false
     eol: false
     link: https://doc.samsungmobile.com/sm-a528b/dbt/doc.html
 
--   releaseCycle: "Galaxy M42 5G"
+-   releaseCycle: "galaxy-m42-5g"
+    releaseLabel: "Galaxy M42 5G"
     releaseDate: 2021-04-30
     eoas: false
     eol: false
     link: https://doc.samsungmobile.com/SM-M426B/INS/doc.html
 
--   releaseCycle: "Galaxy A Quantum2"
+-   releaseCycle: "galaxy-a-quantum2"
+    releaseLabel: "Galaxy A Quantum2"
     releaseDate: 2021-04-23
     eoas: false
     eol: false
     link: https://doc.samsungmobile.com/sm-a826s/skc/doc.html
 
--   releaseCycle: "Galaxy F12"
+-   releaseCycle: "galaxy-f12"
+    releaseLabel: "Galaxy F12"
     releaseDate: 2021-04-12
     eoas: false
     eol: false
     link: https://doc.samsungmobile.com/SM-F127G/INS/doc.html
 
--   releaseCycle: "Galaxy F02s"
+-   releaseCycle: "galaxy-f02s"
+    releaseLabel: "Galaxy F02s"
     releaseDate: 2021-04-09
     eoas: false
     eol: false
     link: https://doc.samsungmobile.com/SM-E025F/INS/doc.html
 
--   releaseCycle: "Galaxy A52"
+-   releaseCycle: "galaxy-a52"
+    releaseLabel: "Galaxy A52"
     releaseDate: 2021-03-26
     eoas: false
     eol: false
     link: https://doc.samsungmobile.com/SM-A525F/XID/doc.html
 
--   releaseCycle: "Galaxy A72"
+-   releaseCycle: "galaxy-a72"
+    releaseLabel: "Galaxy A72"
     releaseDate: 2021-03-26
     eoas: false
     eol: false
     link: https://doc.samsungmobile.com/SM-A725F/XEO/doc.html
 
--   releaseCycle: "Galaxy M12 (India)"
+-   releaseCycle: "galaxy-m12-india"
+    releaseLabel: "Galaxy M12 (India)"
     releaseDate: 2021-03-18
     eoas: false
     eol: false
     link: https://doc.samsungmobile.com/SM-M127G/INS/doc.html
 
--   releaseCycle: "Galaxy A52 5G"
+-   releaseCycle: "galaxy-a52-5g"
+    releaseLabel: "Galaxy A52 5G"
     releaseDate: 2021-03-17
     eoas: false
     eol: false
     link: https://doc.samsungmobile.com/sm-a526b/dbt/doc.html
 
--   releaseCycle: "Galaxy Xcover 5"
+-   releaseCycle: "galaxy-xcover-5"
+    releaseLabel: "Galaxy Xcover 5"
     releaseDate: 2021-03-12
     eoas: false
     eol: false
     link: https://doc.samsungmobile.com/SM-G525F/XNZ/doc.html
 
--   releaseCycle: "Galaxy M62"
+-   releaseCycle: "galaxy-m62"
+    releaseLabel: "Galaxy M62"
     releaseDate: 2021-03-03
     eoas: false
     eol: false
     link: https://doc.samsungmobile.com/SM-M625F/NPL/doc.html
 
--   releaseCycle: "Galaxy A32"
+-   releaseCycle: "galaxy-a32"
+    releaseLabel: "Galaxy A32"
     releaseDate: 2021-02-25
     eoas: false
     eol: false
     link: https://doc.samsungmobile.com/sm-a325f/ins/doc.html
 
--   releaseCycle: "Galaxy F62"
+-   releaseCycle: "galaxy-f62"
+    releaseLabel: "Galaxy F62"
     releaseDate: 2021-02-22
     eoas: false
     eol: false
     link: https://doc.samsungmobile.com/SM-E625F/INS/doc.html
 
--   releaseCycle: "Galaxy M02"
+-   releaseCycle: "galaxy-m02"
+    releaseLabel: "Galaxy M02"
     releaseDate: 2021-02-09
     eoas: false
     eol: false
     link: https://doc.samsungmobile.com/SM-M022F/XTC/doc.html
 
--   releaseCycle: "Galaxy M31s"
+-   releaseCycle: "galaxy-m31s"
+    releaseLabel: "Galaxy M31s"
     releaseDate: 2021-02-09
     eoas: false
     eol: false
     link: https://doc.samsungmobile.com/sm-m317f/ins/doc.html
 
--   releaseCycle: "Galaxy S21 Ultra 5G"
+-   releaseCycle: "galaxy-s21-ultra-5g"
+    releaseLabel: "Galaxy S21 Ultra 5G"
     releaseDate: 2021-01-29
     eoas: false
     eol: 2026-01-29 # "five years of security updates" (https://security.samsungmobile.com/securityPost.smsb)
     link: https://doc.samsungmobile.com/sm-g998b/dbt/doc.html
 
--   releaseCycle: "Galaxy S21+ 5G"
+-   releaseCycle: "galaxy-s21-plus-5g"
+    releaseLabel: "Galaxy S21+ 5G"
     releaseDate: 2021-01-29
     eoas: false
     eol: 2026-01-29 # "five years of security updates" (https://security.samsungmobile.com/securityPost.smsb)
     link: https://doc.samsungmobile.com/SM-G996B/DBT/doc.html
 
--   releaseCycle: "Galaxy S21 5G"
+-   releaseCycle: "galaxy-s21-5g"
+    releaseLabel: "Galaxy S21 5G"
     releaseDate: 2021-01-29
     eoas: false
     eol: 2026-01-29 # "five years of security updates" (https://security.samsungmobile.com/securityPost.smsb)
     link: https://doc.samsungmobile.com/SM-G991B/DBT/doc.html
 
--   releaseCycle: "Galaxy A02"
+-   releaseCycle: "galaxy-a02"
+    releaseLabel: "Galaxy A02"
     releaseDate: 2021-01-27
     eoas: true
     eol: 2024-03-05 # approximate (https://www.gizchina.com/2024/03/05/samsung-galaxy-smartphone-end-of-support-march-2024/)
     link: https://doc.samsungmobile.com/SM-A022F/XID/doc.html
 
--   releaseCycle: "Galaxy A32 5G"
+-   releaseCycle: "galaxy-a32-5g"
+    releaseLabel: "Galaxy A32 5G"
     releaseDate: 2021-01-13
     eoas: false
     eol: false
     link: https://doc.samsungmobile.com/sm-a326u/tmb/doc.html
 
--   releaseCycle: "Galaxy M02s"
+-   releaseCycle: "galaxy-m02s"
+    releaseLabel: "Galaxy M02s"
     releaseDate: 2021-01-07
     eoas: false
     eol: false
     link: https://doc.samsungmobile.com/SM-M025F/SLK/doc.html
 
--   releaseCycle: "Galaxy A02s"
+-   releaseCycle: "galaxy-a02s"
+    releaseLabel: "Galaxy A02s"
     releaseDate: 2021-01-04
     eoas: true
     eol: 2025-01-04 # 4 years of security updates
     link: https://doc.samsungmobile.com/SM-A025G/XEF/doc.html
 
--   releaseCycle: "Galaxy A12"
+-   releaseCycle: "galaxy-a12"
+    releaseLabel: "Galaxy A12"
     releaseDate: 2020-11-24
     eoas: false
     eol: false
     link: https://doc.samsungmobile.com/SM-A125F/XEF/doc.html
 
--   releaseCycle: "Galaxy M12"
+-   releaseCycle: "galaxy-m12"
+    releaseLabel: "Galaxy M12"
     releaseDate: 2020-11-24
     eoas: false
     eol: false
     link: https://doc.samsungmobile.com/SM-M127F/ARO/doc.html
 
--   releaseCycle: "Galaxy A42 5G"
+-   releaseCycle: "galaxy-a42-5g"
+    releaseLabel: "Galaxy A42 5G"
     releaseDate: 2020-11-11
     eoas: true
     eol: 2024-06-20
     link: https://doc.samsungmobile.com/SM-A426B/XEF/doc.html
 
--   releaseCycle: "Galaxy M21s"
+-   releaseCycle: "galaxy-m21s"
+    releaseLabel: "Galaxy M21s"
     releaseDate: 2020-11-06
     eoas: false
     eol: false
     link: https://doc.samsungmobile.com/SM-F415F/INS/doc.html
 
--   releaseCycle: "Galaxy Z Fold2 5G"
+-   releaseCycle: "galaxy-z-fold2-5g"
+    releaseLabel: "Galaxy Z Fold2 5G"
     releaseDate: 2020-11-04
     eoas: true
     eol: false
     link: https://doc.samsungmobile.com/SM-F916B/XEH/doc.html
 
--   releaseCycle: "Galaxy M31 Prime"
+-   releaseCycle: "galaxy-m31-prime"
+    releaseLabel: "Galaxy M31 Prime"
     releaseDate: 2020-10-17
     eoas: false
     eol: false
     link: https://doc.samsungmobile.com/sm-m315f/ins/doc.html
 
--   releaseCycle: "Galaxy F41"
+-   releaseCycle: "galaxy-f41"
+    releaseLabel: "Galaxy F41"
     releaseDate: 2020-10-16
     eoas: false
     eol: false
     link: https://doc.samsungmobile.com/SM-F415F/INS/doc.html
 
--   releaseCycle: "Galaxy S20 FE 5G"
+-   releaseCycle: "galaxy-s20-fe-5g"
+    releaseLabel: "Galaxy S20 FE 5G"
     releaseDate: 2020-10-02
     eoas: true # three generations of upgrades
     eol: 2025-10-01 # Samsung provides a 5th year security support  for S20
     link: https://doc.samsungmobile.com/SM-G781B/BTU/doc.html
 
--   releaseCycle: "Galaxy S20 FE"
+-   releaseCycle: "galaxy-s20-fe"
+    releaseLabel: "Galaxy S20 FE"
     releaseDate: 2020-10-02
     eoas: true # three generations of upgrades
     eol: 2025-10-01 # Samsung provides a 5th year security support  for S20
     link: https://doc.samsungmobile.com/SM-G780G/BTU/doc.html
 
--   releaseCycle: "Galaxy Tab Active3"
+-   releaseCycle: "galaxy-tab-active3"
+    releaseLabel: "Galaxy Tab Active3"
     releaseDate: 2020-09-28
     eoas: false
     eol: false
     link: https://doc.samsungmobile.com/SM-T575/XEF/doc.html
 
--   releaseCycle: "Galaxy Z Fold 2"
+-   releaseCycle: "galaxy-z-fold-2"
+    releaseLabel: "Galaxy Z Fold 2"
     releaseDate: 2020-09-18
     eoas: false
     eol: false
     link: https://doc.samsungmobile.com/SM-F916B/XEH/doc.html
 
--   releaseCycle: "Galaxy Tab A7 10.4 (2020)"
+-   releaseCycle: "galaxy-tab-a7-10.4-2020"
+    releaseLabel: "Galaxy Tab A7 10.4 (2020)"
     releaseDate: 2020-09-11
     eoas: false
     eol: false
     link: https://doc.samsungmobile.com/SM-T505/BTU/doc.html
 
--   releaseCycle: "Galaxy Note 20 Ultra 5G"
+-   releaseCycle: "galaxy-note-20-ultra-5g"
+    releaseLabel: "Galaxy Note 20 Ultra 5G"
     releaseDate: 2020-08-21
     eoas: false
     eol: false
     link: https://doc.samsungmobile.com/SM-N986U1/VZW/doc.html
 
--   releaseCycle: "Galaxy Note 20 5G"
+-   releaseCycle: "galaxy-note-20-5g"
+    releaseLabel: "Galaxy Note 20 5G"
     releaseDate: 2020-08-21
     eoas: false
     eol: false
     link: https://doc.samsungmobile.com/SM-N981U1/VZW/doc.html
 
--   releaseCycle: "Galaxy Note20 Ultra"
+-   releaseCycle: "galaxy-note20-ultra"
+    releaseLabel: "Galaxy Note20 Ultra"
     releaseDate: 2020-08-21
     eoas: false
     eol: false
     link: https://doc.samsungmobile.com/SM-N985F/XNZ/doc.html
 
--   releaseCycle: "Galaxy Tab S7"
+-   releaseCycle: "galaxy-tab-s7"
+    releaseLabel: "Galaxy Tab S7"
     releaseDate: 2020-08-21
     eoas: false
     eol: false
     link: https://doc.samsungmobile.com/SM-T875/DBT/doc.html
 
--   releaseCycle: "Galaxy Note20"
+-   releaseCycle: "galaxy-note20"
+    releaseLabel: "Galaxy Note20"
     releaseDate: 2020-08-21
     eoas: false
     eol: false
     link: https://doc.samsungmobile.com/SM-N980F/XEO/doc.html
 
--   releaseCycle: "Galaxy A51 5G UW"
+-   releaseCycle: "galaxy-a51-5g-uw"
+    releaseLabel: "Galaxy A51 5G UW"
     releaseDate: 2020-08-14
     eoas: true
     eol: 2024-06-05
     link: https://doc.samsungmobile.com/SM-A516V/CHA/doc.html
 
--   releaseCycle: "Galaxy Z Flip 5G"
+-   releaseCycle: "galaxy-z-flip-5g"
+    releaseLabel: "Galaxy Z Flip 5G"
     releaseDate: 2020-08-07
     eoas: false
     eol: false
     link: https://doc.samsungmobile.com/SM-F707B/XEH/doc.html
 
--   releaseCycle: "Galaxy A51 5G"
+-   releaseCycle: "galaxy-a51-5g"
+    releaseLabel: "Galaxy A51 5G"
     releaseDate: 2020-08-07
     eoas: true
     eol: 2024-06-05
     link: https://doc.samsungmobile.com/SM-A516B/012784200623/nld.html
 
--   releaseCycle: "Galaxy M51"
+-   releaseCycle: "galaxy-m51"
+    releaseLabel: "Galaxy M51"
     releaseDate: 2020-08-06
     eoas: false
     eol: false
     link: https://doc.samsungmobile.com/SM-M515F/DBT/doc.html
 
--   releaseCycle: "Galaxy Watch3"
+-   releaseCycle: "galaxy-watch3"
+    releaseLabel: "Galaxy Watch3"
     releaseDate: 2020-08-06
     eoas: true
     eol: true
     link: https://doc.samsungmobile.com/sm-r850/btu/doc.html
 
--   releaseCycle: "Galaxy A01 Core"
+-   releaseCycle: "galaxy-a01-core"
+    releaseLabel: "Galaxy A01 Core"
     releaseDate: 2020-08-06
     eoas: true
     eol: true
     link: https://doc.samsungmobile.com/SM-A013F/SEK/doc.html
 
--   releaseCycle: "Galaxy Tab S7+"
+-   releaseCycle: "galaxy-tab-s7-plus"
+    releaseLabel: "Galaxy Tab S7+"
     releaseDate: 2020-08-05
     eoas: false
     eol: false
     link: https://doc.samsungmobile.com/SM-T970/XAR/doc.html
 
--   releaseCycle: "Galaxy M01 Core"
+-   releaseCycle: "galaxy-m01-core"
+    releaseLabel: "Galaxy M01 Core"
     releaseDate: 2020-07-29
     eoas: true
     eol: true
     link: https://doc.samsungmobile.com/SM-M013F/INS/doc.html
 
--   releaseCycle: "Galaxy M01s"
+-   releaseCycle: "galaxy-m01s"
+    releaseLabel: "Galaxy M01s"
     releaseDate: 2020-07-16
     eoas: true
     eol: true
     link: https://doc.samsungmobile.com/SM-M017F/INS/doc.html
 
--   releaseCycle: "Galaxy A71 5G UW"
+-   releaseCycle: "galaxy-a71-5g-uw"
+    releaseLabel: "Galaxy A71 5G UW"
     releaseDate: 2020-07-16
     eoas: true
     eol: true
     link: https://doc.samsungmobile.com/SM-A716V/CCT/doc.html
 
--   releaseCycle: "Galaxy A21"
+-   releaseCycle: "galaxy-a21"
+    releaseLabel: "Galaxy A21"
     releaseDate: 2020-06-26
     eoas: true
     eol: true
     link: https://doc.samsungmobile.com/sm-a215u/usc/doc.html
 
--   releaseCycle: "Galaxy A71 5G"
+-   releaseCycle: "galaxy-a71-5g"
+    releaseLabel: "Galaxy A71 5G"
     releaseDate: 2020-06-15
     eoas: true
     eol: true
     link: https://doc.samsungmobile.com/sm-a716u/spr/doc.html
 
--   releaseCycle: "Galaxy S20 5G UW" # Verizon only
+-   releaseCycle: "galaxy-s20-5g-uw"
+    releaseLabel: "Galaxy S20 5G UW" # Verizon only
     releaseDate: 2020-06-04
     eoas: true # three generations of upgrades
     eol: 2024-06-04 # "minimum of four (4) years following their global launch" (https://security.samsungmobile.com/workScope.smsb)
     link: https://www.verizon.com/support/samsung-galaxy-s20-5g-uw-update/
 
--   releaseCycle: "Galaxy A21s"
+-   releaseCycle: "galaxy-a21s"
+    releaseLabel: "Galaxy A21s"
     releaseDate: 2020-06-02
     eoas: true
     eol: true
     link: https://doc.samsungmobile.com/SM-A217F/XEF/doc.html
 
--   releaseCycle: "Galaxy M01"
+-   releaseCycle: "galaxy-m01"
+    releaseLabel: "Galaxy M01"
     releaseDate: 2020-06-02
     eoas: true
     eol: true
     link: https://doc.samsungmobile.com/SM-M015G/INS/doc.html
 
--   releaseCycle: "Galaxy A Quantum"
+-   releaseCycle: "galaxy-a-quantum"
+    releaseLabel: "Galaxy A Quantum"
     releaseDate: 2020-05-22
     eoas: false
     eol: false
     link: https://doc.samsungmobile.com/sm-a716s/skc/doc.html
 
--   releaseCycle: "Galaxy Tab S6 Lite"
+-   releaseCycle: "galaxy-tab-s6-lite"
+    releaseLabel: "Galaxy Tab S6 Lite"
     releaseDate: 2020-05-16
     eoas: false
     eol: false
     link: https://doc.samsungmobile.com/SM-P610/XEH/doc.html
 
--   releaseCycle: "Galaxy A11"
+-   releaseCycle: "galaxy-a11"
+    releaseLabel: "Galaxy A11"
     releaseDate: 2020-05-15
     eoas: true
     eol: true
     link: https://doc.samsungmobile.com/SM-A115F/XSG/doc.html
 
--   releaseCycle: "Galaxy M11"
+-   releaseCycle: "galaxy-m11"
+    releaseLabel: "Galaxy M11"
     releaseDate: 2020-05-04
     eoas: true
     eol: true
     link: https://doc.samsungmobile.com/SM-M115F/INS/doc.html
 
--   releaseCycle: "Galaxy A31"
+-   releaseCycle: "galaxy-a31"
+    releaseLabel: "Galaxy A31"
     releaseDate: 2020-04-27
     eoas: true
     eol: true
     link: https://doc.samsungmobile.com/SM-A315F/MID/doc.html
 
--   releaseCycle: "Galaxy J2 Core (2020)"
+-   releaseCycle: "galaxy-j2-core-2020"
+    releaseLabel: "Galaxy J2 Core (2020)"
     releaseDate: 2020-04-27
     eoas: true # Android 8.1 Oreo (Go edition) is not supported anymore
     eol: true
     link: https://doc.samsungmobile.com/SM-J260FU/SER/doc.html
 
--   releaseCycle: "Galaxy Xcover FieldPro"
+-   releaseCycle: "galaxy-xcover-fieldpro"
+    releaseLabel: "Galaxy Xcover FieldPro"
     releaseDate: 2020-04-06
     eoas: 2022-10-01 # Approximate from here: https://9to5google.com/2022/10/04/samsung-android-12-update-rollout/
     eol: false
     link: https://doc.samsungmobile.com/SM-G889YB/DBT/doc.html
 
--   releaseCycle: "Galaxy Tab A 8.4 (2020)" # Yeah we need to specify the year here, multiple models from different years with the same name.
+-   releaseCycle: "galaxy-tab-a-8.4-2020"
+    releaseLabel: "Galaxy Tab A 8.4 (2020)" # Yeah we need to specify the year here, multiple models from different years with the same name.
     releaseDate: 2020-03-25
     eoas: false
     eol: false
     link: https://doc.samsungmobile.com/sm-t307u/glw/doc.html
 
--   releaseCycle: "Galaxy M21"
+-   releaseCycle: "galaxy-m21"
+    releaseLabel: "Galaxy M21"
     releaseDate: 2020-03-23
     eoas: false
     eol: false
     link: https://doc.samsungmobile.com/sm-m215f/ins/doc.html
 
--   releaseCycle: "Galaxy A41"
+-   releaseCycle: "galaxy-a41"
+    releaseLabel: "Galaxy A41"
     releaseDate: 2020-03-18
     eoas: true
     eol: true
     link: https://doc.samsungmobile.com/SM-A415F/TMH/doc.html
 
--   releaseCycle: "Galaxy S20 Ultra"
+-   releaseCycle: "galaxy-s20-ultra"
+    releaseLabel: "Galaxy S20 Ultra"
     releaseDate: 2020-03-15
     eoas: true
     eol: 2025-03-14 # Samsung provides a 5th year security support  for S20
     link: https://doc.samsungmobile.com/SM-G988B/DCO/doc.html
 
--   releaseCycle: "Galaxy S20 Ultra 5G"
+-   releaseCycle: "galaxy-s20-ultra-5g"
+    releaseLabel: "Galaxy S20 Ultra 5G"
     releaseDate: 2020-03-06
     eoas: true
     eol: 2025-03-05 # Samsung provides a 5th year security support for S20
     link: https://doc.samsungmobile.com/SM-G988B/ATO/doc.html
 
--   releaseCycle: "Galaxy S20+ 5G"
+-   releaseCycle: "galaxy-s20-plus-5g"
+    releaseLabel: "Galaxy S20+ 5G"
     releaseDate: 2020-03-06
     eoas: true
     eol: 2025-03-05 # Samsung provides a 5th year security support for S20
     link: https://doc.samsungmobile.com/SM-G986B/XEF/doc.html
 
--   releaseCycle: "Galaxy S20+"
+-   releaseCycle: "galaxy-s20-plus"
+    releaseLabel: "Galaxy S20+"
     releaseDate: 2020-03-06
     eoas: true
     eol: 2025-03-05 # Samsung provides a 5th year security support for S20
     link: https://doc.samsungmobile.com/SM-G985F/XEH/doc.html
 
--   releaseCycle: "Galaxy S20 5G"
+-   releaseCycle: "galaxy-s20-5g"
+    releaseLabel: "Galaxy S20 5G"
     releaseDate: 2020-03-06
     eoas: true
     eol: 2025-03-05 # Samsung provides a 5th year security support for S20
     link: https://doc.samsungmobile.com/SM-G981B/ITV/doc.html
 
--   releaseCycle: "Galaxy S20"
+-   releaseCycle: "galaxy-s20"
+    releaseLabel: "Galaxy S20"
     releaseDate: 2020-03-06
     eoas: true
     eol: 2025-03-05 # Samsung provides a 5th year security support for S20
     link: https://doc.samsungmobile.com/SM-G980F/VDC/doc.html
 
--   releaseCycle: "Galaxy M31"
+-   releaseCycle: "galaxy-m31"
+    releaseLabel: "Galaxy M31"
     releaseDate: 2020-03-05
     eoas: true
     eol: true
     link: https://doc.samsungmobile.com/sm-m315f/ins/doc.html
 
--   releaseCycle: "Galaxy Z Flip"
+-   releaseCycle: "galaxy-z-flip"
+    releaseLabel: "Galaxy Z Flip"
     releaseDate: 2020-02-14
     eoas: true
     eol: true
     link: https://doc.samsungmobile.com/SM-F700F/XEH/doc.html
 
--   releaseCycle: "Galaxy Tab S6 5G"
+-   releaseCycle: "galaxy-tab-s6-5g"
+    releaseLabel: "Galaxy Tab S6 5G"
     releaseDate: 2020-01-30
     eoas: true
     eol: true
     link: https://doc.samsungmobile.com/sm-t866n/koo/doc.html
 
--   releaseCycle: "Galaxy A71"
+-   releaseCycle: "galaxy-a71"
+    releaseLabel: "Galaxy A71"
     releaseDate: 2020-01-17
     eoas: true
     eol: true
     link: https://doc.samsungmobile.com/sm-a715f/ins/doc.html
 
--   releaseCycle: "Galaxy S10 Lite"
+-   releaseCycle: "galaxy-s10-lite"
+    releaseLabel: "Galaxy S10 Lite"
     releaseDate: 2020-01-03
     eoas: true
     eol: true
     link: https://doc.samsungmobile.com/sm-g770f/phe/doc.html
 
--   releaseCycle: "Galaxy Note10 Lite"
+-   releaseCycle: "galaxy-note10-lite"
+    releaseLabel: "Galaxy Note10 Lite"
     releaseDate: 2020-01-03
     eoas: true
     eol: true
     link: https://doc.samsungmobile.com/sm-n770f/xef/doc.html
 
--   releaseCycle: "Galaxy XCover Pro" # Unclear release date.
+-   releaseCycle: "galaxy-xcover-pro"
+    releaseLabel: "Galaxy XCover Pro" # Unclear release date.
     releaseDate: 2020-01-01
     eoas: false
     eol: false
     link: https://doc.samsungmobile.com/SM-G715FN/XEH/doc.html
 
--   releaseCycle: "Galaxy A51"
+-   releaseCycle: "galaxy-a51"
+    releaseLabel: "Galaxy A51"
     releaseDate: 2019-12-27
     eoas: true
     eol: true
     link: https://doc.samsungmobile.com/SM-A515F/XEF/doc.html
 
--   releaseCycle: "Galaxy A01"
+-   releaseCycle: "galaxy-a01"
+    releaseLabel: "Galaxy A01"
     releaseDate: 2019-12-18
     eoas: true
     eol: true
     link: https://doc.samsungmobile.com/SM-A015F/THL/doc.html
 
--   releaseCycle: "Galaxy Fold 5G"
+-   releaseCycle: "galaxy-fold-5g"
+    releaseLabel: "Galaxy Fold 5G"
     releaseDate: 2019-11-20
     eoas: true
     eol: true
     link: https://doc.samsungmobile.com/SM-F907B/AUT/doc.html
 
--   releaseCycle: "Galaxy M30s"
+-   releaseCycle: "galaxy-m30s"
+    releaseLabel: "Galaxy M30s"
     releaseDate: 2019-10-30
     eoas: true
     eol: true
     link: https://doc.samsungmobile.com/sm-m307f/ins/doc.html
 
--   releaseCycle: "Galaxy A20s"
+-   releaseCycle: "galaxy-a20s"
+    releaseLabel: "Galaxy A20s"
     releaseDate: 2019-10-05
     eoas: true
     eol: true
     link: https://doc.samsungmobile.com/SM-A207F/XEH/doc.html
 
--   releaseCycle: "Galaxy Tab Active Pro"
+-   releaseCycle: "galaxy-tab-active-pro"
+    releaseLabel: "Galaxy Tab Active Pro"
     releaseDate: 2019-10-01
     eoas: 2022-10-01 # Approximate from here: https://9to5google.com/2022/10/04/samsung-android-12-update-rollout/
     eol: true
     link: https://doc.samsungmobile.com/SM-T540/XEH/doc.html
 
--   releaseCycle: "Galaxy A30s"
+-   releaseCycle: "galaxy-a30s"
+    releaseLabel: "Galaxy A30s"
     releaseDate: 2019-09-11
     eoas: true
     eol: true
     link: https://doc.samsungmobile.com/SM-A307GN/XXV/doc.html
 
--   releaseCycle: "Galaxy Fold"
+-   releaseCycle: "galaxy-fold"
+    releaseLabel: "Galaxy Fold"
     releaseDate: 2019-09-06
     eoas: true
     eol: true
     link: https://doc.samsungmobile.com/SM-F900F/XEH/doc.html
 
--   releaseCycle: "Galaxy A90 5G"
+-   releaseCycle: "galaxy-a90-5g"
+    releaseLabel: "Galaxy A90 5G"
     releaseDate: 2019-09-03
     eoas: true
     eol: true
     link: https://doc.samsungmobile.com/SM-A908B/009444191005/eng.html
 
--   releaseCycle: "Galaxy A70s"
+-   releaseCycle: "galaxy-a70s"
+    releaseLabel: "Galaxy A70s"
     releaseDate: 2019-09-01
     eoas: true
     eol: true
     link: https://doc.samsungmobile.com/sm-a707f/ins/doc.html
 
--   releaseCycle: "Galaxy A50s"
+-   releaseCycle: "galaxy-a50s"
+    releaseLabel: "Galaxy A50s"
     releaseDate: 2019-09-01
     eoas: true
     eol: true
     link: https://doc.samsungmobile.com/sm-a507fn/ins/doc.html
 
--   releaseCycle: "Galaxy M10s"
+-   releaseCycle: "galaxy-m10s"
+    releaseLabel: "Galaxy M10s"
     releaseDate: 2019-09-01
     eoas: true
     eol: true
     link: https://doc.samsungmobile.com/SM-M107F/INS/doc.html
 
--   releaseCycle: "Galaxy Watch Active2"
+-   releaseCycle: "galaxy-watch-active2"
+    releaseLabel: "Galaxy Watch Active2"
     releaseDate: 2019-09-01 # Approximate to the month and year.
     eoas: true
     eol: true
     link: https://doc.samsungmobile.com/sm-r825f/dbt/doc.html
 
--   releaseCycle: "Galaxy Watch Active2 Aluminum"
+-   releaseCycle: "galaxy-watch-active2-aluminum"
+    releaseLabel: "Galaxy Watch Active2 Aluminum"
     releaseDate: 2019-09-01 # Approximate to the month and year.
     eoas: true
     eol: true
     link: https://doc.samsungmobile.com/SM-R830/XAR/doc.html
 
--   releaseCycle: "Galaxy A10s"
+-   releaseCycle: "galaxy-a10s"
+    releaseLabel: "Galaxy A10s"
     releaseDate: 2019-08-27
     eoas: true
     eol: true
     link: https://doc.samsungmobile.com/SM-A107F/SEK/doc.html
 
--   releaseCycle: "Galaxy A10e"
+-   releaseCycle: "galaxy-a10e"
+    releaseLabel: "Galaxy A10e"
     releaseDate: 2019-08-27
     eoas: true
     eol: true
     link: https://doc.samsungmobile.com/SM-A102U/DSH/doc.html
 
--   releaseCycle: "Galaxy Note10+"
+-   releaseCycle: "galaxy-note10-plus"
+    releaseLabel: "Galaxy Note10+"
     releaseDate: 2019-08-23
     eoas: true
     eol: true
     link: https://doc.samsungmobile.com/SM-N975U/008579190821/fra.html
 
--   releaseCycle: "Galaxy Note10"
+-   releaseCycle: "galaxy-note10"
+    releaseLabel: "Galaxy Note10"
     releaseDate: 2019-08-23
     eoas: true
     eol: true
     link: https://doc.samsungmobile.com/SM-N970F/XEF/doc.html
 
--   releaseCycle: "Galaxy Tab S6"
+-   releaseCycle: "galaxy-tab-s6"
+    releaseLabel: "Galaxy Tab S6"
     releaseDate: 2019-08-01
     eoas: true
     eol: true
     link: https://doc.samsungmobile.com/SM-T860/XAR/doc.html
 
--   releaseCycle: "Galaxy Note10+ 5G"
+-   releaseCycle: "galaxy-note10-plus-5g"
+    releaseLabel: "Galaxy Note10+ 5G"
     releaseDate: 2019-08-01 # Approximate to the month and year.
     eoas: true
     eol: true
     link: https://doc.samsungmobile.com/SM-N976B/SFR/doc.html
 
--   releaseCycle: "Galaxy Note10 5G"
+-   releaseCycle: "galaxy-note10-5g"
+    releaseLabel: "Galaxy Note10 5G"
     releaseDate: 2019-08-01 # Approximate to the month and year.
     eoas: true
     eol: true
     link: https://doc.samsungmobile.com/sm-n971n/koo/doc.html
 
--   releaseCycle: "Galaxy Tab A 8.0 (2019)"
+-   releaseCycle: "galaxy-tab-a-8.0-2019"
+    releaseLabel: "Galaxy Tab A 8.0 (2019)"
     releaseDate: 2019-07-01
     eoas: true
     eol: true
     link: https://doc.samsungmobile.com/SM-T290/008916190830/mlt.html
 
--   releaseCycle: "Galaxy Xcover 4s"
+-   releaseCycle: "galaxy-xcover-4s"
+    releaseLabel: "Galaxy Xcover 4s"
     releaseDate: 2019-07-01 # Approximate to the month and year.
     eoas: 2022-10-01 # Approximate from here: https://9to5google.com/2022/10/04/samsung-android-12-update-rollout/
     eol: true
     link: https://doc.samsungmobile.com/SM-G398FN/ATO/doc.html
 
--   releaseCycle: "Galaxy A60"
+-   releaseCycle: "galaxy-a60"
+    releaseLabel: "Galaxy A60"
     releaseDate: 2019-06-01
     eoas: true
     eol: true
     link: https://doc.samsungmobile.com/SM-A6060/TGY/doc.html
 
--   releaseCycle: "Galaxy M40"
+-   releaseCycle: "galaxy-m40"
+    releaseLabel: "Galaxy M40"
     releaseDate: 2019-06-01 # Approximate to the month and year.
     eoas: true
     eol: true
     link: https://doc.samsungmobile.com/SM-M405F/INS/doc.html
 
--   releaseCycle: "Galaxy A80"
+-   releaseCycle: "galaxy-a80"
+    releaseLabel: "Galaxy A80"
     releaseDate: 2019-05-01
     eoas: true
     eol: true
     link: https://doc.samsungmobile.com/SM-A805F/XEH/doc.html
 
--   releaseCycle: "Galaxy A70"
+-   releaseCycle: "galaxy-a70"
+    releaseLabel: "Galaxy A70"
     releaseDate: 2019-05-01
     eoas: true
     eol: true
     link: https://doc.samsungmobile.com/SM-A705F/XID/doc.html
 
--   releaseCycle: "Galaxy A20e"
+-   releaseCycle: "galaxy-a20e"
+    releaseLabel: "Galaxy A20e"
     releaseDate: 2019-05-01
     eoas: true
     eol: true
     link: https://doc.samsungmobile.com/SM-A202F/DBT/doc.html
 
--   releaseCycle: "Galaxy A20"
+-   releaseCycle: "galaxy-a20"
+    releaseLabel: "Galaxy A20"
     releaseDate: 2019-04-05
     eoas: true
     eol: true
     link: https://doc.samsungmobile.com/SM-A205F/AFR/doc.html
 
--   releaseCycle: "Galaxy A40"
+-   releaseCycle: "galaxy-a40"
+    releaseLabel: "Galaxy A40"
     releaseDate: 2019-04-01
     eoas: 2022-10-01 # Approximate from here: https://9to5google.com/2022/10/04/samsung-android-12-update-rollout/
     eol: true
     link: https://doc.samsungmobile.com/SM-A405FN/XEH/doc.html
 
--   releaseCycle: "Galaxy Watch Active"
+-   releaseCycle: "galaxy-watch-active"
+    releaseLabel: "Galaxy Watch Active"
     releaseDate: 2019-04-01 # Approximate to the month and year.
     eoas: true
     eol: true
     link: https://doc.samsungmobile.com/sm-r500/xar/doc.html
 
--   releaseCycle: "Galaxy View2"
+-   releaseCycle: "galaxy-view2"
+    releaseLabel: "Galaxy View2"
     releaseDate: 2019-04-01
     eoas: true
     eol: 2021-12-31
     link: null
 
--   releaseCycle: "Galaxy Tab S5e"
+-   releaseCycle: "galaxy-tab-s5e"
+    releaseLabel: "Galaxy Tab S5e"
     releaseDate: 2019-04-01
     eoas: true
     eol: true
     link: https://doc.samsungmobile.com/SM-T725/XEO/doc.html
 
--   releaseCycle: "Galaxy Tab A 8.0 with S Pen (2019)"
+-   releaseCycle: "galaxy-tab-a-8.0-with-s-pen-2019"
+    releaseLabel: "Galaxy Tab A 8.0 with S Pen (2019)"
     releaseDate: 2019-04-01
     eoas: true
     eol: 2021-11-17
     link: https://doc.samsungmobile.com/sm-p205/xtc/doc.html
 
--   releaseCycle: "Galaxy Tab A 10.1 (2019)"
+-   releaseCycle: "galaxy-tab-a-10.1-2019"
+    releaseLabel: "Galaxy Tab A 10.1 (2019)"
     releaseDate: 2019-04-01
     eoas: true
     eol: true
     link: https://doc.samsungmobile.com/SM-T515/TMZ/doc.html
 
--   releaseCycle: "Galaxy A2 Core"
+-   releaseCycle: "galaxy-a2-core"
+    releaseLabel: "Galaxy A2 Core"
     releaseDate: 2019-04-01
     eoas: true
     eol: 2021-10-01
     link: https://doc.samsungmobile.com/SM-A260F/ECT/doc.html
 
--   releaseCycle: "Galaxy A10"
+-   releaseCycle: "galaxy-a10"
+    releaseLabel: "Galaxy A10"
     releaseDate: 2019-03-19
     eoas: true
     eol: true
     link: https://doc.samsungmobile.com/SM-A105F/AFR/doc.html
 
--   releaseCycle: "Galaxy A50"
+-   releaseCycle: "galaxy-a50"
+    releaseLabel: "Galaxy A50"
     releaseDate: 2019-03-18
     eoas: 2022-10-01 # Approximate from here: https://9to5google.com/2022/10/04/samsung-android-12-update-rollout/
     eol: 2023-04-01 # https://www.sammobile.com/news/samsung-galaxy-s10-a50-software-update-support-discontinued/
     link: https://doc.samsungmobile.com/SM-A505G/CHL/doc.html
 
--   releaseCycle: "Galaxy A30"
+-   releaseCycle: "galaxy-a30"
+    releaseLabel: "Galaxy A30"
     releaseDate: 2019-03-01
     eoas: true
     eol: true
     link: https://doc.samsungmobile.com/SM-A305F/AFR/doc.html
 
--   releaseCycle: "Galaxy M30"
+-   releaseCycle: "galaxy-m30"
+    releaseLabel: "Galaxy M30"
     releaseDate: 2019-03-01 # Approximate to the month and year.
     eoas: true
     eol: true
     link: https://doc.samsungmobile.com/SM-M305M/XXV/doc.html
 
--   releaseCycle: "Galaxy S10 5G"
+-   releaseCycle: "galaxy-s10-5g"
+    releaseLabel: "Galaxy S10 5G"
     releaseDate: 2019-02-20
     eoas: true
     eol: true
     link: https://doc.samsungmobile.com/SM-G977B/EVR/doc.html
 
--   releaseCycle: "Galaxy S10"
+-   releaseCycle: "galaxy-s10"
+    releaseLabel: "Galaxy S10"
     releaseDate: 2019-02-20
     eoas: true
     eol: 2023-04-01 # https://www.sammobile.com/news/samsung-galaxy-s10-a50-software-update-support-discontinued/
     link: https://doc.samsungmobile.com/SM-G973F/XEF/doc.html
 
--   releaseCycle: "Galaxy S10+"
+-   releaseCycle: "galaxy-s10-plus"
+    releaseLabel: "Galaxy S10+"
     releaseDate: 2019-02-20
     eoas: true
     eol: 2023-04-01 # https://www.sammobile.com/news/samsung-galaxy-s10-a50-software-update-support-discontinued/
     link: https://doc.samsungmobile.com/SM-G975F/XEF/doc.html
 
--   releaseCycle: "Galaxy S10e"
+-   releaseCycle: "galaxy-s10e"
+    releaseLabel: "Galaxy S10e"
     releaseDate: 2019-02-20
     eoas: true
     eol: 2023-04-01 # https://www.sammobile.com/news/samsung-galaxy-s10-a50-software-update-support-discontinued/
     link: https://doc.samsungmobile.com/sm-g970f/dbt/doc.html
 
--   releaseCycle: "Galaxy M20"
+-   releaseCycle: "galaxy-m20"
+    releaseLabel: "Galaxy M20"
     releaseDate: 2019-02-01 # Approximate to the month and year.
     eoas: true
     eol: true
     link: https://doc.samsungmobile.com/SM-M205F/INS/doc.html
 
--   releaseCycle: "Galaxy M10"
+-   releaseCycle: "galaxy-m10"
+    releaseLabel: "Galaxy M10"
     releaseDate: 2019-02-01 # Approximate to the month and year.
     eoas: true
     eol: true
     link: https://doc.samsungmobile.com/SM-M105F/INS/doc.html
 
--   releaseCycle: "Galaxy A8s"
+-   releaseCycle: "galaxy-a8s"
+    releaseLabel: "Galaxy A8s"
     releaseDate: 2018-12-01
     eoas: true
     eol: true
     link: https://doc.samsungmobile.com/SM-G8870/TGY/doc.html
 
--   releaseCycle: "Galaxy Tab Advanced2"
+-   releaseCycle: "galaxy-tab-advanced2"
+    releaseLabel: "Galaxy Tab Advanced2"
     releaseDate: 2018-12-01 # Approximate to the month and year.
     eoas: true
     eol: true
     link: https://doc.samsungmobile.com/SM-T583/KOO/doc.html
 
--   releaseCycle: "Galaxy J4 Core"
+-   releaseCycle: "galaxy-j4-core"
+    releaseLabel: "Galaxy J4 Core"
     releaseDate: 2018-11-01
     eoas: true
     eol: 2020-12-01
     link: https://doc.samsungmobile.com/SM-J410F/AFR/doc.html
 
--   releaseCycle: "Galaxy A6s"
+-   releaseCycle: "galaxy-a6s"
+    releaseLabel: "Galaxy A6s"
     releaseDate: 2018-11-01 # Approximate to the month and year.
     eoas: true
     eol: true
     link: https://doc.samsungmobile.com/SM-A600FN/XEF/doc.html
 
--   releaseCycle: "Galaxy A9 (2018)"
+-   releaseCycle: "galaxy-a9-2018"
+    releaseLabel: "Galaxy A9 (2018)"
     releaseDate: 2018-11-01
     eoas: true
     eol: 2022-06-01
     link: https://doc.samsungmobile.com/SM-A920F/XEO/doc.html
 
--   releaseCycle: "Galaxy J6+"
+-   releaseCycle: "galaxy-j6-plus"
+    releaseLabel: "Galaxy J6+"
     releaseDate: 2018-10-01
     eoas: true
     eol: 2022-06-01
     link: https://doc.samsungmobile.com/SM-J610FN/XEF/doc.html
 
--   releaseCycle: "Galaxy J4+"
+-   releaseCycle: "galaxy-j4-plus"
+    releaseLabel: "Galaxy J4+"
     releaseDate: 2018-10-01
     eoas: true
     eol: 2020-12-01
     link: https://doc.samsungmobile.com/SM-J415F/AFR/doc.html
 
--   releaseCycle: "Galaxy A7 (2018)"
+-   releaseCycle: "galaxy-a7-2018"
+    releaseLabel: "Galaxy A7 (2018)"
     releaseDate: 2018-10-01
     eoas: true
     eol: 2022-07-01
     link: https://doc.samsungmobile.com/SM-A750GN/XXV/doc.html
 
--   releaseCycle: "Galaxy Tab A 8.0 (2018)"
+-   releaseCycle: "galaxy-tab-a-8.0-2018"
+    releaseLabel: "Galaxy Tab A 8.0 (2018)"
     releaseDate: 2018-09-01 # Approximate to the month and year.
     eoas: true
     eol: true
     link: https://doc.samsungmobile.com/SM-A530F/FTM/doc.html
 
--   releaseCycle: "Galaxy Note 9"
+-   releaseCycle: "galaxy-note-9"
+    releaseLabel: "Galaxy Note 9"
     releaseDate: 2018-08-24
     eoas: true
     eol: 2022-07-01
     link: https://doc.samsungmobile.com/sm-n960f/dbt/doc.html
 
--   releaseCycle: "Galaxy Tab S4 10.5"
+-   releaseCycle: "galaxy-tab-s4-10.5"
+    releaseLabel: "Galaxy Tab S4 10.5"
     releaseDate: 2018-08-01
     eoas: true
     eol: 2022-06-01
     link: https://doc.samsungmobile.com/SM-T830/XAR/doc.html
 
--   releaseCycle: "Galaxy Tab A 10.5 (2018)"
+-   releaseCycle: "galaxy-tab-a-10.5-2018"
+    releaseLabel: "Galaxy Tab A 10.5 (2018)"
     releaseDate: 2018-08-01 # Approximate to the month and year.
     eoas: true
     eol: 2022-06-01
     link: https://doc.samsungmobile.com/SM-T595/SER/doc.html
 
--   releaseCycle: "Galaxy Watch"
+-   releaseCycle: "galaxy-watch"
+    releaseLabel: "Galaxy Watch"
     releaseDate: 2018-08-01 # Approximate to the month and year.
     eoas: true
     eol: true
     link: https://doc.samsungmobile.com/SM-R810/001398180827/fra.html
 
--   releaseCycle: "Galaxy J2 Core"
+-   releaseCycle: "galaxy-j2-core"
+    releaseLabel: "Galaxy J2 Core"
     releaseDate: 2018-08-01
     eoas: true
     eol: 2021-12-31
     link: https://doc.samsungmobile.com/SM-J260M/COM/doc.html
 
--   releaseCycle: "Galaxy J8"
+-   releaseCycle: "galaxy-j8"
+    releaseLabel: "Galaxy J8"
     releaseDate: 2018-07-01
     eoas: true
     eol: 2021-09-01
     link: https://doc.samsungmobile.com/SM-J810G/INS/doc.html
 
--   releaseCycle: "Galaxy On6"
+-   releaseCycle: "galaxy-on6"
+    releaseLabel: "Galaxy On6"
     releaseDate: 2018-07-01 # Approximate to the month and year.
     eoas: true
     eol: 2022-02-01
     link: https://doc.samsungmobile.com/SM-J600GF/INS/doc.html
 
--   releaseCycle: "Galaxy J7 (2018)"
+-   releaseCycle: "galaxy-j7-2018"
+    releaseLabel: "Galaxy J7 (2018)"
     releaseDate: 2018-07-01 # Approximate to the month and year.
     eoas: true
     eol: 2021-12-01
     link: https://doc.samsungmobile.com/SM-J700F/023395220803/roh.html
 
--   releaseCycle: "Galaxy J7 Top"
+-   releaseCycle: "galaxy-j7-top"
+    releaseLabel: "Galaxy J7 Top"
     releaseDate: 2018-07-01
     eoas: true
     eol: 2021-12-31
     link: https://doc.samsungmobile.com/SM-J737U/XAR/doc.html
 
--   releaseCycle: "Galaxy J3 (2018)"
+-   releaseCycle: "galaxy-j3-2018"
+    releaseLabel: "Galaxy J3 (2018)"
     releaseDate: 2018-06-01 # Approximate to the month and year.
     eoas: true
     eol: 2021-11-01
     link: https://doc.samsungmobile.com/SM-J3300/CHC/doc.html
 
--   releaseCycle: "Galaxy A8 Star"
+-   releaseCycle: "galaxy-a8-star"
+    releaseLabel: "Galaxy A8 Star"
     releaseDate: 2018-06-01
     eoas: true
     eol: 2022-06-01
     link: https://doc.samsungmobile.com/SM-G885F/XXV/doc.html
 
--   releaseCycle: "Galaxy J6"
+-   releaseCycle: "galaxy-j6"
+    releaseLabel: "Galaxy J6"
     releaseDate: 2018-05-01
     eoas: true
     eol: 2022-02-01
     link: https://doc.samsungmobile.com/SM-J600G/INS/doc.html
 
--   releaseCycle: "Galaxy J4"
+-   releaseCycle: "galaxy-j4"
+    releaseLabel: "Galaxy J4"
     releaseDate: 2018-05-01
     eoas: true
     eol: 2022-02-01
     link: https://doc.samsungmobile.com/SM-J400G/BRI/doc.html
 
--   releaseCycle: "Galaxy S Light Luxury"
+-   releaseCycle: "galaxy-s-light-luxury"
+    releaseLabel: "Galaxy S Light Luxury"
     releaseDate: 2018-05-01 # Approximate to the month and year.
     eoas: true
     eol: true
     link: https://doc.samsungmobile.com/SM-G8750/000773180601/zho-cn.html
 
--   releaseCycle: "Galaxy A6+ (2018)"
+-   releaseCycle: "galaxy-a6-plus-2018"
+    releaseLabel: "Galaxy A6+ (2018)"
     releaseDate: 2018-05-01 # Approximate to the month and year.
     eoas: true
     eol: 2021-12-01
     link: https://doc.samsungmobile.com/SM-A605G/XXV/doc.html
 
--   releaseCycle: "Galaxy A6 (2018)"
+-   releaseCycle: "galaxy-a6-2018"
+    releaseLabel: "Galaxy A6 (2018)"
     releaseDate: 2018-05-01 # Approximate to the month and year.
     eoas: true
     eol: 2022-03-01
     link: https://doc.samsungmobile.com/SM-A600U/XAR/doc.html
 
--   releaseCycle: "Galaxy J7 Prime 2"
+-   releaseCycle: "galaxy-j7-prime-2"
+    releaseLabel: "Galaxy J7 Prime 2"
     releaseDate: 2018-04-01
     eoas: true
     eol: 2021-12-31
     link: null
 
--   releaseCycle: "Galaxy J7 Duo"
+-   releaseCycle: "galaxy-j7-duo"
+    releaseLabel: "Galaxy J7 Duo"
     releaseDate: 2018-04-01
     eoas: true
     eol: 2021-12-31
     link: null
 
--   releaseCycle: "Galaxy S9+"
+-   releaseCycle: "galaxy-s9-plus"
+    releaseLabel: "Galaxy S9+"
     releaseDate: 2018-03-09
     eoas: true
     eol: 2022-04-05
     link: https://doc.samsungmobile.com/sm-g965f/dbt/doc.html
 
--   releaseCycle: "Galaxy S9"
+-   releaseCycle: "galaxy-s9"
+    releaseLabel: "Galaxy S9"
     releaseDate: 2018-03-09
     eoas: true
     eol: 2022-04-05
     link: https://doc.samsungmobile.com/sm-g960f/dbt/doc.html
 
--   releaseCycle: "Galaxy A8 (2018) Enterprise"
+-   releaseCycle: "galaxy-a8-2018-enterprise"
+    releaseLabel: "Galaxy A8 (2018) Enterprise"
     releaseDate: 2018-01-01
     eoas: true
     eol: 2021-12-31
     link: null
 
--   releaseCycle: "Galaxy A8+ (2018)"
+-   releaseCycle: "galaxy-a8-plus-2018"
+    releaseLabel: "Galaxy A8+ (2018)"
     releaseDate: 2018-01-01 # Approximate to the month and year.
     eoas: true
     eol: 2021-09-01
     link: https://doc.samsungmobile.com/SM-A730F/INS/doc.html
 
--   releaseCycle: "Galaxy A8 (2018)"
+-   releaseCycle: "galaxy-a8-2018"
+    releaseLabel: "Galaxy A8 (2018)"
     releaseDate: 2018-01-01 # Approximate to the month and year.
     eoas: true
     eol: 2022-01-01
     link: https://doc.samsungmobile.com/SM-A530F/CHL/doc.html
 
--   releaseCycle: "Galaxy J2 Pro (2018)"
+-   releaseCycle: "galaxy-j2-pro-2018"
+    releaseLabel: "Galaxy J2 Pro (2018)"
     releaseDate: 2018-01-01 # Approximate to the month and year.
     eoas: true
     eol: 2019-10-01
     link: https://doc.samsungmobile.com/SM-J250Y/ITV/doc.html
 
--   releaseCycle: "Galaxy Tab Active2"
+-   releaseCycle: "galaxy-tab-active2"
+    releaseLabel: "Galaxy Tab Active2"
     releaseDate: 2017-10-20
     eoas: true
     eol: 2021-11-17
     link: https://doc.samsungmobile.com/SM-T395/DBT/doc.html
 
--   releaseCycle: "Galaxy J2 (2017)"
+-   releaseCycle: "galaxy-j2-2017"
+    releaseLabel: "Galaxy J2 (2017)"
     releaseDate: 2017-10-01 # Approximate to the month and year.
     eoas: true
     eol: true
     link: null
 
--   releaseCycle: "Galaxy C7 (2017)"
+-   releaseCycle: "galaxy-c7-2017"
+    releaseLabel: "Galaxy C7 (2017)"
     releaseDate: 2017-10-01 # Approximate to the month and year.
     eoas: true
     eol: true
     link: https://doc.samsungmobile.com/SM-C710F/XXV/doc.html
 
--   releaseCycle: "Gear Sport"
+-   releaseCycle: "gear-sport"
+    releaseLabel: "Gear Sport"
     releaseDate: 2017-10-01 # Approximate to the month and year.
     eoas: true
     eol: true
     link: https://doc.samsungmobile.com/SM-R600/CHC/doc.html
 
--   releaseCycle: "Galaxy Note8"
+-   releaseCycle: "galaxy-note8"
+    releaseLabel: "Galaxy Note8"
     releaseDate: 2017-09-01
     eoas: true
     eol: 2021-11-17
     link: https://doc.samsungmobile.com/sm-n950f/dbt/doc.html
 
--   releaseCycle: "Galaxy Tab A 8.0 (2017)"
+-   releaseCycle: "galaxy-tab-a-8.0-2017"
+    releaseLabel: "Galaxy Tab A 8.0 (2017)"
     releaseDate: 2017-09-01
     eoas: true
     eol: 2021-11-17
     link: https://doc.samsungmobile.com/SM-T380/COO/doc.html
 
--   releaseCycle: "Galaxy S8 Active"
+-   releaseCycle: "galaxy-s8-active"
+    releaseLabel: "Galaxy S8 Active"
     releaseDate: 2017-08-01
     eoas: true
     eol: 2021-11-17
     link: null
 
--   releaseCycle: "Galaxy Note FE"
+-   releaseCycle: "galaxy-note-fe"
+    releaseLabel: "Galaxy Note FE"
     releaseDate: 2017-07-01 # Approximate to the month and year.
     eoas: true
     eol: 2019-03-01
     link: https://doc.samsungmobile.com/SM-N935F/XXV/doc.html
 
--   releaseCycle: "Galaxy J7 (2017)"
+-   releaseCycle: "galaxy-j7-2017"
+    releaseLabel: "Galaxy J7 (2017)"
     releaseDate: 2017-07-01 # Approximate to the month and year.
     eoas: true
     eol: 2019-05-01
     link: https://doc.samsungmobile.com/SM-J730F/XEF/doc.html
 
--   releaseCycle: "Galaxy J7 Pro"
+-   releaseCycle: "galaxy-j7-pro"
+    releaseLabel: "Galaxy J7 Pro"
     releaseDate: 2017-07-01 # Approximate to the month and year.
     eoas: true
     eol: 2019-04-01
     link: https://doc.samsungmobile.com/SM-J730G/TNZ/doc.html
 
--   releaseCycle: "Galaxy J3 (2017)"
+-   releaseCycle: "galaxy-j3-2017"
+    releaseLabel: "Galaxy J3 (2017)"
     releaseDate: 2017-07-01 # Approximate to the month and year.
     eoas: true
     eol: 2019-07-01
     link: https://doc.samsungmobile.com/SM-J327U/XAR/doc.html
 
--   releaseCycle: "Galaxy Folder2"
+-   releaseCycle: "galaxy-folder2"
+    releaseLabel: "Galaxy Folder2"
     releaseDate: 2017-07-01 # Approximate to the month and year.
     eoas: true
     eol: true
     link: https://doc.samsungmobile.com/SM-G160N/KOO/doc.html
 
--   releaseCycle: "Galaxy J7 Neo"
+-   releaseCycle: "galaxy-j7-neo"
+    releaseLabel: "Galaxy J7 Neo"
     releaseDate: 2017-07-01 # Approximate to the month and year.
     eoas: true
     eol: 2019-05-01
     link: https://doc.samsungmobile.com/SM-J701M/PET/doc.html
 
--   releaseCycle: "Galaxy J7 Max"
+-   releaseCycle: "galaxy-j7-max"
+    releaseLabel: "Galaxy J7 Max"
     releaseDate: 2017-06-01 # Approximate to the month and year.
     eoas: true
     eol: 2019-03-01
     link: https://doc.samsungmobile.com/SM-G615FU/INS/doc.html
 
--   releaseCycle: "Galaxy J5 (2017)"
+-   releaseCycle: "galaxy-j5-2017"
+    releaseLabel: "Galaxy J5 (2017)"
     releaseDate: 2017-06-01 # Approximate to the month and year.
     eoas: true
     eol: 2019-03-01
     link: https://doc.samsungmobile.com/SM-J530F/XEO/doc.html
 
--   releaseCycle: "Z4"
+-   releaseCycle: "z4"
+    releaseLabel: "Z4"
     releaseDate: 2017-06-01 # Approximate to the month and year.
     eoas: true
     eol: true
     link: null
 
--   releaseCycle: "Gear S3 classic LTE"
+-   releaseCycle: "gear-s3-classic-lte"
+    releaseLabel: "Gear S3 classic LTE"
     releaseDate: 2017-05-01 # Approximate to the month and year.
     eoas: true
     eol: true
     link: https://doc.samsungmobile.com/SM-R770/BRI/doc.html
 
--   releaseCycle: "Galaxy S8"
+-   releaseCycle: "galaxy-s8"
+    releaseLabel: "Galaxy S8"
     releaseDate: 2017-04-24
     eoas: true
     eol: 2021-04-01
     link: https://doc.samsungmobile.com/SM-G950F/ITV/doc.html
 
--   releaseCycle: "Galaxy S8+"
+-   releaseCycle: "galaxy-s8-plus"
+    releaseLabel: "Galaxy S8+"
     releaseDate: 2017-04-01 # Approximate to the month and year.
     eoas: true
     eol: 2021-04-01
     link: https://doc.samsungmobile.com/SM-G955F/SER/doc.html
 
--   releaseCycle: "Galaxy Xcover 4"
+-   releaseCycle: "galaxy-xcover-4"
+    releaseLabel: "Galaxy Xcover 4"
     releaseDate: 2017-04-01 # Approximate to the month and year.
     eoas: true
     eol: 2019-06-01
     link: https://doc.samsungmobile.com/SM-G390F/ATO/doc.html
 
--   releaseCycle: "Galaxy Tab S3 9.7"
+-   releaseCycle: "galaxy-tab-s3-9.7"
+    releaseLabel: "Galaxy Tab S3 9.7"
     releaseDate: 2017-04-01 # Approximate to the month and year.
     eoas: true
     eol: 2019-04-01
     link: https://doc.samsungmobile.com/SM-T825Y/XXV/doc.html
 
--   releaseCycle: "Galaxy J7 V"
+-   releaseCycle: "galaxy-j7-v"
+    releaseLabel: "Galaxy J7 V"
     releaseDate: 2017-03-01 # Approximate to the month and year.
     eoas: true
     eol: 2019-03-01
     link: https://doc.samsungmobile.com/SM-J727U/XAA/doc.html
 
--   releaseCycle: "Galaxy C5 Pro"
+-   releaseCycle: "galaxy-c5-pro"
+    releaseLabel: "Galaxy C5 Pro"
     releaseDate: 2017-03-01 # Approximate to the month and year.
     eoas: true
     eol: 2018-10-01
     link: https://doc.samsungmobile.com/SM-C5010/TGY/doc.html
 
--   releaseCycle: "Galaxy C7 Pro"
+-   releaseCycle: "galaxy-c7-pro"
+    releaseLabel: "Galaxy C7 Pro"
     releaseDate: 2017-02-01 # Approximate to the month and year.
     eoas: true
     eol: 2019-05-01
     link: https://doc.samsungmobile.com/SM-C701F/INS/doc.html
 
--   releaseCycle: "Galaxy J3 Emerge"
+-   releaseCycle: "galaxy-j3-emerge"
+    releaseLabel: "Galaxy J3 Emerge"
     releaseDate: 2017-01-01 # Approximate to the month and year.
     eoas: true
     eol: 2019-08-01
     link: https://doc.samsungmobile.com/SM-J327T/TMB/doc.html
 
--   releaseCycle: "Galaxy A7 (2017)"
+-   releaseCycle: "galaxy-a7-2017"
+    releaseLabel: "Galaxy A7 (2017)"
     releaseDate: 2017-01-01 # Approximate to the month and year.
     eoas: true
     eol: 2020-08-01
     link: https://doc.samsungmobile.com/SM-A720F/CHL/doc.html
 
--   releaseCycle: "Galaxy A5 (2017)"
+-   releaseCycle: "galaxy-a5-2017"
+    releaseLabel: "Galaxy A5 (2017)"
     releaseDate: 2017-01-01 # Approximate to the month and year.
     eoas: true
     eol: 2019-04-01
     link: https://doc.samsungmobile.com/SM-A520F/XSA/doc.html
 
--   releaseCycle: "Galaxy A3 (2017)"
+-   releaseCycle: "galaxy-a3-2017"
+    releaseLabel: "Galaxy A3 (2017)"
     releaseDate: 2017-01-01 # Approximate to the month and year.
     eoas: true
     eol: 2020-11-01
     link: https://doc.samsungmobile.com/SM-A320FL/ITV/doc.html
 
--   releaseCycle: "Galaxy J1 mini prime"
+-   releaseCycle: "galaxy-j1-mini-prime"
+    releaseLabel: "Galaxy J1 mini prime"
     releaseDate: 2016-12-01 # Approximate to the month and year.
     eoas: true
     eol: true
     link: null
 
--   releaseCycle: "Galaxy J7 Prime"
+-   releaseCycle: "galaxy-j7-prime"
+    releaseLabel: "Galaxy J7 Prime"
     releaseDate: 2016-11-30
     eoas: true
     eol: 2020-04-01
     link: https://doc.samsungmobile.com/SM-G610F/XXV/doc.html
 
--   releaseCycle: "Galaxy Grand Prime Plus"
+-   releaseCycle: "galaxy-grand-prime-plus"
+    releaseLabel: "Galaxy Grand Prime Plus"
     releaseDate: 2016-11-01 # Approximate to the month and year.
     eoas: true
     eol: true
     link: null
 
--   releaseCycle: "Galaxy J2 Prime"
+-   releaseCycle: "galaxy-j2-prime"
+    releaseLabel: "Galaxy J2 Prime"
     releaseDate: 2016-11-01 # Approximate to the month and year.
     eoas: true
     eol: true
     link: null
 
--   releaseCycle: "Galaxy C9 Pro"
+-   releaseCycle: "galaxy-c9-pro"
+    releaseLabel: "Galaxy C9 Pro"
     releaseDate: 2016-11-01 # Approximate to the month and year.
     eoas: true
     eol: 2019-07-01
     link: https://doc.samsungmobile.com/SM-C900F/INS/doc.html
 
--   releaseCycle: "Gear S3 classic"
+-   releaseCycle: "gear-s3-classic"
+    releaseLabel: "Gear S3 classic"
     releaseDate: 2016-11-01 # Approximate to the month and year.
     eoas: true
     eol: true
     link: https://doc.samsungmobile.com/SM-R770/BRI/doc.html
 
--   releaseCycle: "Gear S3 frontier"
+-   releaseCycle: "gear-s3-frontier"
+    releaseLabel: "Gear S3 frontier"
     releaseDate: 2016-11-01 # Approximate to the month and year.
     eoas: true
     eol: true
     link: https://doc.samsungmobile.com/SM-R770/BRI/doc.html
 
--   releaseCycle: "Gear S3 frontier LTE"
+-   releaseCycle: "gear-s3-frontier-lte"
+    releaseLabel: "Gear S3 frontier LTE"
     releaseDate: 2016-11-01 # Approximate to the month and year.
     eoas: true
     eol: true
     link: https://doc.samsungmobile.com/SM-R770/BRI/doc.html
 
--   releaseCycle: "Galaxy A8 (2016)"
+-   releaseCycle: "galaxy-a8-2016"
+    releaseLabel: "Galaxy A8 (2016)"
     releaseDate: 2016-10-01 # Approximate to the month and year.
     eoas: true
     eol: true
     link: https://doc.samsungmobile.com/SM-A800IZ/000065170406/zho-tw.html
 
--   releaseCycle: "Galaxy On8"
+-   releaseCycle: "galaxy-on8"
+    releaseLabel: "Galaxy On8"
     releaseDate: 2016-10-01 # Approximate to the month and year.
     eoas: true
     eol: 2019-01-01
     link: https://doc.samsungmobile.com/SM-J710FN/INS/doc.html
 
--   releaseCycle: "Galaxy On7 (2016)"
+-   releaseCycle: "galaxy-on7-2016"
+    releaseLabel: "Galaxy On7 (2016)"
     releaseDate: 2016-10-01 # Approximate to the month and year.
     eoas: true
     eol: 2020-07-01
     link: https://doc.samsungmobile.com/SM-G6100/TGY/doc.html
 
--   releaseCycle: "Galaxy J5 Prime"
+-   releaseCycle: "galaxy-j5-prime"
+    releaseLabel: "Galaxy J5 Prime"
     releaseDate: 2016-10-01 # Approximate to the month and year.
     eoas: true
     eol: 2020-10-01
     link: https://doc.samsungmobile.com/SM-G570F/SER/doc.html
 
--   releaseCycle: "Galaxy Note7"
+-   releaseCycle: "galaxy-note7"
+    releaseLabel: "Galaxy Note7"
     releaseDate: 2016-09-01 # Approximate to the month and year.
     eoas: true
     eol: true
     link: null
 
--   releaseCycle: "Z2"
+-   releaseCycle: "z2"
+    releaseLabel: "Z2"
     releaseDate: 2016-08-01 # Approximate to the month and year.
     eoas: true
     eol: true
     link: null
 
--   releaseCycle: "Galaxy Note 7 (USA)"
+-   releaseCycle: "galaxy-note-7-usa"
+    releaseLabel: "Galaxy Note 7 (USA)"
     releaseDate: 2016-08-01 # Approximate to the month and year.
     eoas: true
     eol: true
     link: null
 
--   releaseCycle: "Galaxy Tab J"
+-   releaseCycle: "galaxy-tab-j"
+    releaseLabel: "Galaxy Tab J"
     releaseDate: 2016-08-01 # Approximate to the month and year.
     eoas: true
     eol: true
     link: null
 
--   releaseCycle: "Galaxy J Max"
+-   releaseCycle: "galaxy-j-max"
+    releaseLabel: "Galaxy J Max"
     releaseDate: 2016-08-01 # Approximate to the month and year.
     eoas: true
     eol: true
     link: null
 
--   releaseCycle: "Galaxy On7 Pro"
+-   releaseCycle: "galaxy-on7-pro"
+    releaseLabel: "Galaxy On7 Pro"
     releaseDate: 2016-07-01 # Approximate to the month and year.
     eoas: true
     eol: true
     link: null
 
--   releaseCycle: "Galaxy On5 Pro"
+-   releaseCycle: "galaxy-on5-pro"
+    releaseLabel: "Galaxy On5 Pro"
     releaseDate: 2016-07-01 # Approximate to the month and year.
     eoas: true
     eol: true
     link: null
 
--   releaseCycle: "Galaxy J2 Pro (2016)"
+-   releaseCycle: "galaxy-j2-pro-2016"
+    releaseLabel: "Galaxy J2 Pro (2016)"
     releaseDate: 2016-07-01 # Approximate to the month and year.
     eoas: true
     eol: 2019-10-01
     link: https://doc.samsungmobile.com/SM-J250F/TUR/doc.html
 
--   releaseCycle: "Galaxy J2 (2016)"
+-   releaseCycle: "galaxy-j2-2016"
+    releaseLabel: "Galaxy J2 (2016)"
     releaseDate: 2016-07-01 # Approximate to the month and year.
     eoas: true
     eol: 2018-08-01
     link: https://doc.samsungmobile.com/SM-J210F/INS/doc.html
 
--   releaseCycle: "Z3 Corporate"
+-   releaseCycle: "z3-corporate"
+    releaseLabel: "Z3 Corporate"
     releaseDate: 2016-06-01 # Approximate to the month and year.
     eoas: true
     eol: true
     link: null
 
--   releaseCycle: "Galaxy S7 active"
+-   releaseCycle: "galaxy-s7-active"
+    releaseLabel: "Galaxy S7 active"
     releaseDate: 2016-06-01 # Approximate to the month and year.
     eoas: true
     eol: true
     link: null
 
--   releaseCycle: "Galaxy J3 Pro"
+-   releaseCycle: "galaxy-j3-pro"
+    releaseLabel: "Galaxy J3 Pro"
     releaseDate: 2016-06-01 # Approximate to the month and year.
     eoas: true
     eol: 2021-04-01
     link: https://doc.samsungmobile.com/SM-J330G/BRI/doc.html
 
--   releaseCycle: "Galaxy C7"
+-   releaseCycle: "galaxy-c7"
+    releaseLabel: "Galaxy C7"
     releaseDate: 2016-06-01 # Approximate to the month and year.
     eoas: true
     eol: 2018-10-01
     link: https://doc.samsungmobile.com/SM-C7000/CHC/doc.html
 
--   releaseCycle: "Galaxy C5"
+-   releaseCycle: "galaxy-c5"
+    releaseLabel: "Galaxy C5"
     releaseDate: 2016-06-01 # Approximate to the month and year.
     eoas: true
     eol: 2019-01-01
     link: https://doc.samsungmobile.com/sm-c5000/tgy/doc.html
 
--   releaseCycle: "Galaxy J3 (2016)"
+-   releaseCycle: "galaxy-j3-2016"
+    releaseLabel: "Galaxy J3 (2016)"
     releaseDate: 2016-05-06
     eoas: true
     eol: 2019-04-02
     link: https://doc.samsungmobile.com/SM-J320H/AFR/doc.html
 
--   releaseCycle: "Galaxy A9 Pro (2016)"
+-   releaseCycle: "galaxy-a9-pro-2016"
+    releaseLabel: "Galaxy A9 Pro (2016)"
     releaseDate: 2016-05-01 # Approximate to the month and year.
     eoas: true
     eol: 2019-02-01
     link: https://doc.samsungmobile.com/SM-A910F/INS/doc.html
 
--   releaseCycle: "Galaxy Tab A 10.1 (2016)"
+-   releaseCycle: "galaxy-tab-a-10.1-2016"
+    releaseLabel: "Galaxy Tab A 10.1 (2016)"
     releaseDate: 2016-05-01 # Approximate to the month and year.
     eoas: true
     eol: 2020-04-01
     link: https://doc.samsungmobile.com/SM-T580/ATO/doc.html
 
--   releaseCycle: "Galaxy Xcover3 G389F"
+-   releaseCycle: "galaxy-xcover3-g389f"
+    releaseLabel: "Galaxy Xcover3 G389F"
     releaseDate: 2016-04-01 # Approximate to the month and year.
     eoas: true
     eol: 2018-06-01
     link: https://doc.samsungmobile.com/SM-G389F/ATO/doc.html
 
--   releaseCycle: "Galaxy J7 (2016)"
+-   releaseCycle: "galaxy-j7-2016"
+    releaseLabel: "Galaxy J7 (2016)"
     releaseDate: 2016-04-01 # Approximate to the month and year.
     eoas: true
     eol: 2019-11-01
     link: https://doc.samsungmobile.com/SM-J710F/INS/doc.html
 
--   releaseCycle: "Galaxy J5 (2016)"
+-   releaseCycle: "galaxy-j5-2016"
+    releaseLabel: "Galaxy J5 (2016)"
     releaseDate: 2016-04-01 # Approximate to the month and year.
     eoas: true
     eol: 2019-08-01
     link: https://doc.samsungmobile.com/SM-J510FN/ATO/doc.html
 
--   releaseCycle: "Gear S2 classic 3G"
+-   releaseCycle: "gear-s2-classic-3g"
+    releaseLabel: "Gear S2 classic 3G"
     releaseDate: 2016-04-01 # Approximate to the month and year.
     eoas: true
     eol: true
     link: null
 
--   releaseCycle: "Galaxy Express Prime"
+-   releaseCycle: "galaxy-express-prime"
+    releaseLabel: "Galaxy Express Prime"
     releaseDate: 2016-04-01 # Approximate to the month and year.
     eoas: true
     eol: true
     link: null
 
--   releaseCycle: "Galaxy S7 edge"
+-   releaseCycle: "galaxy-s7-edge"
+    releaseLabel: "Galaxy S7 edge"
     releaseDate: 2016-03-11
     eoas: true
     eol: 2019-03-01
     link: https://doc.samsungmobile.com/SM-G935F/AFR/doc.html
 
--   releaseCycle: "Galaxy S7"
+-   releaseCycle: "galaxy-s7"
+    releaseLabel: "Galaxy S7"
     releaseDate: 2016-03-11
     eoas: true
     eol: 2019-06-01
     link: https://doc.samsungmobile.com/SM-G930F/CHL/doc.html
 
--   releaseCycle: "Galaxy Tab A 7.0 (2016)"
+-   releaseCycle: "galaxy-tab-a-7.0-2016"
+    releaseLabel: "Galaxy Tab A 7.0 (2016)"
     releaseDate: 2016-03-01 # Approximate to the month and year.
     eoas: true
     eol: 2016-12-30
     link: https://doc.samsungmobile.com/SM-T280/KOO/doc.html
 
--   releaseCycle: "Galaxy J1 Nxt"
+-   releaseCycle: "galaxy-j1-nxt"
+    releaseLabel: "Galaxy J1 Nxt"
     releaseDate: 2016-02-01 # Approximate to the month and year.
     eoas: true
     eol: true
     link: null
 
--   releaseCycle: "Galaxy J1 (2016)"
+-   releaseCycle: "galaxy-j1-2016"
+    releaseLabel: "Galaxy J1 (2016)"
     releaseDate: 2016-01-01 # Approximate to the month and year.
     eoas: true
     eol: true
     link: null
 
--   releaseCycle: "Galaxy A9 (2016)"
+-   releaseCycle: "galaxy-a9-2016"
+    releaseLabel: "Galaxy A9 (2016)"
     releaseDate: 2016-01-01 # Approximate to the month and year.
     eoas: true
     eol: true
     link: null
 
--   releaseCycle: "Galaxy Tab E 8.0"
+-   releaseCycle: "galaxy-tab-e-8.0"
+    releaseLabel: "Galaxy Tab E 8.0"
     releaseDate: 2016-01-01
     eoas: true
     eol: 2020-11-10
     link: https://doc.samsungmobile.com/SM-A710S/SKC/doc.html
 
--   releaseCycle: "Galaxy A7 (2016)"
+-   releaseCycle: "galaxy-a7-2016"
+    releaseLabel: "Galaxy A7 (2016)"
     releaseDate: 2015-12-01 # Approximate to the month and year.
     eoas: true
     eol: 2018-11-01
     link: https://doc.samsungmobile.com/SM-A710F/INS/doc.html
 
--   releaseCycle: "Galaxy A5 (2016)"
+-   releaseCycle: "galaxy-a5-2016"
+    releaseLabel: "Galaxy A5 (2016)"
     releaseDate: 2015-12-01 # Approximate to the month and year.
     eoas: true
     eol: 2019-06-01
     link: https://doc.samsungmobile.com/SM-A510F/INS/doc.html
 
--   releaseCycle: "Galaxy A3 (2016)"
+-   releaseCycle: "galaxy-a3-2016"
+    releaseLabel: "Galaxy A3 (2016)"
     releaseDate: 2015-12-01 # Approximate to the month and year.
     eoas: true
     eol: 2018-06-01
     link: https://doc.samsungmobile.com/SM-A310F/BTU/doc.html
 
--   releaseCycle: "Galaxy View"
+-   releaseCycle: "galaxy-view"
+    releaseLabel: "Galaxy View"
     releaseDate: 2015-11-01 # Approximate to the month and year.
     eoas: true
     eol: 2018-01-01
     link: https://doc.samsungmobile.com/SM-T810/XSA/doc.html
 
--   releaseCycle: "Galaxy On7"
+-   releaseCycle: "galaxy-on7"
+    releaseLabel: "Galaxy On7"
     releaseDate: 2015-11-01 # Approximate to the month and year.
     eoas: true
     eol: 2018-01-01
     link: https://doc.samsungmobile.com/SM-G600S/SKC/doc.html
 
--   releaseCycle: "Galaxy On5"
+-   releaseCycle: "galaxy-on5"
+    releaseLabel: "Galaxy On5"
     releaseDate: 2015-11-01 # Approximate to the month and year.
     eoas: true
     eol: true
     link: null
 
--   releaseCycle: "Z3"
+-   releaseCycle: "z3"
+    releaseLabel: "Z3"
     releaseDate: 2015-10-01 # Approximate to the month and year.
     eoas: true
     eol: true
     link: null
 
--   releaseCycle: "Galaxy J1 Ace"
+-   releaseCycle: "galaxy-j1-ace"
+    releaseLabel: "Galaxy J1 Ace"
     releaseDate: 2015-10-01 # Approximate to the month and year.
     eoas: true
     eol: true
     link: null
 
--   releaseCycle: "Gear S2 classic"
+-   releaseCycle: "gear-s2-classic"
+    releaseLabel: "Gear S2 classic"
     releaseDate: 2015-10-01 # Approximate to the month and year.
     eoas: true
     eol: 2018-03-26
     link: https://doc.samsungmobile.com/SM-R720/CHC/doc.html
 
--   releaseCycle: "Gear S2"
+-   releaseCycle: "gear-s2"
+    releaseLabel: "Gear S2"
     releaseDate: 2015-10-01 # Approximate to the month and year.
     eoas: true
     eol: 2018-03-26
     link: https://doc.samsungmobile.com/SM-R720/CHC/doc.html
 
--   releaseCycle: "Gear S2 3G"
+-   releaseCycle: "gear-s2-3g"
+    releaseLabel: "Gear S2 3G"
     releaseDate: 2015-10-01 # Approximate to the month and year.
     eoas: true
     eol: 2018-03-26
     link: https://doc.samsungmobile.com/SM-R720/CHC/doc.html
 
--   releaseCycle: "Galaxy Tab S2 9.7"
+-   releaseCycle: "galaxy-tab-s2-9.7"
+    releaseLabel: "Galaxy Tab S2 9.7"
     releaseDate: 2015-09-01 # Approximate to the month and year.
     eoas: true
     eol: 2019-07-01
     link: https://doc.samsungmobile.com/SM-T819Y/INS/doc.html
 
--   releaseCycle: "Galaxy Tab S2 8.0"
+-   releaseCycle: "galaxy-tab-s2-8.0"
+    releaseLabel: "Galaxy Tab S2 8.0"
     releaseDate: 2015-09-01 # Approximate to the month and year.
     eoas: true
     eol: 2019-07-01
     link: https://doc.samsungmobile.com/SM-T713/BTU/doc.html
 
--   releaseCycle: "Galaxy J2"
+-   releaseCycle: "galaxy-j2"
+    releaseLabel: "Galaxy J2"
     releaseDate: 2015-09-01 # Approximate to the month and year.
     eoas: true
     eol: true
     link: null
 
--   releaseCycle: "Galaxy Note 5 (USA)"
+-   releaseCycle: "galaxy-note-5-usa"
+    releaseLabel: "Galaxy Note 5 (USA)"
     releaseDate: 2015-08-01 # Approximate to the month and year.
     eoas: true
     eol: true
     link: null
 
--   releaseCycle: "Galaxy Note 5"
+-   releaseCycle: "galaxy-note-5"
+    releaseLabel: "Galaxy Note 5"
     releaseDate: 2015-08-01 # Approximate to the month and year.
     eoas: true
     eol: 2018-08-01
     link: https://doc.samsungmobile.com/SM-N920G/CHL/doc.html
 
--   releaseCycle: "Galaxy Note 5 Duos"
+-   releaseCycle: "galaxy-note-5-duos"
+    releaseLabel: "Galaxy Note 5 Duos"
     releaseDate: 2015-08-01 # Approximate to the month and year.
     eoas: true
     eol: 2018-08-01
     link: https://doc.samsungmobile.com/SM-N920C/SER/doc.html
 
--   releaseCycle: "Galaxy S6 edge+ (USA)"
+-   releaseCycle: "galaxy-s6-edge-plus-usa"
+    releaseLabel: "Galaxy S6 edge+ (USA)"
     releaseDate: 2015-08-01 # Approximate to the month and year.
     eoas: true
     eol: true
     link: null
 
--   releaseCycle: "Galaxy S6 edge+"
+-   releaseCycle: "galaxy-s6-edge-plus"
+    releaseLabel: "Galaxy S6 edge+"
     releaseDate: 2015-08-01 # Approximate to the month and year.
     eoas: true
     eol: 2018-08-01
     link: https://doc.samsungmobile.com/SM-G928C/XXV/doc.html
 
--   releaseCycle: "Galaxy S6 edge+ Duos"
+-   releaseCycle: "galaxy-s6-edge-plus-duos"
+    releaseLabel: "Galaxy S6 edge+ Duos"
     releaseDate: 2015-08-01 # Approximate to the month and year.
     eoas: true
     eol: 2018-08-01
     link: https://doc.samsungmobile.com/SM-G928F/ITV/doc.html
 
--   releaseCycle: "Galaxy S5 Neo"
+-   releaseCycle: "galaxy-s5-neo"
+    releaseLabel: "Galaxy S5 Neo"
     releaseDate: 2015-08-01 # Approximate to the month and year.
     eoas: true
     eol: 2018-04-01
     link: https://doc.samsungmobile.com/SM-G903F/DBT/doc.html
 
--   releaseCycle: "Galaxy A8 Duos"
+-   releaseCycle: "galaxy-a8-duos"
+    releaseLabel: "Galaxy A8 Duos"
     releaseDate: 2015-08-01 # Approximate to the month and year.
     eoas: true
     eol: 2017-08-01
     link: https://doc.samsungmobile.com/SM-A800I/INS/doc.html
 
--   releaseCycle: "Galaxy A8"
+-   releaseCycle: "galaxy-a8"
+    releaseLabel: "Galaxy A8"
     releaseDate: 2015-08-01 # Approximate to the month and year.
     eoas: true
     eol: 2017-08-01
     link: https://doc.samsungmobile.com/SM-A800F/INS/doc.html
 
--   releaseCycle: "Galaxy J5"
+-   releaseCycle: "galaxy-j5"
+    releaseLabel: "Galaxy J5"
     releaseDate: 2015-07-28
     eoas: true
     eol: 2019-12-03
     link: https://doc.samsungmobile.com/SM-J500F/INS/doc.html
 
--   releaseCycle: "Galaxy J7"
+-   releaseCycle: "galaxy-j7"
+    releaseLabel: "Galaxy J7"
     releaseDate: 2015-07-16
     eoas: true
     eol: 2018-04-01
     link: https://doc.samsungmobile.com/SM-J700F/INS/doc.html
 
--   releaseCycle: "Galaxy Folder"
+-   releaseCycle: "galaxy-folder"
+    releaseLabel: "Galaxy Folder"
     releaseDate: 2015-07-01 # Approximate to the month and year.
     eoas: true
     eol: true
     link: null
 
--   releaseCycle: "Galaxy V Plus"
+-   releaseCycle: "galaxy-v-plus"
+    releaseLabel: "Galaxy V Plus"
     releaseDate: 2015-07-01 # Approximate to the month and year.
     eoas: true
     eol: true
     link: null
 
--   releaseCycle: "Galaxy Tab E 9.6"
+-   releaseCycle: "galaxy-tab-e-9.6"
+    releaseLabel: "Galaxy Tab E 9.6"
     releaseDate: 2015-07-01 # Approximate to the month and year.
     eoas: true
     eol: true
     link: null
 
--   releaseCycle: "Galaxy Tab A 9.7 & S Pen"
+-   releaseCycle: "galaxy-tab-a-9.7-and-s-pen"
+    releaseLabel: "Galaxy Tab A 9.7 & S Pen"
     releaseDate: 2015-07-01 # Approximate to the month and year.
     eoas: true
     eol: 2017-08-01
     link: https://doc.samsungmobile.com/SM-P555/XXV/doc.html
 
--   releaseCycle: "Galaxy S4 mini I9195I"
+-   releaseCycle: "galaxy-s4-mini-i9195i"
+    releaseLabel: "Galaxy S4 mini I9195I"
     releaseDate: 2015-06-01 # Approximate to the month and year.
     eoas: true
     eol: true
     link: null
 
--   releaseCycle: "Galaxy S6 active"
+-   releaseCycle: "galaxy-s6-active"
+    releaseLabel: "Galaxy S6 active"
     releaseDate: 2015-06-01 # Approximate to the month and year.
     eoas: true
     eol: true
     link: null
 
--   releaseCycle: "Galaxy S6 Duos"
+-   releaseCycle: "galaxy-s6-duos"
+    releaseLabel: "Galaxy S6 Duos"
     releaseDate: 2015-06-01 # Approximate to the month and year.
     eoas: true
     eol: true
     link: null
 
--   releaseCycle: "Galaxy Tab A 9.7"
+-   releaseCycle: "galaxy-tab-a-9.7"
+    releaseLabel: "Galaxy Tab A 9.7"
     releaseDate: 2015-05-01 # Approximate to the month and year.
     eoas: true
     eol: 2017-08-01
     link: https://doc.samsungmobile.com/SM-P550/XSA/doc.html
 
--   releaseCycle: "Galaxy Tab A 8.0 & S Pen (2015)"
+-   releaseCycle: "galaxy-tab-a-8.0-and-s-pen-2015"
+    releaseLabel: "Galaxy Tab A 8.0 & S Pen (2015)"
     releaseDate: 2015-05-01 # Approximate to the month and year.
     eoas: true
     eol: 2017-08-01
     link: https://doc.samsungmobile.com/SM-P355/XXV/doc.html
 
--   releaseCycle: "Galaxy Tab A 8.0 (2015)"
+-   releaseCycle: "galaxy-tab-a-8.0-2015"
+    releaseLabel: "Galaxy Tab A 8.0 (2015)"
     releaseDate: 2015-05-01 # Approximate to the month and year.
     eoas: true
     eol: 2017-08-01
     link: https://doc.samsungmobile.com/SM-T355/SER/doc.html
 
--   releaseCycle: "Galaxy Tab 3 V"
+-   releaseCycle: "galaxy-tab-3-v"
+    releaseLabel: "Galaxy Tab 3 V"
     releaseDate: 2015-04-01 # Approximate to the month and year.
     eoas: true
     eol: true
     link: null
 
--   releaseCycle: "Galaxy Xcover 3"
+-   releaseCycle: "galaxy-xcover-3"
+    releaseLabel: "Galaxy Xcover 3"
     releaseDate: 2015-04-01 # Approximate to the month and year.
     eoas: true
     eol: true
     link: null
 
--   releaseCycle: "Galaxy S6 edge (USA)"
+-   releaseCycle: "galaxy-s6-edge-usa"
+    releaseLabel: "Galaxy S6 edge (USA)"
     releaseDate: 2015-04-01 # Approximate to the month and year.
     eoas: true
     eol: true
     link: null
 
--   releaseCycle: "Galaxy S6 (USA)"
+-   releaseCycle: "galaxy-s6-usa"
+    releaseLabel: "Galaxy S6 (USA)"
     releaseDate: 2015-04-01 # Approximate to the month and year.
     eoas: true
     eol: 2018-03-01
     link: https://doc.samsungmobile.com/SM-G920T1/TMB/doc.html
 
--   releaseCycle: "Galaxy S6 edge"
+-   releaseCycle: "galaxy-s6-edge"
+    releaseLabel: "Galaxy S6 edge"
     releaseDate: 2015-04-01 # Approximate to the month and year.
     eoas: true
     eol: 2018-06-01
     link: https://doc.samsungmobile.com/SM-G925I/PET/doc.html
 
--   releaseCycle: "Galaxy S6"
+-   releaseCycle: "galaxy-s6"
+    releaseLabel: "Galaxy S6"
     releaseDate: 2015-04-01 # Approximate to the month and year.
     eoas: true
     eol: 2018-06-01
     link: https://doc.samsungmobile.com/SM-G920I/INS/doc.html
 
--   releaseCycle: "Galaxy J1 4G"
+-   releaseCycle: "galaxy-j1-4g"
+    releaseLabel: "Galaxy J1 4G"
     releaseDate: 2015-03-01 # Approximate to the month and year.
     eoas: true
     eol: true
     link: null
 
--   releaseCycle: "Galaxy Tab 3 Lite 7.0 VE"
+-   releaseCycle: "galaxy-tab-3-lite-7.0-ve"
+    releaseLabel: "Galaxy Tab 3 Lite 7.0 VE"
     releaseDate: 2015-03-01 # Approximate to the month and year.
     eoas: true
     eol: true
     link: null
 
--   releaseCycle: "Galaxy J1"
+-   releaseCycle: "galaxy-j1"
+    releaseLabel: "Galaxy J1"
     releaseDate: 2015-02-01 # Approximate to the month and year.
     eoas: true
     eol: true
     link: null
 
--   releaseCycle: "Galaxy A7 Duos"
+-   releaseCycle: "galaxy-a7-duos"
+    releaseLabel: "Galaxy A7 Duos"
     releaseDate: 2015-02-01 # Approximate to the month and year.
     eoas: true
     eol: true
     link: null
 
--   releaseCycle: "Galaxy E7"
+-   releaseCycle: "galaxy-e7"
+    releaseLabel: "Galaxy E7"
     releaseDate: 2015-02-01 # Approximate to the month and year.
     eoas: true
     eol: true
     link: null
 
--   releaseCycle: "Galaxy E5"
+-   releaseCycle: "galaxy-e5"
+    releaseLabel: "Galaxy E5"
     releaseDate: 2015-02-01 # Approximate to the month and year.
     eoas: true
     eol: true
     link: null
 
--   releaseCycle: "Z1"
+-   releaseCycle: "z1"
+    releaseLabel: "Z1"
     releaseDate: 2015-01-01 # Approximate to the month and year.
     eoas: true
     eol: true
     link: null
 
--   releaseCycle: "Galaxy Grand Max"
+-   releaseCycle: "galaxy-grand-max"
+    releaseLabel: "Galaxy Grand Max"
     releaseDate: 2015-01-01 # Approximate to the month and year.
     eoas: true
     eol: true
     link: null
 
--   releaseCycle: "Galaxy A5"
+-   releaseCycle: "galaxy-a5"
+    releaseLabel: "Galaxy A5"
     releaseDate: 2014-12-01 # Approximate to the month and year.
     eoas: true
     eol: true
     link: null
 
--   releaseCycle: "Galaxy A3 Duos"
+-   releaseCycle: "galaxy-a3-duos"
+    releaseLabel: "Galaxy A3 Duos"
     releaseDate: 2014-12-01 # Approximate to the month and year.
     eoas: true
     eol: true
     link: null
 
--   releaseCycle: "Galaxy A3"
+-   releaseCycle: "galaxy-a3"
+    releaseLabel: "Galaxy A3"
     releaseDate: 2014-12-01 # Approximate to the month and year.
     eoas: true
     eol: true
     link: null
 
--   releaseCycle: "Galaxy Tab Active LTE"
+-   releaseCycle: "galaxy-tab-active-lte"
+    releaseLabel: "Galaxy Tab Active LTE"
     releaseDate: 2014-12-01 # Approximate to the month and year.
     eoas: true
     eol: true
     link: null
 
--   releaseCycle: "Galaxy Tab Active"
+-   releaseCycle: "galaxy-tab-active"
+    releaseLabel: "Galaxy Tab Active"
     releaseDate: 2014-12-01 # Approximate to the month and year.
     eoas: true
     eol: true
     link: null
 
--   releaseCycle: "Galaxy Core Prime"
+-   releaseCycle: "galaxy-core-prime"
+    releaseLabel: "Galaxy Core Prime"
     releaseDate: 2014-11-01 # Approximate to the month and year.
     eoas: true
     eol: true
     link: null
 
--   releaseCycle: "Galaxy A5 Duos"
+-   releaseCycle: "galaxy-a5-duos"
+    releaseLabel: "Galaxy A5 Duos"
     releaseDate: 2014-11-01 # Approximate to the month and year.
     eoas: true
     eol: true
     link: null
 
--   releaseCycle: "Galaxy S5 Plus"
+-   releaseCycle: "galaxy-s5-plus"
+    releaseLabel: "Galaxy S5 Plus"
     releaseDate: 2014-11-01 # Approximate to the month and year.
     eoas: true
     eol: true
     link: null
 
--   releaseCycle: "Galaxy Note Edge"
+-   releaseCycle: "galaxy-note-edge"
+    releaseLabel: "Galaxy Note Edge"
     releaseDate: 2014-11-01 # Approximate to the month and year.
     eoas: true
     eol: true
     link: null
 
--   releaseCycle: "Galaxy Core LTE G386W"
+-   releaseCycle: "galaxy-core-lte-g386w"
+    releaseLabel: "Galaxy Core LTE G386W"
     releaseDate: 2014-11-01 # Approximate to the month and year.
     eoas: true
     eol: true
     link: null
 
--   releaseCycle: "Galaxy Grand Prime Duos TV"
+-   releaseCycle: "galaxy-grand-prime-duos-tv"
+    releaseLabel: "Galaxy Grand Prime Duos TV"
     releaseDate: 2014-10-01 # Approximate to the month and year.
     eoas: true
     eol: true
     link: null
 
--   releaseCycle: "Galaxy Grand Prime"
+-   releaseCycle: "galaxy-grand-prime"
+    releaseLabel: "Galaxy Grand Prime"
     releaseDate: 2014-10-01 # Approximate to the month and year.
     eoas: true
     eol: true
     link: null
 
--   releaseCycle: "Galaxy Note 4 Duos"
+-   releaseCycle: "galaxy-note-4-duos"
+    releaseLabel: "Galaxy Note 4 Duos"
     releaseDate: 2014-10-01 # Approximate to the month and year.
     eoas: true
     eol: true
     link: null
 
--   releaseCycle: "Galaxy Note4"
+-   releaseCycle: "galaxy-note4"
+    releaseLabel: "Galaxy Note4"
     releaseDate: 2014-10-01 # Approximate to the month and year.
     eoas: true
     eol: 2017-08-01
     link: https://doc.samsungmobile.com/SM-N910U/TNZ/doc.html
 
--   releaseCycle: "Gear S"
+-   releaseCycle: "gear-s"
+    releaseLabel: "Gear S"
     releaseDate: 2014-10-01 # Approximate to the month and year.
     eoas: true
     eol: true
     link: null
 
--   releaseCycle: "Galaxy Young 2"
+-   releaseCycle: "galaxy-young-2"
+    releaseLabel: "Galaxy Young 2"
     releaseDate: 2014-10-01 # Approximate to the month and year.
     eoas: true
     eol: true
     link: null
 
--   releaseCycle: "Galaxy Pocket 2"
+-   releaseCycle: "galaxy-pocket-2"
+    releaseLabel: "Galaxy Pocket 2"
     releaseDate: 2014-09-01 # Approximate to the month and year.
     eoas: true
     eol: true
     link: null
 
--   releaseCycle: "Galaxy V"
+-   releaseCycle: "galaxy-v"
+    releaseLabel: "Galaxy V"
     releaseDate: 2014-09-01 # Approximate to the month and year.
     eoas: true
     eol: true
     link: null
 
--   releaseCycle: "Galaxy Ace Style LTE G357"
+-   releaseCycle: "galaxy-ace-style-lte-g357"
+    releaseLabel: "Galaxy Ace Style LTE G357"
     releaseDate: 2014-09-01 # Approximate to the month and year.
     eoas: true
     eol: true
     link: null
 
--   releaseCycle: "Galaxy Mega 2"
+-   releaseCycle: "galaxy-mega-2"
+    releaseLabel: "Galaxy Mega 2"
     releaseDate: 2014-09-01 # Approximate to the month and year.
     eoas: true
     eol: true
     link: null
 
--   releaseCycle: "Galaxy Alpha (S801)"
+-   releaseCycle: "galaxy-alpha-s801"
+    releaseLabel: "Galaxy Alpha (S801)"
     releaseDate: 2014-09-01 # Approximate to the month and year.
     eoas: true
     eol: true
     link: null
 
--   releaseCycle: "Galaxy Alpha"
+-   releaseCycle: "galaxy-alpha"
+    releaseLabel: "Galaxy Alpha"
     releaseDate: 2014-09-01 # Approximate to the month and year.
     eoas: true
     eol: 2017-01-01
     link: https://doc.samsungmobile.com/SM-G850Y/XSA/doc.html
 
--   releaseCycle: "Galaxy W"
+-   releaseCycle: "galaxy-w"
+    releaseLabel: "Galaxy W"
     releaseDate: 2014-09-01 # Approximate to the month and year.
     eoas: true
     eol: true
     link: null
 
--   releaseCycle: "Galaxy S5 LTE-A G901F"
+-   releaseCycle: "galaxy-s5-lte-a-g901f"
+    releaseLabel: "Galaxy S5 LTE-A G901F"
     releaseDate: 2014-08-01 # Approximate to the month and year.
     eoas: true
     eol: true
     link: null
 
--   releaseCycle: "Galaxy S5 mini Duos"
+-   releaseCycle: "galaxy-s5-mini-duos"
+    releaseLabel: "Galaxy S5 mini Duos"
     releaseDate: 2014-08-01 # Approximate to the month and year.
     eoas: true
     eol: true
     link: null
 
--   releaseCycle: "Galaxy S Duos 3"
+-   releaseCycle: "galaxy-s-duos-3"
+    releaseLabel: "Galaxy S Duos 3"
     releaseDate: 2014-08-01 # Approximate to the month and year.
     eoas: true
     eol: true
     link: null
 
--   releaseCycle: "Galaxy Ace NXT"
+-   releaseCycle: "galaxy-ace-nxt"
+    releaseLabel: "Galaxy Ace NXT"
     releaseDate: 2014-08-01 # Approximate to the month and year.
     eoas: true
     eol: true
     link: null
 
--   releaseCycle: "Galaxy Star 2 Plus"
+-   releaseCycle: "galaxy-star-2-plus"
+    releaseLabel: "Galaxy Star 2 Plus"
     releaseDate: 2014-08-01 # Approximate to the month and year.
     eoas: true
     eol: true
     link: null
 
--   releaseCycle: "Galaxy Ace 4 LTE G313"
+-   releaseCycle: "galaxy-ace-4-lte-g313"
+    releaseLabel: "Galaxy Ace 4 LTE G313"
     releaseDate: 2014-08-01 # Approximate to the month and year.
     eoas: true
     eol: true
     link: null
 
--   releaseCycle: "Galaxy Ace 4"
+-   releaseCycle: "galaxy-ace-4"
+    releaseLabel: "Galaxy Ace 4"
     releaseDate: 2014-08-01 # Approximate to the month and year.
     eoas: true
     eol: true
     link: null
 
--   releaseCycle: "Galaxy Star 2"
+-   releaseCycle: "galaxy-star-2"
+    releaseLabel: "Galaxy Star 2"
     releaseDate: 2014-08-01 # Approximate to the month and year.
     eoas: true
     eol: true
     link: null
 
--   releaseCycle: "Gear Live"
+-   releaseCycle: "gear-live"
+    releaseLabel: "Gear Live"
     releaseDate: 2014-07-01 # Approximate to the month and year.
     eoas: true
     eol: true
     link: null
 
--   releaseCycle: "Galaxy Avant"
+-   releaseCycle: "galaxy-avant"
+    releaseLabel: "Galaxy Avant"
     releaseDate: 2014-07-01 # Approximate to the month and year.
     eoas: true
     eol: true
     link: null
 
--   releaseCycle: "Galaxy S5 mini"
+-   releaseCycle: "galaxy-s5-mini"
+    releaseLabel: "Galaxy S5 mini"
     releaseDate: 2014-07-01 # Approximate to the month and year.
     eoas: true
     eol: 2017-08-01
     link: https://doc.samsungmobile.com/SM-G800F/DBT/doc.html
 
--   releaseCycle: "Galaxy Core II"
+-   releaseCycle: "galaxy-core-ii"
+    releaseLabel: "Galaxy Core II"
     releaseDate: 2014-07-01 # Approximate to the month and year.
     eoas: true
     eol: true
     link: null
 
--   releaseCycle: "Galaxy S5 LTE-A G906S"
+-   releaseCycle: "galaxy-s5-lte-a-g906s"
+    releaseLabel: "Galaxy S5 LTE-A G906S"
     releaseDate: 2014-07-01 # Approximate to the month and year.
     eoas: true
     eol: 2017-01-04
     link: https://doc.samsungmobile.com/sm-g906s/skc/doc.html
 
--   releaseCycle: "Galaxy Tab S 8.4 LTE"
+-   releaseCycle: "galaxy-tab-s-8.4-lte"
+    releaseLabel: "Galaxy Tab S 8.4 LTE"
     releaseDate: 2014-07-01 # Approximate to the month and year.
     eoas: true
     eol: 2016-12-01
     link: https://doc.samsungmobile.com/SM-T705/INS/doc.html
 
--   releaseCycle: "Galaxy Tab S 8.4"
+-   releaseCycle: "galaxy-tab-s-8.4"
+    releaseLabel: "Galaxy Tab S 8.4"
     releaseDate: 2014-07-01 # Approximate to the month and year.
     eoas: true
     eol: 2017-08-01
     link: https://doc.samsungmobile.com/SM-T700/BTU/doc.html
 
--   releaseCycle: "Galaxy Tab S 10.5 LTE"
+-   releaseCycle: "galaxy-tab-s-10.5-lte"
+    releaseLabel: "Galaxy Tab S 10.5 LTE"
     releaseDate: 2014-07-01 # Approximate to the month and year.
     eoas: true
     eol: 2016-12-01
     link: https://doc.samsungmobile.com/SM-T805/ATO/doc.html
 
--   releaseCycle: "Galaxy Tab S 10.5"
+-   releaseCycle: "galaxy-tab-s-10.5"
+    releaseLabel: "Galaxy Tab S 10.5"
     releaseDate: 2014-07-01 # Approximate to the month and year.
     eoas: true
     eol: 2017-08-01
     link: https://doc.samsungmobile.com/SM-T800/ATO/doc.html
 
--   releaseCycle: "Galaxy Beam2"
+-   releaseCycle: "galaxy-beam2"
+    releaseLabel: "Galaxy Beam2"
     releaseDate: 2014-07-01 # Approximate to the month and year.
     eoas: true
     eol: true
     link: null
 
--   releaseCycle: "Galaxy S5 Sport"
+-   releaseCycle: "galaxy-s5-sport"
+    releaseLabel: "Galaxy S5 Sport"
     releaseDate: 2014-06-01 # Approximate to the month and year.
     eoas: true
     eol: true
     link: null
 
--   releaseCycle: "Galaxy Core Lite LTE"
+-   releaseCycle: "galaxy-core-lite-lte"
+    releaseLabel: "Galaxy Core Lite LTE"
     releaseDate: 2014-06-01 # Approximate to the month and year.
     eoas: true
     eol: true
     link: null
 
--   releaseCycle: "I9301I Galaxy S3 Neo"
+-   releaseCycle: "i9301i-galaxy-s3-neo"
+    releaseLabel: "I9301I Galaxy S3 Neo"
     releaseDate: 2014-06-01 # Approximate to the month and year.
     eoas: true
     eol: true
     link: null
 
--   releaseCycle: "Galaxy K zoom"
+-   releaseCycle: "galaxy-k-zoom"
+    releaseLabel: "Galaxy K zoom"
     releaseDate: 2014-06-01 # Approximate to the month and year.
     eoas: true
     eol: true
     link: null
 
--   releaseCycle: "Galaxy Tab 4 8.0"
+-   releaseCycle: "galaxy-tab-4-8.0"
+    releaseLabel: "Galaxy Tab 4 8.0"
     releaseDate: 2014-06-01 # Approximate to the month and year.
     eoas: true
     eol: true
     link: https://doc.samsungmobile.com/SM-T330/KSA/doc.html
 
--   releaseCycle: "Galaxy Tab 4 8.0 3G"
+-   releaseCycle: "galaxy-tab-4-8.0-3g"
+    releaseLabel: "Galaxy Tab 4 8.0 3G"
     releaseDate: 2014-06-01 # Approximate to the month and year.
     eoas: true
     eol: true
     link: null
 
--   releaseCycle: "Galaxy Tab 4 8.0 LTE"
+-   releaseCycle: "galaxy-tab-4-8.0-lte"
+    releaseLabel: "Galaxy Tab 4 8.0 LTE"
     releaseDate: 2014-06-01 # Approximate to the month and year.
     eoas: true
     eol: true
     link: null
 
--   releaseCycle: "Galaxy Tab 4 10.1"
+-   releaseCycle: "galaxy-tab-4-10.1"
+    releaseLabel: "Galaxy Tab 4 10.1"
     releaseDate: 2014-06-01 # Approximate to the month and year.
     eoas: true
     eol: true
     link: https://doc.samsungmobile.com/SM-T530/KOO/doc.html
 
--   releaseCycle: "Galaxy Tab 4 10.1 3G"
+-   releaseCycle: "galaxy-tab-4-10.1-3g"
+    releaseLabel: "Galaxy Tab 4 10.1 3G"
     releaseDate: 2014-06-01 # Approximate to the month and year.
     eoas: true
     eol: true
     link: null
 
--   releaseCycle: "Galaxy Tab 4 10.1 LTE"
+-   releaseCycle: "galaxy-tab-4-10.1-lte"
+    releaseLabel: "Galaxy Tab 4 10.1 LTE"
     releaseDate: 2014-06-01 # Approximate to the month and year.
     eoas: true
     eol: true
     link: null
 
--   releaseCycle: "Galaxy S5 Duos"
+-   releaseCycle: "galaxy-s5-duos"
+    releaseLabel: "Galaxy S5 Duos"
     releaseDate: 2014-06-01 # Approximate to the month and year.
     eoas: true
     eol: true
     link: null
 
--   releaseCycle: "Gear 2 Neo"
+-   releaseCycle: "gear-2-neo"
+    releaseLabel: "Gear 2 Neo"
     releaseDate: 2014-05-01 # Approximate to the month and year.
     eoas: true
     eol: true
     link: null
 
--   releaseCycle: "Galaxy S5 Active"
+-   releaseCycle: "galaxy-s5-active"
+    releaseLabel: "Galaxy S5 Active"
     releaseDate: 2014-05-01 # Approximate to the month and year.
     eoas: true
     eol: true
     link: null
 
--   releaseCycle: "Galaxy Ace Style"
+-   releaseCycle: "galaxy-ace-style"
+    releaseLabel: "Galaxy Ace Style"
     releaseDate: 2014-05-01 # Approximate to the month and year.
     eoas: true
     eol: true
     link: null
 
--   releaseCycle: "Galaxy Tab 4 7.0"
+-   releaseCycle: "galaxy-tab-4-7.0"
+    releaseLabel: "Galaxy Tab 4 7.0"
     releaseDate: 2014-05-01 # Approximate to the month and year.
     eoas: true
     eol: true
     link: null
 
--   releaseCycle: "Galaxy Tab 4 7.0 3G"
+-   releaseCycle: "galaxy-tab-4-7.0-3g"
+    releaseLabel: "Galaxy Tab 4 7.0 3G"
     releaseDate: 2014-05-01 # Approximate to the month and year.
     eoas: true
     eol: true
     link: null
 
--   releaseCycle: "Galaxy Tab 4 7.0 LTE"
+-   releaseCycle: "galaxy-tab-4-7.0-lte"
+    releaseLabel: "Galaxy Tab 4 7.0 LTE"
     releaseDate: 2014-05-01 # Approximate to the month and year.
     eoas: true
     eol: true
     link: null
 
--   releaseCycle: "Galaxy Core LTE"
+-   releaseCycle: "galaxy-core-lte"
+    releaseLabel: "Galaxy Core LTE"
     releaseDate: 2014-05-01 # Approximate to the month and year.
     eoas: true
     eol: true
     link: null
 
--   releaseCycle: "Galaxy Star Trios S5283"
+-   releaseCycle: "galaxy-star-trios-s5283"
+    releaseLabel: "Galaxy Star Trios S5283"
     releaseDate: 2014-05-01 # Approximate to the month and year.
     eoas: true
     eol: true
     link: null
 
--   releaseCycle: "Galaxy Tab Pro 12.2 LTE"
+-   releaseCycle: "galaxy-tab-pro-12.2-lte"
+    releaseLabel: "Galaxy Tab Pro 12.2 LTE"
     releaseDate: 2014-05-01 # Approximate to the month and year.
     eoas: true
     eol: true
     link: null
 
--   releaseCycle: "Gear 2"
+-   releaseCycle: "gear-2"
+    releaseLabel: "Gear 2"
     releaseDate: 2014-04-01 # Approximate to the month and year.
     eoas: true
     eol: true
     link: null
 
--   releaseCycle: "I9300I Galaxy S3 Neo"
+-   releaseCycle: "i9300i-galaxy-s3-neo"
+    releaseLabel: "I9300I Galaxy S3 Neo"
     releaseDate: 2014-04-01 # Approximate to the month and year.
     eoas: true
     eol: true
     link: null
 
--   releaseCycle: "ATIV SE"
+-   releaseCycle: "ativ-se"
+    releaseLabel: "ATIV SE"
     releaseDate: 2014-04-01 # Approximate to the month and year.
     eoas: true
     eol: true
     link: null
 
--   releaseCycle: "Galaxy S5 (octa-core)"
+-   releaseCycle: "galaxy-s5-octa-core"
+    releaseLabel: "Galaxy S5 (octa-core)"
     releaseDate: 2014-04-01 # Approximate to the month and year.
     eoas: true
     eol: 2017-04-01
     link: https://doc.samsungmobile.com/SM-G900H/XXV/doc.html
 
--   releaseCycle: "Galaxy S5"
+-   releaseCycle: "galaxy-s5"
+    releaseLabel: "Galaxy S5"
     releaseDate: 2014-04-01 # Approximate to the month and year.
     eoas: true
     eol: 2017-04-01
     link: https://doc.samsungmobile.com/SM-G900H/XXV/doc.html
 
--   releaseCycle: "Galaxy Tab Pro 12.2 3G"
+-   releaseCycle: "galaxy-tab-pro-12.2-3g"
+    releaseLabel: "Galaxy Tab Pro 12.2 3G"
     releaseDate: 2014-04-01 # Approximate to the month and year.
     eoas: true
     eol: true
     link: null
 
--   releaseCycle: "G3812B Galaxy S3 Slim"
+-   releaseCycle: "g3812b-galaxy-s3-slim"
+    releaseLabel: "G3812B Galaxy S3 Slim"
     releaseDate: 2014-03-01 # Approximate to the month and year.
     eoas: true
     eol: true
     link: null
 
--   releaseCycle: "I8200 Galaxy S III mini VE"
+-   releaseCycle: "i8200-galaxy-s-iii-mini-ve"
+    releaseLabel: "I8200 Galaxy S III mini VE"
     releaseDate: 2014-03-01 # Approximate to the month and year.
     eoas: true
     eol: true
     link: null
 
--   releaseCycle: "Galaxy Note Pro 12.2 LTE"
+-   releaseCycle: "galaxy-note-pro-12.2-lte"
+    releaseLabel: "Galaxy Note Pro 12.2 LTE"
     releaseDate: 2014-03-01 # Approximate to the month and year.
     eoas: true
     eol: true
     link: null
 
--   releaseCycle: "Galaxy Note Pro 12.2 3G"
+-   releaseCycle: "galaxy-note-pro-12.2-3g"
+    releaseLabel: "Galaxy Note Pro 12.2 3G"
     releaseDate: 2014-03-01 # Approximate to the month and year.
     eoas: true
     eol: true
     link: null
 
--   releaseCycle: "Galaxy Tab Pro 12.2"
+-   releaseCycle: "galaxy-tab-pro-12.2"
+    releaseLabel: "Galaxy Tab Pro 12.2"
     releaseDate: 2014-03-01 # Approximate to the month and year.
     eoas: true
     eol: true
     link: null
 
--   releaseCycle: "Galaxy Note 3 Neo Duos"
+-   releaseCycle: "galaxy-note-3-neo-duos"
+    releaseLabel: "Galaxy Note 3 Neo Duos"
     releaseDate: 2014-02-01 # Approximate to the month and year.
     eoas: true
     eol: true
     link: null
 
--   releaseCycle: "Galaxy Note 3 Neo"
+-   releaseCycle: "galaxy-note-3-neo"
+    releaseLabel: "Galaxy Note 3 Neo"
     releaseDate: 2014-02-01 # Approximate to the month and year.
     eoas: true
     eol: true
     link: https://doc.samsungmobile.com/SM-N750K/KTC/doc.html
 
--   releaseCycle: "Galaxy Tab 3 Lite 7.0 3G"
+-   releaseCycle: "galaxy-tab-3-lite-7.0-3g"
+    releaseLabel: "Galaxy Tab 3 Lite 7.0 3G"
     releaseDate: 2014-02-01 # Approximate to the month and year.
     eoas: true
     eol: true
     link: null
 
--   releaseCycle: "Galaxy Tab 3 Lite 7.0"
+-   releaseCycle: "galaxy-tab-3-lite-7.0"
+    releaseLabel: "Galaxy Tab 3 Lite 7.0"
     releaseDate: 2014-02-01 # Approximate to the month and year.
     eoas: true
     eol: true
     link: null
 
--   releaseCycle: "Galaxy Grand Neo"
+-   releaseCycle: "galaxy-grand-neo"
+    releaseLabel: "Galaxy Grand Neo"
     releaseDate: 2014-02-01 # Approximate to the month and year.
     eoas: true
     eol: true
     link: null
 
--   releaseCycle: "Galaxy Note Pro 12.2"
+-   releaseCycle: "galaxy-note-pro-12.2"
+    releaseLabel: "Galaxy Note Pro 12.2"
     releaseDate: 2014-02-01 # Approximate to the month and year.
     eoas: true
     eol: true
     link: https://doc.samsungmobile.com/SM-P900/KOO/doc.html
 
--   releaseCycle: "Galaxy Gear"
+-   releaseCycle: "galaxy-gear"
+    releaseLabel: "Galaxy Gear"
     releaseDate: 2013-09-01 # Approximate to the month and year.
     eoas: true
     eol: true


### PR DESCRIPTION
Release labels were added so that it renders the same as the current https://endoflife.date/samsungmobile page.