### PR TITLE
Schedule dependabot using a cron expression

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,7 +9,8 @@ updates:
   - package-ecosystem: "gitsubmodule"
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "cron"
+      cronjob: "0 0 * * *" # every day at midnight UTC
 
   - package-ecosystem: "bundler"
     vendor: true


### PR DESCRIPTION
Up to now dependabot was triggered once a day, but only on week-days (see https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference#interval). This was not the best for endoflife.date as there are updates on weekends too. Now that schedule.interval support cron expressions, we can use it to update the site even on weekends.

I choose to run this update every day at midnight UTC, which roughly correspond to the end of the working day in US (California).

Closes #7261.