### PR TITLE
[MotorolaMobility] Add Motto-E15 and Motto-E14

### DIFF
--- a/products/motorola-mobility.md
+++ b/products/motorola-mobility.md
@@ -23,7 +23,7 @@ releases:
   releaseLabel: "Motorola Moto E15"
   releaseDate: 2024-12-01
   eol: 2026-12-01 # 2 years (until 12/2026) - https://www.motorola.com/gb/en/p/phones/moto-e/15/pmipmhk40mb?pn=PB6S0012GB
-  link: https://en-us.support.motorola.com/app/software-security-update/g_id/#gs=eyJndWlkZUlEIjo3MTEyLCJxdWVzdGlvbklEIjo1LCJyZXNwb25zZUlEIjoxNzQsImd1aWRlU2Vzc2lvbiI6ImlJYm5jbzNyIiwic2Vzc2lvbklEIjoiNExRV2FvM3IifQ..
+  link: https://en-us.support.motorola.com/app/product_page/faqs/p/10395
 
 - releaseCycle: "moto-e14"
   releaseLabel: "Motorola Moto E14"

--- a/products/motorola-mobility.md
+++ b/products/motorola-mobility.md
@@ -28,7 +28,7 @@ releases:
 - releaseCycle: "moto-e14"
   releaseLabel: "Motorola Moto E14"
   releaseDate: 2024-04-01
-  eol: 2026-04-01
+  eol: 2026-04-01 # 2 years (until 04/2026) - https://www.motorola.com/gb/en/p/phones/moto-e/14/pmipmhb38m2?pn=PB3C0002GB
   link: https://en-us.support.motorola.com/app/product_page/faqs/p/10216
 
 

--- a/products/motorola-mobility.md
+++ b/products/motorola-mobility.md
@@ -19,6 +19,12 @@ eolColumn: Security Updates
 #
 
 releases:
+- releaseCycle: "moto-e15"
+  releaseLabel: "Motorola Moto E15"
+  releaseDate: 2024-12-01
+  eol: 2026-12-01
+  link: https://en-us.support.motorola.com/app/software-security-update/g_id/#gs=eyJndWlkZUlEIjo3MTEyLCJxdWVzdGlvbklEIjo1LCJyZXNwb25zZUlEIjoxNzQsImd1aWRlU2Vzc2lvbiI6ImlJYm5jbzNyIiwic2Vzc2lvbklEIjoiNExRV2FvM3IifQ..
+
 - releaseCycle: "moto-e14"
   releaseLabel: "Motorola Moto E14"
   releaseDate: 2024-04-01

--- a/products/motorola-mobility.md
+++ b/products/motorola-mobility.md
@@ -29,7 +29,7 @@ releases:
   releaseLabel: "Motorola Moto E14"
   releaseDate: 2024-04-01
   eol: 2026-04-01
-  link: https://en-us.support.motorola.com/app/software-security-update/g_id/#gs=eyJndWlkZUlEIjo3MTEyLCJxdWVzdGlvbklEIjo1LCJyZXNwb25zZUlEIjoxMjgsImd1aWRlU2Vzc2lvbiI6ImlJYm5jbzNyIiwic2Vzc2lvbklEIjoiNExRV2FvM3IifQ..
+  link: https://en-us.support.motorola.com/app/product_page/faqs/p/10216
 
 
 - releaseCycle: "motorola-razr-40s"

--- a/products/motorola-mobility.md
+++ b/products/motorola-mobility.md
@@ -19,6 +19,13 @@ eolColumn: Security Updates
 #
 
 releases:
+- releaseCycle: "moto-e14"
+  releaseLabel: "Motorola Moto E14"
+  releaseDate: 2024-04-01
+  eol: 2026-04-01
+  link: https://en-us.support.motorola.com/app/software-security-update/g_id/#gs=eyJndWlkZUlEIjo3MTEyLCJxdWVzdGlvbklEIjo1LCJyZXNwb25zZUlEIjoxMjgsImd1aWRlU2Vzc2lvbiI6ImlJYm5jbzNyIiwic2Vzc2lvbklEIjoiNExRV2FvM3IifQ..
+
+
 - releaseCycle: "motorola-razr-40s"
   releaseLabel: "Motorola Razr 40S"
   releaseDate: 2023-11-01

--- a/products/motorola-mobility.md
+++ b/products/motorola-mobility.md
@@ -22,7 +22,7 @@ releases:
 - releaseCycle: "moto-e15"
   releaseLabel: "Motorola Moto E15"
   releaseDate: 2024-12-01
-  eol: 2026-12-01
+  eol: 2026-12-01 # 2 years (until 12/2026) - https://www.motorola.com/gb/en/p/phones/moto-e/15/pmipmhk40mb?pn=PB6S0012GB
   link: https://en-us.support.motorola.com/app/software-security-update/g_id/#gs=eyJndWlkZUlEIjo3MTEyLCJxdWVzdGlvbklEIjo1LCJyZXNwb25zZUlEIjoxNzQsImd1aWRlU2Vzc2lvbiI6ImlJYm5jbzNyIiwic2Vzc2lvbklEIjoiNExRV2FvM3IifQ..
 
 - releaseCycle: "moto-e14"

--- a/products/motorola-mobility.md
+++ b/products/motorola-mobility.md
@@ -21,14 +21,14 @@ eolColumn: Security Updates
 releases:
 - releaseCycle: "moto-e15"
   releaseLabel: "Motorola Moto E15"
-  releaseDate: 2024-12-01
-  eol: 2026-12-01 # 2 years (until 12/2026) - https://www.motorola.com/gb/en/p/phones/moto-e/15/pmipmhk40mb?pn=PB6S0012GB
+  releaseDate: 2025-01-22
+  eol: 2026-12-31 # until 12/2026, see https://www.motorola.com/gb/en/p/phones/moto-e/15/pmipmhk40mb?pn=PB6S0012GB
   link: https://en-us.support.motorola.com/app/product_page/faqs/p/10395
 
 - releaseCycle: "moto-e14"
   releaseLabel: "Motorola Moto E14"
-  releaseDate: 2024-04-01
-  eol: 2026-04-01 # 2 years (until 04/2026) - https://www.motorola.com/gb/en/p/phones/moto-e/14/pmipmhb38m2?pn=PB3C0002GB
+  releaseDate: 2024-06-01
+  eol: 2026-04-30 # until 04/2026, see https://www.motorola.com/gb/en/p/phones/moto-e/14/pmipmhb38m2?pn=PB3C0002GB
   link: https://en-us.support.motorola.com/app/product_page/faqs/p/10216
 
 

--- a/products/motorola-mobility.md
+++ b/products/motorola-mobility.md
@@ -31,7 +31,6 @@ releases:
   eol: 2026-04-30 # until 04/2026, see https://www.motorola.com/gb/en/p/phones/moto-e/14/pmipmhb38m2?pn=PB3C0002GB
   link: https://en-us.support.motorola.com/app/product_page/faqs/p/10216
 
-
 - releaseCycle: "motorola-razr-40s"
   releaseLabel: "Motorola Razr 40S"
   releaseDate: 2023-11-01


### PR DESCRIPTION
This PR adds information for the Motorola E14 and E15 devices to the product licecycle information as it did not appear to exit.

I know the URLs I have are not consistent with the formatting of the prevuius URLs; I could not identify how the prior uRLs had been made to format in that way as my attempts to selct the product always added in the character string.