### PR TITLE
[pan-gp]  Updated GlobalProtect App 6.2 latest to 6.2.8-c243 (2025-06-23)

### DIFF
--- a/products/pan-gp.md
+++ b/products/pan-gp.md
@@ -41,8 +41,8 @@ releases:
     releaseDate: 2023-05-23
     eol: 2026-12-31
     eoas: 2026-12-31
-    latest: "6.2.8-c223"
-    latestReleaseDate: 2025-05-15
+    latest: "6.2.8-c243"
+    latestReleaseDate: 2025-06-23
     link: https://docs.paloaltonetworks.com/globalprotect/6-2/globalprotect-app-release-notes/globalprotect-addressed-issues
 
 -   releaseCycle: "6.1"


### PR DESCRIPTION
This PR updates the releases section for GlobalProtect App 6.2

Version: 6.2.8-c243

Release Date: 2025-06-23

Release Notes: https://docs.paloaltonetworks.com/globalprotect/6-2/globalprotect-app-release-notes/globalprotect-addressed-issues/globalprotect-app-6-2-8-h2-6-2-8-c243-windows-and-macos-addressed-issues