### PR TITLE
[Apache Flink] supported java versions

### DIFF
--- a/products/apache-flink.md
+++ b/products/apache-flink.md
@@ -66,6 +66,7 @@ backports seem to be maintained for the last 3 releases.
 
 ## [Java Compatibility](https://nightlies.apache.org/flink/flink-docs-release-1.19/docs/deployment/java_compatibility/)
 
-- Java 8 is supported but deprecated.
+- Java 8 is supported but deprecated (support dropped since 2.0).
 - Java 11 is the recommended version.
-- Java 17 is supported experimentally for Flink 1.18 and above.
+- Java 17 is supported experimentally for Flink 1.18 and above,
+- Java 21 is supported for Flink 1.19 and above

--- a/products/apache-flink.md
+++ b/products/apache-flink.md
@@ -67,6 +67,6 @@ backports seem to be maintained for the last 3 releases.
 ## [Java Compatibility](https://nightlies.apache.org/flink/flink-docs-release-1.19/docs/deployment/java_compatibility/)
 
 - Java 8 is supported but deprecated (support dropped since 2.0).
-- Java 11 is the recommended version.
-- Java 17 is supported experimentally for Flink 1.18 and above,
-- Java 21 is supported for Flink 1.19 and above
+- Java 17 is the recommended version (since 2.0).
+- Java 17 is supported experimentally for Flink 1.18 and above.
+- Java 21 is supported for Flink 1.19 and above.


### PR DESCRIPTION
* Update Recommended java version info
* Add info about support drop of java 8 with Flink 2.0
