### PR TITLE
Drop explicit Ruby version in check-links.yml

### DIFF
--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -17,7 +17,6 @@ jobs:
       - name: Setup ruby
         uses: ruby/setup-ruby@dffc446db9ba5a0c4446edb5bca1c5c473a806c5 # v1
         with:
-          ruby-version: 3.3
           bundler-cache: true
 
       - name: Perform URLs check


### PR DESCRIPTION
As seen on https://github.com/ruby/setup-ruby?tab=readme-ov-file#single-job, the version is not needed with a .ruby-version.

Closes #6945.