### PR TITLE
[apache-kafka] Fix 3.8 eol

### DIFF
--- a/products/apache-kafka.md
+++ b/products/apache-kafka.md
@@ -46,7 +46,7 @@ releases:
 
 -   releaseCycle: "3.8"
     releaseDate: 2024-07-26
-    eol: false
+    eol: 2024-11-06
     eoes: 2026-12-02
     latest: "3.8.1"
     latestReleaseDate: 2024-10-29


### PR DESCRIPTION
3.8 should be eol on 3.9 release