### PR TITLE
[apache-maven] Align permalink with the title

### DIFF
--- a/products/apache-maven.md
+++ b/products/apache-maven.md
@@ -3,9 +3,9 @@ title: Apache Maven
 category: app
 tags: apache build-tool java-runtime
 iconSlug: apachemaven
-permalink: /maven
+permalink: /apache-maven
 alternate_urls:
--   /apache-maven
+-   /maven
 -   /mvn
 versionCommand: mvn --version
 releasePolicyLink: https://maven.apache.org/docs/history.html


### PR DESCRIPTION
Most Apache products follow this "convention".

Users still using current's URL (https://endoflife.date/maven) will be redirected to the new URL (https://endoflife.date/apache-maven).