### PR TITLE
[dotnetfx] Update auto configuration

### DIFF
--- a/products/dotnetfx.md
+++ b/products/dotnetfx.md
@@ -20,6 +20,7 @@ auto:
       fields:
         releaseCycle:
           column: "Version"
+          type: "identifier"
           regex: '^\.NET Framework (?P<value>\d+(\.\d+)+( SP1)?)$'
         eol: "End of support"
 


### PR DESCRIPTION
So that "3.5 SP1" release name is properly transformed to a valid identifier.