### PR TITLE
New Product - Chef Workstation

### DIFF
--- a/products/chef-infra-client.md
+++ b/products/chef-infra-client.md
@@ -2,7 +2,7 @@
 title: Chef Infra Client
 addedAt: 2024-07-19
 category: app
-tags: ruby-runtime
+tags: progress ruby-runtime
 iconSlug: chef
 permalink: /chef-infra-client
 alternate_urls:

--- a/products/chef-infra-server.md
+++ b/products/chef-infra-server.md
@@ -2,7 +2,7 @@
 title: Chef Infra Server
 addedAt: 2024-03-11
 category: server-app
-tags: erlang-runtime ruby-runtime
+tags: erlang-runtime progress ruby-runtime
 iconSlug: chef
 permalink: /chef-infra-server
 alternate_urls:

--- a/products/chef-inspec.md
+++ b/products/chef-inspec.md
@@ -2,7 +2,7 @@
 title: Chef InSpec
 addedAt: 2024-08-14
 category: app
-tags: ruby-runtime
+tags: progress ruby-runtime
 iconSlug: chef
 permalink: /chef-inspec
 versionCommand: inspec version

--- a/products/chef-supermarket.md
+++ b/products/chef-supermarket.md
@@ -2,7 +2,7 @@
 title: Chef Supermarket
 addedAt: 2025-07-14
 category: server-app
-tags: ruby-runtime
+tags: progress ruby-runtime
 iconSlug: chef
 permalink: /chef-supermarket
 versionCommand: supermarket-ctl version

