### PR TITLE
chore(api/v1): add server `description` field

### DIFF
--- a/api_v1/openapi.yml
+++ b/api_v1/openapi.yml
@@ -38,7 +38,7 @@ info:
 
 servers:
   - url: "{{ site.url }}/api/v1"
-    description: Production
+    description: Production v1
 
 tags:
   - name: Index

--- a/api_v1/openapi.yml
+++ b/api_v1/openapi.yml
@@ -38,6 +38,7 @@ info:
 
 servers:
   - url: "{{ site.url }}/api/v1"
+    description: Production
 
 tags:
   - name: Index


### PR DESCRIPTION
I noticed this while integrating with [0], that it may be nicer to
provide a `description` for the URL.

[0]: https://github.com/oapi-codegen/oapi-codegen/pull/2002