### PR TITLE
[zabbix] Update automation configuration

### DIFF
--- a/products/zabbix.md
+++ b/products/zabbix.md
@@ -19,20 +19,8 @@ identifiers:
 auto:
   methods:
   -   git: https://github.com/zabbix/zabbix.git
-  -   release_table: https://www.zabbix.com/life_cycle_and_release_policy
-      selector: "table"
-      header_selector: "tr:nth-of-type(1)"
-      fields:
-        releaseCycle:
-          column: "Release name"
-          regex: '^Zabbix (?P<value>\d+\.\d+).*$'
-        releaseDate: "Release date"
-        eoas: "End of Full Support*"
-        eol: "End of Limited Support**"
 
-# For non-LTS releases :
-# - eoas(x) = release(x) + 6 months
-# - eol(x) = release(x) + 7 months
+# See https://www.zabbix.com/life_cycle_and_release_policy for EOAS/EOL dates.
 releases:
 -   releaseCycle: "7.2"
     releaseDate: 2024-12-10


### PR DESCRIPTION
Remove the automation based on https://www.zabbix.com/life_cycle_and_release_policy. The page was updated not long ago and EOAS/EOL information cannot be parsed easily anymore (see https://github.com/endoflife-date/release-data/actions/runs/15308039654).