--- a/products/chef-workstation.md
+++ b/products/chef-workstation.md
@@ -1,0 +1,66 @@
+---
+title: Chef Workstation
+category: app
+tags: ruby-runtime
+iconSlug: chef
+permalink: /chef-workstation
+versionCommand: chef --version
+releasePolicyLink: https://docs.chef.io/versions/
+changelogTemplate: "https://docs.chef.io/release_notes_workstation/#__LATEST__"
+eoasColumn: true
+
+identifiers:
+-   repology: chef-workstation
+
+auto:
+  methods:
+  -   chef-workstation: https://docs.chef.io/release_notes_workstation/
+
+releases:
+-   releaseCycle: "2025"
+    releaseDate: 2025-02-05
+    eoas: false
+    eol: false
+    latest: "25.5.1084"
+    latestReleaseDate: 2025-05-27
+
+-   releaseCycle: "2024"
+    releaseDate: 2024-02-20
+    eoas: false
+    eol: false
+    latest: "24.12.1073"
+    latestReleaseDate: 2024-12-18
+
+-   releaseCycle: "2023"
+    releaseDate: 2023-02-09
+    eoas: 2024-12-31
+    eol: 2024-12-31
+    latest: "23.12.1055"
+    latestReleaseDate: 2023-12-07
+
+-   releaseCycle: "2022"
+    releaseDate: 2022-01-10
+    eoas: 2024-12-31
+    eol: 2024-12-31
+    latest: "22.12.1024"
+    latestReleaseDate: 2023-01-08
+
+-   releaseCycle: "2021"
+    releaseDate: 2021-01-05
+    eoas: 2024-12-31
+    eol: 2024-12-31
+    latest: "21.12.720"
+    latestReleaseDate: 2021-12-07
+
+-   releaseCycle: "2020"
+    releaseDate: 2020-06-02
+    eoas: 2024-12-31
+    eol: 2024-12-31
+    latest: "20.8.111"
+    latestReleaseDate: 2020-08-04
+
+---
+
+> [Chef Workstation](https://docs.chef.io/workstation/) gives you everything you need to get started with Chef -
+> ad hoc remote execution, remote scanning, configuration tasks, cookbook creation tools as well as robust
+> dependency and testing software - all in one easy-to-install package.

--- a/products/chef-workstation.md
+++ b/products/chef-workstation.md
@@ -58,6 +58,4 @@ releases:
 ---
 
 > [Chef Workstation](https://docs.chef.io/workstation/) provides a single installation that includes tools for
-> writing, testing, and managing infrastructure code with the Chef Infra suite. It includes utilities for
-> generating and testing cookbooks, managing dependencies, running Chef Infra Client, and applying configuration
-> policies to systems.
+> writing, testing, and managing infrastructure code with the Chef Infra suite.

--- a/products/chef-workstation.md
+++ b/products/chef-workstation.md
@@ -12,10 +12,6 @@ eoasColumn: true
 identifiers:
 -   repology: chef-workstation
 
-auto:
-  methods:
-  -   chef-workstation: https://docs.chef.io/release_notes_workstation/
-
 releases:
 -   releaseCycle: "2025"
     releaseDate: 2025-02-05

--- a/products/chef-workstation.md
+++ b/products/chef-workstation.md
@@ -57,6 +57,7 @@ releases:
 
 ---
 
-> [Chef Workstation](https://docs.chef.io/workstation/) gives you everything you need to get started with Chef -
-> ad hoc remote execution, remote scanning, configuration tasks, cookbook creation tools as well as robust
-> dependency and testing software - all in one easy-to-install package.
+> [Chef Workstation](https://docs.chef.io/workstation/) provides a single installation that includes tools for
+> writing, testing, and managing infrastructure code with the Chef Infra suite. It includes utilities for
+> generating and testing cookbooks, managing dependencies, running Chef Infra Client, and applying configuration
+> policies to systems.

--- a/products/chef-workstation.md
+++ b/products/chef-workstation.md
@@ -1,7 +1,8 @@
 ---
 title: Chef Workstation
+addedAt: 2025-08-09
 category: app
-tags: ruby-runtime
+tags: progress ruby-runtime
 iconSlug: chef
 permalink: /chef-workstation
 versionCommand: chef --version

--- a/products/chef-workstation.md
+++ b/products/chef-workstation.md
@@ -11,48 +11,59 @@ eoasColumn: true
 identifiers:
 -   repology: chef-workstation
 
+auto:
+  methods:
+  -   chef-infra: https://docs.chef.io/release_notes_workstation/
+      repository: https://github.com/chef/chef-workstation.git
+
 releases:
--   releaseCycle: "2025"
-    releaseDate: 2025-02-05
+-   releaseCycle: "25"
+    releaseLabel: "2025"
+    releaseDate: 2025-02-03
     eoas: false
     eol: false
     latest: "25.5.1084"
-    latestReleaseDate: 2025-05-27
+    latestReleaseDate: 2025-05-22
 
--   releaseCycle: "2024"
-    releaseDate: 2024-02-20
+-   releaseCycle: "24"
+    releaseLabel: "2024"
+    releaseDate: 2024-02-07
     eoas: false
     eol: false
     latest: "24.12.1073"
-    latestReleaseDate: 2024-12-18
+    latestReleaseDate: 2024-12-16
 
--   releaseCycle: "2023"
+-   releaseCycle: "23"
+    releaseLabel: "2023"
     releaseDate: 2023-02-09
     eoas: 2024-12-31
     eol: 2024-12-31
     latest: "23.12.1055"
-    latestReleaseDate: 2023-12-07
+    latestReleaseDate: 2023-12-04
 
--   releaseCycle: "2022"
-    releaseDate: 2022-01-10
+-   releaseCycle: "22"
+    releaseLabel: "2021"
+    releaseDate: 2022-01-06
     eoas: 2024-12-31
     eol: 2024-12-31
     latest: "22.12.1024"
-    latestReleaseDate: 2023-01-08
+    latestReleaseDate: 2022-12-20
 
--   releaseCycle: "2021"
+-   releaseCycle: "21"
+    releaseLabel: "2021"
     releaseDate: 2021-01-05
     eoas: 2024-12-31
     eol: 2024-12-31
     latest: "21.12.720"
-    latestReleaseDate: 2021-12-07
+    latestReleaseDate: 2021-12-17
 
--   releaseCycle: "2020"
+-   releaseCycle: "20"
+    releaseLabel: "2020"
     releaseDate: 2020-06-02
     eoas: 2024-12-31
     eol: 2024-12-31
-    latest: "20.8.111"
-    latestReleaseDate: 2020-08-04
+    latest: "20.12.205"
+    latestReleaseDate: 2020-12-14
 
 ---
 

--- a/products/chef-workstation.md
+++ b/products/chef-workstation.md
@@ -5,7 +5,6 @@ tags: ruby-runtime
 iconSlug: chef
 permalink: /chef-workstation
 versionCommand: chef --version
-releasePolicyLink: https://docs.chef.io/versions/
 changelogTemplate: "https://docs.chef.io/release_notes_workstation/#__LATEST__"
 eoasColumn: true
 
@@ -59,3 +58,7 @@ releases:
 
 > [Chef Workstation](https://docs.chef.io/workstation/) provides a single installation that includes tools for
 > writing, testing, and managing infrastructure code with the Chef Infra suite.
+
+Supported releases of Chef Workstation are documented on the [Chef Documentation website](https://docs.chef.io/versions/#supported-commercial-distributions).
+Looking at this document, it seems that Chef Workstation follows an N-1 support strategy,
+with the last two release supported with bug and security fixes.


### PR DESCRIPTION
Add Chef Workstation using release dates from https://discourse.chef.io/ and https://docs.chef.io/release_notes_workstation/

Note: As an ex-PM and engineer on this project I think their stated support structure is a bit of a lie, but it's what they claim. According to their site they fully support both 2024 and 2025, but they only roll forward so any issue in 2024 (CVE or bug) is always going to be met with a support request that you upgrade to the latest. "Technically" 2024.x.x is in active support though so I marked it as such.