### PR TITLE
Align custom and generic auto scripts configuration

### DIFF
--- a/products/amazon-eks.md
+++ b/products/amazon-eks.md
@@ -15,7 +15,9 @@ eoesColumn: true
 
 auto:
   methods:
-  -   custom: amazon-eks
+  -   amazon-eks: https://web.archive.org/web/20221007150452/https://docs.aws.amazon.com/eks/latest/userguide/platform-versions.html # 1.19
+  -   amazon-eks: https://web.archive.org/web/20230521061347/https://docs.aws.amazon.com/eks/latest/userguide/platform-versions.html # 1.20
+  -   amazon-eks: https://docs.aws.amazon.com/eks/latest/userguide/platform-versions.html
   -   release_table: https://docs.aws.amazon.com/eks/latest/userguide/kubernetes-versions.html
       selector: "table"
       fields:

--- a/products/amazon-neptune.md
+++ b/products/amazon-neptune.md
@@ -21,7 +21,9 @@ customFields:
 
 auto:
   methods:
-  -   custom: amazon-neptune
+  -   amazon-neptune: https://docs.aws.amazon.com/neptune/latest/userguide/rssupdates.rss
+      regex: '^Engine version (?P<version>[0-9R.]+)$'
+      template: "{{version}}"
   -   release_table: https://docs.aws.amazon.com/neptune/latest/userguide/engine-releases.html
       selector: "table"
       fields:

--- a/products/amazon-rds-mariadb.md
+++ b/products/amazon-rds-mariadb.md
@@ -8,7 +8,9 @@ releasePolicyLink: https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/MariaD
 
 auto:
   methods:
-  -   custom: rds
+  -   rds: https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/MariaDB.Concepts.VersionMgmt.html
+      regex: '(?P<version>\d+(\.\d+)*)'
+      template: "{{version}}"
   -   release_table: https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/MariaDB.Concepts.VersionMgmt.html
       selector: "#rds-mariadb-version-release-calendar table"
       fields:

--- a/products/amazon-rds-mysql.md
+++ b/products/amazon-rds-mysql.md
@@ -9,7 +9,9 @@ eoesColumn: Extended Support
 
 auto:
   methods:
-  -   custom: rds
+  -   rds: https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/MySQL.Concepts.VersionMgmt.html
+      regex: '(?P<version>\d+(\.\d+)*)'
+      template: "{{version}}"
   -   release_table: https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/MySQL.Concepts.VersionMgmt.html
       selector: "#rds-mysql-version-release-calendar table"
       fields:

--- a/products/amazon-rds-postgresql.md
+++ b/products/amazon-rds-postgresql.md
@@ -9,7 +9,9 @@ eoesColumn: Extended Support
 
 auto:
   methods:
-  -   custom: rds
+  -   rds: https://docs.aws.amazon.com/AmazonRDS/latest/PostgreSQLReleaseNotes/postgresql-release-calendar.html
+      regex: '(?P<version>\d+(\.\d+)*)'
+      template: "{{version}}"
   -   release_table: https://docs.aws.amazon.com/AmazonRDS/latest/PostgreSQLReleaseNotes/postgresql-release-calendar.html
       selector: "table"
       fields:

--- a/products/apache-http-server.md
+++ b/products/apache-http-server.md
@@ -21,7 +21,14 @@ identifiers:
 
 auto:
   methods:
-  -   custom: apache-http-server
+  -   apache-http-server: https://github.com/apache/httpd.git
+      regex:
+      # for most versions
+      - '\s+(?P<version>\d+\.\d+\.\d+)\s*:.*(?:Released|Announced|Released and Retired)\s(?:on\s)?(?P<date>\w+\s\d\d?,\s\d{4})'
+      # for older 2.0.x versions (only GA versions are considered)
+      - '\s+(?P<version>\d+\.\d+\.\d+)\s*:.*released\s(?P<date>\w+\s\d\d?,\s\d{4}) as GA'
+      # for older 1.3.x versions, we take the date of the tag and not the date of the release (too difficult to parse)
+      - '\s+(?P<version>\d+\.\d+\.\d+)\s*:.*Tagged and [rR]olled\s(?:on\s)?(?P<date>\w+\.?\s\d\d?,\s\d{4})'
 
 releases:
 -   releaseCycle: "2.4"

