### PR TITLE
[rhel] Add 10.0

### DIFF
--- a/products/rhel.md
+++ b/products/rhel.md
@@ -30,6 +30,15 @@ auto:
         eoes: Extended life cycle support (ELS) add-on
 
 releases:
+-   releaseCycle: "10"
+    releaseDate: 2025-05-13
+    eoas: 2030-05-31
+    eol: 2035-05-31
+    lts: 2035-05-31
+    eoes: 2038-05-31
+    latest: "10.0"
+    latestReleaseDate: 2025-05-13
+
 -   releaseCycle: "9"
     releaseDate: 2022-05-18
     eoas: 2027-05-31

--- a/products/rhel.md
+++ b/products/rhel.md
@@ -34,7 +34,7 @@ releases:
     releaseDate: 2025-05-20
     eoas: 2030-05-31
     eol: 2035-05-31
-    lts: 2035-05-31
+    lts: true
     eoes: 2038-05-31
     latest: "10.0"
     latestReleaseDate: 2025-05-20

--- a/products/rhel.md
+++ b/products/rhel.md
@@ -31,13 +31,13 @@ auto:
 
 releases:
 -   releaseCycle: "10"
-    releaseDate: 2025-05-13
+    releaseDate: 2025-05-20
     eoas: 2030-05-31
     eol: 2035-05-31
     lts: 2035-05-31
     eoes: 2038-05-31
     latest: "10.0"
-    latestReleaseDate: 2025-05-13
+    latestReleaseDate: 2025-05-20
 
 -   releaseCycle: "9"
     releaseDate: 2022-05-18

--- a/products/rhel.md
+++ b/products/rhel.md
@@ -34,7 +34,7 @@ releases:
     releaseDate: 2025-05-20
     eoas: 2030-05-31
     eol: 2035-05-31
-    lts: true
+    lts: 2035-05-31
     eoes: 2038-05-31
     latest: "10.0"
     latestReleaseDate: 2025-05-20


### PR DESCRIPTION
I found out about this through Reddit: https://www.reddit.com/r/linux/comments/1klnqws/red_hat_enterprise_linux_release_dates_rhel_10_is/

ISOs are available at https://access.redhat.com/downloads/content/479/ver=/rhel---10/10.0/x86_64/product-software

I used the same software support lifecycles as 9.x for the other values.

![image](https://github.com/user-attachments/assets/4dfcdf89-7e72-476e-b496-e5448be78cd5)
![image](https://github.com/user-attachments/assets/4f8f1bcd-9dc8-4f14-88ff-64f4164afd24)
