### PR TITLE
[alpine-linux] Align the permalink with the product name

### DIFF
--- a/products/alpine-linux.md
+++ b/products/alpine-linux.md
@@ -3,8 +3,9 @@ title: Alpine Linux
 category: os
 tags: linux-distribution
 iconSlug: alpinelinux
-permalink: /alpine
+permalink: /alpine-linux
 alternate_urls:
+-   /alpine
 -   /alpinelinux
 versionCommand: cat /etc/alpine-release
 releasePolicyLink: https://alpinelinux.org/releases/


### PR DESCRIPTION
Users still using current's URL (https://endoflife.date/alpine) will be redirected to the new URL (https://endoflife.date/alpine-linux).