### PR TITLE
Replace reference links by real links on the homepage

### DIFF
--- a/index.md
+++ b/index.md
@@ -17,15 +17,15 @@ and has iCalendar support.
 endoflife.date currently tracks {{ site.pages | where: "layout", "product" | size }} products.
 Here are some of our most popular pages:
 
-Programming           | [Python][python] | [Ruby][ruby] | [Java][java] | [PHP][php]
-Devices               | [iPhone][iphone] | [Android][android] | [Google Pixel][pixel] | [Nokia][nokia]
-Databases             | [MongoDB][mongodb] | [PostgreSQL][postgresql] | [Redis][redis] | [MySQL][mysql]
-Operating Systems     | [Windows][windows] | [Windows Server][windows-server] | [macOS][macos] | [FortiOS][fortios]
-Frameworks            | [Angular][angular] | [Django][django] | [Ruby on Rails][rails] | [.NET][net]
-Desktop Applications  | [Firefox][firefox] | [Internet Explorer][ie] | [Godot][godot] | [Unity][unity]
-Server Applications   | [Nginx][nginx] | [Kubernetes][k8s] | [Tomcat][tomcat] | [HAProxy][haproxy]
-Cloud Services        | [Amazon Elastic Kubernetes Service][eks] | [Google Kubernetes Engine][gke] | [Azure Kubernetes Service][aks]
-Standards             | [PCI-DSS][pci-dss]
+Programming           | [Python](/python) | [Ruby](/ruby) | [Java](/tags/java-distribution) | [PHP](/php)
+Devices               | [iPhone](/iphone) | [Android](/android) | [Google Pixel](/pixel) | [Nokia](/nokia)
+Databases             | [MongoDB](/mongodb) | [PostgreSQL](/postgresql) | [Redis](/redis) | [MySQL](/mysql)
+Operating Systems     | [Windows](/windows) | [Windows Server](/windows-server) | [macOS](/macos) | [FortiOS](/fortios)
+Frameworks            | [Angular](/angular) | [Django](/django) | [Ruby on Rails](/rails) | [.NET](/dotnet)
+Desktop Applications  | [Firefox](/firefox) | [Internet Explorer](/internet-explorer) | [Godot](/godot) | [Unity](/unity)
+Server Applications   | [Nginx](/nginx) | [Kubernetes](/kubernetes) | [Tomcat](/tomcat) | [HAProxy](/haproxy)
+Cloud Services        | [Amazon Elastic Kubernetes Service](/amazon-eks) | [Google Kubernetes Engine](/google-kubernetes-engine) | [Azure Kubernetes Service](/azure-kubernetes-service)
+Standards             | [PCI-DSS](/pci-dss)
 
 ## Contributing
 
@@ -58,38 +58,3 @@ tools that already did it: [norwegianblue](https://github.com/hugovk/norwegianbl
 
 [![Powered by Netlify](https://www.netlify.com/v3/img/components/netlify-light.svg)](https://www.netlify.com)
 [![Sponsored under Datadog OSS Plan](assets/datadog-logo.png)](https://datadog.com)
-
-
-[python]: /python
-[nodejs]: /nodejs
-[java]: /java
-[php]: /php
-[iphone]: /iphone
-[android]: /android
-[pixel]: /pixel
-[nokia]: /nokia
-[mongodb]: /mongodb
-[postgresql]: /postgresql
-[redis]: /redis
-[mysql]: /mysql
-[windows]: /windows
-[windows-server]: /windows-server
-[macos]: /macos
-[fortios]: /fortios
-[angular]: /angular
-[django]: /django
-[ruby]: /ruby
-[net]: /dotnet
-[firefox]: /firefox
-[ie]: /internet-explorer
-[godot]: /godot
-[unity]: /unity
-[nginx]: /nginx
-[k8s]: /k8s
-[tomcat]: /tomcat
-[haproxy]: /haproxy
-[rails]: /rails
-[eks]: /eks
-[gke]: /gke
-[aks]: /azure-kubernetes-service
-[pci-dss]: /pci-dss


### PR DESCRIPTION
While reference links may improve markdown readability, it did not add much in this case and was more a burden than an help.

This also:

- replaces `alternate_url`s by their corresponding permalink to avoid unnecessary redirects,
- use `/tags/java-distribution` for Java (previously it redirected to Oracle Java).