--- a/products/apache-subversion.md
+++ b/products/apache-subversion.md
@@ -15,7 +15,8 @@ identifiers:
 
 auto:
   methods:
-  -   custom: apache-subversion
+  -   apache-subversion: https://subversion.apache.org/docs/release-notes/release-history.html
+      regex: '^Subversion\s(?P<version>[1-9]\d*.\d+\.\d+)\s*\((?P<date>\w+, \d+ \w+ \d{4}).*$'
 
 # Cycles documented in https://subversion.apache.org/docs/release-notes
 # EOL documented on https://subversion.apache.org/roadmap.html

--- a/products/artifactory.md
+++ b/products/artifactory.md
@@ -14,7 +14,7 @@ identifiers:
 
 auto:
   methods:
-  -   custom: artifactory
+  -   artifactory: https://jfrog.com/help/r/jfrog-release-information/artifactory-end-of-life
 
 # EOL documented on https://jfrog.com/help/r/jfrog-release-information/artifactory-end-of-life.
 releases:

--- a/products/aws-lambda.md
+++ b/products/aws-lambda.md
@@ -11,7 +11,7 @@ eolColumn: Deprecated Support
 
 auto:
   methods:
-  -   custom: aws-lambda
+  -   aws-lambda: https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html
 
 # The custom script will only detect new releases and update support and eol dates based on dates found on https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html.
 # The release dates must be retrieved from announcement blog posts on https://aws.amazon.com/blogs/compute/category/compute/aws-lambda/.

--- a/products/bamboo.md
+++ b/products/bamboo.md
@@ -17,7 +17,9 @@ identifiers:
 auto:
   methods:
   -   atlassian_versions: https://www.atlassian.com/software/bamboo/download-archives
-  -   atlassian_eol: AtlassianEndofSupportPolicy-Bamboo
+  -   atlassian_eol: https://confluence.atlassian.com/support/atlassian-support-end-of-life-policy-201851003.html
+      selector: AtlassianEndofSupportPolicy-Bamboo
+      regex: '(?P<release>\d+(\.\d+)+) \(EO[SL] date: (?P<date>.+)\).*$'
 
 # Release dates from https://www.atlassian.com/software/bamboo/download-archives.
 # LTS/EOL dates can be found on https://confluence.atlassian.com/support/atlassian-support-end-of-life-policy-201851003.html

--- a/products/bitbucket.md
+++ b/products/bitbucket.md
@@ -17,7 +17,9 @@ identifiers:
 auto:
   methods:
   -   atlassian_versions: https://www.atlassian.com/software/bitbucket/download-archives
-  -   atlassian_eol: AtlassianEndofSupportPolicy-Bitbucket
+  -   atlassian_eol: https://confluence.atlassian.com/support/atlassian-support-end-of-life-policy-201851003.html
+      selector: AtlassianEndofSupportPolicy-Bitbucket
+      regex: '(?P<release>\d+(\.\d+)+) \(EO[SL] date: (?P<date>.+)\).*$'
 
 # Release dates from https://www.atlassian.com/software/bitbucket/download-archives.
 # LTS/EOL dates can be found on https://confluence.atlassian.com/support/atlassian-support-end-of-life-policy-201851003.html

--- a/products/chef-infra-client.md
+++ b/products/chef-infra-client.md
@@ -18,7 +18,8 @@ identifiers:
 
 auto:
   methods:
