### PR TITLE
New Product - Chef Supermarket

### DIFF
--- a/products/chef-supermarket.md
+++ b/products/chef-supermarket.md
@@ -1,0 +1,44 @@
+---
+title: Chef Supermarket
+category: server-app
+tags: ruby-runtime
+iconSlug: chef
+permalink: /chef-supermarket
+versionCommand: supermarket-ctl version
+releasePolicyLink: https://docs.chef.io/versions/
+changelogTemplate: "https://docs.chef.io/release_notes_supermarket/#__LATEST__"
+
+
+# https://docs.chef.io/versions/ only lists 5.x as supported. Historically Chef has had a roll-forward approach
+# to Supermarket so this document marks all previous releases as EOL
+releases:
+-   releaseCycle: "5"
+    releaseDate: 2022-03-03
+    eol: false
+    latest: "5.2.0"
+    latestReleaseDate: 2025-06-02
+
+-   releaseCycle: "4"
+    releaseDate: 2021-09-23
+    eol: true
+    latest: "4.2.89"
+    latestReleaseDate: 2022-01-04
+
+-   releaseCycle: "3"
+    releaseDate: 2017-04-10
+    eol: true
+    latest: "3.4.8"
+    latestReleaseDate: 2021-06-16
+
+-   releaseCycle: "2"
+    releaseDate: 2015-08-17
+    eol: true
+    latest: "2.9.30"
+    latestReleaseDate: 2017-04-04
+
+
+---
+
+> [Chef Workstation](https://docs.chef.io/workstation/) gives you everything you need to get started with Chef -
+> ad hoc remote execution, remote scanning, configuration tasks, cookbook creation tools as well as robust
+> dependency and testing software - all in one easy-to-install package.

--- a/products/chef-supermarket.md
+++ b/products/chef-supermarket.md
@@ -9,10 +9,15 @@ versionCommand: supermarket-ctl version
 releasePolicyLink: https://docs.chef.io/versions/
 changelogTemplate: "https://docs.chef.io/release_notes_supermarket/#__LATEST__"
 
+auto:
+  methods:
+  -   chef-infra: https://docs.chef.io/release_notes_supermarket/
+      repository: https://github.com/chef/supermarket.git
+
 # eol(x) = releaseDate(x+1)
 releases:
 -   releaseCycle: "5"
-    releaseDate: 2022-03-03
+    releaseDate: 2022-02-28
     eol: false
     latest: "5.2.0"
     latestReleaseDate: 2025-06-02
@@ -24,13 +29,13 @@ releases:
     latestReleaseDate: 2022-01-04
 
 -   releaseCycle: "3"
-    releaseDate: 2017-04-10
+    releaseDate: 2017-04-07
     eol: 2021-09-23
     latest: "3.4.8"
-    latestReleaseDate: 2021-06-16
+    latestReleaseDate: 2021-03-05
 
 -   releaseCycle: "2"
-    releaseDate: 2015-08-17
+    releaseDate: 2015-08-13
     eol: 2017-04-10
     latest: "2.9.30"
     latestReleaseDate: 2017-04-04

--- a/products/chef-supermarket.md
+++ b/products/chef-supermarket.md
@@ -8,9 +8,6 @@ versionCommand: supermarket-ctl version
 releasePolicyLink: https://docs.chef.io/versions/
 changelogTemplate: "https://docs.chef.io/release_notes_supermarket/#__LATEST__"
 
-
-# https://docs.chef.io/versions/ only lists 5.x as supported. Historically Chef has had a roll-forward approach
-# to Supermarket so this document marks all previous releases as EOL
 releases:
 -   releaseCycle: "5"
     releaseDate: 2022-03-03
@@ -43,3 +40,8 @@ releases:
 > manage, and share your own cookbooks, tools, and other Chef artifacts internally within your organization.
 > It allows sourcing both internal and community cookbooks during Policyfile and Berkshelf depsolving without
 > reliance on the Public Chef Supermarket site.
+>
+> The [Chef Supported versions](https://docs.chef.io/versions/) page only lists the 5.x release as supported.
+> Chef historically has not supported earlier major versions of Supermarket, opting instead to apply all bug
+> and security fixes to the latest release. While there is no formal end-of-life announcement for older
+> versions, the absence of backported fixes indicates they are no longer supported.

--- a/products/chef-supermarket.md
+++ b/products/chef-supermarket.md
@@ -39,6 +39,7 @@ releases:
 
 ---
 
-> [Chef Workstation](https://docs.chef.io/workstation/) gives you everything you need to get started with Chef -
-> ad hoc remote execution, remote scanning, configuration tasks, cookbook creation tools as well as robust
-> dependency and testing software - all in one easy-to-install package.
+> [Chef Supermarket](https://docs.chef.io/supermarket/) is a self-hosted artifact store that lets you store,
+> manage, and share your own cookbooks, tools, and other Chef artifacts internally within your organization.
+> It allows sourcing both internal and community cookbooks during Policyfile and Berkshelf depsolving without
+> reliance on the Public Chef Supermarket site.

--- a/products/chef-supermarket.md
+++ b/products/chef-supermarket.md
@@ -1,5 +1,6 @@
 ---
 title: Chef Supermarket
+addedAt: 2025-07-14
 category: server-app
 tags: ruby-runtime
 iconSlug: chef
@@ -8,6 +9,7 @@ versionCommand: supermarket-ctl version
 releasePolicyLink: https://docs.chef.io/versions/
 changelogTemplate: "https://docs.chef.io/release_notes_supermarket/#__LATEST__"
 
+# eol(x) = releaseDate(x+1)
 releases:
 -   releaseCycle: "5"
     releaseDate: 2022-03-03
@@ -17,31 +19,30 @@ releases:
 
 -   releaseCycle: "4"
     releaseDate: 2021-09-23
-    eol: true
+    eol: 2022-03-03
     latest: "4.2.89"
     latestReleaseDate: 2022-01-04
 
 -   releaseCycle: "3"
     releaseDate: 2017-04-10
-    eol: true
+    eol: 2021-09-23
     latest: "3.4.8"
     latestReleaseDate: 2021-06-16
 
 -   releaseCycle: "2"
     releaseDate: 2015-08-17
-    eol: true
+    eol: 2017-04-10
     latest: "2.9.30"
     latestReleaseDate: 2017-04-04
-
 
 ---
 
 > [Chef Supermarket](https://docs.chef.io/supermarket/) is a self-hosted artifact store that lets you store,
-> manage, and share your own cookbooks, tools, and other Chef artifacts internally within your organization.
+> manage, and share cookbooks, tools, and other Chef artifacts internally within an organization.
 > It allows sourcing both internal and community cookbooks during Policyfile and Berkshelf depsolving without
 > reliance on the Public Chef Supermarket site.
->
-> The [Chef Supported versions](https://docs.chef.io/versions/) page only lists the 5.x release as supported.
-> Chef historically has not supported earlier major versions of Supermarket, opting instead to apply all bug
-> and security fixes to the latest release. While there is no formal end-of-life announcement for older
-> versions, the absence of backported fixes indicates they are no longer supported.
+
+The [Chef Supported versions page](https://docs.chef.io/versions/) only lists the latest release as supported.
+Chef historically has not supported earlier major versions of Supermarket, opting instead to apply all bug
+and security fixes to the latest release. While there is no formal end-of-life announcement for older
+versions, the absence of backported fixes indicates they are no longer supported.


### PR DESCRIPTION
This one is a bit tricky in Chef-land. Supermarket was always just a SaaS service that they also shipped packages for so users could run it on-prem. The SaaS nature meant it only rolled forward and previous releases were never supported. I've marked the current 5.x as supported, but previous versions aren't technically on their EOL list, but they are very much unsupported.