### PR TITLE
[mysql] Remove broken links for 5.5 and 5.6

### DIFF
--- a/products/mysql.md
+++ b/products/mysql.md
@@ -113,7 +113,7 @@ releases:
     eol: 2021-02-28
     latest: '5.6.51'
     latestReleaseDate: 2021-01-05
-    link: null
+    link: https://web.archive.org/web/20211229071247/https://dev.mysql.com/doc/relnotes/mysql/5.6/en/news-5-6-51.html
 
 -   releaseCycle: "5.5"
     releaseDate: 2010-12-03

--- a/products/mysql.md
+++ b/products/mysql.md
@@ -113,6 +113,7 @@ releases:
     eol: 2021-02-28
     latest: '5.6.51'
     latestReleaseDate: 2021-01-05
+    link: null
 
 -   releaseCycle: "5.5"
     releaseDate: 2010-12-03
@@ -120,6 +121,7 @@ releases:
     eol: 2018-12-31
     latest: '5.5.63'
     latestReleaseDate: 2018-12-21
+    link: null
 
 ---
 


### PR DESCRIPTION
Those were removed from https://dev.mysql.com ( Even doesnt exist on webarchive's history )