### PR TITLE
[oracle-linux] Add 10.x version

### DIFF
--- a/products/oracle-linux.md
+++ b/products/oracle-linux.md
@@ -28,8 +28,8 @@ identifiers:
 releases:
 -   releaseCycle: "10"
     releaseDate: 2025-06-26
-    eol: 2035-06-30
-    eoes: 2038-06-30
+    eol: false
+    eoes: false
     latest: "10.0"
     latestReleaseDate: 2025-06-26
 

--- a/products/oracle-linux.md
+++ b/products/oracle-linux.md
@@ -26,6 +26,13 @@ identifiers:
 -   purl: pkg:docker/library/oraclelinux
 
 releases:
+-   releaseCycle: "10"
+    releaseDate: 2025-06-26
+    eol: 2035-06-30
+    eoes: 2038-06-30
+    latest: "10.0"
+    latestReleaseDate: 2025-06-26
+
 -   releaseCycle: "9"
     releaseDate: 2022-07-06
     eol: 2032-06-30


### PR DESCRIPTION
https://blogs.oracle.com/linux/post/oracle-linux-10-now-generally-available