### PR TITLE
[oracle-graalvm] Fix title

### DIFF
--- a/products/oracle-graalvm.md
+++ b/products/oracle-graalvm.md
@@ -1,5 +1,5 @@
 ---
-title: GraalVM Enterprise
+title: Oracle GraalVM
 category: lang
 tags: java-distribution oracle
 permalink: /oracle-graalvm


### PR DESCRIPTION
GraalVM Enterprise is the previous name of Oracle GraalVM.