### PR TITLE
[pan-gp]Update GlobalProtect 6.2 metadata: set latest version to 6.28-c223 (2025-05-15)

### DIFF
--- a/products/pan-gp.md
+++ b/products/pan-gp.md
@@ -41,8 +41,8 @@ releases:
     releaseDate: 2023-05-23
     eol: 2026-12-31
     eoas: 2026-12-31
-    latest: "6.2.8"
-    latestReleaseDate: 2025-04-03
+    latest: "6.2.8-c223"
+    latestReleaseDate: 2025-05-15
     link: https://docs.paloaltonetworks.com/globalprotect/6-2/globalprotect-app-release-notes/globalprotect-addressed-issues
 
 -   releaseCycle: "6.1"


### PR DESCRIPTION


## Update GlobalProtect 6.2 Metadata to 6.2.8-c223

### Summary
This PR updates the metadata for GlobalProtect release cycle **6.2**:

- **Latest Version:** `6.2.8-c223`
- **Release Date:** `2025-05-15`
- **Release Notes:** [GlobalProtect Addressed Issues](https://docs.paloaltonetworks.com/globalprotect/6-2/globalprotect-app-release-notes/globalprotect-addressed-issues)

### Details
- Updated `latest` version from `6.2.8` to `6.2.8-c223`
- Updated `latestReleaseDate` to `2025-05-15`


