### PR TITLE
[liquibase] Update changelogTemplate

### DIFF
--- a/products/liquibase.md
+++ b/products/liquibase.md
@@ -5,7 +5,7 @@ tags: java-runtime
 iconSlug: liquibase
 permalink: /liquibase
 versionCommand: liquibase --version
-changelogTemplate: https://docs.liquibase.com/start/release-notes/liquibase-release-notes/liquibase-__LATEST__.html
+changelogTemplate: https://github.com/liquibase/liquibase/releases/tag/v__LATEST__
 
 identifiers:
 -   repology: liquibase


### PR DESCRIPTION
A few release notes, such as https://docs.liquibase.com/start/release-notes/liquibase-release-notes/liquibase-4.16.1.html or https://docs.liquibase.com/start/release-notes/liquibase-release-notes/liquibase-4.3.5.html, are not available on https://docs.liquibase.com, while they are on GitHub releases.