### PR TITLE
Make custom fields declaration mandatory

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -167,42 +167,42 @@ eoesColumn: Extended Support
 # to indicate that the extended support date is approaching (optional, default = 121 days).
 eoesWarnThreshold: 121
 
-# Custom columns configuration (optional).
-# Custom columns are columns that will be added to the releases table and populated based on a
-# custom release cycle property.
-# They can be used for documenting things such as related runtime versions, custom dates that
-# cannot be expressed using the default columns, etc.
-# Note that the use of a table include (see https://github.com/endoflife-date/endoflife.date/blob/master/products/ansible.md)
-# is usually preferred when there is more than two or three custom columns.
-customColumns:
+# Custom fields configuration (optional).
+# Custom fields are non-standard fields used for documenting things such as related runtime versions, custom dates that
+# cannot be expressed using the standard fields, etc.
+# They can be:
+# - displayed in the release table,
+# - made available in API responses,
+# - used in table includes, such as in https://github.com/endoflife-date/endoflife.date/blob/master/products/ansible.md
+#   (preferred this over release table when there are more than 2 or 3 custom fields),
+# - or even just used for internal documentation.
+# Search in the existing products source file to see how they are used.
+customFields:
 
-  # Name of the custom property in release cycles (mandatory).
-  # If the release cycle does not declare this property, the label 'N/A' will be displayed instead.
-  # Custom properties follows the camel-case syntax for naming.
-  - property: supportedIosVersions
+  # Name of the custom field (mandatory, unique).
+  # If the release cycle does not declare this field, the label 'N/A' will be displayed instead.
+  # Custom fields follow the camel-case syntax for naming.
+  - name: supportedIosVersions
 
-    # Position of the custom column in the table (mandatory).
-    # Allowed values are:
-    # - after-release-column: this is typically used for documenting related runtime versions
-    #   (such as the supported iOS version range for iphone models),
-    # - before-latest-column: this is typically used for documenting additional dates
-    #   (such as an obsolescence date for an iphone model - https://support.apple.com/en-us/HT201624),
-    # - after-latest-column: this is typically used for documenting a corresponding latest version
-    #   number (such as the OpenJDK version for https://endoflife.date/azul-zulu).
-    # If multiple columns have the same position, the order of the column in the customColumns list
-    # will be respected.
-    position: after-release-column
+    # Where the custom field should be displayed (mandatory). Allowed values are:
+    # - none: do not display the custom field in API responses nor in release table.
+    # - api-only: only display the custom field in API responses.
+    # - after-release-column: display the custom field in API and in the release table after the release column.
+    # - before-latest-column: display the custom field in API and in the release table before the latest column.
+    # - after-latest-column: display the custom field in API and in the release table after the latest column.
+    # If multiple columns have the same position, the order of the column in the customFields list will be respected.
+    display: after-release-column
 
-    # Label of the custom column (mandatory).
-    # It will be displayed in the table header.
+    # Label of the custom field (mandatory).
+    # It will notably be used as the column's name in the release table.
     label: iOS
 
     # A description of what the custom column contains (optional).
-    # It will be displayed as a tooltip of the column table header cell.
+    # It will notably be used as the column's tooltip in the release table.
     description: Supported iOS versions
 
-    # A link that gives more information about what the custom column contains (optional).
-    # It will be used to transform the table label to a link.
+    # A link that gives more information about what the custom field contains (optional).
+    # It will notably transform the label into a link in the release table.
     link: https://en.wikipedia.org/wiki/IPhone#Models
 
 # Auto-update release configuration (optional).

--- a/_config.yml
+++ b/_config.yml
@@ -104,7 +104,7 @@ defaults:
       eoesColumn: false
       eoesColumnLabel: 'Extended Support'
       eoesWarnThreshold: 121
-      customColumns: []
+      customFields: []
       LTSLabel: '<abbr title="Long Term Support">LTS</abbr>'
 
 

--- a/_includes/custom-column-td.html
+++ b/_includes/custom-column-td.html
@@ -7,6 +7,6 @@ Parameters:
 - cssClasses (optional): a space-separated list of CSS classes to add to the cell.
 {% endcomment %}
 {%- assign release = include.release %}
-{%- assign propertyName = include.column.property %}
+{%- assign name = include.column.name %}
 {%- assign cssClasses = include.cssClasses | default:'' %}
-<td class="{{ cssClasses }}">{{ release[propertyName] | default: 'N/A' }}</td>
+<td class="{{ cssClasses }}">{{ release[name] | default: 'N/A' }}</td>

--- a/_layouts/product.html
+++ b/_layouts/product.html
@@ -30,9 +30,9 @@ layout: default
 {% endif %}
 
 {%- capture now %}{{ "now" | date: "%s" | plus:0 }}{% endcapture %}
-{%- assign customColumnsAfterRelease = page.customColumns | where: 'position', 'after-release-column' %}
-{%- assign customColumnsBeforeLatest = page.customColumns | where: 'position', 'before-latest-column' %}
-{%- assign customColumnsAfterLatest = page.customColumns | where: 'position', 'after-latest-column' %}
+{%- assign customColumnsAfterRelease = page.customFields | where: 'display', 'after-release-column' %}
+{%- assign customColumnsBeforeLatest = page.customFields | where: 'display', 'before-latest-column' %}
+{%- assign customColumnsAfterLatest = page.customFields | where: 'display', 'after-latest-column' %}
 
 <table class="lifecycle">
   <thead>

