### PR TITLE
[express] Fix link template for 5.x series

### DIFF
--- a/products/express.md
+++ b/products/express.md
@@ -19,6 +19,7 @@ releases:
     eol: false
     latest: "5.1.0"
     latestReleaseDate: 2025-03-28
+    link: https://github.com/expressjs/express/releases/tag/v__LATEST__
 
 -   releaseCycle: "4"
     releaseDate: 2014-04-09


### PR DESCRIPTION
Looks like they have put an a v suffix for their 5.1 version. Not sure if they will keep going in same syntax but at least this will fix 5.x cycle until they release a new version