-  -   custom: chef-infra-client
+  -   chef-infra: https://docs.chef.io/release_notes_client/
+      repository: https://github.com/chef/chef.git
 
 # eol(x) = releaseDate(x+2) > confirm EOL date here https://docs.chef.io/versions/
 # eoas(x) = releaseDate(x+1)

--- a/products/chef-infra-server.md
+++ b/products/chef-infra-server.md
@@ -17,7 +17,8 @@ identifiers:
 
 auto:
   methods:
-  -   custom: chef-infra-server
+  -   chef-infra: https://docs.chef.io/release_notes_server/
+      repository: https://github.com/chef/chef-server.git
 
 # eoas(x) = releaseDate(x+1)
 # eol(x) = releaseDate(x+2) or the date documented on https://docs.chef.io/versions/

--- a/products/chef-inspec.md
+++ b/products/chef-inspec.md
@@ -15,7 +15,7 @@ identifiers:
 
 auto:
   methods:
-  -   custom: chef-inspec
+  -   chef-inspec: https://docs.chef.io/release_notes_inspec/
 
 # eoas(x) = releaseDate(x+1)
 # eol(x) = releaseDate(x+2) or the date documented on https://docs.chef.io/versions/

--- a/products/coldfusion.md
+++ b/products/coldfusion.md
@@ -13,11 +13,15 @@ identifiers:
 -   cpe: cpe:2.3:a:adobe:coldfusion
 -   cpe: cpe:/a:adobe:coldfusion
 
-# Anti-scraping measures have been taken, so the script does not work anymore.
-# It has been disabled for now as it significantly increases the Update data job duration.
-#Auto:
+# Disabled, as the Adobe ColdFusion website is now protected by anti-bot measures.
+#auto:
 #  methods:
-#  -   custom: coldfusion
+#  -   coldfusion: https://helpx.adobe.com/coldfusion/kb/coldfusion-10-updates.html
+#  -   coldfusion: https://helpx.adobe.com/coldfusion/kb/coldfusion-11-updates.html
+#  -   coldfusion: https://helpx.adobe.com/coldfusion/kb/coldfusion-2016-updates.html
+#  -   coldfusion: https://helpx.adobe.com/coldfusion/kb/coldfusion-2018-updates.html
+#  -   coldfusion: https://helpx.adobe.com/coldfusion/kb/coldfusion-2021-updates.html
+#  -   coldfusion: https://helpx.adobe.com/coldfusion/kb/coldfusion-2023-updates.html
 
 # When adding a cycle, remember to add its release note URL in
 # https://github.com/endoflife-date/release-data/blob/main/src/coldfusion.py

--- a/products/confluence.md
+++ b/products/confluence.md
@@ -18,7 +18,9 @@ identifiers:
 auto:
   methods:
   -   atlassian_versions: https://www.atlassian.com/software/confluence/download-archives
-  -   atlassian_eol: AtlassianEndofSupportPolicy-Confluence
+  -   atlassian_eol: https://confluence.atlassian.com/support/atlassian-support-end-of-life-policy-201851003.html
+      selector: AtlassianEndofSupportPolicy-Confluence
+      regex: '(?P<release>\d+(\.\d+)+) \(EO[SL] date: (?P<date>.+)\).*$'
 
 # Release dates from https://www.atlassian.com/software/confluence/download-archives.
 # LTS/EOL dates can be found on https://confluence.atlassian.com/support/atlassian-support-end-of-life-policy-201851003.html.

--- a/products/cos.md
+++ b/products/cos.md
@@ -19,7 +19,7 @@ identifiers:
 
 auto:
   methods:
-  -   custom: cos
+  -   cos: https://cloud.google.com/container-optimized-os/docs/release-notes/
 
 # For EOL dates, see https://cloud.google.com/container-optimized-os/docs/release-notes#lts_image_families.
 releases:

--- a/products/couchbase-server.md
+++ b/products/couchbase-server.md
@@ -19,7 +19,8 @@ identifiers:
 
 auto:
   methods:
