### PR TITLE
[pixel-watch] Fix supportedAndroidVersions values

### DIFF
--- a/products/pixel-watch.md
+++ b/products/pixel-watch.md
@@ -25,7 +25,7 @@ releases:
     eol: 2027-10-01
     discontinued: false
     link: https://en.wikipedia.org/wiki/Pixel_Watch_3
-    supportedAndroidVersions: 5 # https://www.gsmarena.com/google_pixel_watch_3-13253.php
+    supportedAndroidVersions: "5" # https://www.gsmarena.com/google_pixel_watch_3-13253.php
 
 -   releaseCycle: "2"
     releaseLabel: "Pixel Watch 2"
@@ -34,7 +34,7 @@ releases:
     eol: 2026-10-01
     discontinued: false
     link: https://en.wikipedia.org/wiki/Pixel_Watch_2
-    supportedAndroidVersions: 4 - 5 # https://www.gsmarena.com/google_pixel_watch_2-12547.php
+    supportedAndroidVersions: "4 - 5" # https://www.gsmarena.com/google_pixel_watch_2-12547.php
 
 -   releaseCycle: "1"
     releaseLabel: "Pixel Watch"
@@ -43,7 +43,7 @@ releases:
     eol: 2025-10-01
     discontinued: false
     link: https://en.wikipedia.org/wiki/Pixel_Watch
-    supportedAndroidVersions: 3.5 - 5 # https://www.gsmarena.com/google_pixel_watch-11546.php
+    supportedAndroidVersions: "3.5 - 5" # https://www.gsmarena.com/google_pixel_watch-11546.php
 
 ---
 


### PR DESCRIPTION
Comment values for supportedAndroidVersions so that it is always interpreted as a string.