--- a/product-schema.json
+++ b/product-schema.json
@@ -89,12 +89,12 @@
         }
       }
     },
-    "customColumns": {
-      "title": "Custom columns",
-      "description": "Array of custom columns for this product.",
+    "customFields": {
+      "title": "Custom fields",
+      "description": "Array of custom fields for this product's releases.",
       "type": "array",
       "items": {
-        "$ref": "#/$defs/customColumn"
+        "$ref": "#/$defs/customField"
       }
     },
     "releases": {
@@ -158,22 +158,24 @@
         }
       ]
     },
-    "customColumn": {
+    "customField": {
       "type": "object",
       "properties": {
-        "property": {
-          "title": "Property",
-          "description": "Name of the custom property in release cycles.",
+        "name": {
+          "title": "Name",
+          "description": "Name of the custom field.",
           "examples": [
             "supportedIosVersions",
             "correspondingAndroidVersion"
           ],
           "type": "string"
         },
-        "position": {
-          "title": "Position",
-          "description": "Position of the custom column in the table.",
+        "display": {
+          "title": "Display",
+          "description": "Where to display the custom field.",
           "enum": [
+            "none",
+            "api-only",
             "after-release-column",
             "before-latest-column",
             "after-latest-column"

--- a/products/amazon-glue.md
+++ b/products/amazon-glue.md
@@ -7,6 +7,18 @@ permalink: /amazon-glue
 releasePolicyLink: https://docs.aws.amazon.com/glue/latest/dg/glue-version-support-policy.html
 releaseColumn: false
 
+customFields:
+-   name: pythonVersion
+    display: api-only
+    label: Python
+    description: Python version
+    link: https://docs.aws.amazon.com/glue/latest/dg/release-notes.html
+-   name: sparkVersion
+    display: api-only
+    label: Spark
+    description: Spark version
+    link: https://docs.aws.amazon.com/glue/latest/dg/release-notes.html
+
 # Versions taken from https://docs.aws.amazon.com/glue/latest/dg/release-notes.html
 # EOL dates from https://docs.aws.amazon.com/glue/latest/dg/glue-version-support-policy.html.
 releases:

--- a/products/amazon-neptune.md
+++ b/products/amazon-neptune.md
@@ -14,6 +14,11 @@ versionCommand: >
 releasePolicyLink: https://docs.aws.amazon.com/neptune/latest/userguide/engine-releases.html
 changelogTemplate: https://docs.aws.amazon.com/neptune/latest/userguide/engine-releases-__LATEST__.html
 
+customFields:
+-   name: upgradeVersion
+    display: api-only
+    label: Upgrade to
+
 auto:
   methods:
   -   custom: amazon-neptune

--- a/products/android.md
+++ b/products/android.md
@@ -13,9 +13,9 @@ releaseLabel: "__RELEASE_CYCLE__ '__CODENAME__'"
 releaseColumn: false
 eolColumn: Security Support
 
-customColumns:
--   property: apiVersion
-    position: after-release-column
+customFields:
+-   name: apiVersion
+    display: after-release-column
     label: API Version
 
 identifiers:

--- a/products/angularjs.md
+++ b/products/angularjs.md
@@ -10,9 +10,10 @@ releasePolicyLink: https://docs.angularjs.org/misc/version-support-status
 changelogTemplate: https://github.com/angular/angular.js/blob/v__LATEST__/CHANGELOG.md
 eolColumn: Support
 eoesColumn: Extended Long Term Support
-customColumns:
--   property: eoesProvider
-    position: before-latest-column
+
+customFields:
+-   name: eoesProvider
+    display: before-latest-column
     label: Extended Long Term Support provider
     description: Companies that provide extended Long Term Support for AngularJS.
 

--- a/products/ansible-core.md
+++ b/products/ansible-core.md
@@ -9,6 +9,23 @@ releasePolicyLink: https://docs.ansible.com/ansible-core/devel/reference_appendi
 changelogTemplate: https://github.com/ansible/ansible/blob/stable-__RELEASE_CYCLE__/changelogs/CHANGELOG-v__RELEASE_CYCLE__.rst
 eolColumn: Supported
 
+customFields:
+-   name: pythonVersionsControlNode
+    display: api-only
+    label: Control node Python
+    description: Control node Python support
+    link: https://docs.ansible.com/ansible/latest/reference_appendices/release_and_maintenance.html#ansible-community-changelogs
+-   name: pythonVersionsManagedNode
+    display: api-only
+    label: Managed node Python
+    description: Managed node Python support
+    link: https://docs.ansible.com/ansible/latest/reference_appendices/release_and_maintenance.html#ansible-community-changelogs
+-   name: powershellVersionsManagedNode
+    display: api-only
+    label: Managed node PowerShell
+    description: Managed node PowerShell support
+    link: https://docs.ansible.com/ansible/latest/reference_appendices/release_and_maintenance.html#ansible-community-changelogs
+
 identifiers:
 -   repology: ansible-core
 -   cpe: cpe:/a:redhat:ansible_engine

--- a/products/ansible.md
+++ b/products/ansible.md
@@ -10,6 +10,28 @@ releasePolicyLink: https://docs.ansible.com/ansible/devel/reference_appendices/r
 changelogTemplate: https://github.com/ansible-community/ansible-build-data/blob/main/__RELEASE_CYCLE__/CHANGELOG-v__RELEASE_CYCLE__.rst
 eolColumn: Supported
 
+customFields:
+-   name: ansibleCoreVersion
+    display: api-only
+    label: ansible-core
+    description: ansible-core version
+    link: https://docs.ansible.com/ansible/latest/reference_appendices/release_and_maintenance.html#ansible-community-changelogs
+-   name: pythonVersionsControlNode
+    display: api-only
+    label: Control node Python
+    description: Control node Python support
+    link: https://docs.ansible.com/ansible/latest/reference_appendices/release_and_maintenance.html#ansible-community-changelogs
+-   name: pythonVersionsManagedNode
+    display: api-only
+    label: Managed node Python
+    description: Managed node Python support
+    link: https://docs.ansible.com/ansible/latest/reference_appendices/release_and_maintenance.html#ansible-community-changelogs
+-   name: powershellVersionsManagedNode
+    display: api-only
+    label: Managed node PowerShell
+    description: Managed node PowerShell support
+    link: https://docs.ansible.com/ansible/latest/reference_appendices/release_and_maintenance.html#ansible-community-changelogs
+
 identifiers:
 -   purl: pkg:pypi/ansible
 -   purl: pkg:deb/debian/ansible

--- a/products/apache-camel.md
+++ b/products/apache-camel.md
@@ -9,9 +9,10 @@ alternate_urls:
 releasePolicyLink: https://camel.apache.org/blog/2020/03/LTS-Release-Schedule/
 changelogTemplate: https://camel.apache.org/releases/release-__LATEST__/
 eolColumn: Bug and Security Fixes
-customColumns:
--   property: supportedJavaVersions
-    position: after-release-column
+
+customFields:
+-   name: supportedJavaVersions
+    display: after-release-column
     label: Java support
     description: Supported Java versions list
     link: https://camel.apache.org/manual/what-are-the-dependencies.html

--- a/products/apple-watch.md
+++ b/products/apple-watch.md
@@ -9,6 +9,12 @@ discontinuedColumn: true
 eolColumn: Supported
 releaseColumn: false
 
+customFields:
+-   name: supportedWatchOsVersions
+    display: api-only
+    label: WatchOS
+    description: Supported WatchOS versions
+
 # Links send to the Technical Specifications of each model.
 # All links can be found on https://support.apple.com/en_US/specs/applewatch.
 # All supported watchOS versions can be found on https://en.wikipedia.org/wiki/Apple_Watch#Support.

--- a/products/azul-zulu.md
+++ b/products/azul-zulu.md
@@ -10,9 +10,10 @@ versionCommand: java -version
 releasePolicyLink: https://www.azul.com/products/azul-support-roadmap/
 eolColumn: Support
 eoesColumn: true
-customColumns:
--   property: latestJdkVersion
-    position: after-latest-column
+
+customFields:
+-   name: latestJdkVersion
+    display: after-latest-column
     label: Latest JDK
     description: Corresponding latest Java version
     link: https://docs.azul.com/core/zulu-openjdk/versioning-and-naming

--- a/products/cakephp.md
+++ b/products/cakephp.md
@@ -12,6 +12,13 @@ releasePolicyLink: https://github.com/cakephp/cakephp/wiki
 changelogTemplate: https://github.com/cakephp/cakephp/releases/__LATEST__
 eoasColumn: true
 
+customFields:
+-   name: supportedPhpVersions
+    display: api-only
+    label: PHP
+    description: Supported PHP versions
+    link: https://github.com/cakephp/cakephp/wiki#version-map
+
 identifiers:
 -   repology: cakephp
 -   cpe: cpe:/a:cakephp:cakephp

--- a/products/django.md
+++ b/products/django.md
@@ -9,9 +9,10 @@ releasePolicyLink: https://www.djangoproject.com/download/#supported-versions
 releaseImage: https://static.djangoproject.com/img/release-roadmap.fdaa7bc5861f.png
 changelogTemplate: https://docs.djangoproject.com/en/__RELEASE_CYCLE__/releases/__LATEST__/
 eoasColumn: true
-customColumns:
--   property: supportedPythonVersions
-    position: after-release-column
+
+customFields:
+-   name: supportedPythonVersions
+    display: after-release-column
     label: Python
     description: Supported Python versions
     link: https://docs.djangoproject.com/en/stable/faq/install/#what-python-version-can-i-use-with-django

--- a/products/drush.md
+++ b/products/drush.md
@@ -9,6 +9,18 @@ releasePolicyLink: https://www.drush.org/latest/install/#drupal-compatibility
 changelogTemplate: https://github.com/drush-ops/drush/releases/tag/__LATEST__
 eolColumn: Support
 
+customFields:
+-   name: supportedPhpVersions
+    display: api-only
+    label: PHP
+    description: Supported PHP versions
+    link: https://www.drush.org/latest/install/
+-   name: supportedDrupalVersions
+    display: api-only
+    label: Drupal
+    description: Supported Drupal versions
+    link: https://www.drush.org/latest/install/
+
 identifiers:
 -   repology: drush
 -   purl: pkg:composer/drush/drush

--- a/products/eclipse-jetty.md
+++ b/products/eclipse-jetty.md
@@ -12,6 +12,23 @@ eoasColumn: "Open Source Support"
 eolColumn: true
 eoesColumn: "Extended Support"
 
+customFields:
+-   name: minJvmVersion
+    display: api-only
+    label: JVM
+    description: Minimum required JVM version
+    link: https://jetty.org/download.html
+-   name: servletVersion
+    display: api-only
+    label: Servlet
+    description: Supported Servlet versions
+    link: https://jetty.org/download.html
+-   name: jspVersion
+    display: api-only
+    label: JSP
+    description: Supported JSP versions
+    link: https://jetty.org/download.html
+
 identifiers:
 -   repology: jetty
 -   purl: pkg:maven/org.eclipse.jetty/jetty-server

--- a/products/electron.md
+++ b/products/electron.md
@@ -8,13 +8,14 @@ versionCommand: npm show electron version
 releasePolicyLink: https://www.electronjs.org/docs/latest/tutorial/electron-timelines
 changelogTemplate: https://releases.electronjs.org/release/v__LATEST__
 eolColumn: Supported
-customColumns:
--   property: chromeVersion
-    position: after-release-column
+
+customFields:
+-   name: chromeVersion
+    display: after-release-column
     label: Chrome
     description: Corresponding Chrome version used in the Electron release
--   property: nodeVersion
-    position: after-release-column
+-   name: nodeVersion
+    display: after-release-column
     label: Node
     description: Corresponding Node version used in the Electron release
 

--- a/products/eslint.md
+++ b/products/eslint.md
@@ -9,9 +9,10 @@ changelogTemplate: https://github.com/eslint/eslint/releases/tag/v__LATEST__
 eoasColumn: Active Support
 eolColumn: Maintenance Support
 eoesColumn: Extended Long Term Support
-customColumns:
--   property: eoesProvider
-    position: before-latest-column
+
+customFields:
+-   name: eoesProvider
+    display: before-latest-column
     label: Extended Support Provider
     description: Companies that provide extended EOL support for eslint.
 

--- a/products/fairphone.md
+++ b/products/fairphone.md
@@ -9,9 +9,10 @@ releaseColumn: false
 eoasColumn: Active Major Updates
 discontinuedColumn: true
 eolColumn: Security Updates
-customColumns:
--   property: supportedAndroidVersions
-    position: after-release-column
+
+customFields:
+-   name: supportedAndroidVersions
+    display: after-release-column
     label: Supported Android
     description: Supported Android version range
     link: https://support.fairphone.com/hc/articles/9979180437393-Fairphone-OS

--- a/products/google-nexus.md
+++ b/products/google-nexus.md
@@ -10,9 +10,10 @@ releaseColumn: false
 discontinuedColumn: true
 eoasColumn: Android updates
 eolColumn: Security Updates
-customColumns:
--   property: supportedAndroidVersions # data usually found on wikipedia
-    position: after-release-column
+
+customFields:
+-   name: supportedAndroidVersions # data usually found on wikipedia
+    display: after-release-column
     label: Supported Android Versions
     description: Supported Android versions range
     link: https://endoflife.date/android

--- a/products/gradle.md
+++ b/products/gradle.md
@@ -10,6 +10,33 @@ changelogTemplate: https://github.com/gradle/gradle/releases/tag/v__LATEST__
 eoasColumn: true
 eolColumn: Critical Bug and Security Fixes
 
+customFields:
+-   name: runningJavaVersions
+    display: api-only
+    label: Java (running)
+    description: Java support for running Gradle
+    link: https://docs.gradle.org/current/userguide/compatibility.html
+-   name: testedJavaVersions
+    display: api-only
+    label: Java
+    description: Java support for compiling/testing/…
+    link: https://docs.gradle.org/current/userguide/compatibility.html
+-   name: testedKotlinVersions
+    display: api-only
+    label: Kotlin
+    description: Kotlin support for compiling/testing/…
+    link: https://docs.gradle.org/current/userguide/compatibility.html
+-   name: testedGroovyVersions
+    display: api-only
+    label: Groovy
+    description: Groovy support for compiling/testing/…
+    link: https://docs.gradle.org/current/userguide/compatibility.html
+-   name: testedAndroidVersions
+    display: api-only
+    label: Android
+    description: Android support for compiling/testing/…
+    link: https://docs.gradle.org/current/userguide/compatibility.html
+
 identifiers:
 -   repology: gradle
 -   cpe: cpe:/a:gradle:gradle

--- a/products/guzzle.md
+++ b/products/guzzle.md
@@ -4,9 +4,10 @@ category: framework
 tags: php-runtime
 permalink: /guzzle
 releasePolicyLink: https://github.com/guzzle/guzzle?tab=readme-ov-file#version-guidance
-customColumns:
--   property: supportedPHPVersions
-    position: after-release-column
+
+customFields:
+-   name: supportedPHPVersions
+    display: after-release-column
     label: PHP versions
     description: Supported PHP versions range
 

--- a/products/ionic.md
+++ b/products/ionic.md
@@ -12,6 +12,28 @@ eoasColumn: true
 eolColumn: Maintenance
 eoesColumn: true
 
+customFields:
+-   name: minAngularVersion
+    display: api-only
+    label: Min. Angular
+    description: Minimum required Angular version
+    link: https://ionicframework.com/docs/reference/support#compatibility-recommendations
+-   name: maxAngularVersion
+    display: api-only
+    label: Max Angular
+    description: Maximum required Angular version
+    link: https://ionicframework.com/docs/reference/support#compatibility-recommendations
+-   name: supportedReactVersions
+    display: api-only
+    label: React
+    description: Supported React versions
+    link: https://ionicframework.com/docs/reference/support#compatibility-recommendations
+-   name: supportedVueVersions
+    display: api-only
+    label: Vue
+    description: Supported Vue versions
+    link: https://ionicframework.com/docs/reference/support#compatibility-recommendations
+
 identifiers:
 -   purl: pkg:github/ionic-team/ionic-framework
 -   purl: pkg:npm/%40ionic/core
@@ -42,7 +64,6 @@ auto:
 
 # eoas(x) = releaseDate(x+1)
 # For eol / eoes see https://ionicframework.com/docs/reference/support#framework-maintenance-and-support-status.
-# For 
 releases:
 -   releaseCycle: "8"
     releaseDate: 2024-04-17

--- a/products/ipad.md
+++ b/products/ipad.md
@@ -9,6 +9,12 @@ discontinuedColumn: true
 eolColumn: Supported
 releaseColumn: false
 
+customFields:
+-   name: supportedIpadOsVersions
+    display: api-only
+    label: iPadOS
+    description: Supported iPadOS versions
+
 # Links send to the Technical Specifications of each model.
 # All links can be found on https://support.apple.com/HT201471.
 # All supported iPadOS versions can be found on https://en.wikipedia.org/wiki/List_of_iPad_models#iPad.
@@ -28,7 +34,7 @@ releases:
     eol: false
     link: https://support.apple.com/122241
     supportedIpadOsVersions: 18
-    
+
 -   releaseCycle: "mini-7"
     releaseLabel: "iPad Mini (7th generation)"
     releaseDate: 2024-10-23

--- a/products/iphone.md
+++ b/products/iphone.md
@@ -8,9 +8,10 @@ releasePolicyLink: https://en.wikipedia.org/wiki/List_of_iPhone_models#Release_d
 discontinuedColumn: true
 eolColumn: Supported
 releaseColumn: false
-customColumns:
--   property: supportedIosVersions
-    position: after-release-column
+
+customFields:
+-   name: supportedIosVersions
+    display: after-release-column
     label: Supported iOS
     description: Supported iOS versions range
     link: https://endoflife.date/ios

--- a/products/istio.md
+++ b/products/istio.md
@@ -7,6 +7,13 @@ versionCommand: istioctl version
 releasePolicyLink: https://istio.io/latest/docs/releases/supported-releases/#support-policy
 changelogTemplate: https://istio.io/latest/news/releases/__RELEASE_CYCLE__.x/announcing-{{'__LATEST__'|drop_zero_patch}}/
 
+customFields:
+-   name: supportedKubernetesVersions
+    display: api-only
+    label: Kubernetes
+    description: Supported Kubernetes versions
+    link: https://istio.io/latest/docs/releases/supported-releases/#support-status-of-istio-releases
+
 identifiers:
 -   repology: istio
 -   repology: istioctl

--- a/products/jekyll.md
+++ b/products/jekyll.md
@@ -9,6 +9,13 @@ changelogTemplate: https://github.com/jekyll/jekyll/releases/tag/v__LATEST__
 eoasColumn: Active Development
 eolColumn: Active Maintenance
 
+customFields:
+-   name: minRubyVersion
+    display: api-only
+    label: Ruby
+    description: Minimum required Ruby version
+    link: https://jekyllrb.com/docs/installation/
+
 identifiers:
 -   cpe: cpe:/a:jekyllrb:jekyll
 -   cpe: cpe:2.3:a:jekyllrb:jekyll

--- a/products/keda.md
+++ b/products/keda.md
@@ -7,6 +7,13 @@ releasePolicyLink: https://github.com/kedacore/keda?tab=security-ov-file#readme
 changelogTemplate: "https://github.com/kedacore/keda/releases/tag/v__LATEST__"
 eolColumn: Support
 
+customFields:
+-   name: supportedKubernetesVersions
+    display: api-only
+    label: Kubernetes
+    description: Supported Kubernetes versions
+    link: https://keda.sh/docs/latest/operate/cluster/#kubernetes-compatibility
+
 auto:
   methods:
   -   git: https://github.com/kedacore/keda.git

--- a/products/kirby.md
+++ b/products/kirby.md
@@ -7,9 +7,9 @@ alternate_urls:
 -   /getkirby
 changelogTemplate: https://github.com/getkirby/kirby/releases/tag/__LATEST__
 releaseLabel: "__RELEASE_CYCLE__{% if '__CODENAME__' != '' %} (__CODENAME__){% endif %}"
-customColumns:
--   property: supportedPhpVersions
-    position: after-release-column
+customFields:
+-   name: supportedPhpVersions
+    display: after-release-column
     label: Supported PHP
     description: Supported PHP versions range
     link: https://getkirby.com/docs/reference/system/requirements#php-version-support-history

--- a/products/kyverno.md
+++ b/products/kyverno.md
@@ -7,9 +7,10 @@ versionCommand: kyverno version
 releasePolicyLink: https://kyverno.io/docs/installation/#compatibility-matrix
 changelogTemplate: https://github.com/kyverno/kyverno/releases/tag/v__LATEST__
 eolColumn: Support
-customColumns:
--   property: supportedK8sVersions
-    position: after-release-column
+
+customFields:
+-   name: supportedK8sVersions
+    display: after-release-column
     label: Kubernetes Version
     description: Supported Kubernetes versions
     link: https://kyverno.io/docs/installation/#compatibility-matrix

--- a/products/laravel.md
+++ b/products/laravel.md
@@ -9,6 +9,12 @@ releasePolicyLink: https://laravel.com/docs/master/releases#support-policy
 changelogTemplate: https://laravel.com/docs/__RELEASE_CYCLE__.x/releases
 eoasColumn: true
 
+customFields:
+-   name: supportedPhpVersions
+    display: api-only
+    label: PHP
+    description: Supported PHP versions
+
 identifiers:
 -   purl: pkg:composer/laravel/laravel
 -   purl: pkg:docker/bitnami/laravel

--- a/products/lineageos.md
+++ b/products/lineageos.md
@@ -6,9 +6,10 @@ permalink: /lineageos
 alternate_urls:
 -   /lineage
 releaseColumn: false
-customColumns:
--   property: androidVersion
-    position: after-release-column
+
+customFields:
+-   name: androidVersion
+    display: after-release-column
     label: Android version
     description: Corresponding Android version
     link: https://endoflife.date/android

--- a/products/magento.md
+++ b/products/magento.md
@@ -13,6 +13,12 @@ eoasColumn: Bug fix maintenance
 eolColumn: Security maintenance
 eoesColumn: Adobe Commerce end of software support
 
+customFields:
+-   name: supportedPhpVersions
+    display: api-only
+    label: PHP
+    description: PHP Compatibility
+
 identifiers:
 -   cpe: cpe:/a:magento:magento
 -   cpe: cpe:2.3:a:magento:magento

--- a/products/moodle.md
+++ b/products/moodle.md
@@ -8,6 +8,13 @@ releasePolicyLink: https://moodledev.io/general/releases
 changelogTemplate: "https://moodledev.io/general/releases/__RELEASE_CYCLE__{% if '__RELEASE_CYCLE__.0'!='__LATEST__' %}/__LATEST__{% endif %}"
 eoasColumn: true
 
+customFields:
+-   name: supportedPhpVersions
+    display: api-only
+    label: PHP
+    description: Supported PHP versions
+    link: https://moodledev.io/general/development/policies/php
+
 identifiers:
 -   repology: moodle
 -   cpe: cpe:/a:moodle:moodle

--- a/products/mssqlserver.md
+++ b/products/mssqlserver.md
@@ -9,9 +9,16 @@ alternate_urls:
 -   /microsoftsqlserver
 versionCommand: select @@version
 releasePolicyLink: https://learn.microsoft.com/lifecycle/products/?terms=SQL%20Server
-
 eoasColumn: true
 eoesColumn: Extended Security Updates
+
+customFields:
+-   name: latestGdr
+    display: api-only
+    label: Latest General Distribution Release
+-   name: latestGdrLink
+    display: api-only
+    label: Latest General Distribution Release link
 
 identifiers:
 -   cpe: cpe:/a:microsoft:sql_server
@@ -44,7 +51,7 @@ releases:
     latestReleaseDate: 2024-11-12
     # SP3 link: https://learn.microsoft.com/troubleshoot/sql/releases/sqlserver-2016/servicepack3
     link: https://support.microsoft.com/help/5046855 # GDR for SP3
-    
+
 -   releaseCycle: "15.0"
     codename: Seattle
     releaseLabel: "2019"
@@ -56,7 +63,7 @@ releases:
     latest: "15.0.4430.1 CU32"
     latestReleaseDate: 2025-02-27
     link: https://learn.microsoft.com/troubleshoot/sql/releases/sqlserver-2019/cumulativeupdate32
-    
+
 -   releaseCycle: "12.0-sp3"
     codename: Hekaton
     releaseLabel: "2014 SP3"

--- a/products/omnissa-horizon.md
+++ b/products/omnissa-horizon.md
@@ -12,6 +12,11 @@ changelogTemplate: https://docs.vmware.com/en/VMware-Horizon/{{"__LATEST__"|repl
 LTSLabel: "<abbr title='Extended Service Branch'>ESB</abbr>"
 eolColumn: General Support
 
+customFields:
+-   name: technicalGuidance
+    display: api-only
+    label: Technical Guidance Ends
+
 releases:
 -   releaseCycle: "8.2412"
     releaseDate: 2025-01-28
@@ -20,7 +25,7 @@ releases:
     latest: "8.2412"
     latestReleaseDate: 2024-01-25
     link: https://docs.omnissa.com/bundle/horizon8-rnV2412/page/Horizon8-ReleaseNotes.html
-    
+
 -   releaseCycle: "8.2406"
     releaseDate: 2024-06-25
     eol: false # is there a date documented somewhere ?

--- a/products/oneplus.md
+++ b/products/oneplus.md
@@ -13,9 +13,10 @@ activeSupportColumn: Active Major Updates
 discontinuedColumn: true
 eoasColumn: Android Updates
 eolColumn: Security Updates
-customColumns:
--   property: supportedOxygenOSVersions
-    position: after-release-column
+
+customFields:
+-   name: supportedOxygenOSVersions
+    display: after-release-column
     label: Supported OxygenOS
     description: Supported OxygenOS versions range
     link: https://wikipedia.org/wiki/OxygenOS

--- a/products/openzfs.md
+++ b/products/openzfs.md
@@ -10,6 +10,16 @@ releasePolicyLink: https://github.com/openzfs/zfs/blob/master/RELEASES.md
 changelogTemplate: https://github.com/openzfs/zfs/releases/tag/zfs-__LATEST__
 eolColumn: Critical bug fixes
 
+customFields:
+-   name: supportedLinux
+    display: api-only
+    label: Linux
+    description: Supported Linux kernel versions
+-   name: supportedFreeBSD
+    display: api-only
+    label: FreeBSD
+    description: Supported FreeBSD versions
+
 identifiers:
 -   repology: openzfs
 -   cpe: cpe:/a:openzfs:openzfs

--- a/products/pixel-watch.md
+++ b/products/pixel-watch.md
@@ -10,9 +10,10 @@ releaseColumn: false
 discontinuedColumn: true
 eoasColumn: WearOS Updates
 eolColumn: Security Updates
-customColumns:
--   property: supportedAndroidVersions
-    position: after-release-column
+
+customFields:
+-   name: supportedAndroidVersions
+    display: after-release-column
     label: Supported Android # https://en.wikipedia.org/wiki/Google_Pixel#Phones
     description: Supported Android versions range
 

--- a/products/pixel.md
+++ b/products/pixel.md
@@ -10,9 +10,10 @@ releaseColumn: false
 discontinuedColumn: true
 eoasColumn: Android Updates
 eolColumn: Security Updates
-customColumns:
--   property: supportedAndroidVersions
-    position: after-release-column
+
+customFields:
+-   name: supportedAndroidVersions
+    display: after-release-column
     label: Supported Android # https://en.wikipedia.org/wiki/Google_Pixel#Phones
     description: Supported Android versions range
     link: https://endoflife.date/android

--- a/products/plone.md
+++ b/products/plone.md
@@ -9,9 +9,9 @@ changelogTemplate: "https://plone.org/download/releases/__LATEST__"
 eoasColumn: Maintenance Support
 eolColumn: Security Support
 
-customColumns:
--   property: pythonVersions
-    position: after-release-column
+customFields:
+-   name: pythonVersions
+    display: after-release-column
     label: Python versions
     description: Supported Python versions range
 

--- a/products/robo.md
+++ b/products/robo.md
@@ -5,9 +5,10 @@ tags: php-runtime
 permalink: /robo
 versionCommand: robo --version
 eoasColumn: true
-customColumns:
--   property: supportedPHPVersions
-    position: after-release-column
+
+customFields:
+-   name: supportedPHPVersions
+    display: after-release-column
     label: PHP versions
     description: Supported PHP versions range
     link: https://github.com/consolidation/robo/blob/5.x/README.md

--- a/products/shopware.md
+++ b/products/shopware.md
@@ -10,9 +10,17 @@ changelogTemplate: https://github.com/shopware/shopware/releases/tag/v__LATEST__
 eoasColumn: true
 eoesColumn: Commercial support
 
+customFields:
+-   name: supportedPhpVersions
+    display: api-only
+    label: PHP
+    description: Supported PHP versions
+    link: https://docs.shopware.com/en/shopware-6-en/first-steps/system-requirements
+
 identifiers:
 -   cpe: cpe:/a:shopware:shopware
 -   cpe: cpe:2.3:a:shopware:shopware
+
 auto:
   methods:
   -   git: https://github.com/shopware/shopware.git # Shopware 6

--- a/products/spring-boot.md
+++ b/products/spring-boot.md
@@ -11,6 +11,12 @@ changelogTemplate: "https://github.com/spring-projects/spring-boot/releases/tag/
 eolColumn: OSS support
 eoesColumn: Commercial Support
 
+customFields:
+-   name: supportedJavaVersions
+    display: api-only
+    label: JDK
+    description: Supported JDK versions
+
 identifiers:
 -   purl: pkg:maven/org.springframework.boot/spring-boot
 -   purl: pkg:maven/org.springframework.boot/spring-boot-starter

--- a/products/spring-framework.md
+++ b/products/spring-framework.md
@@ -11,6 +11,18 @@ changelogTemplate: https://github.com/spring-projects/spring-framework/releases/
 eolColumn: OSS support
 eoesColumn: Commercial Support
 
+customFields:
+-   name: supportedJavaVersions
+    display: api-only
+    label: JDK
+    description: Supported JDK versions
+    link: https://github.com/spring-projects/spring-framework/wiki/Spring-Framework-Versions#jdk-version-range
+-   name: supportedJakartaEEVersions
+    display: api-only
+    label: Jakarta EE
+    description: Supported Jakarta EE versions
+    link: https://github.com/spring-projects/spring-framework/wiki/Spring-Framework-Versions#jdk-version-range
+
 auto:
   methods:
   -   git: https://github.com/spring-projects/spring-framework.git
@@ -30,7 +42,7 @@ auto:
 # Supported Java/Jakarta EE versions available on https://github.com/spring-projects/spring-framework/wiki/Spring-Framework-Versions#jdk-version-range.
 releases:
 -   releaseCycle: "6.2"
-    supportedJavaVersions: "17 - 25(expected)"
+    supportedJavaVersions: "17 - 25"
     supportedJakartaEEVersions: "9 - 10"
     releaseDate: 2024-11-14
     eol: 2026-06-30

--- a/products/tomcat.md
+++ b/products/tomcat.md
@@ -8,6 +8,13 @@ versionCommand: ./bin/version.sh
 releasePolicyLink: https://tomcat.apache.org/whichversion.html
 changelogTemplate: "https://tomcat.apache.org/tomcat-{{'__LATEST__'|split:'.'|pop|join:'.'}}-doc/changelog.html"
 
+customFields:
+-   name: minJavaVersion
+    display: api-only
+    label: Java
+    description: Minimum required Java version
+    link: https://tomcat.apache.org/whichversion.html
+
 identifiers:
 -   repology: tomcat
 -   purl: pkg:maven/org.apache.tomcat/tomcat

--- a/products/vmware-esxi.md
+++ b/products/vmware-esxi.md
@@ -13,6 +13,11 @@ versionCommand: vmware -l
 releasePolicyLink: https://support.broadcom.com/group/ecx/productlifecycle
 eolColumn: General Support
 
+customFields:
+-   name: technicalGuidance
+    display: api-only
+    label: Technical Guidance Ends
+
 identifiers:
 -   cpe: cpe:2.3:o:vmware:esxi
 -   cpe:  cpe:/o:vmware:esxi
@@ -74,7 +79,7 @@ releases:
     latest: "5.1 Update 3d"
     latestReleaseDate: 2016-05-24
     link: https://web.archive.org/web/20190923124908/http://pubs.vmware.com/Release_Notes/en/vsphere/51/vsphere-vcenter-server-51u3d-release-notes.html
-    
+
 -   releaseCycle: "5.0"
     releaseDate: 2011-07-12
     eol: 2016-08-24

--- a/products/vmware-photon.md
+++ b/products/vmware-photon.md
@@ -12,9 +12,9 @@ releasePolicyLink: https://blogs.vmware.com/vsphere/2023/05/announcing-photon-os
 releaseColumn: false
 eolColumn: Security Support
 
-customColumns:
--   property: kernelVersion
-    position: after-release-column
+customFields:
+-   name: kernelVersion
+    display: after-release-column
     label: Kernel Version
     description: Linux Kernel Version
 

--- a/products/vmware-srm.md
+++ b/products/vmware-srm.md
@@ -9,6 +9,11 @@ alternate_urls:
 releasePolicyLink: https://ftpdocs.broadcom.com/WebInterface/phpdocs/0/MSPSaccount/COMPAT/AllProdDates.HTML
 eolColumn: General Support
 
+customFields:
+-   name: technicalGuidance
+    display: api-only
+    label: Technical Guidance Ends
+
 releases:
 -   releaseCycle: "8.8"
     releaseDate: 2023-09-21

--- a/products/vmware-vcenter.md
+++ b/products/vmware-vcenter.md
@@ -10,6 +10,11 @@ alternate_urls:
 releasePolicyLink: https://lifecycle.vmware.com
 eolColumn: General Support
 
+customFields:
+-   name: technicalGuidance
+    display: api-only
+    label: Technical Guidance Ends
+
 identifiers:
 -   cpe: cpe:2.3:a:vmware:vcenter_server
 -   cpe: cpe:/a:vmware:vcenter_server

--- a/products/wordpress.md
+++ b/products/wordpress.md
@@ -8,9 +8,10 @@ versionCommand: wp core version
 releasePolicyLink: https://codex.wordpress.org/Supported_Versions
 changelogTemplate: "https://wordpress.org/documentation/wordpress-version/version-{{'__LATEST__'|drop_zero_patch|replace:'.','-'}}/"
 eolColumn: Support
-customColumns:
--   property: supportedPHPVersions
-    position: after-release-column
+
+customFields:
+-   name: supportedPHPVersions
+    display: after-release-column
     label: Supported PHP
     description: Supported PHP versions range
     link: https://make.wordpress.org/core/handbook/references/php-compatibility-and-wordpress-versions/

--- a/products/zentyal.md
+++ b/products/zentyal.md
@@ -8,9 +8,9 @@ releaseColumn: false
 eolColumn: Development Edition Support
 eoesColumn: Commercial Support
 
-customColumns:
--   property: ubuntuVersion
-    position: after-release-column
+customFields:
+-   name: ubuntuVersion
+    display: after-release-column
     label: Ubuntu Version
     description: Ubuntu LTS corresponding version
 


### PR DESCRIPTION
Adapt custom columns so that they are easier to use with API:

- rename customColumns to customFields,
- rename customColumns.property to customFields.name,
- rename customColumns.position to customFields.display,
- add two new customFields.display: none and api-only,
- make custom fields declaration mandatory, even when not displayed,
- declare missing custom fields.