-  -   custom: couchbase-server
+  -   couchbase-server: https://docs.couchbase.com/server
+      regex: '^Release (?P<version>\d+\.\d+(\.\d+)?) \((?P<date>.+)\)$'
   -   release_table: https://www.couchbase.com/support-policy/EOL/
       selector: "table"
       fields:

--- a/products/debian.md
+++ b/products/debian.md
@@ -16,7 +16,7 @@ identifiers:
 
 auto:
   methods:
-  -   custom: debian
+  -   debian: https://salsa.debian.org/webmaster-team/webwml.git
   -   release_table: https://wiki.debian.org/DebianReleases
       ignore_empty_releases: true # so that future releases are ignored
       selector: "table"

--- a/products/firefox.md
+++ b/products/firefox.md
@@ -20,7 +20,7 @@ auto:
   # See https://github.com/endoflife-date/release-data/blob/main/src/firefox.py for details
   cumulative: true
   methods:
-  -   custom: firefox
+  -   firefox: https://www.mozilla.org/en-US/firefox/releases/
 
 # For non-LTS versions, eol(x) = releaseDate(x+1)
 # For LTS version, eol(x) = releaseDate of the next major after the corresponding version last minor LTS on https://whattrainisitnow.com/calendar/, if available.

--- a/products/ghc.md
+++ b/products/ghc.md
@@ -21,7 +21,7 @@ auto:
   -   git: https://gitlab.haskell.org/ghc/ghc.git
       regex: ^ghc-(?P<major>\d+)[.](?P<minor>\d+)[.](?P<patch>\d+)-release$
       template: '{{major}}.{{minor}}.{{patch}}'
-  -   custom: ghc-wiki
+  -   ghc-wiki: https://gitlab.haskell.org/api/v4/projects/1/wikis/GHC-Status
 
 releases:
 -   releaseCycle: "9.12"

--- a/products/google-kubernetes-engine.md
+++ b/products/google-kubernetes-engine.md
@@ -14,7 +14,7 @@ eolColumn: Maintenance Support
 
 auto:
   methods:
-  -   custom: google-kubernetes-engine
+  -   google-kubernetes-engine: https://cloud.google.com/kubernetes-engine/docs/release-notes-nochannel
 
 # eol: As per https://cloud.google.com/kubernetes-engine/docs/release-schedule
 # eoas:last-date-in-month(eol - 2months)

--- a/products/haproxy.md
+++ b/products/haproxy.md
@@ -9,7 +9,7 @@ changelogTemplate: https://www.haproxy.org/download/__RELEASE_CYCLE__/src/CHANGE
 
 auto:
   methods:
-  -   custom: haproxy
+  -   haproxy: https://www.haproxy.org/download/
 
 identifiers:
 -   repology: haproxy

--- a/products/ibm-aix.md
+++ b/products/ibm-aix.md
@@ -18,7 +18,7 @@ identifiers:
 
 auto:
   methods:
-  -   custom: ibm-aix
+  -   ibm-aix: https://www.ibm.com/support/pages/aix-support-lifecycle-information
   -   release_table: https://www.ibm.com/support/pages/aix-support-lifecycle-information
       selector: "table"
       header_selector: "tbody tr:nth-of-type(1)"

--- a/products/jira-software.md
+++ b/products/jira-software.md
@@ -18,7 +18,9 @@ identifiers:
 auto:
   methods:
   -   atlassian_versions: https://www.atlassian.com/software/jira/download-archives
-  -   atlassian_eol: AtlassianEndofSupportPolicy-JiraSoftware
+  -   atlassian_eol: https://confluence.atlassian.com/support/atlassian-support-end-of-life-policy-201851003.html
+      selector: AtlassianEndofSupportPolicy-JiraSoftware
+      regex: '(?P<release>\d+(\.\d+)+) \(EO[SL] date: (?P<date>.+)\).*$'
 
 # Release dates from https://www.atlassian.com/software/jira/download-archives.
 # LTS/EOL dates can be found on https://confluence.atlassian.com/support/atlassian-support-end-of-life-policy-201851003.html.

