### PR TITLE
[envoy] Remove chainguard purl for dockerhub purl

### DIFF
--- a/products/envoy.md
+++ b/products/envoy.md
@@ -19,7 +19,6 @@ identifiers:
 -   purl: pkg:docker/bitnami/envoy
 -   purl: pkg:docker/rapidfort/envoy-official
 -   purl: pkg:docker/hashicorp/envoy-fips
--   purl: pkg:docker/chainguard/envoy
 -   purl: pkg:github/envoyproxy/envoy
 -   purl: pkg:golang/github.com/envoyproxy/envoy
 -   purl: pkg:oci/envoy?repository_url=cgr.dev/chainguard


### PR DESCRIPTION
They have removed envoy's images so remove this one