### PR TITLE
[apache-http-server] Align permalink with the title

### DIFF
--- a/products/apache-http-server.md
+++ b/products/apache-http-server.md
@@ -3,10 +3,10 @@ title: Apache HTTP Server
 category: server-app
 tags: apache web-server
 iconSlug: apache
-permalink: /apache
+permalink: /apache-http-server
 alternate_urls:
+-   /apache
 -   /httpd
--   /apache-http-server
 releasePolicyLink: https://httpd.apache.org/dev/release.html
 versionCommand: |-
   httpd -v


### PR DESCRIPTION
Most Apache products follow this "convention".

Users still using current's URL (https://endoflife.date/apache) will be redirected to the new URL (https://endoflife.date/apache-http-server).