### PR TITLE
Update popular pages table on homepage

### DIFF
--- a/index.md
+++ b/index.md
@@ -17,15 +17,15 @@ and has iCalendar support.
 endoflife.date currently tracks {{ site.pages | where: "layout", "product" | size }} products.
 Here are some of our most popular pages:
 
-Programming           | [Python](/python) | [Ruby](/ruby) | [Java](/tags/java-distribution) | [PHP](/php)
-Devices               | [iPhone](/iphone) | [Android](/android) | [Google Pixel](/pixel) | [Nokia](/nokia)
-Databases             | [MongoDB](/mongodb) | [PostgreSQL](/postgresql) | [Redis](/redis) | [MySQL](/mysql)
-Operating Systems     | [Windows](/windows) | [Windows Server](/windows-server) | [macOS](/macos) | [FortiOS](/fortios)
-Frameworks            | [Angular](/angular) | [Django](/django) | [Ruby on Rails](/rails) | [.NET](/dotnet)
-Desktop Applications  | [Firefox](/firefox) | [Internet Explorer](/internet-explorer) | [Godot](/godot) | [Unity](/unity)
-Server Applications   | [Nginx](/nginx) | [Kubernetes](/kubernetes) | [Tomcat](/tomcat) | [HAProxy](/haproxy)
-Cloud Services        | [Amazon Elastic Kubernetes Service](/amazon-eks) | [Google Kubernetes Engine](/google-kubernetes-engine) | [Azure Kubernetes Service](/azure-kubernetes-service)
-Standards             | [PCI-DSS](/pci-dss)
+| Programming           | [Python](/python) | [Java](/tags/java-distribution) | [Node.js](/nodejs) | [PHP](/php) |
+| Devices               | [iPhone](/iphone) | [ipad](/iPad) | [Samsung](/samsung-mobile) | [Google Pixel](/pixel) |
+| Databases             | [MongoDB](/mongodb) | [PostgreSQL](/postgresql) | [Redis](/redis) | [MySQL](/mysql) |
+| Operating Systems     | [Windows](/windows) | [Android](/android) | [macOS](/macos) | [Linux](/tags/linux-distribution) |
+| Frameworks            | [Angular](/angular) | [Django](/django) | [Ruby on Rails](/rails) | [.NET](/dotnet) |
+| Desktop Applications  | [Firefox](/firefox) | [Internet Explorer](/internet-explorer) | [Godot](/godot) | [Unity](/unity) |
+| Server Applications   | [Nginx](/nginx) | [Kubernetes](/kubernetes) | [Tomcat](/tomcat) | [HAProxy](/haproxy) |
+| Cloud Services        | [Amazon Elastic Kubernetes Service](/amazon-eks) | [Google Kubernetes Engine](/google-kubernetes-engine) | [Azure Kubernetes Service](/azure-kubernetes-service) | [Alibaba ACK](/alibaba-ack)       |
+| Standards             | [PCI-DSS](/pci-dss) |
 
 ## Contributing
 

--- a/index.md
+++ b/index.md
@@ -18,7 +18,7 @@ endoflife.date currently tracks {{ site.pages | where: "layout", "product" | siz
 Here are some of our most popular pages:
 
 | Programming           | [Python](/python) | [Java](/tags/java-distribution) | [Node.js](/nodejs) | [PHP](/php) |
-| Devices               | [iPhone](/iphone) | [ipad](/iPad) | [Samsung](/samsung-mobile) | [Google Pixel](/pixel) |
+| Devices               | [iPhone](/iphone) | [Apple iPad](/iPad) | [Samsung](/samsung-mobile) | [Google Pixel](/pixel) |
 | Databases             | [MongoDB](/mongodb) | [PostgreSQL](/postgresql) | [Redis](/redis) | [MySQL](/mysql) |
 | Operating Systems     | [Windows](/windows) | [Android](/android) | [macOS](/macos) | [Linux](/tags/linux-distribution) |
 | Frameworks            | [Angular](/angular) | [Django](/django) | [Ruby on Rails](/rails) | [.NET](/dotnet) |


### PR DESCRIPTION
- Replace Ruby by Node.js in _Programming_ as it is one of the most popular programming tool,
- Reorder _Programming_ based on https://www.tiobe.com/tiobe-index/,
- Move Android from Devices to Operating Systems (replaced Windows Server),
- Added iPad to Devices (in replacement of Android) as [it seems to be one of the most popular page](https://github.com/endoflife-date/endoflife.date/discussions/382) in _Devices_,
- Replace Nokia by Samsung in _Devices_,
- Replace FortiOS by Linux in _Operating Systems_,
- Add Alibaba ACK in _Cloud Services_ (there was one slot left empty).