### PR TITLE
[prometheus] remove chainguard's purl for dockerhub

### DIFF
--- a/products/prometheus.md
+++ b/products/prometheus.md
@@ -12,7 +12,6 @@ identifiers:
 -   purl: pkg:docker/prom/prometheus
 -   purl: pkg:docker/bitnami/prometheus
 -   purl: pkg:docker/rapidfort/prometheus-official
--   purl: pkg:docker/chainguard/prometheus
 -   purl: pkg:docker/bitnami/prometheus
 -   purl: pkg:oci/prometheus?repository_url=quay.io/repository/prometheus
 -   purl: pkg:oci/prometheus?repository_url=cgr.dev/chainguard


### PR DESCRIPTION
chainguard removed related image from dockerhub