### PR TITLE
[apache-subversion] Align permalink with the title

### DIFF
--- a/products/apache-subversion.md
+++ b/products/apache-subversion.md
@@ -2,10 +2,10 @@
 title: Apache Subversion
 category: server-app
 iconSlug: subversion
-permalink: /subversion
+permalink: /apache-subversion
 alternate_urls:
 -   /svn
--   /apache-subversion
+-   /subversion
 changelogTemplate: https://subversion.apache.org/docs/release-notes/__RELEASE_CYCLE__.html
 releasePolicyLink: https://subversion.apache.org/roadmap.html
 eolColumn: Support


### PR DESCRIPTION
Most Apache products follow this "convention".

Users still using current's URL (https://endoflife.date/subversion) will be redirected to the new URL (https://endoflife.date/apache-subversion).