### PR TITLE
[logstash] Fix link for 9.x versions

### DIFF
--- a/products/logstash.md
+++ b/products/logstash.md
@@ -24,6 +24,7 @@ releases:
     eol: false  # later of 2027-10-15 or 18 months after the release date of 10.0
     latest: "9.0.2"
     latestReleaseDate: 2025-05-26
+    link: https://www.elastic.co/docs/release-notes/logstash#logstash-__LATEST__-release-notes
 
 -   releaseCycle: "8"
     releaseDate: 2022-02-10


### PR DESCRIPTION
Current one was giving 404