### PR TITLE
Disable winget purls to url until winget.run up again

### DIFF
--- a/_plugins/identifier-to-url.rb
+++ b/_plugins/identifier-to-url.rb
@@ -132,7 +132,8 @@ class IdentifierToUrl
   end
 
   def _build_winget_url(purl)
-    return "https://winget.run/pkg/#{purl.name}"
+    # return "https://winget.run/pkg/#{purl.name}"
+    return nil # keep this as nil until winget.run webserver is up again.
   end
 
   def _build_maven_url(purl)


### PR DESCRIPTION
https://winget.run/ is down and until they fix it we need to disable our purl's url to null otherwise we will hit lots of 404