### PR TITLE
feat(api/v1): add known Identifiers

### DIFF
--- a/CHANGELOG_API.md
+++ b/CHANGELOG_API.md
@@ -1,3 +1,8 @@
+## API v1.2.0
+
+- Introduce a new `/identifiers/{identifier}` API ([#7361](https://github.com/endoflife-date/endoflife.date/pull/7361)) to list known Identifiers for given Products
+  - For instance, `/identifiers/purl` will return all known Package URLs and the Products they correspond to
+
 ## API v1.1.0
 
 - Expose custom releases field values in the API (#7465). Such fields are grouped under the new `custom`

--- a/CHANGELOG_API.md
+++ b/CHANGELOG_API.md
@@ -1,7 +1,8 @@
 ## API v1.2.0
 
-- Introduce a new `/identifiers/{identifier}` API ([#7361](https://github.com/endoflife-date/endoflife.date/pull/7361)) to list known Identifiers for given Products
-  - For instance, `/identifiers/purl` will return all known Package URLs and the Products they correspond to
+- Introduce a new `/identifiers/{identifier}` API ([#7361](https://github.com/endoflife-date/endoflife.date/pull/7361))
+  to list known Identifiers for given Products. For instance, `/identifiers/purl` will return all known Package URLs
+  and the Products they correspond to.
 
 ## API v1.1.0
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -470,7 +470,7 @@ docker run --rm \
 
 ## Testing API payload
 
-There is a GitHub workflow that already validates the OpenAPI specification.
+There is a GitHub workflow that already validates the OpenAPI specification (it can also be checked on https://pb33f.io/doctor/).
 But to test the generated API payload you can do the following:
 
 ```sh

--- a/_plugins/generate-api-v1.rb
+++ b/_plugins/generate-api-v1.rb
@@ -12,6 +12,8 @@
 # - /api/v1/categories/<category> - list products having the given category
 # - /api/v1/tags - list tags used on endoflife.date
 # - /api/v1/tags/<tag> - list products having the given tag
+# - /api/v1/identifiers - list all identifiers
+# - /api/v1/identifiers/<identifier> - retrieve all Products that are identified by the given Identifier.
 
 
 require 'jekyll'
@@ -19,7 +21,7 @@ require 'jekyll'
 module ApiV1
 
   # This version must be kept in sync with the version in api_v1/openapi.yml.
-  VERSION = '1.1.0'
+  VERSION = '1.2.0'
   MAJOR_VERSION = VERSION.split('.')[0]
 
   STRIP_HTML_BLOCKS = Regexp.union(
@@ -63,6 +65,7 @@ module ApiV1
       add_products_related_pages(site, product_pages)
       add_categories_related_pages(site, product_pages)
       add_tags_related_pages(site, product_pages)
+      add_identifiers_related_pages(site, product_pages)
 
       Jekyll.logger.info TOPIC, "Done in #{(Time.now - start).round(3)} seconds."
     end
@@ -159,6 +162,52 @@ module ApiV1
       data = tags.map { |tag| { name: tag, uri: "#{ApiV1.api_url(site, "/tags/#{tag}")}" }}
       meta = { total: tags.size() }
       site.pages << JsonPage.of_raw_data(site, '/tags/', data, meta)
+    end
+
+    def add_identifiers_related_pages(site, products)
+      identifiers, products_by_identifier = products_by_identifier(products)
+
+      add_all_identifiers_page(site, products_by_identifier.keys)
+      products_by_identifier.each do |identifier, products|
+        add_identifier_page(site, identifier, products)
+      end
+    end
+
+    def products_by_identifier(products)
+      products_by_identifier = {}
+      identifiers = []
+      products.each do |product|
+        product.data['identifiers'].each do |identifier|
+          identifier_to_product = {
+            identifier: identifier.values.first,
+            product: product,
+          }
+
+          add_to_map(products_by_identifier, identifier.keys.first, identifier_to_product)
+          identifiers << identifier
+        end
+      end
+
+      return identifiers, products_by_identifier
+    end
+
+    def add_identifier_page(site, identifier, identifiers_to_products)
+      data = identifiers_to_products.map do |identifier_to_product|
+        {
+          identifier: identifier_to_product[:identifier],
+          product: identifier_to_product[:product].data['id'],
+          uri: ApiV1.api_url(site, "/products/#{identifier_to_product[:product].data['id']}")
+        }
+      end
+      meta = { total: data.length }
+
+      site.pages << JsonPage.of_raw_data(site, "/identifiers/#{identifier}", data, meta)
+    end
+
+    def add_all_identifiers_page(site, identifiers)
+      data = identifiers.map { |identifier| { name: identifier, uri: "#{ApiV1.api_url(site, "/identifiers/#{identifier}/")}" }}
+      meta = { total: identifiers.size() }
+      site.pages << JsonPage.of_raw_data(site, '/identifiers/', data, meta)
     end
 
     def add_to_map(map, key, page)

--- a/_plugins/generate-api-v1.rb
+++ b/_plugins/generate-api-v1.rb
@@ -179,8 +179,10 @@ module ApiV1
         product.data['identifiers'].each do |identifier|
           add_to_map(identifiers_by_type, identifier.keys.first, {
             identifier: identifier.values.first,
-            product: product.data['id'],
-            uri: ApiV1.api_url(site, "/products/#{product.data['id']}")
+            product: {
+              name: product.data['id'],
+              uri: ApiV1.api_url(site, "/products/#{product.data['id']}")
+            }
           })
         end
       end

--- a/api_v1/openapi.yml
+++ b/api_v1/openapi.yml
@@ -360,7 +360,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/RetrieveIdentifierResponse'
+                $ref: '#/components/schemas/IdentifierListResponse'
         '404':
           description: The identifier with the given name does not exist.
         '429':
@@ -934,7 +934,7 @@ components:
         result:
           $ref: '#/components/schemas/ProductDetails'
 
-    RetrieveIdentifierResponse:
+    IdentifierListResponse:
       description: A response containing all known Products for a given Identifier.
       type: object
       required:

--- a/api_v1/openapi.yml
+++ b/api_v1/openapi.yml
@@ -318,49 +318,51 @@ paths:
 
   /identifiers:
     get:
-      operationId: list_identifiers
+      operationId: identifier_types
       tags:
         - Identifiers
-      summary: List all identifiers
-      description: <
-        Provides an overview of all Identifiers known to Endoflife.date, which can then be queried independently.
-
-        An Identifier is a product identifier, such as a purl, repology or cpe identifier.
+      summary: List all identifier types
+      description: List all identifier types, such as a purl, known in endoflife.date.
       responses:
         '200':
-          description: The list of Identifiers.
+          description: The list of all identifier types.
           headers: {}
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/UriListResponse'
+        '304':
+          description: Resource not modified since last request.
         '429':
           description: Too many requests, retry later.
 
-  /identifiers/{identifier}:
+  /identifiers/{identifier_type}:
     get:
-      operationId: retrieve_identifier
+      operationId: identifier_by_type
       tags:
         - Identifiers
-      summary: Retrieve all Products that are identified by the given Identifier.
+      summary: List all identifiers for a given type.
       description: >
-        For a given Identifier (such as a purl, repology or cpe identifier), list all known Products.
+        List all identifiers referenced on endoflife.date for the given identifier type.
+        Each identifier reference its related product.
       parameters:
-        - name: identifier
+        - name: identifier_type
           in: path
-          description: Identifier.
+          description: Identifier type.
           required: true
           schema:
             type: string
             example: purl
       responses:
         '200':
-          description: The list of all Products that are identified by this Identifier.
+          description: The list of all identifiers for a given type, along with a reference to the related product.
           headers: {}
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/IdentifierListResponse'
+        '304':
+          description: Resource not modified since last request.
         '404':
           description: The identifier with the given name does not exist.
         '429':
@@ -935,37 +937,38 @@ components:
           $ref: '#/components/schemas/ProductDetails'
 
     IdentifierListResponse:
-      description: A response containing all known Products for a given Identifier.
+      description: A response containing all identifiers for a given type.
       type: object
       required:
         - schema_version
+        - total
         - result
       properties:
         schema_version:
           type: string
           description: Version of this schema.
-          example: 1.0.0
+          examples:
+            - 1.0.0
+        total:
+          description: Number of identifiers in the list.
+          type: integer
+          format: int32
+          examples:
+            - 3
         result:
+          description: The identifiers.
           type: array
-          description: All known Products, and their corresponding Identifier (i.e. pURL), for a given Identifier.
           items:
             type: object
             properties:
               identifier:
                 type: string
-                description: Identifier.
-                example: cpe:/o:canonical:ubuntu_linux
-              product:
-                type: string
-                description: A product name.
-                example: golang
-              uri:
-                description: Link to the full product details.
-                type: string
-                format: uri
+                description: The identifier.
                 examples:
-                  - "{{ site.url }}/api/v1/products/ubuntu/"
+                - cpe:/o:canonical:ubuntu_linux
+              product:
+                $ref: '#/components/schemas/Uri'
+                description: Reference to the product this identifier is related to.
             required:
               - identifier
               - product
-              - uri

--- a/api_v1/openapi.yml
+++ b/api_v1/openapi.yml
@@ -10,7 +10,7 @@ openapi: 3.1.1
 info:
   title: endoflife API
   # This version must be kept in sync with the version in _plugins/generate-api-v1.rb.
-  version: "1.1.0"
+  version: "1.2.0"
   license:
     name: MIT License
     url: 'https://github.com/endoflife-date/endoflife.date/blob/master/LICENSE'
@@ -49,6 +49,8 @@ tags:
     description: Query for products by category.
   - name: Tags
     description: Query for products by tags.
+  - name: Identifiers
+    description: Query for products by identifiers.
 
 paths:
   /:
@@ -311,6 +313,56 @@ paths:
           description: Resource not modified since last request.
         '404':
           description: The tag with the given name does not exist.
+        '429':
+          description: Too many requests, retry later.
+
+  /identifiers:
+    get:
+      operationId: list_identifiers
+      tags:
+        - Identifiers
+      summary: List all identifiers
+      description: <
+        Provides an overview of all Identifiers known to Endoflife.date, which can then be queried independently.
+
+        An Identifier is a product identifier, such as a purl, repology or cpe identifier.
+      responses:
+        '200':
+          description: The list of Identifiers.
+          headers: {}
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UriListResponse'
+        '429':
+          description: Too many requests, retry later.
+
+  /identifiers/{identifier}:
+    get:
+      operationId: retrieve_identifier
+      tags:
+        - Identifiers
+      summary: Retrieve all Products that are identified by the given Identifier.
+      description: >
+        For a given Identifier (such as a purl, repology or cpe identifier), list all known Products.
+      parameters:
+        - name: identifier
+          in: path
+          description: Identifier.
+          required: true
+          schema:
+            type: string
+            example: purl
+      responses:
+        '200':
+          description: The list of all Products that are identified by this Identifier.
+          headers: {}
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RetrieveIdentifierResponse'
+        '404':
+          description: The identifier with the given name does not exist.
         '429':
           description: Too many requests, retry later.
 
@@ -881,3 +933,62 @@ components:
             - "2023-03-01T14:05:52+01:00"
         result:
           $ref: '#/components/schemas/ProductDetails'
+
+    IdentifierReference:
+      type: object
+      description: A reference for a known Identifier, and how to look up any known Products for a given Identifier
+      properties:
+        name:
+          type: string
+          description: A known identifier to Endoflife.date.
+          examples:
+            - purl
+            - cpe
+            - repology
+        uri:
+          type: string
+          format: uri
+          description: The URI to be queried to retrieve the list of Products for a given Identifier
+          examples:
+            - purl
+            - cpe
+            - repology
+      required:
+        - name
+        - uri
+
+    RetrieveIdentifierResponse:
+      description: A response containing all known Products for a given Identifier.
+      type: object
+      required:
+        - schema_version
+        - result
+      properties:
+        schema_version:
+          type: string
+          description: Version of this schema.
+          example: 1.0.0
+        result:
+          type: array
+          description: All known Products, and their corresponding Identifier (i.e. pURL), for a given Identifier.
+          items:
+            type: object
+            properties:
+              identifier:
+                type: string
+                description: Identifier.
+                example: cpe:/o:canonical:ubuntu_linux
+              product:
+                type: string
+                description: A product name.
+                example: golang
+              uri:
+                description: Link to the full product details.
+                type: string
+                format: uri
+                examples:
+                  - "{{ site.url }}/api/v1/products/ubuntu/"
+            required:
+              - identifier
+              - product
+              - uri

--- a/api_v1/openapi.yml
+++ b/api_v1/openapi.yml
@@ -934,29 +934,6 @@ components:
         result:
           $ref: '#/components/schemas/ProductDetails'
 
-    IdentifierReference:
-      type: object
-      description: A reference for a known Identifier, and how to look up any known Products for a given Identifier
-      properties:
-        name:
-          type: string
-          description: A known identifier to Endoflife.date.
-          examples:
-            - purl
-            - cpe
-            - repology
-        uri:
-          type: string
-          format: uri
-          description: The URI to be queried to retrieve the list of Products for a given Identifier
-          examples:
-            - purl
-            - cpe
-            - repology
-      required:
-        - name
-        - uri
-
     RetrieveIdentifierResponse:
       description: A response containing all known Products for a given Identifier.
       type: object


### PR DESCRIPTION
As a means to provide more autodiscovery for known mappings between a
given package and the EndOfLife.date Product, we can introduce a new
"Identifiers" API.

This introduces a new `/identifiers` API which will provide a mapping
for each of the known Identifiers.

This then allows querying i.e. `/identifiers/purl` to list all known
Package URLs (pURLs).
