### PR TITLE
[new-product] Add Veritas NetBackup

### DIFF
--- a/products/netbackup-appliance-os.md
+++ b/products/netbackup-appliance-os.md
@@ -1,300 +1,99 @@
 ---
 title: NetBackup Appliance OS
+addedAt: 2025-08-18
 category: os
+tags: veritas
 iconSlug: veritas
 permalink: /netbackup-appliance-os
 releasePolicyLink: https://sort.veritas.com/eosl
-eolColumn: Extended Support
-eoasColumn: Active Support
-eoesColumn: Sustaining Support
-eoasWarnThreshold: 121
-eoesWarnThreshold: 121
-eolWarnThreshold: 121
-releaseColumn: false
+eolColumn: Primary Support
 
+# - eol(x) = "Extended Support Starts" for "Appliance - Netbackup" on https://sort.veritas.com/eosl
 releases:
-  - releaseCycle: "5.5.0.1"
-    releaseDate: 2025-02-12
-    eoas: true
-    eol: true
-    eoes: false
-
-  - releaseCycle: "5.3.0.1-mr4"
-    releaseLabel: "5.3.0.1 MR4"
-    releaseDate: 2025-01-27
-    eoas: true
-    eol: true
-    eoes: 2026-10-23
-
-  - releaseCycle: "5.3.0.1-mr3"
-    releaseLabel: "5.3.0.1 MR3"
-    releaseDate: 2024-10-18
-    eoas: true
-    eol: true
-    eoes: 2026-10-23
-
-  - releaseCycle: "5.1.1-mr5"
-    releaseLabel: "5.1.1 MR5"
-    releaseDate: 2024-08-28
-    eoas: 2025-09-08
-    eol: 2027-09-08
-    eoes: 2028-09-08
-
-  - releaseCycle: "5.3.0.1-mr2"
-    releaseLabel: "5.3.0.1 MR2"
-    releaseDate: 2024-07-12
-    eoas: true
-    eol: true
-    eoes: 2026-10-23
-
-  - releaseCycle: "5.1.1-mr4"
-    releaseLabel: "5.1.1 MR4"
-    releaseDate: 2024-05-17
-    eoas: true
-    eol: true
-    eoes: 2025-09-08
-
-  - releaseCycle: "5.3.0.1-mr1"
-    releaseLabel: "5.3.0.1 MR1"
-    releaseDate: 2024-03-22
-    eoas: true
-    eol: true
-    eoes: 2026-10-23
-
-  - releaseCycle: "5.1.1-mr3"
-    releaseLabel: "5.1.1 MR3"
-    releaseDate: 2024-02-14
-    eoas: true
-    eol: true
-    eoes: 2025-09-08
+  - releaseCycle: "5.5"
+    releaseDate: 2025-07-31
+    eol: false
+    latest: "5.5.0.1 MR1"
+    latestReleaseDate: 2025-07-31
 
   - releaseCycle: "5.3"
     releaseDate: 2023-11-27
-    eoas: true
-    eol: true
-    eoes: 2026-10-23
+    eol: false
+    latest: "5.3.0.1 MR4"
+    latestReleaseDate: 2025-01-27
 
-  - releaseCycle: "5.0.0.1-mr5"
-    releaseLabel: "5.0.0.1 MR5"
-    releaseDate: 2023-11-08
-    eoas: 2025-03-28
-    eol: 2027-03-28
-    eoes: 2028-03-28
-
-  - releaseCycle: "5.1.1-mr2"
-    releaseLabel: "5.1.1 MR2"
-    releaseDate: 2023-10-20
-    eoas: true
-    eol: true
-    eoes: 2025-09-08
-
-  - releaseCycle: "5.0.0.1-mr4"
-    releaseLabel: "5.0.0.1 MR4"
-    releaseDate: 2023-06-28
-    eoas: true
-    eol: true
-    eoes: 2025-03-28
-
-  - releaseCycle: "5.1.1-mr1"
-    releaseLabel: "5.1.1 MR1"
-    releaseDate: 2023-05-31
-    eoas: true
-    eol: true
-    eoes: 2025-09-08
-
-  - releaseCycle: "5.0.0.1-mr3"
-    releaseLabel: "5.0.0.1 MR3"
-    releaseDate: 2023-03-07
-    eoas: true
-    eol: true
-    eoes: 2025-03-28
-
-  - releaseCycle: "4.1.0.1-mr5"
-    releaseLabel: "4.1.0.1 MR5"
-    releaseDate: 2023-02-14
-    eoas: 2024-06-07
-    eol: 2026-06-07
-    eoes: 2027-06-07
-
-  - releaseCycle: "5.1.1"
+  - releaseCycle: "5.1"
     releaseDate: 2023-02-08
-    eoas: true
-    eol: true
-    eoes: 2025-09-08
-
-  - releaseCycle: "5.0.0.1-mr2"
-    releaseLabel: "5.0.0.1 MR2"
-    releaseDate: 2022-11-24
-    eoas: true
-    eol: true
-    eoes: 2025-03-28
-
-  - releaseCycle: "4.1.0.1-mr4"
-    releaseLabel: "4.1.0.1 MR4"
-    releaseDate: 2022-10-28
-    eoas: true
-    eol: true
-    eoes: 2024-06-07
-
-  - releaseCycle: "5.0.0.1-mr1"
-    releaseLabel: "5.0.0.1 MR1"
-    releaseDate: 2022-08-17
-    eoas: true
-    eol: true
-    eoes: 2025-03-28
-
-  - releaseCycle: "4.1.0.1-mr3"
-    releaseLabel: "4.1.0.1 MR3"
-    releaseDate: 2022-08-08
-    eoas: true
-    eol: true
-    eoes: 2024-06-07
-
-  - releaseCycle: "4.0.0.1-mr4"
-    releaseLabel: "4.0.0.1 MR4"
-    releaseDate: 2022-06-13
-    eoas: 2024-01-01
-    eol: 2026-01-01
-    eoes: 2027-01-01
+    eol: 2025-09-08
+    latest: "5.1.1 MR5"
+    latestReleaseDate: 2024-08-28
 
   - releaseCycle: "5.0"
     releaseDate: 2022-04-25
-    eoas: true
-    eol: true
-    eoes: 2025-03-28
-
-  - releaseCycle: "4.1.0.1-mr2"
-    releaseLabel: "4.1.0.1 MR2"
-    releaseDate: 2022-02-28
-    eoas: true
-    eol: true
-    eoes: 2024-06-07
-
-  - releaseCycle: "4.0.0.1-mr3"
-    releaseLabel: "4.0.0.1 MR3"
-    releaseDate: 2022-01-19
-    eoas: true
-    eol: true
-    eoes: 2024-01-01
-
-  - releaseCycle: "3.3.0.2-mr2"
-    releaseLabel: "3.3.0.2 MR2"
-    releaseDate: 2021-11-12
-    eoas: 2024-07-29
-    eol: 2026-07-29
-    eoes: 2026-07-29
-
-  - releaseCycle: "4.1.0.1-mr1"
-    releaseLabel: "4.1.0.1 MR1"
-    releaseDate: 2021-10-18
-    eoas: true
-    eol: true
-    eoes: 2024-06-07
-
-  - releaseCycle: "4.0.0.1-mr2"
-    releaseLabel: "4.0.0.1 MR2"
-    releaseDate: 2021-09-17
-    eoas: true
-    eol: true
-    eoes: 2024-01-01
-
-  - releaseCycle: "3.3.0.2-mr1"
-    releaseLabel: "3.3.0.2 MR1"
-    releaseDate: 2021-09-03
-    eoas: true
-    eol: true
-    eoes: 2024-07-29
+    eol: 2025-03-28
+    latest: "5.0.0.1 MR5"
+    latestReleaseDate: 2023-11-08
 
   - releaseCycle: "4.1"
     releaseDate: 2021-07-19
-    eoas: true
-    eol: true
-    eoes: 2024-06-07
-
-  - releaseCycle: "3.3.0.1-mr3"
-    releaseLabel: "3.3.0.1 MR3"
-    releaseDate: 2021-07-02
-    eoas: true
-    eol: true
-    eoes: 2024-07-29
-
-  - releaseCycle: "4.0.0.1-mr1"
-    releaseLabel: "4.0.0.1 MR1"
-    releaseDate: 2021-06-15
-    eoas: true
-    eol: true
-    eoes: 2024-01-01
-
-  - releaseCycle: "3.3.0.1-mr2"
-    releaseLabel: "3.3.0.1 MR2"
-    releaseDate: 2021-04-02
-    eoas: true
-    eol: true
-    eoes: 2024-07-29
+    eol: 	2024-06-07
+    latest: "4.1.0.1 MR5"
+    latestReleaseDate: 2023-02-14
 
   - releaseCycle: "4.0"
     releaseDate: 2021-03-01
-    eoas: true
-    eol: true
-    eoes: 2024-01-01
+    eol: 2024-01-01
+    latest: "4.0.0.1 MR4"
+    latestReleaseDate: 2022-06-13
 
-  - releaseCycle: "3.3.0.1"
+  - releaseCycle: "3.3"
     releaseDate: 2020-10-05
-    eoas: true
-    eol: true
-    eoes: 2024-07-29
+    eol: 2024-07-29
+    latest: "3.3.0.2 MR2"
+    latestReleaseDate: 2021-11-12
 
   - releaseCycle: "3.2"
     releaseDate: 2019-11-04
-    eoas: 2023-06-28
-    eol: 2025-06-28
-    eoes: 2026-06-28
-
-  - releaseCycle: "3.1.2"
-    releaseDate: 2018-09-21
-    eoas: 2022-06-28
-    eol: 2024-06-28
-    eoes: 2025-06-28
-
-  - releaseCycle: "3.1.1"
-    releaseDate: 2018-02-22
-    eoas: 2022-06-28
-    eol: true
-    eoes: 2023-06-28
+    eol: 2023-06-28
+    latest: "3.2"
+    latestReleaseDate: 2019-11-04
 
   - releaseCycle: "3.1"
     releaseDate: 2017-09-26
-    eoas: 2022-06-28
-    eol: true
-    eoes: 2023-06-28
+    eol: 2022-06-28
+    latest: "3.1.2"
+    latestReleaseDate: 2018-09-21
 
   - releaseCycle: "3.0"
     releaseDate: 2016-12-04
-    eoas: 2020-10-01
-    eol: 2022-03-26
-    eoes: 2024-03-26
+    eol: 2020-10-01
+    latest: "3.0"
+    latestReleaseDate: 2016-12-04
 
-  - releaseCycle: "2.7.3"
-    releaseDate: 2016-06-05
-    eoas: 2020-10-01
-    eol: 2021-05-06
-    eoes: 2022-01-31
 
-  - releaseCycle: "2.7.2"
-    releaseDate: 2016-02-01
-    eoas: 2020-10-01
-    eol: 2021-05-06
-    eoes: 2022-01-31
-
-  - releaseCycle: "2.7.1"
+  - releaseCycle: "2.7"
     releaseDate: 2015-12-06
-    eoas: 2020-10-01
-    eol: 2021-05-06
-    eoes: 2022-01-31
+    eol: 2020-10-01
+    latest: "2.7.3"
+    latestReleaseDate: 2016-06-05
 ---
 
