### PR TITLE
[pixel] Fix 9a eoas / eol

### DIFF
--- a/products/pixel.md
+++ b/products/pixel.md
@@ -22,13 +22,12 @@ customFields:
 # Past EOL dates from https://source.android.com/docs/setup/about/build-numbers (the latest release date wins).
 # Discontinued dates come from https://en.wikipedia.org/wiki/Google_Pixel
 # Supported Android versions range is based on https://www.gsmarena.com/.
-
 releases:
 -   releaseCycle: "9a"
     releaseLabel: "Pixel 9a"
     releaseDate: 2025-04-10
-    eoas: 2032-10-01 # at least
-    eol: 2032-10-01 # at least
+    eoas: 2032-04-01
+    eol: 2032-04-01
     discontinued: false
     link: https://en.wikipedia.org/wiki/Pixel_9a
     supportedAndroidVersions: "15" # https://www.gsmarena.com/google_pixel_9a-13478.php
@@ -36,8 +35,8 @@ releases:
 -   releaseCycle: "9profold"
     releaseLabel: "Pixel 9 Pro Fold"
     releaseDate: 2024-09-04
-    eoas: 2031-09-01 # at least
-    eol: 2031-09-01 # at least
+    eoas: 2031-09-01
+    eol: 2031-09-01
     discontinued: false
     link: https://en.wikipedia.org/wiki/Pixel_9_Pro_Fold
     supportedAndroidVersions: "14 - 15" # https://www.gsmarena.com/google_pixel_9_pro_fold-13220.php
@@ -45,8 +44,8 @@ releases:
 -   releaseCycle: "9pro"
     releaseLabel: "Pixel 9 Pro"
     releaseDate: 2024-09-04
-    eoas: 2031-09-01 # at least
-    eol: 2031-09-01 # at least
+    eoas: 2031-09-01
+    eol: 2031-09-01
     discontinued: false
     link: https://en.wikipedia.org/wiki/Pixel_9_Pro
     supportedAndroidVersions: "14 - 15" # https://www.gsmarena.com/google_pixel_9_pro-13218.php
@@ -54,8 +53,8 @@ releases:
 -   releaseCycle: "9proxl"
     releaseLabel: "Pixel 9 Pro XL"
     releaseDate: 2024-08-22
-    eoas: 2031-08-01 # at least
-    eol: 2031-08-01 # at least
+    eoas: 2031-08-01
+    eol: 2031-08-01
     discontinued: false
     link: https://en.wikipedia.org/wiki/Pixel_9_Pro_XL
     supportedAndroidVersions: "14 - 15" # https://www.gsmarena.com/google_pixel_9_pro_xl-13217.php
@@ -63,8 +62,8 @@ releases:
 -   releaseCycle: "9"
     releaseLabel: "Pixel 9"
     releaseDate: 2024-08-22
-    eoas: 2031-08-01 # at least
-    eol: 2031-08-01 # at least
+    eoas: 2031-08-01
+    eol: 2031-08-01
     discontinued: false
     link: https://en.wikipedia.org/wiki/Pixel_9
     supportedAndroidVersions: "14 - 15" # https://www.gsmarena.com/google_pixel_9_pro-13219.php
@@ -72,8 +71,8 @@ releases:
 -   releaseCycle: "8a"
     releaseLabel: "Pixel 8a"
     releaseDate: 2024-05-14
-    eoas: 2031-05-01 # at least
-    eol: 2031-05-01 # at least
+    eoas: 2031-05-01
+    eol: 2031-05-01
     discontinued: false
     link: https://en.wikipedia.org/wiki/Pixel_8a
     supportedAndroidVersions: "14 - 15" # https://www.gsmarena.com/google_pixel_8a-12937.php
@@ -81,8 +80,8 @@ releases:
 -   releaseCycle: "8pro"
     releaseLabel: "Pixel 8 Pro"
     releaseDate: 2023-10-04
-    eoas: 2030-10-01 # at least
-    eol: 2030-10-01 # at least
+    eoas: 2030-10-01
+    eol: 2030-10-01
     discontinued: false
     link: https://en.wikipedia.org/wiki/Pixel_8_Pro
     supportedAndroidVersions: "14 - 15" # https://www.gsmarena.com/google_pixel_8-12546.php
@@ -90,8 +89,8 @@ releases:
 -   releaseCycle: "8"
     releaseLabel: "Pixel 8"
     releaseDate: 2023-10-04
-    eoas: 2030-10-01 # at least
-    eol: 2030-10-01 # at least
+    eoas: 2030-10-01
+    eol: 2030-10-01
     discontinued: false
     link: https://en.wikipedia.org/wiki/Pixel_8
     supportedAndroidVersions: "14 - 15" # https://www.gsmarena.com/google_pixel_8-12546.php
@@ -99,8 +98,8 @@ releases:
 -   releaseCycle: "fold"
     releaseLabel: "Pixel Fold"
     releaseDate: 2023-06-28
