### PR TITLE
[pan-os]Update PAN-OS version(s)

### DIFF
--- a/products/pan-os.md
+++ b/products/pan-os.md
@@ -52,9 +52,9 @@ releases:
 -   releaseCycle: "10.2"
     releaseDate: 2022-02-27
     eol: 2026-02-28
-    latest: "10.2.14-h1"
-    latestReleaseDate: 2025-04-16
-    link: https://docs.paloaltonetworks.com/pan-os/10-2/pan-os-release-notes/pan-os-10-2-14-known-and-addressed-issues/pan-os-10-2-14-h1-addressed-issues
+    latest: "10.2.15"
+    latestReleaseDate: 2025-05-19
+    link: https://docs.paloaltonetworks.com/pan-os/10-2/pan-os-release-notes/pan-os-10-2-15-known-and-addressed-issues/pan-os-10-2-15-addressed-issues
 
 -   releaseCycle: "10.1"
     releaseDate: 2021-05-31

--- a/products/pan-os.md
+++ b/products/pan-os.md
@@ -38,9 +38,9 @@ releases:
 -   releaseCycle: "11.1"
     releaseDate: 2023-11-03
     eol: 2027-05-03
-    latest: "11.1.9"
-    latestReleaseDate: 2025-04-21
-    link: https://docs.paloaltonetworks.com/pan-os/11-1/pan-os-release-notes/pan-os-11-1-9-known-and-addressed-issues/pan-os-11-1-9-addressed-issues
+    latest: "11.1.10"
+    latestReleaseDate: 2025-05-20
+    link: https://docs.paloaltonetworks.com/pan-os/11-1/pan-os-release-notes/pan-os-11-1-10-known-and-addressed-issues/pan-os-11-1-10-addressed-issues
 
 -   releaseCycle: "11.0"
     releaseDate: 2022-11-17


### PR DESCRIPTION
[panos] This PR updates the PAN-OS versions, Release dates and the Release Notes url.

Updated Pan-OS Version:  10.2.15 

Released:                2025-05-19 

Release Notes: https://docs.paloaltonetworks.com/pan-os/10-2/pan-os-release-notes/pan-os-10-2-15-known-and-addressed-issues/pan-os-10-2-15-addressed-issues


Updated Pan-OS Version:  11.1.10 

Released:                2025-05-20

Release Notes: https://docs.paloaltonetworks.com/pan-os/11-1/pan-os-release-notes/pan-os-11-1-10-known-and-addressed-issues/pan-os-11-1-10-addressed-issues


