### PR TITLE
[telegraf] update notes and advice

### DIFF
--- a/products/telegraf.md
+++ b/products/telegraf.md
@@ -245,8 +245,6 @@ releases:
 > [Telegraf](https://github.com/influxdata/telegraf) is an agent for collecting, processing,
 > aggregating, and writing metrics.
 
-Telegraf is based on a plugin system, and this page only covers the Telegraf server.
-
 InfluxData do not publish specific support periods for OSS products, though their commercial
 support policy offers support for the last two minor releases.
 

--- a/products/telegraf.md
+++ b/products/telegraf.md
@@ -245,8 +245,8 @@ releases:
 > [Telegraf](https://github.com/influxdata/telegraf) is an agent for collecting, processing,
 > aggregating, and writing metrics.
 
-InfluxData do not publish specific support periods for OSS products, though their commercial
-support policy offers support for the last two minor releases.
+InfluxData have not published specific support periods for their OSS products, although their
+commercial support policy offers support for the last two minor releases.
 
 Compatibility is not guaranteed across major releases.
 

--- a/products/telegraf.md
+++ b/products/telegraf.md
@@ -246,6 +246,11 @@ releases:
 > aggregating, and writing metrics.
 
 Telegraf is based on a plugin system, and this page only covers the Telegraf server.
-Only the latest two minor releases are supported with maintenance patch releases.
-Compatibility is not guaranteed across major releases. Each major release is supported for a
-minimum of 12 months.
+
+InfluxData do not publish specific support periods for OSS products, though their commercial
+support policy offers support for the last two minor releases.
+
+Compatibility is not guaranteed across major releases.
+
+Telegraf's [release cadence](https://github.com/influxdata/telegraf/blob/master/docs/FAQ.md#when-is-the-next-release-when-will-my-pr-or-fix-get-released)
+means that there are four minor releases per year with bug fix releases occurring roughly every three weeks.

--- a/products/telegraf.md
+++ b/products/telegraf.md
@@ -245,10 +245,7 @@ releases:
 > [Telegraf](https://github.com/influxdata/telegraf) is an agent for collecting, processing,
 > aggregating, and writing metrics.
 
+Telegraf follows [SemVer](https://semver.org/). [There are four minor releases a year](https://github.com/influxdata/telegraf/blob/master/docs/FAQ.md#when-is-the-next-release-when-will-my-pr-or-fix-get-released) (in March, June, September, and December), supported with bug and security fixes.
+
 InfluxData have not published specific support periods for their OSS products, although their
 commercial support policy offers support for the last two minor releases.
-
-Compatibility is not guaranteed across major releases.
-
-Telegraf's [release cadence](https://github.com/influxdata/telegraf/blob/master/docs/FAQ.md#when-is-the-next-release-when-will-my-pr-or-fix-get-released)
-means that there are four minor releases per year with bug fix releases occurring roughly every three weeks.


### PR DESCRIPTION
This is a follow up from the observations made in https://github.com/endoflife-date/endoflife.date/pull/7303

It rewords the advice to note that that published link is for commercial support only and that there is no documented EoL policy for Influxdata's OSS products.

This PR also removes a note about the page only covering the Telegraf "server" and not plugins - plugins are not independently versioned and are compiled in (i.e. they're part of the release).