### PR TITLE
[kuma] Remove duplicate url

### DIFF
--- a/products/kuma.md
+++ b/products/kuma.md
@@ -4,8 +4,6 @@ category: server-app
 tags: cncf
 iconSlug: kuma
 permalink: /kuma
-alternate_urls:
--   /kuma
 changelogTemplate: https://github.com/kumahq/kuma/releases/tag/__LATEST__
 eolColumn: Support
 


### PR DESCRIPTION
Remove alternate_urls tag because it is duplicate of permlink