### PR TITLE
Fix brew purl url to fix 404s

### DIFF
--- a/_plugins/identifier-to-url.rb
+++ b/_plugins/identifier-to-url.rb
@@ -128,7 +128,7 @@ class IdentifierToUrl
   end
 
   def _build_brew_url(purl)
-    return "https://formulae.brew.sh/formula/#{purl.name}"
+    return "https://formulae.brew.sh/cask/#{purl.name}"
   end
 
   def _build_winget_url(purl)


### PR DESCRIPTION
formulae.brew.sh website changed url from 
URL/formula/PRODUCT to
URL/cask/PRODUCT