### PR TITLE
[ghc] Disable ghc-wiki auto configuration

### DIFF
--- a/products/ghc.md
+++ b/products/ghc.md
@@ -21,7 +21,8 @@ auto:
   -   git: https://gitlab.haskell.org/ghc/ghc.git
       regex: ^ghc-(?P<major>\d+)[.](?P<minor>\d+)[.](?P<patch>\d+)-release$
       template: '{{major}}.{{minor}}.{{patch}}'
-  -   ghc-wiki: https://gitlab.haskell.org/api/v4/projects/1/wikis/GHC-Status
+  # Disabled because of anti-scraping measures (using https://github.com/TecharoHQ/anubis).
+  #-   ghc-wiki: https://gitlab.haskell.org/api/v4/projects/1/wikis/GHC-Status
 
 releases:
 -   releaseCycle: "9.12"


### PR DESCRIPTION
https://gitlab.haskell.org/api/v4/projects/1/wikis/GHC-Status is now protected by anti-scrapping measures (using https://github.com/TecharoHQ/anubis).