### PR TITLE
[jenkins] Add 2.504 LTS

### DIFF
--- a/products/jenkins.md
+++ b/products/jenkins.md
@@ -36,10 +36,17 @@ releases:
     latest: "2.508"
     latestReleaseDate: 2025-04-29
 
+-   releaseCycle: "2.504"
+    releaseDate: 2025-04-02
+    lts: 2025-04-30
+    eol: false
+    latest: "2.504.1"
+    latestReleaseDate: 2025-04-30
+
 -   releaseCycle: "2.492"
     releaseDate: 2025-01-07
     lts: 2025-02-05
-    eol: false
+    eol: 2025-04-30
     latest: "2.492.3"
     latestReleaseDate: 2025-03-31
 


### PR DESCRIPTION
See [Upgrading to Jenkins LTS 2.504.x](https://www.jenkins.io/doc/upgrade-guide/2.504/)