### PR TITLE
[vmware-photon] Fix kernelVersion values

### DIFF
--- a/products/vmware-photon.md
+++ b/products/vmware-photon.md
@@ -29,31 +29,31 @@ releases:
     releaseDate: 2023-05-02
     eol: false
     link: https://blogs.vmware.com/vsphere/2023/05/announcing-photon-os-5-0-general-availability.html
-    kernelVersion: 6.1
+    kernelVersion: "6.1"
 
 -   releaseCycle: "4.0"
     releaseDate: 2021-02-25
     eol: 2026-03-01
     link: https://blogs.vmware.com/vsphere/2021/02/photon-os-4-0-release-announcement.html
-    kernelVersion: 5.10
+    kernelVersion: "5.10"
 
 -   releaseCycle: "3.0"
     releaseDate: 2019-02-08
     eol: 2024-03-01
     link: https://vmware.github.io/photon/assets/files/html/3.0/What-is-New-in-Photon-OS-3.0.html
-    kernelVersion: 4.19
+    kernelVersion: "4.19"
 
 -   releaseCycle: "2.0"
     releaseDate: 2017-11-01
     eol: 2022-12-01
     link: https://web.archive.org/web/20221224152228/https://blogs.vmware.com/cloudnative/2017/11/01/version-2-0-project-photon-os/
-    kernelVersion: 4.9
+    kernelVersion: "4.9"
 
 -   releaseCycle: "1.0"
     releaseDate: 2016-06-11
     eol: 2022-02-28
     link: https://web.archive.org/web/20220628122239/https://blogs.vmware.com/cloudnative/2016/06/16/vmwares-photon-os-1-0-now-available/
-    kernelVersion: 4.4 # https://github.com/vmware/photon/blob/1.0GA/SPECS/linux/linux.spec
+    kernelVersion: "4.4" # https://github.com/vmware/photon/blob/1.0GA/SPECS/linux/linux.spec
 
 ---
 


### PR DESCRIPTION
Comment values for kernelVersion so that it is always interpreted as a string.