### PR TITLE
[electron] Fixes Nodejs version info for 3.6 cycle

### DIFF
--- a/products/electron.md
+++ b/products/electron.md
@@ -45,7 +45,7 @@ releases:
     latest: "36.2.0"
     latestReleaseDate: 2025-05-07
     chromeVersion: "M136"
-    nodeVersion: "22.15"
+    nodeVersion: "22.15" # https://releases.electronjs.org/
 
 -   releaseCycle: "35"
     releaseDate: 2025-03-04

--- a/products/electron.md
+++ b/products/electron.md
@@ -45,7 +45,7 @@ releases:
     latest: "36.2.0"
     latestReleaseDate: 2025-05-07
     chromeVersion: "M136"
-    nodeVersion: "22.14"
+    nodeVersion: "22.15"
 
 -   releaseCycle: "35"
     releaseDate: 2025-03-04


### PR DESCRIPTION
Node 22.15 is needed for 3.6 cycle