### PR TITLE
[eclipse-temurin] Update auto configuration

### DIFF
--- a/products/eclipse-temurin.md
+++ b/products/eclipse-temurin.md
@@ -56,6 +56,7 @@ auto:
       regex: '^jdk-(?P<version>[\d\.+]+)$'
       template: '{{version}}'
   -   release_table: https://adoptium.net/support/
+      ignore_empty_releases: true # avoid listing upcoming releases in auto-update PRs
       selector: "table"
       fields:
         releaseCycle:


### PR DESCRIPTION
So that future releases are not listed anymore in auto-update PRs, such as https://github.com/endoflife-date/endoflife.date/pull/7466#event-17688396855.