### PR TITLE
[Clamav] Add eol date for 1.3 cycle

### DIFF
--- a/products/clamav.md
+++ b/products/clamav.md
@@ -27,7 +27,7 @@ releases:
 
 -   releaseCycle: "1.3"
     releaseDate: 2024-02-07
-    eol: false # releaseDate(1.5) + 4 months
+    eol: 2024-12-15
     latest: "1.3.2"
     latestReleaseDate: 2024-09-04
 


### PR DESCRIPTION
ClamAV's [EOL policy](https://docs.clamav.net/faq/faq-eol.html#regular-non-lts-feature-releases) uses an `OR`

> Non-LTS feature releases will be supported with critical patch versions for at least four (4) months from the initial publication date of the next feature release or until the next-next feature release is published.

Version 1.4 was released in August 2024, so 1.3 went EOL in Dec 2024

Note: confirmed by a project maintainer [here](https://github.com/Cisco-Talos/clamav/pull/1522#issuecomment-3009075293)