### PR TITLE
[grafana-loki] Remove chainguard 's dockerhub purl

### DIFF
--- a/products/grafana-loki.md
+++ b/products/grafana-loki.md
@@ -16,7 +16,6 @@ identifiers:
 -   purl: pkg:github/grafana/loki
 -   purl: pkg:docker/grafana/loki
 -   purl: pkg:docker/ubuntu/loki
--   purl: pkg:docker/chainguard/loki
 -   purl: pkg:docker/bitnami/grafana-loki
 -   purl: pkg:oci/loki?repository_url=cgr.dev/chainguard
 


### PR DESCRIPTION
chainguard removed images for loki at dockerhub so removing this purl