### PR TITLE
[pan-os]: Update PAN-OS from 10.1.14-h9 to 10.1.14-h14

### DIFF
--- a/products/pan-os.md
+++ b/products/pan-os.md
@@ -59,9 +59,9 @@ releases:
 -   releaseCycle: "10.1"
     releaseDate: 2021-05-31
     eol: 2025-08-31
-    latest: "10.1.14-h9"
-    latestReleaseDate: 2025-02-10
-    link: https://docs.paloaltonetworks.com/pan-os/10-1/pan-os-release-notes/pan-os-10-1-14-known-and-addressed-issues/pan-os-10-1-14-h9-addressed-issues
+    latest: "10.1.14-h14"
+    latestReleaseDate: 2025-05-05
+    link: https://docs.paloaltonetworks.com/pan-os/10-1/pan-os-release-notes/pan-os-10-1-14-known-and-addressed-issues/pan-os-10-1-14-h14-addressed-issues
 
 -   releaseCycle: "10.0"
     releaseDate: 2020-07-16


### PR DESCRIPTION

- Updated PAN-OS from 10.1.14-h9 to 10.1.14-h14.
-  Released: 2025-05-05
- Release notes: https://docs.paloaltonetworks.com/pan-os/10-1/pan-os-release-notes/pan-os-10-1-14-known-and-addressed-issues/pan-os-10-1-14-h14-addressed-issues
