### PR TITLE
[arangodb] Remove 404 link for 2.8

### DIFF
--- a/products/arangodb.md
+++ b/products/arangodb.md
@@ -101,6 +101,7 @@ releases:
     eol: 2018-06-15
     latest: "2.8.11"
     latestReleaseDate: 2016-07-13
+    link: null
 
 ---
 


### PR DESCRIPTION
Looks like they removed pre 3.0 changelogs and it doesnt exist on webarchive too