### PR TITLE
Add custom properties in API

### DIFF
--- a/CHANGELOG_API.md
+++ b/CHANGELOG_API.md
@@ -1,3 +1,8 @@
+## API v1.1.0
+
+- Expose custom releases field values in the API (#7465). Such fields are grouped under the new `custom`
+  field in `ProductRelease`s.
+
 ## API v1.0.0
 
 ### Summary
@@ -83,8 +88,6 @@ rule and [takes precedence](https://docs.netlify.com/routing/redirects/#rule-pro
 - `/api/v1/tags/<tag>`: Get a list of all products having the given tag.
 - `/api/v1/products/full`: Get a list of all products with all their details (including cycles).
   This endpoint provides a dump of nearly all the endoflife.date data.
-
-
 
 ## API v0
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -484,7 +484,7 @@ npx @pb33f/wiretap@latest -s http://localhost:4000/docs/api/v1/openapi.yml -u ht
 # In a third tab, run:
 IFS="
 "
-for file in $(find _site/api/v1 -type f | sort -n); do
+for file in $(find _site/api/v1 -type f | grep -v releases | sort -n); do
   echo $(dirname $file | sed 's|_site|http://localhost:9090|' | sed 's|v1$|v1/|' | sed 's| |%20|')
 done | xargs -n1 -P20 curl -s -o /dev/null -w '%{url} %{http_code}\n'
 ```

--- a/_plugins/generate-api-v1.rb
+++ b/_plugins/generate-api-v1.rb
@@ -18,7 +18,8 @@ require 'jekyll'
 
 module ApiV1
 
-  VERSION = '1.0.0'
+  # This version must be kept in sync with the version in api_v1/openapi.yml.
+  VERSION = '1.1.0'
   MAJOR_VERSION = VERSION.split('.')[0]
 
   STRIP_HTML_BLOCKS = Regexp.union(
@@ -262,7 +263,8 @@ module ApiV1
             name: release['latest'],
             date: release['latestReleaseDate'],
             link: release['link'],
-          }
+          },
+          custom: custom_fields(product, release)
         }
 
         if !product.data['eoasColumn']
@@ -284,6 +286,16 @@ module ApiV1
           json[:latest] = nil
         end
 
+        if product.data['customFields'].empty?
+          json[:custom] = nil
+        end
+
+        json
+      end
+
+      def custom_fields(product, release)
+        json = {}
+        product.data['customFields'].map { |column| column['name'] }.map { |name| json[name] = release[name] }
         json
       end
     end

--- a/api_v1/openapi.yml
+++ b/api_v1/openapi.yml
@@ -9,7 +9,8 @@ openapi: 3.1.1
 
 info:
   title: endoflife API
-  version: "1.0.0"
+  # This version must be kept in sync with the version in _plugins/generate-api-v1.rb.
+  version: "1.1.0"
   license:
     name: MIT License
     url: 'https://github.com/endoflife-date/endoflife.date/blob/master/LICENSE'
@@ -19,6 +20,10 @@ info:
   description: >-
     endoflife.date documents EOL dates and support lifecycles for various products.
     The endoflife API allows users to discover and query for those products.
+
+
+    This API documentation is available at {{ site.url }}/docs/api/v1.
+    The API changelog is available at https://github.com/endoflife-date/endoflife.date/blob/master/CHANGELOG_API.md.
 
 
     Some useful links:
@@ -31,7 +36,6 @@ info:
 
     - [The source API definition](https://github.com/endoflife-date/endoflife.date/blob/master/assets/openapi.yml)
 
-# Replace with your preview URL (such as https://deploy-preview-2080--endoflife-date.netlify.app/api/v1).
 servers:
   - url: "{{ site.url }}/api/v1"
 
@@ -350,6 +354,14 @@ components:
           examples:
             - "cpe"
 
+    UnknownProperties:
+      description: Group properties with name not know in advance, such as custom properties.
+      type: object
+      additionalProperties:
+        type:
+          - string
+          - "null"
+
     ProductVersion:
       description: Information about a product version.
       type: object
@@ -542,6 +554,16 @@ components:
           anyOf:
             - $ref: '#/components/schemas/ProductVersion'
             - type: "null"
+        custom:
+          description: >
+            Custom fields for the product release cycle.
+
+            This field is null when the product does not declare at least one custom fields.
+          anyOf:
+            - $ref: '#/components/schemas/UnknownProperties'
+            - type: "null"
+          examples:
+            - { "chromeVersion": "M136", "nodeVersion": "22.15" }
 
     ProductSummary:
       description: Summary of a product.


### PR DESCRIPTION
Expose custom releases field values in the API. Those fields are already exposed in v0 API, and it was forgotten in #2080.

Such fields are grouped under the new `custom` field in `ProductRelease`s to make it clear those are not standard fields.

It was decided for now not to list the custom fields at product level, the best way to do it (dedicated note, use the `labels` field...) still being unclear

Closes #7465.