-> [Veritas NetBackup](https://www.veritas.com/protection/netbackup) is an enterprise-level data protection and backup solution
+> [Veritas NetBackup Appliance OS](https://www.veritas.com/protection/netbackup) is an operating system designed by Veritas Technologies
+> specifically for their NetBackup Appliance hardware.
 
-Veritas offers full support from general availability for 3 to 4 years.
-At the end of full/active support, extended support is available for 1-2 years with no new bug fixes, but access to existing patches and technical help.
-The final sustaining phase before EOSL lasts for 1 to 6 years with focus on severe service restoration or data retrieval issues.
+{: .note }
+
+The table above only documents the Primary phase because there is no new bug fixes in the Extended and Sustaining phases.
+
+Veritas NetBackup Appliance OS support is split into three phases, each with different support levels and durations:
+Primary, Extended, and Sustaining.
+
+The Primary Phase begins with the general availability of a release and typically lasts for a period of 2 to 3 years.
+During this phase releases are supported with bug fixes,
+as well as patches for the software to establish or restore substantial conformity with the software’s documentation
+
+The Extended Phase starts after the Primary Phase and lasts for 1 to 2 years.
+During this phase no new bug fixes are provided, but customers can still access existing patches and receive technical support.
+
+The Sustaining Phase follows the Extended Phase and can last from 1 to 6 years.
+It is similar to the Extended Phase, but with a focus on on addressing severe service restoration or data retrieval issues.

--- a/products/netbackup-appliance-os.md
+++ b/products/netbackup-appliance-os.md
@@ -1,5 +1,5 @@
 ---
-title: Veritas NetBackup Appliance OS
+title: NetBackup Appliance OS
 category: os
 iconSlug: veritas
 permalink: /netbackup-appliance-os

--- a/products/veritas-netbackup.md
+++ b/products/veritas-netbackup.md
@@ -199,12 +199,12 @@ releases:
     - releaseCycle: "3.1.1"
       releaseDate: 2018-02-22
       eoas: 2022-06-28
-      eol: 2024-06-28
+      eol: false
       eoes: 2023-06-28
     - releaseCycle: "3.1"
       releaseDate: 2017-09-26
       eoas: 2022-06-28
-      eol: 2024-06-28
+      eol: fales
       eoes: 2023-06-28
     - releaseCycle: "3.0"
       releaseDate: 2016-12-04

--- a/products/veritas-netbackup.md
+++ b/products/veritas-netbackup.md
@@ -1,4 +1,4 @@
-___
+---
 title: Veritas NetBackup Appliance OS
 category: os
 iconSlug: veritas
@@ -225,7 +225,7 @@ releases:
       eoes: 2021-05-06
       eol: 2022-01-31
 
-___
+---
 
 > [Veritas NetBackup](https://www.veritas.com/protection/netbackup) is an enterprise-level data protection and backup solution
 

--- a/products/veritas-netbackup.md
+++ b/products/veritas-netbackup.md
@@ -1,5 +1,4 @@
 ---
-
 title: Veritas NetBackup Appliance OS
 category: os
 iconSlug: veritas

--- a/products/veritas-netbackup.md
+++ b/products/veritas-netbackup.md
@@ -204,7 +204,7 @@ releases:
     - releaseCycle: "3.1"
       releaseDate: 2017-09-26
       eoas: 2022-06-28
-      eol: fales
+      eol: false
       eoes: 2023-06-28
     - releaseCycle: "3.0"
       releaseDate: 2016-12-04

--- a/products/veritas-netbackup.md
+++ b/products/veritas-netbackup.md
@@ -1,4 +1,5 @@
 ---
+
 title: Veritas NetBackup Appliance OS
 category: os
 iconSlug: veritas

--- a/products/veritas-netbackup.md
+++ b/products/veritas-netbackup.md
@@ -114,112 +114,112 @@ releases:
       eoas: false
       eoes: false
       eol: 2024-06-07  
-   - releaseCycle: "4.1.0.1 MR3"
+    - releaseCycle: "4.1.0.1 MR3"
       releaseDate: 2022-08-08
       eoas: false
       eoes: false
       eol: 2024-06-07  
-   - releaseCycle: "4.1.0.1 MR2"
+    - releaseCycle: "4.1.0.1 MR2"
       releaseDate: 2022-02-28
       eoas: false
       eoes: false
       eol: 2024-06-07  
-   - releaseCycle: "4.1.0.1 MR1"
+    - releaseCycle: "4.1.0.1 MR1"
       releaseDate: 2021-10-18
       eoas: false
       eoes: false
       eol: 2024-06-07  
-   - releaseCycle: "4.1"
+    - releaseCycle: "4.1"
       releaseDate: 2021-07-19
       eoas: false
       eoes: false
       eol: 2024-06-07  
-   - releaseCycle: "4.0.0.1 MR4"
+    - releaseCycle: "4.0.0.1 MR4"
       releaseDate: 2022-06-13
       eoas: 2024-01-01
       eoes: 2026-01-01
       eol: 2027-01-01 
-   - releaseCycle: "4.0.0.1 MR3"
+    - releaseCycle: "4.0.0.1 MR3"
       releaseDate: 2022-01-19
       eoas: false
       eoes: false
       eol: 2024-01-01 
-   - releaseCycle: "4.0.0.1 MR2"
+    - releaseCycle: "4.0.0.1 MR2"
       releaseDate: 2021-09-17
       eoas: false
       eoes: false
       eol: 2024-01-01 
-   - releaseCycle: "4.0.0.1 MR1"
+    - releaseCycle: "4.0.0.1 MR1"
       releaseDate: 2021-06-15
       eoas: false
       eoes: false
       eol: 2024-01-01 
-   - releaseCycle: "4.0"
+    - releaseCycle: "4.0"
       releaseDate: 2021-03-01
       eoas: false
       eoes: false
       eol: 2024-01-01 
-   - releaseCycle: "3.3.0.2 MR2"
+    - releaseCycle: "3.3.0.2 MR2"
       releaseDate: 2021-11-12
       eoas: 2024-07-29
       eoes: 2026-07-29
       eol: 2026-07-29 
-   - releaseCycle: "3.3.0.2 MR1"
+    - releaseCycle: "3.3.0.2 MR1"
       releaseDate: 2021-09-03
       eoas: false
       eoes: false
       eol: 2024-07-29 
-   - releaseCycle: "3.3.0.1 MR3"
+    - releaseCycle: "3.3.0.1 MR3"
       releaseDate: 2021-07-02
       eoas: false
       eoes: false
       eol: 2024-07-29 
-   - releaseCycle: "3.3.0.1 MR2"
+    - releaseCycle: "3.3.0.1 MR2"
       releaseDate: 2021-04-02
       eoas: false
       eoes: false
       eol: 2024-07-29 
-   - releaseCycle: "3.3.0.1"
+    - releaseCycle: "3.3.0.1"
       releaseDate: 2020-10-05
       eoas: false
       eoes: false
       eol: 2024-07-29 
-   - releaseCycle: "3.2"
+    - releaseCycle: "3.2"
       releaseDate: 2019-11-04
       eoas: 2023-06-28
       eoes: 2025-06-28
       eol: 2026-06-28
-   - releaseCycle: "3.1.2"
+    - releaseCycle: "3.1.2"
       releaseDate: 2018-09-21
       eoas: 2022-06-28
       eoes: 2024-06-28
       eol: 2025-06-28
-   - releaseCycle: "3.1.1"
+    - releaseCycle: "3.1.1"
       releaseDate: 2018-02-22
       eoas: 2022-06-28
       eoes: 2024-06-28
       eol: 2023-06-28
-   - releaseCycle: "3.1"
+    - releaseCycle: "3.1"
       releaseDate: 2017-09-26
       eoas: 2022-06-28
       eoes: 2024-06-28
       eol: 2023-06-28
-   - releaseCycle: "3.0"
+    - releaseCycle: "3.0"
       releaseDate: 2016-12-04
       eoas: 2020-10-01
       eoes: 2022-03-26
       eol: 2024-03-26
-   - releaseCycle: "2.7.3"
+    - releaseCycle: "2.7.3"
       releaseDate: 2016-06-05
       eoas: 2020-10-01
       eoes: 2021-05-06
       eol: 2022-01-31
-   - releaseCycle: "2.7.2"
+    - releaseCycle: "2.7.2"
       releaseDate: 2016-02-01
       eoas: 2020-10-01
       eoes: 2021-05-06
       eol: 2022-01-31
-  - releaseCycle: "2.7.1"
+   - releaseCycle: "2.7.1"
       releaseDate: 2015-12-06
       eoas: 2020-10-01
       eoes: 2021-05-06

--- a/products/veritas-netbackup.md
+++ b/products/veritas-netbackup.md
@@ -1,0 +1,232 @@
+___
+title: Veritas NetBackup Appliance OS
+category: os
+iconSlug: veritas
+permalink: /netbackup-appliance-os
+releasePolicyLink: https://sort.veritas.com/eosl
+eolColumn: EOSL
+eolWarnThreshold: 121
+
+eoasColumn: Active Support
+eoasWarnThreshold: 121
+
+eoesColumn: Extended Support
+eoesWarnThreshold: 121
+
+releases:
+    - releaseCycle: "5.5.0.1"
+      releaseDate: 2025-02-12
+      eoas: false
+      eoes: false
+      eol: false
+    - releaseCycle: "5.3.0.1 MR4"
+      releaseDate: 2025-01-27
+      eoas: false
+      eoes: false
+      eol: 2026-10-23
+    - releaseCycle: "5.3.0.1 MR3"
+      releaseDate: 2024-10-18
+      eoas: false
+      eoes: false
+      eol: 2026-10-23
+    - releaseCycle: "5.3.0.1 MR2"
+      releaseDate: 2024-07-12
+      eoas: false
+      eoes: false
+      eol: 2026-10-23
+    - releaseCycle: "5.3.0.1 MR1"
+      releaseDate: 2024-03-22
+      eoas: false
+      eoes: false
+      eol: 2026-10-23
+    - releaseCycle: "5.3"
+      releaseDate: 2023-11-27
+      eoas: false
+      eoes: false
+      eol: 2026-10-23
+    - releaseCycle: "5.1.1 MR5"
+      releaseDate: 2024-08-28
+      eoas: 2025-09-08
+      eoes: 2027-09-08
+      eol: 2028-09-08
+    - releaseCycle: "5.1.1 MR4"
+      releaseDate: 2024-05-17
+      eoas: false
+      eoes: false
+      eol: 2025-09-08
+    - releaseCycle: "5.1.1 MR3"
+      releaseDate: 2024-02-14
+      eoas: false
+      eoes: false
+      eol: 2025-09-08
+    - releaseCycle: "5.1.1 MR2"
+      releaseDate: 2023-10-20
+      eoas: false
+      eoes: false
+      eol: 2025-09-08
+    - releaseCycle: "5.1.1 MR1"
+      releaseDate: 2023-05-31
+      eoas: false
+      eoes: false
+      eol: 2025-09-08
+    - releaseCycle: "5.1.1"
+      releaseDate: 2023-02-08
+      eoas: false
+      eoes: false
+      eol: 2025-09-08
+    - releaseCycle: "5.0.0.1 MR5"
+      releaseDate: 2023-11-08
+      eoas: 2025-03-28
+      eoes: 2027-03-28
+      eol: 2028-03-28
+    - releaseCycle: "5.0.0.1 MR4"
+      releaseDate: 2023-06-28
+      eoas: false
+      eoes: false
+      eol: 2025-03-28
+    - releaseCycle: "5.0.0.1 MR3"
+      releaseDate: 2023-03-07
+      eoas: false
+      eoes: false
+      eol: 2025-03-28
+    - releaseCycle: "5.0.0.1 MR2"
+      releaseDate: 2022-11-24
+      eoas: false
+      eoes: false
+      eol: 2025-03-28
+    - releaseCycle: "5.0.0.1 MR1"
+      releaseDate: 2022-08-17
+      eoas: false
+      eoes: false
+      eol: 2025-03-28
+    - releaseCycle: "5.0"
+      releaseDate: 2022-04-25
+      eoas: false
+      eoes: false
+      eol: 2025-03-28
+    - releaseCycle: "4.1.0.1 MR5"
+      releaseDate: 2023-02-14
+      eoas: 2024-06-07
+      eoes: 2026-06-07
+      eol: 2027-06-07
+    - releaseCycle: "4.1.0.1 MR4"
+      releaseDate: 2022-10-28
+      eoas: false
+      eoes: false
+      eol: 2024-06-07  
+   - releaseCycle: "4.1.0.1 MR3"
+      releaseDate: 2022-08-08
+      eoas: false
+      eoes: false
+      eol: 2024-06-07  
+   - releaseCycle: "4.1.0.1 MR2"
+      releaseDate: 2022-02-28
+      eoas: false
+      eoes: false
+      eol: 2024-06-07  
+   - releaseCycle: "4.1.0.1 MR1"
+      releaseDate: 2021-10-18
+      eoas: false
+      eoes: false
+      eol: 2024-06-07  
+   - releaseCycle: "4.1"
+      releaseDate: 2021-07-19
+      eoas: false
+      eoes: false
+      eol: 2024-06-07  
+   - releaseCycle: "4.0.0.1 MR4"
+      releaseDate: 2022-06-13
+      eoas: 2024-01-01
+      eoes: 2026-01-01
+      eol: 2027-01-01 
+   - releaseCycle: "4.0.0.1 MR3"
+      releaseDate: 2022-01-19
+      eoas: false
+      eoes: false
+      eol: 2024-01-01 
+   - releaseCycle: "4.0.0.1 MR2"
+      releaseDate: 2021-09-17
+      eoas: false
+      eoes: false
+      eol: 2024-01-01 
+   - releaseCycle: "4.0.0.1 MR1"
+      releaseDate: 2021-06-15
+      eoas: false
+      eoes: false
+      eol: 2024-01-01 
+   - releaseCycle: "4.0"
+      releaseDate: 2021-03-01
+      eoas: false
+      eoes: false
+      eol: 2024-01-01 
+   - releaseCycle: "3.3.0.2 MR2"
+      releaseDate: 2021-11-12
+      eoas: 2024-07-29
+      eoes: 2026-07-29
+      eol: 2026-07-29 
+   - releaseCycle: "3.3.0.2 MR1"
+      releaseDate: 2021-09-03
+      eoas: false
+      eoes: false
+      eol: 2024-07-29 
+   - releaseCycle: "3.3.0.1 MR3"
+      releaseDate: 2021-07-02
+      eoas: false
+      eoes: false
+      eol: 2024-07-29 
+   - releaseCycle: "3.3.0.1 MR2"
+      releaseDate: 2021-04-02
+      eoas: false
+      eoes: false
+      eol: 2024-07-29 
+   - releaseCycle: "3.3.0.1"
+      releaseDate: 2020-10-05
+      eoas: false
+      eoes: false
+      eol: 2024-07-29 
+   - releaseCycle: "3.2"
+      releaseDate: 2019-11-04
+      eoas: 2023-06-28
+      eoes: 2025-06-28
+      eol: 2026-06-28
+   - releaseCycle: "3.1.2"
+      releaseDate: 2018-09-21
+      eoas: 2022-06-28
+      eoes: 2024-06-28
+      eol: 2025-06-28
+   - releaseCycle: "3.1.1"
+      releaseDate: 2018-02-22
+      eoas: 2022-06-28
+      eoes: 2024-06-28
+      eol: 2023-06-28
+   - releaseCycle: "3.1"
+      releaseDate: 2017-09-26
+      eoas: 2022-06-28
+      eoes: 2024-06-28
+      eol: 2023-06-28
+   - releaseCycle: "3.0"
+      releaseDate: 2016-12-04
+      eoas: 2020-10-01
+      eoes: 2022-03-26
+      eol: 2024-03-26
+   - releaseCycle: "2.7.3"
+      releaseDate: 2016-06-05
+      eoas: 2020-10-01
+      eoes: 2021-05-06
+      eol: 2022-01-31
+   - releaseCycle: "2.7.2"
+      releaseDate: 2016-02-01
+      eoas: 2020-10-01
+      eoes: 2021-05-06
+      eol: 2022-01-31
+  - releaseCycle: "2.7.1"
+      releaseDate: 2015-12-06
+      eoas: 2020-10-01
+      eoes: 2021-05-06
+      eol: 2022-01-31
+
+___
+
+> [Veritas NetBackup](https://www.veritas.com/protection/netbackup) is an enterprise-level data protection and backup solution
+
+Veritas offers full support from general availability for 3 to 4 years. At the end of full/active, support, extended support is available for 1-2 years with no new bug fixes, but access to existing patches and technical help. The final sustaining phase before EOSL lasts for 1 to 6 years with focus on severe service restoration or data retrieval issues.

--- a/products/veritas-netbackup.md
+++ b/products/veritas-netbackup.md
@@ -219,7 +219,7 @@ releases:
       eoas: 2020-10-01
       eoes: 2021-05-06
       eol: 2022-01-31
-   - releaseCycle: "2.7.1"
+    - releaseCycle: "2.7.1"
       releaseDate: 2015-12-06
       eoas: 2020-10-01
       eoes: 2021-05-06

--- a/products/veritas-netbackup.md
+++ b/products/veritas-netbackup.md
@@ -13,28 +13,30 @@ eoasWarnThreshold: 121
 eoesColumn: Extended Support
 eoesWarnThreshold: 121
 
+releaseColumn: false
+
 releases:
     - releaseCycle: "5.5.0.1"
       releaseDate: 2025-02-12
       eoas: false
       eoes: false
       eol: false
-    - releaseCycle: "5.3.0.1 MR4"
+    - releaseCycle: "5.3.0.1.mr4"
       releaseDate: 2025-01-27
       eoas: false
       eoes: false
       eol: 2026-10-23
-    - releaseCycle: "5.3.0.1 MR3"
+    - releaseCycle: "5.3.0.1.mr3"
       releaseDate: 2024-10-18
       eoas: false
       eoes: false
       eol: 2026-10-23
-    - releaseCycle: "5.3.0.1 MR2"
+    - releaseCycle: "5.3.0.1.mr2"
       releaseDate: 2024-07-12
       eoas: false
       eoes: false
       eol: 2026-10-23
-    - releaseCycle: "5.3.0.1 MR1"
+    - releaseCycle: "5.3.0.1.mr1"
       releaseDate: 2024-03-22
       eoas: false
       eoes: false
@@ -44,27 +46,27 @@ releases:
       eoas: false
       eoes: false
       eol: 2026-10-23
-    - releaseCycle: "5.1.1 MR5"
+    - releaseCycle: "5.1.1.mr5"
       releaseDate: 2024-08-28
       eoas: 2025-09-08
       eoes: 2027-09-08
       eol: 2028-09-08
-    - releaseCycle: "5.1.1 MR4"
+    - releaseCycle: "5.1.1.mr4"
       releaseDate: 2024-05-17
       eoas: false
       eoes: false
       eol: 2025-09-08
-    - releaseCycle: "5.1.1 MR3"
+    - releaseCycle: "5.1.1.mr3"
       releaseDate: 2024-02-14
       eoas: false
       eoes: false
       eol: 2025-09-08
-    - releaseCycle: "5.1.1 MR2"
+    - releaseCycle: "5.1.1.mr2"
       releaseDate: 2023-10-20
       eoas: false
       eoes: false
       eol: 2025-09-08
-    - releaseCycle: "5.1.1 MR1"
+    - releaseCycle: "5.1.1.mr1"
       releaseDate: 2023-05-31
       eoas: false
       eoes: false
@@ -74,27 +76,27 @@ releases:
       eoas: false
       eoes: false
       eol: 2025-09-08
-    - releaseCycle: "5.0.0.1 MR5"
+    - releaseCycle: "5.0.0.1.mr5"
       releaseDate: 2023-11-08
       eoas: 2025-03-28
       eoes: 2027-03-28
       eol: 2028-03-28
-    - releaseCycle: "5.0.0.1 MR4"
+    - releaseCycle: "5.0.0.1.mr4"
       releaseDate: 2023-06-28
       eoas: false
       eoes: false
       eol: 2025-03-28
-    - releaseCycle: "5.0.0.1 MR3"
+    - releaseCycle: "5.0.0.1.mr3"
       releaseDate: 2023-03-07
       eoas: false
       eoes: false
       eol: 2025-03-28
-    - releaseCycle: "5.0.0.1 MR2"
+    - releaseCycle: "5.0.0.1.mr2"
       releaseDate: 2022-11-24
       eoas: false
       eoes: false
       eol: 2025-03-28
-    - releaseCycle: "5.0.0.1 MR1"
+    - releaseCycle: "5.0.0.1.mr1"
       releaseDate: 2022-08-17
       eoas: false
       eoes: false
@@ -104,27 +106,27 @@ releases:
       eoas: false
       eoes: false
       eol: 2025-03-28
-    - releaseCycle: "4.1.0.1 MR5"
+    - releaseCycle: "4.1.0.1.mr5"
       releaseDate: 2023-02-14
       eoas: 2024-06-07
       eoes: 2026-06-07
       eol: 2027-06-07
-    - releaseCycle: "4.1.0.1 MR4"
+    - releaseCycle: "4.1.0.1.mr4"
       releaseDate: 2022-10-28
       eoas: false
       eoes: false
       eol: 2024-06-07  
-    - releaseCycle: "4.1.0.1 MR3"
+    - releaseCycle: "4.1.0.1.mr3"
       releaseDate: 2022-08-08
       eoas: false
       eoes: false
       eol: 2024-06-07  
-    - releaseCycle: "4.1.0.1 MR2"
+    - releaseCycle: "4.1.0.1.mr2"
       releaseDate: 2022-02-28
       eoas: false
       eoes: false
       eol: 2024-06-07  
-    - releaseCycle: "4.1.0.1 MR1"
+    - releaseCycle: "4.1.0.1.mr1"
       releaseDate: 2021-10-18
       eoas: false
       eoes: false
@@ -134,22 +136,22 @@ releases:
       eoas: false
       eoes: false
       eol: 2024-06-07  
-    - releaseCycle: "4.0.0.1 MR4"
+    - releaseCycle: "4.0.0.1.mr4"
       releaseDate: 2022-06-13
       eoas: 2024-01-01
       eoes: 2026-01-01
       eol: 2027-01-01 
-    - releaseCycle: "4.0.0.1 MR3"
+    - releaseCycle: "4.0.0.1.mr3"
       releaseDate: 2022-01-19
       eoas: false
       eoes: false
       eol: 2024-01-01 
-    - releaseCycle: "4.0.0.1 MR2"
+    - releaseCycle: "4.0.0.1.mr2"
       releaseDate: 2021-09-17
       eoas: false
       eoes: false
       eol: 2024-01-01 
-    - releaseCycle: "4.0.0.1 MR1"
+    - releaseCycle: "4.0.0.1.mr1"
       releaseDate: 2021-06-15
       eoas: false
       eoes: false
@@ -159,22 +161,22 @@ releases:
       eoas: false
       eoes: false
       eol: 2024-01-01 
-    - releaseCycle: "3.3.0.2 MR2"
+    - releaseCycle: "3.3.0.2.mr2"
       releaseDate: 2021-11-12
       eoas: 2024-07-29
       eoes: 2026-07-29
       eol: 2026-07-29 
-    - releaseCycle: "3.3.0.2 MR1"
+    - releaseCycle: "3.3.0.2.mr1"
       releaseDate: 2021-09-03
       eoas: false
       eoes: false
       eol: 2024-07-29 
-    - releaseCycle: "3.3.0.1 MR3"
+    - releaseCycle: "3.3.0.1.mr3"
       releaseDate: 2021-07-02
       eoas: false
       eoes: false
       eol: 2024-07-29 
-    - releaseCycle: "3.3.0.1 MR2"
+    - releaseCycle: "3.3.0.1.mr2"
       releaseDate: 2021-04-02
       eoas: false
       eoes: false

--- a/products/veritas-netbackup.md
+++ b/products/veritas-netbackup.md
@@ -4,13 +4,13 @@ category: os
 iconSlug: veritas
 permalink: /netbackup-appliance-os
 releasePolicyLink: https://sort.veritas.com/eosl
-eolColumn: EOSL
+eolColumn: Extended Support
 eolWarnThreshold: 121
 
 eoasColumn: Active Support
 eoasWarnThreshold: 121
 
-eoesColumn: Extended Support
+eoesColumn: Sustaining Support
 eoesWarnThreshold: 121
 
 releaseColumn: false
@@ -19,216 +19,212 @@ releases:
     - releaseCycle: "5.5.0.1"
       releaseDate: 2025-02-12
       eoas: false
-      eoes: false
       eol: false
+      eoes: false
     - releaseCycle: "5.3.0.1.mr4"
       releaseDate: 2025-01-27
       eoas: false
-      eoes: false
-      eol: 2026-10-23
+      eol: false
+      eoes: 2026-10-23
     - releaseCycle: "5.3.0.1.mr3"
       releaseDate: 2024-10-18
       eoas: false
-      eoes: false
-      eol: 2026-10-23
+      eol: false
+      eoes: 2026-10-23
     - releaseCycle: "5.3.0.1.mr2"
       releaseDate: 2024-07-12
       eoas: false
-      eoes: false
-      eol: 2026-10-23
+      eol: false
+      eoes: 2026-10-23
     - releaseCycle: "5.3.0.1.mr1"
       releaseDate: 2024-03-22
       eoas: false
-      eoes: false
-      eol: 2026-10-23
+      eol: false
+      eoes: 2026-10-23
     - releaseCycle: "5.3"
       releaseDate: 2023-11-27
       eoas: false
-      eoes: false
-      eol: 2026-10-23
+      eol: false
+      eoes: 2026-10-23
     - releaseCycle: "5.1.1.mr5"
       releaseDate: 2024-08-28
       eoas: 2025-09-08
-      eoes: 2027-09-08
-      eol: 2028-09-08
+      eol: 2027-09-08
+      eoes: 2028-09-08
     - releaseCycle: "5.1.1.mr4"
       releaseDate: 2024-05-17
       eoas: false
-      eoes: false
-      eol: 2025-09-08
+      eol: false
+      eoes: 2025-09-08
     - releaseCycle: "5.1.1.mr3"
       releaseDate: 2024-02-14
       eoas: false
-      eoes: false
-      eol: 2025-09-08
+      eol: false
+      eoes: 2025-09-08
     - releaseCycle: "5.1.1.mr2"
       releaseDate: 2023-10-20
       eoas: false
-      eoes: false
-      eol: 2025-09-08
+      eol: false
+      eoes: 2025-09-08
     - releaseCycle: "5.1.1.mr1"
       releaseDate: 2023-05-31
       eoas: false
-      eoes: false
-      eol: 2025-09-08
+      eol: false
+      eoes: 2025-09-08
     - releaseCycle: "5.1.1"
       releaseDate: 2023-02-08
       eoas: false
-      eoes: false
-      eol: 2025-09-08
+      eol: false
+      eoes: 2025-09-08
     - releaseCycle: "5.0.0.1.mr5"
       releaseDate: 2023-11-08
       eoas: 2025-03-28
-      eoes: 2027-03-28
-      eol: 2028-03-28
+      eol: 2027-03-28
+      eoes: 2028-03-28
     - releaseCycle: "5.0.0.1.mr4"
       releaseDate: 2023-06-28
       eoas: false
-      eoes: false
-      eol: 2025-03-28
+      eol: false
+      eoes: 2025-03-28
     - releaseCycle: "5.0.0.1.mr3"
       releaseDate: 2023-03-07
       eoas: false
-      eoes: false
-      eol: 2025-03-28
+      eol: false
+      eoes: 2025-03-28
     - releaseCycle: "5.0.0.1.mr2"
       releaseDate: 2022-11-24
       eoas: false
-      eoes: false
-      eol: 2025-03-28
+      eol: false
+      eoes: 2025-03-28
     - releaseCycle: "5.0.0.1.mr1"
       releaseDate: 2022-08-17
       eoas: false
-      eoes: false
-      eol: 2025-03-28
+      eol: false
+      eoes: 2025-03-28
     - releaseCycle: "5.0"
       releaseDate: 2022-04-25
       eoas: false
-      eoes: false
-      eol: 2025-03-28
+      eol: false
+      eoes: 2025-03-28
     - releaseCycle: "4.1.0.1.mr5"
       releaseDate: 2023-02-14
       eoas: 2024-06-07
-      eoes: 2026-06-07
-      eol: 2027-06-07
+      eol: 2026-06-07
+      eoes: 2027-06-07
     - releaseCycle: "4.1.0.1.mr4"
       releaseDate: 2022-10-28
       eoas: false
-      eoes: false
-      eol: 2024-06-07  
+      eol: false
+      eoes: 2024-06-07  
     - releaseCycle: "4.1.0.1.mr3"
       releaseDate: 2022-08-08
       eoas: false
-      eoes: false
-      eol: 2024-06-07  
+      eol: false
+      eoes: 2024-06-07  
     - releaseCycle: "4.1.0.1.mr2"
       releaseDate: 2022-02-28
       eoas: false
-      eoes: false
-      eol: 2024-06-07  
+      eol: false
+      eoes: 2024-06-07  
     - releaseCycle: "4.1.0.1.mr1"
       releaseDate: 2021-10-18
       eoas: false
-      eoes: false
-      eol: 2024-06-07  
+      eol: false
+      eoes: 2024-06-07  
     - releaseCycle: "4.1"
       releaseDate: 2021-07-19
       eoas: false
-      eoes: false
-      eol: 2024-06-07  
+      eol: false
+      eoes: 2024-06-07  
     - releaseCycle: "4.0.0.1.mr4"
       releaseDate: 2022-06-13
       eoas: 2024-01-01
-      eoes: 2026-01-01
-      eol: 2027-01-01 
+      eol: 2026-01-01
+      eoes: 2027-01-01 
     - releaseCycle: "4.0.0.1.mr3"
       releaseDate: 2022-01-19
       eoas: false
-      eoes: false
-      eol: 2024-01-01 
+      eol: false
+      eoes: 2024-01-01 
     - releaseCycle: "4.0.0.1.mr2"
       releaseDate: 2021-09-17
       eoas: false
-      eoes: false
-      eol: 2024-01-01 
+      eol: false
+      eoes: 2024-01-01 
     - releaseCycle: "4.0.0.1.mr1"
       releaseDate: 2021-06-15
       eoas: false
-      eoes: false
-      eol: 2024-01-01 
+      eol: false
+      eoes: 2024-01-01 
     - releaseCycle: "4.0"
       releaseDate: 2021-03-01
       eoas: false
-      eoes: false
-      eol: 2024-01-01 
+      eol: false
+      eoes: 2024-01-01 
     - releaseCycle: "3.3.0.2.mr2"
       releaseDate: 2021-11-12
       eoas: 2024-07-29
-      eoes: 2026-07-29
-      eol: 2026-07-29 
+      eol: 2026-07-29
+      eoes: 2026-07-29 
     - releaseCycle: "3.3.0.2.mr1"
       releaseDate: 2021-09-03
       eoas: false
-      eoes: false
-      eol: 2024-07-29 
+      eol: false
+      eoes: 2024-07-29 
     - releaseCycle: "3.3.0.1.mr3"
       releaseDate: 2021-07-02
       eoas: false
-      eoes: false
-      eol: 2024-07-29 
+      eol: false
+      eoes: 2024-07-29 
     - releaseCycle: "3.3.0.1.mr2"
       releaseDate: 2021-04-02
       eoas: false
-      eoes: false
-      eol: 2024-07-29 
+      eol: false
+      eoes: 2024-07-29 
     - releaseCycle: "3.3.0.1"
       releaseDate: 2020-10-05
       eoas: false
-      eoes: false
-      eol: 2024-07-29 
+      eol: false
+      eoes: 2024-07-29 
     - releaseCycle: "3.2"
       releaseDate: 2019-11-04
       eoas: 2023-06-28
-      eoes: 2025-06-28
-      eol: 2026-06-28
+      eol: 2025-06-28
+      eoes: 2026-06-28
     - releaseCycle: "3.1.2"
       releaseDate: 2018-09-21
       eoas: 2022-06-28
-      eoes: 2024-06-28
-      eol: 2025-06-28
+      eol: 2024-06-28
+      eoes: 2025-06-28
     - releaseCycle: "3.1.1"
       releaseDate: 2018-02-22
       eoas: 2022-06-28
-      eoes: 2024-06-28
-      eol: 2023-06-28
+      eol: 2024-06-28
+      eoes: 2023-06-28
     - releaseCycle: "3.1"
       releaseDate: 2017-09-26
       eoas: 2022-06-28
-      eoes: 2024-06-28
-      eol: 2023-06-28
+      eol: 2024-06-28
+      eoes: 2023-06-28
     - releaseCycle: "3.0"
       releaseDate: 2016-12-04
       eoas: 2020-10-01
-      eoes: 2022-03-26
-      eol: 2024-03-26
+      eol: 2022-03-26
+      eoes: 2024-03-26
     - releaseCycle: "2.7.3"
       releaseDate: 2016-06-05
       eoas: 2020-10-01
-      eoes: 2021-05-06
-      eol: 2022-01-31
+      eol: 2021-05-06
+      eoes: 2022-01-31
     - releaseCycle: "2.7.2"
       releaseDate: 2016-02-01
       eoas: 2020-10-01
-      eoes: 2021-05-06
-      eol: 2022-01-31
+      eol: 2021-05-06
+      eoes: 2022-01-31
     - releaseCycle: "2.7.1"
       releaseDate: 2015-12-06
       eoas: 2020-10-01
-      eoes: 2021-05-06
-      eol: 2022-01-31
+      eol: 2021-05-06
+      eoes: 2022-01-31
 
 ---
-
-> [Veritas NetBackup](https://www.veritas.com/protection/netbackup) is an enterprise-level data protection and backup solution
-
-Veritas offers full support from general availability for 3 to 4 years. At the end of full/active, support, extended support is available for 1-2 years with no new bug fixes, but access to existing patches and technical help. The final sustaining phase before EOSL lasts for 1 to 6 years with focus on severe service restoration or data retrieval issues.

--- a/products/veritas-netbackup.md
+++ b/products/veritas-netbackup.md
@@ -14,150 +14,152 @@ releaseColumn: false
 
 releases:
     - releaseCycle: "5.5.0.1"
+      releaseLabel: "5.5.0.1"
       releaseDate: 2025-02-12
-      eoas: false
-      eol: false
-      eoes: false
 
     - releaseCycle: "5.3.0.1-mr4"
+      releaseLabel: "5.3.0.1 MR4"
       releaseDate: 2025-01-27
-      eoas: false
-      eol: false
       eoes: 2026-10-23
 
     - releaseCycle: "5.3.0.1-mr3"
+      releaseLabel: "5.3.0.1 MR3"
       releaseDate: 2024-10-18
-      eoas: false
-      eol: false
       eoes: 2026-10-23
 
     - releaseCycle: "5.1.1-mr5"
+      releaseLabel: "5.1.1 MR5"
       releaseDate: 2024-08-28
       eoas: 2025-09-08
       eol: 2027-09-08
       eoes: 2028-09-08
 
     - releaseCycle: "5.3.0.1-mr2"
+      releaseLabel: "5.3.0.1 MR2"
       releaseDate: 2024-07-12
-      eoas: false
-      eol: false
       eoes: 2026-10-23
 
     - releaseCycle: "5.1.1-mr4"
+      releaseLabel: "5.1.1 MR4"
       releaseDate: 2024-05-17
-      eoas: false
-      eol: false
       eoes: 2025-09-08
 
     - releaseCycle: "5.3.0.1-mr1"
+      releaseLabel: "5.3.0.1 MR1"
       releaseDate: 2024-03-22
-      eoas: false
-      eol: false
       eoes: 2026-10-23
 
     - releaseCycle: "5.1.1-mr3"
+      releaseLabel: "5.1.1 MR3"
       releaseDate: 2024-02-14
-      eoas: false
-      eol: false
       eoes: 2025-09-08
 
     - releaseCycle: "5.3"
+      releaseLabel: "5.3"
       releaseDate: 2023-11-27
-      eoas: false
-      eol: false
       eoes: 2026-10-23
 
     - releaseCycle: "5.0.0.1-mr5"
+      releaseLabel: "5.0.0.1 MR5"
       releaseDate: 2023-11-08
       eoas: 2025-03-28
       eol: 2027-03-28
       eoes: 2028-03-28
 
     - releaseCycle: "5.1.1-mr2"
+      releaseLabel: "5.1.1 MR2"
       releaseDate: 2023-10-20
-      eoas: false
-      eol: false
       eoes: 2025-09-08
 
     - releaseCycle: "5.0.0.1-mr4"
+      releaseLabel: "5.0.0.1 MR4"
       releaseDate: 2023-06-28
-      eoas: false
-      eol: false
+      eoas: true
+      eol: true
       eoes: 2025-03-28
 
     - releaseCycle: "5.1.1-mr1"
+      releaseLabel: "5.1.1 MR1"
       releaseDate: 2023-05-31
-      eoas: false
-      eol: false
       eoes: 2025-09-08
 
     - releaseCycle: "5.0.0.1-mr3"
+      releaseLabel: "5.0.0.1 MR3"
       releaseDate: 2023-03-07
-      eoas: false
-      eol: false
+      eoas: true
+      eol: true
       eoes: 2025-03-28
 
     - releaseCycle: "4.1.0.1-mr5"
+      releaseLabel: "4.1.0.1 MR5"
       releaseDate: 2023-02-14
       eoas: 2024-06-07
       eol: 2026-06-07
       eoes: 2027-06-07
 
     - releaseCycle: "5.1.1"
+      releaseLabel: "5.1.1"
       releaseDate: 2023-02-08
-      eoas: false
-      eol: false
       eoes: 2025-09-08
 
     - releaseCycle: "5.0.0.1-mr2"
+      releaseLabel: "5.0.0.1 MR2"
       releaseDate: 2022-11-24
-      eoas: false
-      eol: false
+      eoas: true
+      eol: true
       eoes: 2025-03-28
 
     - releaseCycle: "4.1.0.1-mr4"
+      releaseLabel: "4.1.0.1 MR4"
       releaseDate: 2022-10-28
-      eoas: false
-      eol: false
+      eoas: true
+      eol: true
       eoes: 2024-06-07  
 
     - releaseCycle: "5.0.0.1-mr1"
+      releaseLabel: "5.0.0.1 MR1"
       releaseDate: 2022-08-17
-      eoas: false
-      eol: false
+      eoas: true
+      eol: true
       eoes: 2025-03-28
 
     - releaseCycle: "4.1.0.1-mr3"
+      releaseLabel: "4.1.0.1 MR3"
       releaseDate: 2022-08-08
-      eoas: false
-      eol: false
+      eoas: true
+      eol: true
       eoes: 2024-06-07  
 
     - releaseCycle: "4.0.0.1-mr4"
+      releaseLabel: "4.0.0.1 MR4"
       releaseDate: 2022-06-13
       eoas: 2024-01-01
       eol: 2026-01-01
       eoes: 2027-01-01 
 
     - releaseCycle: "5.0"
+      releaseLabel: "5.0"
       releaseDate: 2022-04-25
-      eoas: false
-      eol: false
+      eoas: true
+      eol: true
       eoes: 2025-03-28
 
     - releaseCycle: "4.1.0.1-mr2"
+      releaseLabel: "4.1.0.1 MR2"
       releaseDate: 2022-02-28
-      eoas: false
-      eol: false
+      eoas: true
+      eol: true
       eoes: 2024-06-07  
 
     - releaseCycle: "4.0.0.1-mr3"
+      releaseLabel: "4.0.0.1 MR3"
       releaseDate: 2022-01-19
-      eoas: false
-      eol: false
+      eoas: true
+      eol: true
       eoes: 2024-01-01 
 
     - releaseCycle: "3.3.0.2-mr2"
+      releaseLabel: "3.3.0.2 MR2"
       releaseDate: 2021-11-12
       eoas: 2024-07-29
       eol: 2026-07-29
@@ -165,101 +167,117 @@ releases:
 
     - releaseCycle: "4.1.0.1-mr1"
       releaseDate: 2021-10-18
-      eoas: false
-      eol: false
+      eoas: true
+      eol: true
       eoes: 2024-06-07 
 
     - releaseCycle: "4.0.0.1-mr2"
+      releaseLabel: "4.0.0.1 MR2"
       releaseDate: 2021-09-17
-      eoas: false
-      eol: false
+      eoas: true
+      eol: true
       eoes: 2024-01-01 
 
     - releaseCycle: "3.3.0.2-mr1"
+      releaseLabel: "3.3.0.2 MR1"
       releaseDate: 2021-09-03
-      eoas: false
-      eol: false
+      eoas: true
+      eol: true
       eoes: 2024-07-29 
 
     - releaseCycle: "4.1"
+      releaseLabel: "4.1"
       releaseDate: 2021-07-19
-      eoas: false
-      eol: false
+      eoas: true
+      eol: true
       eoes: 2024-06-07  
 
     - releaseCycle: "3.3.0.1-mr3"
+      releaseLabel: "3.3.0.1 MR3"
       releaseDate: 2021-07-02
-      eoas: false
-      eol: false
+      eoas: true
+      eol: true
       eoes: 2024-07-29 
 
     - releaseCycle: "4.0.0.1-mr1"
+      releaseLabel: "4.0.0.1 MR1"
       releaseDate: 2021-06-15
-      eoas: false
-      eol: false
+      eoas: true
+      eol: true
       eoes: 2024-01-01
 
     - releaseCycle: "3.3.0.1-mr2"
+      releaseLabel: "3.3.0.1 MR2"
       releaseDate: 2021-04-02
-      eoas: false
-      eol: false
+      eoas: true
+      eol: true
       eoes: 2024-07-29 
 
     - releaseCycle: "4.0"
+      releaseLabel: "4.0"
       releaseDate: 2021-03-01
-      eoas: false
-      eol: false
+      eoas: true
+      eol: true
       eoes: 2024-01-01 
 
     - releaseCycle: "3.3.0.1"
+      releaseLabel "3.3.0.1"
       releaseDate: 2020-10-05
-      eoas: false
-      eol: false
+      eoas: true
+      eol: true
       eoes: 2024-07-29 
 
     - releaseCycle: "3.2"
+      releaseLabel: "3.2"
       releaseDate: 2019-11-04
       eoas: 2023-06-28
       eol: 2025-06-28
       eoes: 2026-06-28
 
     - releaseCycle: "3.1.2"
+      releaseLabel: "3.1.2"
       releaseDate: 2018-09-21
       eoas: 2022-06-28
       eol: 2024-06-28
       eoes: 2025-06-28
 
     - releaseCycle: "3.1.1"
+      releaseLabel: "3.1.1"
       releaseDate: 2018-02-22
       eoas: 2022-06-28
-      eol: false
+      eol: true
       eoes: 2023-06-28
 
     - releaseCycle: "3.1"
+      releaseLabel: "3.1"
       releaseDate: 2017-09-26
       eoas: 2022-06-28
-      eol: false
+      eol: true
       eoes: 2023-06-28
 
     - releaseCycle: "3.0"
+      releaseLabel: "3.0"
       releaseDate: 2016-12-04
       eoas: 2020-10-01
       eol: 2022-03-26
       eoes: 2024-03-26
 
     - releaseCycle: "2.7.3"
+      releaseLabel: "2.7.3"
       releaseDate: 2016-06-05
       eoas: 2020-10-01
       eol: 2021-05-06
       eoes: 2022-01-31
 
     - releaseCycle: "2.7.2"
+      releaseLabel: "2.7.2"
       releaseDate: 2016-02-01
       eoas: 2020-10-01
       eol: 2021-05-06
       eoes: 2022-01-31
 
     - releaseCycle: "2.7.1"
+      releaseLabel: "2.7.1"
       releaseDate: 2015-12-06
       eoas: 2020-10-01
       eol: 2021-05-06

--- a/products/veritas-netbackup.md
+++ b/products/veritas-netbackup.md
@@ -16,19 +16,23 @@ releases:
     - releaseCycle: "5.5.0.1"
       releaseDate: 2025-02-12
       eoas: true
-      eoes: true
-      eol: false
+      eol: true
+      eoes: false      
 
     - releaseCycle: "5.3.0.1-mr4"
       releaseLabel: "5.3.0.1 MR4"
       releaseDate: 2025-01-27
+      eoas: true
+      eol: true
       eoes: 2026-10-23
 
     - releaseCycle: "5.3.0.1-mr3"
       releaseLabel: "5.3.0.1 MR3"
       releaseDate: 2024-10-18
+      eoas: true
+      eol: true
       eoes: 2026-10-23
-      eol: false
+      
 
     - releaseCycle: "5.1.1-mr5"
       releaseLabel: "5.1.1 MR5"
@@ -40,25 +44,35 @@ releases:
     - releaseCycle: "5.3.0.1-mr2"
       releaseLabel: "5.3.0.1 MR2"
       releaseDate: 2024-07-12
+      eoas: true
+      eol: true
       eoes: 2026-10-23
 
     - releaseCycle: "5.1.1-mr4"
       releaseLabel: "5.1.1 MR4"
       releaseDate: 2024-05-17
+      eoas: true
+      eol: true
       eoes: 2025-09-08
 
     - releaseCycle: "5.3.0.1-mr1"
       releaseLabel: "5.3.0.1 MR1"
       releaseDate: 2024-03-22
+      eoas: true
+      eol: true
       eoes: 2026-10-23
 
     - releaseCycle: "5.1.1-mr3"
       releaseLabel: "5.1.1 MR3"
       releaseDate: 2024-02-14
+      eoas: true
+      eol: true
       eoes: 2025-09-08
 
     - releaseCycle: "5.3"
       releaseDate: 2023-11-27
+      eoas: true
+      eol: true
       eoes: 2026-10-23
 
     - releaseCycle: "5.0.0.1-mr5"
@@ -71,6 +85,8 @@ releases:
     - releaseCycle: "5.1.1-mr2"
       releaseLabel: "5.1.1 MR2"
       releaseDate: 2023-10-20
+      eoas: true
+      eol: true
       eoes: 2025-09-08
 
     - releaseCycle: "5.0.0.1-mr4"
@@ -83,6 +99,8 @@ releases:
     - releaseCycle: "5.1.1-mr1"
       releaseLabel: "5.1.1 MR1"
       releaseDate: 2023-05-31
+      eoas: true
+      eol: true
       eoes: 2025-09-08
 
     - releaseCycle: "5.0.0.1-mr3"
@@ -101,6 +119,8 @@ releases:
 
     - releaseCycle: "5.1.1"
       releaseDate: 2023-02-08
+      eoas: true
+      eol: true
       eoes: 2025-09-08
 
     - releaseCycle: "5.0.0.1-mr2"

--- a/products/veritas-netbackup.md
+++ b/products/veritas-netbackup.md
@@ -5,14 +5,11 @@ iconSlug: veritas
 permalink: /netbackup-appliance-os
 releasePolicyLink: https://sort.veritas.com/eosl
 eolColumn: Extended Support
-eolWarnThreshold: 121
-
 eoasColumn: Active Support
-eoasWarnThreshold: 121
-
 eoesColumn: Sustaining Support
+eoasWarnThreshold: 121
 eoesWarnThreshold: 121
-
+eolWarnThreshold: 121
 releaseColumn: false
 
 releases:
@@ -21,206 +18,247 @@ releases:
       eoas: false
       eol: false
       eoes: false
-    - releaseCycle: "5.3.0.1.mr4"
+
+    - releaseCycle: "5.3.0.1-mr4"
       releaseDate: 2025-01-27
       eoas: false
       eol: false
       eoes: 2026-10-23
-    - releaseCycle: "5.3.0.1.mr3"
+
+    - releaseCycle: "5.3.0.1-mr3"
       releaseDate: 2024-10-18
       eoas: false
       eol: false
       eoes: 2026-10-23
-    - releaseCycle: "5.3.0.1.mr2"
+
+    - releaseCycle: "5.1.1-mr5"
+      releaseDate: 2024-08-28
+      eoas: 2025-09-08
+      eol: 2027-09-08
+      eoes: 2028-09-08
+
+    - releaseCycle: "5.3.0.1-mr2"
       releaseDate: 2024-07-12
       eoas: false
       eol: false
       eoes: 2026-10-23
-    - releaseCycle: "5.3.0.1.mr1"
+
+    - releaseCycle: "5.1.1-mr4"
+      releaseDate: 2024-05-17
+      eoas: false
+      eol: false
+      eoes: 2025-09-08
+
+    - releaseCycle: "5.3.0.1-mr1"
       releaseDate: 2024-03-22
       eoas: false
       eol: false
       eoes: 2026-10-23
+
+    - releaseCycle: "5.1.1-mr3"
+      releaseDate: 2024-02-14
+      eoas: false
+      eol: false
+      eoes: 2025-09-08
+
     - releaseCycle: "5.3"
       releaseDate: 2023-11-27
       eoas: false
       eol: false
       eoes: 2026-10-23
-    - releaseCycle: "5.1.1.mr5"
-      releaseDate: 2024-08-28
-      eoas: 2025-09-08
-      eol: 2027-09-08
-      eoes: 2028-09-08
-    - releaseCycle: "5.1.1.mr4"
-      releaseDate: 2024-05-17
-      eoas: false
-      eol: false
-      eoes: 2025-09-08
-    - releaseCycle: "5.1.1.mr3"
-      releaseDate: 2024-02-14
-      eoas: false
-      eol: false
-      eoes: 2025-09-08
-    - releaseCycle: "5.1.1.mr2"
+
+    - releaseCycle: "5.0.0.1-mr5"
+      releaseDate: 2023-11-08
+      eoas: 2025-03-28
+      eol: 2027-03-28
+      eoes: 2028-03-28
+
+    - releaseCycle: "5.1.1-mr2"
       releaseDate: 2023-10-20
       eoas: false
       eol: false
       eoes: 2025-09-08
-    - releaseCycle: "5.1.1.mr1"
+
+    - releaseCycle: "5.0.0.1-mr4"
+      releaseDate: 2023-06-28
+      eoas: false
+      eol: false
+      eoes: 2025-03-28
+
+    - releaseCycle: "5.1.1-mr1"
       releaseDate: 2023-05-31
       eoas: false
       eol: false
       eoes: 2025-09-08
+
+    - releaseCycle: "5.0.0.1-mr3"
+      releaseDate: 2023-03-07
+      eoas: false
+      eol: false
+      eoes: 2025-03-28
+
+    - releaseCycle: "4.1.0.1-mr5"
+      releaseDate: 2023-02-14
+      eoas: 2024-06-07
+      eol: 2026-06-07
+      eoes: 2027-06-07
+
     - releaseCycle: "5.1.1"
       releaseDate: 2023-02-08
       eoas: false
       eol: false
       eoes: 2025-09-08
-    - releaseCycle: "5.0.0.1.mr5"
-      releaseDate: 2023-11-08
-      eoas: 2025-03-28
-      eol: 2027-03-28
-      eoes: 2028-03-28
-    - releaseCycle: "5.0.0.1.mr4"
-      releaseDate: 2023-06-28
-      eoas: false
-      eol: false
-      eoes: 2025-03-28
-    - releaseCycle: "5.0.0.1.mr3"
-      releaseDate: 2023-03-07
-      eoas: false
-      eol: false
-      eoes: 2025-03-28
-    - releaseCycle: "5.0.0.1.mr2"
+
+    - releaseCycle: "5.0.0.1-mr2"
       releaseDate: 2022-11-24
       eoas: false
       eol: false
       eoes: 2025-03-28
-    - releaseCycle: "5.0.0.1.mr1"
+
+    - releaseCycle: "4.1.0.1-mr4"
+      releaseDate: 2022-10-28
+      eoas: false
+      eol: false
+      eoes: 2024-06-07  
+
+    - releaseCycle: "5.0.0.1-mr1"
       releaseDate: 2022-08-17
       eoas: false
       eol: false
       eoes: 2025-03-28
+
+    - releaseCycle: "4.1.0.1-mr3"
+      releaseDate: 2022-08-08
+      eoas: false
+      eol: false
+      eoes: 2024-06-07  
+
+    - releaseCycle: "4.0.0.1-mr4"
+      releaseDate: 2022-06-13
+      eoas: 2024-01-01
+      eol: 2026-01-01
+      eoes: 2027-01-01 
+
     - releaseCycle: "5.0"
       releaseDate: 2022-04-25
       eoas: false
       eol: false
       eoes: 2025-03-28
-    - releaseCycle: "4.1.0.1.mr5"
-      releaseDate: 2023-02-14
-      eoas: 2024-06-07
-      eol: 2026-06-07
-      eoes: 2027-06-07
-    - releaseCycle: "4.1.0.1.mr4"
-      releaseDate: 2022-10-28
-      eoas: false
-      eol: false
-      eoes: 2024-06-07  
-    - releaseCycle: "4.1.0.1.mr3"
-      releaseDate: 2022-08-08
-      eoas: false
-      eol: false
-      eoes: 2024-06-07  
-    - releaseCycle: "4.1.0.1.mr2"
+
+    - releaseCycle: "4.1.0.1-mr2"
       releaseDate: 2022-02-28
       eoas: false
       eol: false
       eoes: 2024-06-07  
-    - releaseCycle: "4.1.0.1.mr1"
+
+    - releaseCycle: "4.0.0.1-mr3"
+      releaseDate: 2022-01-19
+      eoas: false
+      eol: false
+      eoes: 2024-01-01 
+
+    - releaseCycle: "3.3.0.2-mr2"
+      releaseDate: 2021-11-12
+      eoas: 2024-07-29
+      eol: 2026-07-29
+      eoes: 2026-07-29 
+
+    - releaseCycle: "4.1.0.1-mr1"
       releaseDate: 2021-10-18
       eoas: false
       eol: false
-      eoes: 2024-06-07  
+      eoes: 2024-06-07 
+
+    - releaseCycle: "4.0.0.1-mr2"
+      releaseDate: 2021-09-17
+      eoas: false
+      eol: false
+      eoes: 2024-01-01 
+
+    - releaseCycle: "3.3.0.2-mr1"
+      releaseDate: 2021-09-03
+      eoas: false
+      eol: false
+      eoes: 2024-07-29 
+
     - releaseCycle: "4.1"
       releaseDate: 2021-07-19
       eoas: false
       eol: false
       eoes: 2024-06-07  
-    - releaseCycle: "4.0.0.1.mr4"
-      releaseDate: 2022-06-13
-      eoas: 2024-01-01
-      eol: 2026-01-01
-      eoes: 2027-01-01 
-    - releaseCycle: "4.0.0.1.mr3"
-      releaseDate: 2022-01-19
+
+    - releaseCycle: "3.3.0.1-mr3"
+      releaseDate: 2021-07-02
       eoas: false
       eol: false
-      eoes: 2024-01-01 
-    - releaseCycle: "4.0.0.1.mr2"
-      releaseDate: 2021-09-17
-      eoas: false
-      eol: false
-      eoes: 2024-01-01 
-    - releaseCycle: "4.0.0.1.mr1"
+      eoes: 2024-07-29 
+
+    - releaseCycle: "4.0.0.1-mr1"
       releaseDate: 2021-06-15
       eoas: false
       eol: false
-      eoes: 2024-01-01 
+      eoes: 2024-01-01
+
+    - releaseCycle: "3.3.0.1-mr2"
+      releaseDate: 2021-04-02
+      eoas: false
+      eol: false
+      eoes: 2024-07-29 
+
     - releaseCycle: "4.0"
       releaseDate: 2021-03-01
       eoas: false
       eol: false
       eoes: 2024-01-01 
-    - releaseCycle: "3.3.0.2.mr2"
-      releaseDate: 2021-11-12
-      eoas: 2024-07-29
-      eol: 2026-07-29
-      eoes: 2026-07-29 
-    - releaseCycle: "3.3.0.2.mr1"
-      releaseDate: 2021-09-03
-      eoas: false
-      eol: false
-      eoes: 2024-07-29 
-    - releaseCycle: "3.3.0.1.mr3"
-      releaseDate: 2021-07-02
-      eoas: false
-      eol: false
-      eoes: 2024-07-29 
-    - releaseCycle: "3.3.0.1.mr2"
-      releaseDate: 2021-04-02
-      eoas: false
-      eol: false
-      eoes: 2024-07-29 
+
     - releaseCycle: "3.3.0.1"
       releaseDate: 2020-10-05
       eoas: false
       eol: false
       eoes: 2024-07-29 
+
     - releaseCycle: "3.2"
       releaseDate: 2019-11-04
       eoas: 2023-06-28
       eol: 2025-06-28
       eoes: 2026-06-28
+
     - releaseCycle: "3.1.2"
       releaseDate: 2018-09-21
       eoas: 2022-06-28
       eol: 2024-06-28
       eoes: 2025-06-28
+
     - releaseCycle: "3.1.1"
       releaseDate: 2018-02-22
       eoas: 2022-06-28
       eol: false
       eoes: 2023-06-28
+
     - releaseCycle: "3.1"
       releaseDate: 2017-09-26
       eoas: 2022-06-28
       eol: false
       eoes: 2023-06-28
+
     - releaseCycle: "3.0"
       releaseDate: 2016-12-04
       eoas: 2020-10-01
       eol: 2022-03-26
       eoes: 2024-03-26
+
     - releaseCycle: "2.7.3"
       releaseDate: 2016-06-05
       eoas: 2020-10-01
       eol: 2021-05-06
       eoes: 2022-01-31
+
     - releaseCycle: "2.7.2"
       releaseDate: 2016-02-01
       eoas: 2020-10-01
       eol: 2021-05-06
       eoes: 2022-01-31
+
     - releaseCycle: "2.7.1"
       releaseDate: 2015-12-06
       eoas: 2020-10-01

--- a/products/veritas-netbackup.md
+++ b/products/veritas-netbackup.md
@@ -14,8 +14,10 @@ releaseColumn: false
 
 releases:
     - releaseCycle: "5.5.0.1"
-      releaseLabel: "5.5.0.1"
       releaseDate: 2025-02-12
+      eoas: true
+      eoes: true
+      eol: false
 
     - releaseCycle: "5.3.0.1-mr4"
       releaseLabel: "5.3.0.1 MR4"
@@ -26,6 +28,7 @@ releases:
       releaseLabel: "5.3.0.1 MR3"
       releaseDate: 2024-10-18
       eoes: 2026-10-23
+      eol: false
 
     - releaseCycle: "5.1.1-mr5"
       releaseLabel: "5.1.1 MR5"
@@ -55,7 +58,6 @@ releases:
       eoes: 2025-09-08
 
     - releaseCycle: "5.3"
-      releaseLabel: "5.3"
       releaseDate: 2023-11-27
       eoes: 2026-10-23
 
@@ -98,7 +100,6 @@ releases:
       eoes: 2027-06-07
 
     - releaseCycle: "5.1.1"
-      releaseLabel: "5.1.1"
       releaseDate: 2023-02-08
       eoes: 2025-09-08
 
@@ -138,7 +139,6 @@ releases:
       eoes: 2027-01-01 
 
     - releaseCycle: "5.0"
-      releaseLabel: "5.0"
       releaseDate: 2022-04-25
       eoas: true
       eol: true
@@ -166,6 +166,7 @@ releases:
       eoes: 2026-07-29 
 
     - releaseCycle: "4.1.0.1-mr1"
+      releaseLabel: "4.1.0.1 MR1"
       releaseDate: 2021-10-18
       eoas: true
       eol: true
@@ -186,7 +187,6 @@ releases:
       eoes: 2024-07-29 
 
     - releaseCycle: "4.1"
-      releaseLabel: "4.1"
       releaseDate: 2021-07-19
       eoas: true
       eol: true
@@ -214,70 +214,60 @@ releases:
       eoes: 2024-07-29 
 
     - releaseCycle: "4.0"
-      releaseLabel: "4.0"
       releaseDate: 2021-03-01
       eoas: true
       eol: true
       eoes: 2024-01-01 
 
     - releaseCycle: "3.3.0.1"
-      releaseLabel: "3.3.0.1"
       releaseDate: 2020-10-05
       eoas: true
       eol: true
       eoes: 2024-07-29 
 
     - releaseCycle: "3.2"
-      releaseLabel: "3.2"
       releaseDate: 2019-11-04
       eoas: 2023-06-28
       eol: 2025-06-28
       eoes: 2026-06-28
 
     - releaseCycle: "3.1.2"
-      releaseLabel: "3.1.2"
       releaseDate: 2018-09-21
       eoas: 2022-06-28
       eol: 2024-06-28
       eoes: 2025-06-28
 
     - releaseCycle: "3.1.1"
-      releaseLabel: "3.1.1"
       releaseDate: 2018-02-22
       eoas: 2022-06-28
       eol: true
       eoes: 2023-06-28
 
     - releaseCycle: "3.1"
-      releaseLabel: "3.1"
       releaseDate: 2017-09-26
       eoas: 2022-06-28
       eol: true
       eoes: 2023-06-28
 
     - releaseCycle: "3.0"
-      releaseLabel: "3.0"
       releaseDate: 2016-12-04
       eoas: 2020-10-01
       eol: 2022-03-26
       eoes: 2024-03-26
 
     - releaseCycle: "2.7.3"
-      releaseLabel: "2.7.3"
       releaseDate: 2016-06-05
       eoas: 2020-10-01
       eol: 2021-05-06
       eoes: 2022-01-31
 
     - releaseCycle: "2.7.2"
-      releaseLabel: "2.7.2"
       releaseDate: 2016-02-01
       eoas: 2020-10-01
       eol: 2021-05-06
       eoes: 2022-01-31
 
     - releaseCycle: "2.7.1"
-      releaseLabel: "2.7.1"
       releaseDate: 2015-12-06
       eoas: 2020-10-01
       eol: 2021-05-06

--- a/products/veritas-netbackup.md
+++ b/products/veritas-netbackup.md
@@ -221,7 +221,7 @@ releases:
       eoes: 2024-01-01 
 
     - releaseCycle: "3.3.0.1"
-      releaseLabel "3.3.0.1"
+      releaseLabel: "3.3.0.1"
       releaseDate: 2020-10-05
       eoas: true
       eol: true

--- a/products/veritas-netbackup.md
+++ b/products/veritas-netbackup.md
@@ -266,3 +266,7 @@ releases:
       eoes: 2022-01-31
 
 ---
+
+> [Veritas NetBackup](https://www.veritas.com/protection/netbackup) is an enterprise-level data protection and backup solution
+
+Veritas offers full support from general availability for 3 to 4 years. At the end of full/active, support, extended support is available for 1-2 years with no new bug fixes, but access to existing patches and technical help. The final sustaining phase before EOSL lasts for 1 to 6 years with focus on severe service restoration or data retrieval issues.

--- a/products/veritas-netbackup.md
+++ b/products/veritas-netbackup.md
@@ -13,288 +13,288 @@ eolWarnThreshold: 121
 releaseColumn: false
 
 releases:
-    - releaseCycle: "5.5.0.1"
-      releaseDate: 2025-02-12
-      eoas: true
-      eol: true
-      eoes: false      
+  - releaseCycle: "5.5.0.1"
+    releaseDate: 2025-02-12
+    eoas: true
+    eol: true
+    eoes: false
 
-    - releaseCycle: "5.3.0.1-mr4"
-      releaseLabel: "5.3.0.1 MR4"
-      releaseDate: 2025-01-27
-      eoas: true
-      eol: true
-      eoes: 2026-10-23
+  - releaseCycle: "5.3.0.1-mr4"
+    releaseLabel: "5.3.0.1 MR4"
+    releaseDate: 2025-01-27
+    eoas: true
+    eol: true
+    eoes: 2026-10-23
 
-    - releaseCycle: "5.3.0.1-mr3"
-      releaseLabel: "5.3.0.1 MR3"
-      releaseDate: 2024-10-18
-      eoas: true
-      eol: true
-      eoes: 2026-10-23
-      
+  - releaseCycle: "5.3.0.1-mr3"
+    releaseLabel: "5.3.0.1 MR3"
+    releaseDate: 2024-10-18
+    eoas: true
+    eol: true
+    eoes: 2026-10-23
 
-    - releaseCycle: "5.1.1-mr5"
-      releaseLabel: "5.1.1 MR5"
-      releaseDate: 2024-08-28
-      eoas: 2025-09-08
-      eol: 2027-09-08
-      eoes: 2028-09-08
+  - releaseCycle: "5.1.1-mr5"
+    releaseLabel: "5.1.1 MR5"
+    releaseDate: 2024-08-28
+    eoas: 2025-09-08
+    eol: 2027-09-08
+    eoes: 2028-09-08
 
-    - releaseCycle: "5.3.0.1-mr2"
-      releaseLabel: "5.3.0.1 MR2"
-      releaseDate: 2024-07-12
-      eoas: true
-      eol: true
-      eoes: 2026-10-23
+  - releaseCycle: "5.3.0.1-mr2"
+    releaseLabel: "5.3.0.1 MR2"
+    releaseDate: 2024-07-12
+    eoas: true
+    eol: true
+    eoes: 2026-10-23
 
-    - releaseCycle: "5.1.1-mr4"
-      releaseLabel: "5.1.1 MR4"
-      releaseDate: 2024-05-17
-      eoas: true
-      eol: true
-      eoes: 2025-09-08
+  - releaseCycle: "5.1.1-mr4"
+    releaseLabel: "5.1.1 MR4"
+    releaseDate: 2024-05-17
+    eoas: true
+    eol: true
+    eoes: 2025-09-08
 
-    - releaseCycle: "5.3.0.1-mr1"
-      releaseLabel: "5.3.0.1 MR1"
-      releaseDate: 2024-03-22
-      eoas: true
-      eol: true
-      eoes: 2026-10-23
+  - releaseCycle: "5.3.0.1-mr1"
+    releaseLabel: "5.3.0.1 MR1"
+    releaseDate: 2024-03-22
+    eoas: true
+    eol: true
+    eoes: 2026-10-23
 
-    - releaseCycle: "5.1.1-mr3"
-      releaseLabel: "5.1.1 MR3"
-      releaseDate: 2024-02-14
-      eoas: true
-      eol: true
-      eoes: 2025-09-08
+  - releaseCycle: "5.1.1-mr3"
+    releaseLabel: "5.1.1 MR3"
+    releaseDate: 2024-02-14
+    eoas: true
+    eol: true
+    eoes: 2025-09-08
 
-    - releaseCycle: "5.3"
-      releaseDate: 2023-11-27
-      eoas: true
-      eol: true
-      eoes: 2026-10-23
+  - releaseCycle: "5.3"
+    releaseDate: 2023-11-27
+    eoas: true
+    eol: true
+    eoes: 2026-10-23
 
-    - releaseCycle: "5.0.0.1-mr5"
-      releaseLabel: "5.0.0.1 MR5"
-      releaseDate: 2023-11-08
-      eoas: 2025-03-28
-      eol: 2027-03-28
-      eoes: 2028-03-28
+  - releaseCycle: "5.0.0.1-mr5"
+    releaseLabel: "5.0.0.1 MR5"
+    releaseDate: 2023-11-08
+    eoas: 2025-03-28
+    eol: 2027-03-28
+    eoes: 2028-03-28
 
-    - releaseCycle: "5.1.1-mr2"
-      releaseLabel: "5.1.1 MR2"
-      releaseDate: 2023-10-20
-      eoas: true
-      eol: true
-      eoes: 2025-09-08
+  - releaseCycle: "5.1.1-mr2"
+    releaseLabel: "5.1.1 MR2"
+    releaseDate: 2023-10-20
+    eoas: true
+    eol: true
+    eoes: 2025-09-08
 
-    - releaseCycle: "5.0.0.1-mr4"
-      releaseLabel: "5.0.0.1 MR4"
-      releaseDate: 2023-06-28
-      eoas: true
-      eol: true
-      eoes: 2025-03-28
+  - releaseCycle: "5.0.0.1-mr4"
+    releaseLabel: "5.0.0.1 MR4"
+    releaseDate: 2023-06-28
+    eoas: true
+    eol: true
+    eoes: 2025-03-28
 
-    - releaseCycle: "5.1.1-mr1"
-      releaseLabel: "5.1.1 MR1"
-      releaseDate: 2023-05-31
-      eoas: true
-      eol: true
-      eoes: 2025-09-08
+  - releaseCycle: "5.1.1-mr1"
+    releaseLabel: "5.1.1 MR1"
+    releaseDate: 2023-05-31
+    eoas: true
+    eol: true
+    eoes: 2025-09-08
 
-    - releaseCycle: "5.0.0.1-mr3"
-      releaseLabel: "5.0.0.1 MR3"
-      releaseDate: 2023-03-07
-      eoas: true
-      eol: true
-      eoes: 2025-03-28
+  - releaseCycle: "5.0.0.1-mr3"
+    releaseLabel: "5.0.0.1 MR3"
+    releaseDate: 2023-03-07
+    eoas: true
+    eol: true
+    eoes: 2025-03-28
 
-    - releaseCycle: "4.1.0.1-mr5"
-      releaseLabel: "4.1.0.1 MR5"
-      releaseDate: 2023-02-14
-      eoas: 2024-06-07
-      eol: 2026-06-07
-      eoes: 2027-06-07
+  - releaseCycle: "4.1.0.1-mr5"
+    releaseLabel: "4.1.0.1 MR5"
+    releaseDate: 2023-02-14
+    eoas: 2024-06-07
+    eol: 2026-06-07
+    eoes: 2027-06-07
 
-    - releaseCycle: "5.1.1"
-      releaseDate: 2023-02-08
-      eoas: true
-      eol: true
-      eoes: 2025-09-08
+  - releaseCycle: "5.1.1"
+    releaseDate: 2023-02-08
+    eoas: true
+    eol: true
+    eoes: 2025-09-08
 
-    - releaseCycle: "5.0.0.1-mr2"
-      releaseLabel: "5.0.0.1 MR2"
-      releaseDate: 2022-11-24
-      eoas: true
-      eol: true
-      eoes: 2025-03-28
+  - releaseCycle: "5.0.0.1-mr2"
+    releaseLabel: "5.0.0.1 MR2"
+    releaseDate: 2022-11-24
+    eoas: true
+    eol: true
+    eoes: 2025-03-28
 
-    - releaseCycle: "4.1.0.1-mr4"
-      releaseLabel: "4.1.0.1 MR4"
-      releaseDate: 2022-10-28
-      eoas: true
-      eol: true
-      eoes: 2024-06-07  
+  - releaseCycle: "4.1.0.1-mr4"
+    releaseLabel: "4.1.0.1 MR4"
+    releaseDate: 2022-10-28
+    eoas: true
+    eol: true
+    eoes: 2024-06-07
 
-    - releaseCycle: "5.0.0.1-mr1"
-      releaseLabel: "5.0.0.1 MR1"
-      releaseDate: 2022-08-17
-      eoas: true
-      eol: true
-      eoes: 2025-03-28
+  - releaseCycle: "5.0.0.1-mr1"
+    releaseLabel: "5.0.0.1 MR1"
+    releaseDate: 2022-08-17
+    eoas: true
+    eol: true
+    eoes: 2025-03-28
 
-    - releaseCycle: "4.1.0.1-mr3"
-      releaseLabel: "4.1.0.1 MR3"
-      releaseDate: 2022-08-08
-      eoas: true
-      eol: true
-      eoes: 2024-06-07  
+  - releaseCycle: "4.1.0.1-mr3"
+    releaseLabel: "4.1.0.1 MR3"
+    releaseDate: 2022-08-08
+    eoas: true
+    eol: true
+    eoes: 2024-06-07
 
-    - releaseCycle: "4.0.0.1-mr4"
-      releaseLabel: "4.0.0.1 MR4"
-      releaseDate: 2022-06-13
-      eoas: 2024-01-01
-      eol: 2026-01-01
-      eoes: 2027-01-01 
+  - releaseCycle: "4.0.0.1-mr4"
+    releaseLabel: "4.0.0.1 MR4"
+    releaseDate: 2022-06-13
+    eoas: 2024-01-01
+    eol: 2026-01-01
+    eoes: 2027-01-01
 
-    - releaseCycle: "5.0"
-      releaseDate: 2022-04-25
-      eoas: true
-      eol: true
-      eoes: 2025-03-28
+  - releaseCycle: "5.0"
+    releaseDate: 2022-04-25
+    eoas: true
+    eol: true
+    eoes: 2025-03-28
 
-    - releaseCycle: "4.1.0.1-mr2"
-      releaseLabel: "4.1.0.1 MR2"
-      releaseDate: 2022-02-28
-      eoas: true
-      eol: true
-      eoes: 2024-06-07  
+  - releaseCycle: "4.1.0.1-mr2"
+    releaseLabel: "4.1.0.1 MR2"
+    releaseDate: 2022-02-28
+    eoas: true
+    eol: true
+    eoes: 2024-06-07
 
-    - releaseCycle: "4.0.0.1-mr3"
-      releaseLabel: "4.0.0.1 MR3"
-      releaseDate: 2022-01-19
-      eoas: true
-      eol: true
-      eoes: 2024-01-01 
+  - releaseCycle: "4.0.0.1-mr3"
+    releaseLabel: "4.0.0.1 MR3"
+    releaseDate: 2022-01-19
+    eoas: true
+    eol: true
+    eoes: 2024-01-01
 
-    - releaseCycle: "3.3.0.2-mr2"
-      releaseLabel: "3.3.0.2 MR2"
-      releaseDate: 2021-11-12
-      eoas: 2024-07-29
-      eol: 2026-07-29
-      eoes: 2026-07-29 
+  - releaseCycle: "3.3.0.2-mr2"
+    releaseLabel: "3.3.0.2 MR2"
+    releaseDate: 2021-11-12
+    eoas: 2024-07-29
+    eol: 2026-07-29
+    eoes: 2026-07-29
 
-    - releaseCycle: "4.1.0.1-mr1"
-      releaseLabel: "4.1.0.1 MR1"
-      releaseDate: 2021-10-18
-      eoas: true
-      eol: true
-      eoes: 2024-06-07 
+  - releaseCycle: "4.1.0.1-mr1"
+    releaseLabel: "4.1.0.1 MR1"
+    releaseDate: 2021-10-18
+    eoas: true
+    eol: true
+    eoes: 2024-06-07
 
-    - releaseCycle: "4.0.0.1-mr2"
-      releaseLabel: "4.0.0.1 MR2"
-      releaseDate: 2021-09-17
-      eoas: true
-      eol: true
-      eoes: 2024-01-01 
+  - releaseCycle: "4.0.0.1-mr2"
+    releaseLabel: "4.0.0.1 MR2"
+    releaseDate: 2021-09-17
+    eoas: true
+    eol: true
+    eoes: 2024-01-01
 
-    - releaseCycle: "3.3.0.2-mr1"
-      releaseLabel: "3.3.0.2 MR1"
-      releaseDate: 2021-09-03
-      eoas: true
-      eol: true
-      eoes: 2024-07-29 
+  - releaseCycle: "3.3.0.2-mr1"
+    releaseLabel: "3.3.0.2 MR1"
+    releaseDate: 2021-09-03
+    eoas: true
+    eol: true
+    eoes: 2024-07-29
 
-    - releaseCycle: "4.1"
-      releaseDate: 2021-07-19
-      eoas: true
-      eol: true
-      eoes: 2024-06-07  
+  - releaseCycle: "4.1"
+    releaseDate: 2021-07-19
+    eoas: true
+    eol: true
+    eoes: 2024-06-07
 
-    - releaseCycle: "3.3.0.1-mr3"
-      releaseLabel: "3.3.0.1 MR3"
-      releaseDate: 2021-07-02
-      eoas: true
-      eol: true
-      eoes: 2024-07-29 
+  - releaseCycle: "3.3.0.1-mr3"
+    releaseLabel: "3.3.0.1 MR3"
+    releaseDate: 2021-07-02
+    eoas: true
+    eol: true
+    eoes: 2024-07-29
 
-    - releaseCycle: "4.0.0.1-mr1"
-      releaseLabel: "4.0.0.1 MR1"
-      releaseDate: 2021-06-15
-      eoas: true
-      eol: true
-      eoes: 2024-01-01
+  - releaseCycle: "4.0.0.1-mr1"
+    releaseLabel: "4.0.0.1 MR1"
+    releaseDate: 2021-06-15
+    eoas: true
+    eol: true
+    eoes: 2024-01-01
 
-    - releaseCycle: "3.3.0.1-mr2"
-      releaseLabel: "3.3.0.1 MR2"
-      releaseDate: 2021-04-02
-      eoas: true
-      eol: true
-      eoes: 2024-07-29 
+  - releaseCycle: "3.3.0.1-mr2"
+    releaseLabel: "3.3.0.1 MR2"
+    releaseDate: 2021-04-02
+    eoas: true
+    eol: true
+    eoes: 2024-07-29
 
-    - releaseCycle: "4.0"
-      releaseDate: 2021-03-01
-      eoas: true
-      eol: true
-      eoes: 2024-01-01 
+  - releaseCycle: "4.0"
+    releaseDate: 2021-03-01
+    eoas: true
+    eol: true
+    eoes: 2024-01-01
 
-    - releaseCycle: "3.3.0.1"
-      releaseDate: 2020-10-05
-      eoas: true
-      eol: true
-      eoes: 2024-07-29 
+  - releaseCycle: "3.3.0.1"
+    releaseDate: 2020-10-05
+    eoas: true
+    eol: true
+    eoes: 2024-07-29
 
-    - releaseCycle: "3.2"
-      releaseDate: 2019-11-04
-      eoas: 2023-06-28
-      eol: 2025-06-28
-      eoes: 2026-06-28
+  - releaseCycle: "3.2"
+    releaseDate: 2019-11-04
+    eoas: 2023-06-28
+    eol: 2025-06-28
+    eoes: 2026-06-28
 
-    - releaseCycle: "3.1.2"
-      releaseDate: 2018-09-21
-      eoas: 2022-06-28
-      eol: 2024-06-28
-      eoes: 2025-06-28
+  - releaseCycle: "3.1.2"
+    releaseDate: 2018-09-21
+    eoas: 2022-06-28
+    eol: 2024-06-28
+    eoes: 2025-06-28
 
-    - releaseCycle: "3.1.1"
-      releaseDate: 2018-02-22
-      eoas: 2022-06-28
-      eol: true
-      eoes: 2023-06-28
+  - releaseCycle: "3.1.1"
+    releaseDate: 2018-02-22
+    eoas: 2022-06-28
+    eol: true
+    eoes: 2023-06-28
 
-    - releaseCycle: "3.1"
-      releaseDate: 2017-09-26
-      eoas: 2022-06-28
-      eol: true
-      eoes: 2023-06-28
+  - releaseCycle: "3.1"
+    releaseDate: 2017-09-26
+    eoas: 2022-06-28
+    eol: true
+    eoes: 2023-06-28
 
-    - releaseCycle: "3.0"
-      releaseDate: 2016-12-04
-      eoas: 2020-10-01
-      eol: 2022-03-26
-      eoes: 2024-03-26
+  - releaseCycle: "3.0"
+    releaseDate: 2016-12-04
+    eoas: 2020-10-01
+    eol: 2022-03-26
+    eoes: 2024-03-26
 
-    - releaseCycle: "2.7.3"
-      releaseDate: 2016-06-05
-      eoas: 2020-10-01
-      eol: 2021-05-06
-      eoes: 2022-01-31
+  - releaseCycle: "2.7.3"
+    releaseDate: 2016-06-05
+    eoas: 2020-10-01
+    eol: 2021-05-06
+    eoes: 2022-01-31
 
-    - releaseCycle: "2.7.2"
-      releaseDate: 2016-02-01
-      eoas: 2020-10-01
-      eol: 2021-05-06
-      eoes: 2022-01-31
+  - releaseCycle: "2.7.2"
+    releaseDate: 2016-02-01
+    eoas: 2020-10-01
+    eol: 2021-05-06
+    eoes: 2022-01-31
 
-    - releaseCycle: "2.7.1"
-      releaseDate: 2015-12-06
-      eoas: 2020-10-01
-      eol: 2021-05-06
-      eoes: 2022-01-31
-
+  - releaseCycle: "2.7.1"
+    releaseDate: 2015-12-06
+    eoas: 2020-10-01
+    eol: 2021-05-06
+    eoes: 2022-01-31
 ---
 
 > [Veritas NetBackup](https://www.veritas.com/protection/netbackup) is an enterprise-level data protection and backup solution
 
-Veritas offers full support from general availability for 3 to 4 years. At the end of full/active, support, extended support is available for 1-2 years with no new bug fixes, but access to existing patches and technical help. The final sustaining phase before EOSL lasts for 1 to 6 years with focus on severe service restoration or data retrieval issues.
+Veritas offers full support from general availability for 3 to 4 years.
+At the end of full/active support, extended support is available for 1-2 years with no new bug fixes, but access to existing patches and technical help.
+The final sustaining phase before EOSL lasts for 1 to 6 years with focus on severe service restoration or data retrieval issues.


### PR DESCRIPTION
This is a start to addressing #4215. It does not close that issue but this is the first pull request of the OS of the Netbackup appliances.  Separate pages may be needed for the Netbackup appliance hardware and software.

Information pulled from: https://www.veritas.com/support/en_US/eosl (under Appliances --> NetBackup). While the website uses start dates for extended support/sustaining support, I have treated these as the same as end of active support/extended support respectively (rather than maybe referring to the previous day).

I imagine new release data could potentially be automated by a custom python script. 
