### PR TITLE
[rocky-linux] Revert 9 to 9.5

### DIFF
--- a/products/rocky-linux.md
+++ b/products/rocky-linux.md
@@ -36,8 +36,8 @@ releases:
     releaseDate: 2022-07-14
     eoas: 2027-05-31
     eol: 2032-05-31
-    latest: "9.6"
-    latestReleaseDate: 2025-06-02
+    latest: "9.5"
+    latestReleaseDate: 2024-11-19
 
 -   releaseCycle: "8"
     releaseDate: 2021-05-01


### PR DESCRIPTION
9.6 is not published yet, but was caught by the automation because it tracked the development branch. This has been fixed in https://github.com/endoflife-date/release-data/commit/d3adaa2b774ea1e7acbedda30531acb0a6ce96f4.

Closes #7609.