### PR TITLE
[pan-gp] bump GlobalProtect latest to v6.3.3-c650 (2025-06-12)

### DIFF
--- a/products/pan-gp.md
+++ b/products/pan-gp.md
@@ -33,8 +33,8 @@ releases:
     releaseDate: 2024-06-13
     eol: 2026-06-13
     eoas: 2026-06-13
-    latest: "6.3.3"
-    latestReleaseDate: 2025-04-30
+    latest: "6.3.3-c650"
+    latestReleaseDate: 2025-06-12
     link: https://docs.paloaltonetworks.com/globalprotect/6-3/globalprotect-app-release-notes/globalprotect-addressed-issues
 
 -   releaseCycle: "6.2"


### PR DESCRIPTION
This PR updates the GlobalProtect 6.3 release metadata to reflect the newest patch release. The latest field is now set to 6.3.3-c650, and latestReleaseDate is updated to 2025-06-12.

Changes

releaseCycle: remains "6.3"

latest: updated from "6.3.3" → "6.3.3-c650"

latestReleaseDate: updated from 2025-04-30 → 2025-06-12

link: unchanged, still points to the official release notes