--- a/products/kuma.md
+++ b/products/kuma.md
@@ -10,7 +10,7 @@ eolColumn: Support
 auto:
   methods:
   -   git: https://github.com/kumahq/kuma.git
-#  -   custom: kuma # disabled, versions have been messed up in https://github.com/kumahq/kuma/commit/87e225ecb794f7c0d9d5c0bf9a2ef2c33f7acbd0
+  -   kuma: https://raw.githubusercontent.com/kumahq/kuma/master/versions.yml # disabled, versions have been messed up in https://github.com/kumahq/kuma/commit/87e225ecb794f7c0d9d5c0bf9a2ef2c33f7acbd0
 
 # EOL dates can be found on https://github.com/kumahq/kuma/blob/master/versions.yml
 releases:

--- a/products/libreoffice.md
+++ b/products/libreoffice.md
@@ -14,7 +14,9 @@ identifiers:
 
 auto:
   methods:
-  -   custom: libreoffice
+  -   libreoffice: https://downloadarchive.documentfoundation.org/libreoffice/old/
+      regex: '^(?P<version>\d+(\.\d+)*)/$'
+      template: '{{version}}'
 
 releases:
 -   releaseCycle: "25.2"

--- a/products/looker.md
+++ b/products/looker.md
@@ -14,7 +14,9 @@ releaseColumn: false
 # Used only for detecting new minor releases.
 auto:
   methods:
-  -   custom: looker
+  -   looker: https://cloud.google.com/feeds/looker-release-notes.xml
+      regex: 'Looker\s+(?P<version>\d+\.\d+)'
+      template: '{{version}}'
 
 # eol/esr dates on https://cloud.google.com/looker/docs/officially-supported-releases
 releases:

--- a/products/lua.md
+++ b/products/lua.md
@@ -17,7 +17,7 @@ identifiers:
 auto:
   cumulative: true # Only the latest versions are available on https://www.lua.org/versions.html.
   methods:
-  -   custom: lua
+  -   lua: https://www.lua.org/versions.html
 
 # EOL date is the date of the last release of the version.
 # The last releases are documented on https://www.lua.org/versions.html with a sentence similar to

--- a/products/netbsd.md
+++ b/products/netbsd.md
@@ -15,7 +15,7 @@ identifiers:
 
 auto:
   methods:
-  -   custom: netbsd
+  -   netbsd: https://www.netbsd.org/releases/formal.html
 
 # eoas(x) = releaseDate(x+1)
 # For eol see https://www.netbsd.org/releases/formal.html

--- a/products/oracle-jdk.md
+++ b/products/oracle-jdk.md
@@ -20,7 +20,7 @@ identifiers:
 
 auto:
   methods:
-  -   custom: oracle-jdk
+  -   oracle-jdk: https://www.java.com/releases/
   -   release_table: https://www.oracle.com/java/technologies/java-se-support-roadmap.html
       selector: "table"
       header_selector: "thead tr:nth-of-type(2)"

--- a/products/pan-os.md
+++ b/products/pan-os.md
@@ -15,7 +15,7 @@ auto:
   # https://github.com/endoflife-date/release-data/blob/main/src/pan-os.py works great, but the latest.py script does not
   # compute the latest version accurately, and the link is not updated either. So we better disable this for now.
   # See https://github.com/endoflife-date/endoflife.date/issues/5775.
-  #-   custom: pan-os
+  #-   pan-os: https://raw.githubusercontent.com/mrjcap/panos-versions/master/PaloAltoVersions.json
   -   release_table: https://www.paloaltonetworks.com/services/support/end-of-life-announcements/end-of-life-summary
       selector: "table#pan-os-panorama"
       header_selector: "tr:nth-of-type(3)"

