### PR TITLE
Force releaseCycle to be unique and adhere to a naming convention

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -301,9 +301,9 @@ identifiers:
 # Do not add releases that are not considered "stable" (such as RC/Alpha/Beta/Nightly).
 releases:
 
-    # Release range (mandatory, always put in quotes).
+    # Release cycle name (mandatory, unique, always put in quotes).
+    # Only lowercase letters, numbers, dots, dashes, plus and underscores are allowed (/^[a-z0-9.\-_+]+$/).
     # This is usually major.minor. Do not prefix with "v" or suffix with ".x".
-    # This becomes part of our API URL, so try to avoid spaces and use lowercase for words.
 -   releaseCycle: "1.2"
 
     # Name displayed for the release (optional, default = global releaseLabel value).

--- a/product-schema.json
+++ b/product-schema.json
@@ -408,7 +408,8 @@
             "1",
             "1.0"
           ],
-          "type": "string"
+          "type": "string",
+          "pattern": "^[a-z0-9.\\-+_]+$"
         },
         "link": {
           "title": "Link",


### PR DESCRIPTION
Only lowercase letters, numbers, dots, dashes, plus and underscores are now allowed.