### PR TITLE
[eurolinux] remove links because of project itself became eoled

### DIFF
--- a/products/eurolinux.md
+++ b/products/eurolinux.md
@@ -4,7 +4,7 @@ category: os
 tags: linux-distribution
 permalink: /eurolinux
 versionCommand: cat /etc/os-release
-releasePolicyLink: https://euro-linux.com/en/about-us/
+releasePolicyLink: https://web.archive.org/web/20240916162852/https://euro-linux.com/en/software/eurolinux/specification/
 eoasColumn: true
 
 identifiers:

--- a/products/eurolinux.md
+++ b/products/eurolinux.md
@@ -4,8 +4,8 @@ category: os
 tags: linux-distribution
 permalink: /eurolinux
 versionCommand: cat /etc/os-release
-releasePolicyLink: https://euro-linux.com/en/software/eurolinux/specification/
-changelogTemplate: https://euro-linux.com/en/software/eurolinux/specification/
+releasePolicyLink: https://euro-linux.com/en/about-us/
+changelogTemplate: null
 eoasColumn: true
 
 identifiers:

--- a/products/eurolinux.md
+++ b/products/eurolinux.md
@@ -5,7 +5,6 @@ tags: linux-distribution
 permalink: /eurolinux
 versionCommand: cat /etc/os-release
 releasePolicyLink: https://euro-linux.com/en/about-us/
-changelogTemplate: null
 eoasColumn: true
 
 identifiers:


### PR DESCRIPTION
The EuroLinux distribution reached End-Of-Life in October 2024