--- a/products/php.md
+++ b/products/php.md
@@ -20,7 +20,7 @@ identifiers:
 
 auto:
   methods:
-  -   custom: php
+  -   php: https://www.php.net/releases/index.php?json&max=-1
 
 releases:
 -   releaseCycle: "8.4"

--- a/products/plesk.md
+++ b/products/plesk.md
@@ -12,7 +12,7 @@ eolWarnThreshold: 21
 
 auto:
   methods:
-  -   custom: plesk
+  -   plesk: https://docs.plesk.com/release-notes/obsidian/change-log
 
 # eol(x) = releaseDate(x) + 12 weeks
 releases:

--- a/products/red-hat-jboss-eap.md
+++ b/products/red-hat-jboss-eap.md
@@ -17,8 +17,8 @@ eoesColumn: Extended Life Support 1
 
 auto:
   methods:
-  -   custom: red-hat-jboss-eap-7
-  -   custom: red-hat-jboss-eap-8
+  -   red-hat-jboss-eap-7: https://access.redhat.com/articles/2332721
+  -   red-hat-jboss-eap-8: https://maven.repository.redhat.com/ga/org/jboss/eap/channels/eap-8.0/maven-metadata.xml
   -   redhat_lifecycles: Red Hat JBoss Enterprise Application Platform
       regex: '^(?P<major>\d+)(\.(?P<minor>\d+))?(\.x)?$'
       fields:

--- a/products/red-hat-openshift.md
+++ b/products/red-hat-openshift.md
@@ -22,7 +22,7 @@ identifiers:
 
 auto:
   methods:
-  -   custom: red-hat-openshift
+  -   red-hat-openshift: https://github.com/openshift/openshift-docs.git
 
 # All dates can be found on https://access.redhat.com/support/policy/updates/openshift#dates
 releases:

--- a/products/red-hat-satellite.md
+++ b/products/red-hat-satellite.md
@@ -22,7 +22,8 @@ eolColumn: Maintenance support
 
 auto:
   methods:
-  -   custom: red-hat-satellite
+  -   red-hat-satellite: https://access.redhat.com/articles/1365633
+      regex: '^Satellite (?P<version>\d+\.\d+\.\d+([.-]\d+)?) ([Uu]pdate|[Rr]elease)$'
 
 releases:
 -   releaseCycle: "6.17"

--- a/products/rhel.md
+++ b/products/rhel.md
@@ -21,6 +21,7 @@ identifiers:
 
 auto:
   methods:
+  #-   rhel: https://access.redhat.com/articles/3078 # Deprecated, use redhat_lifecycles instead
   -   redhat_lifecycles: Red Hat Enterprise Linux
       regex: '^(?P<major>\d+)$'
       fields:

--- a/products/rocky-linux.md
+++ b/products/rocky-linux.md
@@ -20,7 +20,7 @@ identifiers:
 # so we track https://wiki.rockylinux.org/rocky/version/#current-supported-releases
 auto:
   methods:
-  -   custom: rocky-linux
+  -   rocky-linux: https://raw.githubusercontent.com/rocky-linux/wiki.rockylinux.org/main/docs/include/releng/version_table.md
   -   release_table: https://wiki.rockylinux.org/rocky/version/
       selector: "table"
       fields:

--- a/products/ros.md
+++ b/products/ros.md
@@ -10,6 +10,12 @@ releaseLabel: '__CODENAME__'
 releaseColumn: false
 eolColumn: End Of Life
 
+auto:
+  methods:
+  -   ros: https://wiki.ros.org/Distributions
+      regex: '^ROS (?P<name>(\w| )+)'
+      template: "{{name}}"
+
 releases:
 -   releaseCycle: 'noetic'
     codename: 'Noetic Ninjemys'

--- a/products/sles.md
+++ b/products/sles.md
@@ -19,6 +19,10 @@ identifiers:
 -   cpe: cpe:/o:suse:sles
 -   cpe: cpe:2.3:o:suse:sles
 
