### PR TITLE
[graalvm-ce] Mark 17 as EOL

### DIFF
--- a/products/graalvm-ce.md
+++ b/products/graalvm-ce.md
@@ -52,7 +52,7 @@ releases:
 
 -   releaseCycle: "17"
     releaseDate: 2023-06-13
-    eol: 2029-09-30 # java 17 is LTS, oracle extended support until September 2029
+    eol: 2023-10-24
     latest: "17.0.9"
     latestReleaseDate: 2023-10-24
 


### PR DESCRIPTION
The comment, _java 17 is LTS, oracle extended support until September 2029_, looks more appropriated to OpenJDK / Oracle JDK. Marking the release EOL as there was no update since 2023.