### PR TITLE
[bigbluebutton] Update EOL date for 2.7 cycle

### DIFF
--- a/products/bigbluebutton.md
+++ b/products/bigbluebutton.md
@@ -22,7 +22,7 @@ releases:
 
 -   releaseCycle: "2.7"
     releaseDate: 2023-09-06
-    eol: false
+    eol: true
     latest: "2.7.16"
     latestReleaseDate: 2024-12-11
 

--- a/products/bigbluebutton.md
+++ b/products/bigbluebutton.md
@@ -22,7 +22,7 @@ releases:
 
 -   releaseCycle: "2.7"
     releaseDate: 2023-09-06
-    eol: true
+    eol: 2025-05-31
     latest: "2.7.16"
     latestReleaseDate: 2024-12-11
 

--- a/products/bigbluebutton.md
+++ b/products/bigbluebutton.md
@@ -22,7 +22,7 @@ releases:
 
 -   releaseCycle: "2.7"
     releaseDate: 2023-09-06
-    eol: 2025-05-31
+    eol: 2025-05-31 # https://github.com/bigbluebutton/bigbluebutton/pull/23340
     latest: "2.7.16"
     latestReleaseDate: 2024-12-11
 


### PR DESCRIPTION
BigBlueButton 2.7 is EOL because it depends on Ubuntu 20.04. https://github.com/bigbluebutton/bigbluebutton/pull/23340