+auto:
+  methods:
+  -   sles: https://www.suse.com/lifecycle
+
 releases:
 -   releaseCycle: "15.6"
     releaseDate: 2024-06-26

--- a/products/splunk.md
+++ b/products/splunk.md
@@ -7,12 +7,12 @@ versionCommand: splunk --version
 releasePolicyLink: https://www.splunk.com/en_us/legal/splunk-software-support-policy.html
 changelogTemplate: https://docs.splunk.com/Documentation/Splunk/__LATEST__/ReleaseNotes/MeetSplunk
 
-auto:
-  methods:
-  -   custom: splunk
-
 identifiers:
 -   repology: splunk
+
+auto:
+  methods:
+  -   splunk: https://docs.splunk.com/Documentation/Splunk
 
 # EOL dates can be found on https://www.splunk.com/en_us/legal/splunk-software-support-policy.html.
 releases:

--- a/products/typo3.md
+++ b/products/typo3.md
@@ -15,7 +15,7 @@ identifiers:
 
 auto:
   methods:
-  -   custom: typo3
+  -   typo3: https://get.typo3.org/api/v1/release/
 
 releases:
 -   releaseCycle: "13"

--- a/products/unity.md
+++ b/products/unity.md
@@ -11,7 +11,7 @@ changelogTemplate: "https://unity.com/releases/editor/whats-new/{{'__LATEST__'|s
 # Disabled because there are anti-bot protection measures on https://unity.com/.
 #auto:
 #  methods:
-#  -   custom: unity
+#  -   unity: https://unity.com/releases/editor/qa/lts-releases
 
 releases:
 -   releaseCycle: "6.1"

--- a/products/unrealircd.md
+++ b/products/unrealircd.md
@@ -15,7 +15,7 @@ identifiers:
 # https://www.unrealircd.org is now protected by anti-bot measures.
 #auto:
 #  methods:
-#  -   custom: unrealircd
+#  -   unrealircd: https://www.unrealircd.org/docwiki/index.php?title=History_of_UnrealIRCd_releases&action=raw
 #  -   release_table: https://www.unrealircd.org/docs/UnrealIRCd_releases
 #      selector: "table"
 #      header_selector: "tr:nth-of-type(1)"

--- a/products/virtualbox.md
+++ b/products/virtualbox.md
@@ -19,7 +19,8 @@ identifiers:
 
 auto:
   methods:
-  -   custom: virtualbox
+  -   virtualbox: https://www.virtualbox.org/wiki/Download_Old_Builds
+      regex: '^VirtualBox (?P<value>\d+\.\d+)$'
 
 # eol(x) = latestReleaseDate(x)
 # See EOL status on https://www.virtualbox.org/wiki/Download_Old_Builds.

--- a/products/visual-studio.md
+++ b/products/visual-studio.md
@@ -13,7 +13,11 @@ eolColumn: Active Support
 
 auto:
   methods:
-  -   custom: visual-studio
+  # There is no build history for versions 2015 and below.
+  # This is not a big deal because there was no version for those releases in a very long time.
+  -   visual-studio: https://learn.microsoft.com/en-us/visualstudio/releasenotes/vs2017-relnotes-history
+  -   visual-studio: https://learn.microsoft.com/en-us/visualstudio/releases/2019/history
+  -   visual-studio: https://learn.microsoft.com/en-us/visualstudio/releases/2022/release-history
 
 # For non-LTSC, eol(x) = releaseDate(x+1)
 # For LTSC, EOL dates can be found on https://learn.microsoft.com/visualstudio/productinfo/vs-servicing#long-term-servicing-channel-ltsc-support


### PR DESCRIPTION
Update auto configuration following https://github.com/endoflife-date/release-data/pull/445.

Also re-enabled auto-configuration for:

- Kuma: the issues has now been fixed.
- Ros: the product is deprecated, but this is not much and the script already exist,
- SLES: not sure why this was disabled.