-    eoas: 2028-06-01  # at least
-    eol: 2028-06-01  # at least
+    eoas: 2028-06-01
+    eol: 2028-06-01
     discontinued: true
     link: https://en.wikipedia.org/wiki/Pixel_Fold
     supportedAndroidVersions: "13 - 15" # https://www.gsmarena.com/google_pixel_fold-12265.php
@@ -108,8 +107,8 @@ releases:
 -   releaseCycle: "tablet"
     releaseLabel: "Pixel Tablet"
     releaseDate: 2023-06-20
-    eoas: 2026-06-01 # at least
-    eol: 2028-06-01 # at least
+    eoas: 2026-06-01
+    eol: 2028-06-01
     discontinued: false
     link: https://en.wikipedia.org/wiki/Pixel_Tablet
     supportedAndroidVersions: "13 - 15" # https://www.gsmarena.com/google_pixel_tablet-11905.php
@@ -117,8 +116,8 @@ releases:
 -   releaseCycle: "7a"
     releaseLabel: "Pixel 7a"
     releaseDate: 2023-05-10
-    eoas: 2028-05-01 # at least
-    eol: 2028-05-01 # at least
+    eoas: 2028-05-01
+    eol: 2028-05-01
     discontinued: true
     link: https://en.wikipedia.org/wiki/Pixel_7a
     supportedAndroidVersions: "13 - 15" # https://www.gsmarena.com/google_pixel_7a-12170.php
@@ -126,8 +125,8 @@ releases:
 -   releaseCycle: "7pro"
     releaseLabel: "Pixel 7 Pro"
     releaseDate: 2022-10-13
-    eoas: 2027-10-01 # at least
-    eol: 2027-10-01 # at least
+    eoas: 2027-10-01
+    eol: 2027-10-01
     discontinued: true
     link: https://en.wikipedia.org/wiki/Pixel_7_Pro
     supportedAndroidVersions: "13 - 15" # https://www.gsmarena.com/google_pixel_7_pro-11908.php
@@ -135,8 +134,8 @@ releases:
 -   releaseCycle: "7"
     releaseLabel: "Pixel 7"
     releaseDate: 2022-10-13
-    eoas: 2027-10-01 # at least
-    eol: 2027-10-01 # at least
+    eoas: 2027-10-01
+    eol: 2027-10-01
     discontinued: true
     link: https://en.wikipedia.org/wiki/Pixel_7
     supportedAndroidVersions: "13 - 15" # https://www.gsmarena.com/google_pixel_7-11903.php
@@ -144,8 +143,8 @@ releases:
 -   releaseCycle: "6a"
     releaseLabel: "Pixel 6a"
     releaseDate: 2022-07-28
-    eoas: 2027-07-01 # at least
-    eol: 2027-07-01 # at least
+    eoas: 2027-07-01
+    eol: 2027-07-01
     discontinued: true
     link: https://en.wikipedia.org/wiki/Pixel_6a
     supportedAndroidVersions: "12 - 15" # https://www.gsmarena.com/google_pixel_6a-11229.php
@@ -153,8 +152,8 @@ releases:
 -   releaseCycle: "6pro"
     releaseLabel: "Pixel 6 Pro"
     releaseDate: 2021-10-28
-    eoas: 2026-10-01 # at least
-    eol: 2026-10-01 # at least
+    eoas: 2026-10-01
+    eol: 2026-10-01
     discontinued: 2022-10-06
     link: https://en.wikipedia.org/wiki/Pixel_6_Pro
     supportedAndroidVersions: "12 - 15" # https://www.gsmarena.com/google_pixel_6_pro-10918.php
@@ -162,8 +161,8 @@ releases:
 -   releaseCycle: "6"
     releaseLabel: "Pixel 6"
     releaseDate: 2021-10-28
-    eoas: 2026-10-01 # at least
-    eol: 2026-10-01 # at least
+    eoas: 2026-10-01
+    eol: 2026-10-01
     discontinued: 2022-10-06
     link: https://en.wikipedia.org/wiki/Pixel_6
     supportedAndroidVersions: "12 - 15" # https://www.gsmarena.com/google_pixel_6-11037.php
@@ -171,8 +170,8 @@ releases:
 -   releaseCycle: "5a"
     releaseLabel: "Pixel 5a"
     releaseDate: 2021-08-26
-    eoas: 2024-08-01 # at least
-    eol: 2024-08-01 # at least
+    eoas: 2024-08-01
+    eol: 2024-08-01
     discontinued: 2022-07-21
     link: https://en.wikipedia.org/wiki/Pixel_5a
     supportedAndroidVersions: "11 - 14" # https://www.gsmarena.com/google_pixel_5a_5g-11059.php


### PR DESCRIPTION
Dates are off by half a year. https://support.google.com/nexus/answer/4457705 indicates 7 years of OS upgrades / security support. See also https://github.com/endoflife-date/endoflife.date/pull/7210#issuecomment-2888364296.

Also removed `at least` comments has it does not give any information.