### PR TITLE
[elastic] Update products description

### DIFF
--- a/products/beats.md
+++ b/products/beats.md
@@ -69,9 +69,14 @@ Beats are part of the [Elastic Stack](https://www.elastic.co/elastic-stack/), al
 [ELK Stack](https://www.elastic.co/what-is/elk-stack). It shares the same support policy as the
 other products in the Elastic Stack (Elasticsearch, Logstash, Kibana...).
 
-Elastic Stack product releases follow [Semantic Versioning](https://semver.org/). Elastic provides
-maintenance for each major release series for the longest of 30 months after the GA date of the
-major release or 18 months after the GA date of the following major release.
+Elastic Stack product releases follow [Semantic Versioning](https://semver.org/).
+Elastic provides maintenance for each major release series for the longest of 30 months after the GA date of the major release
+or 18 months after the GA date of the following major release.
+For example, if version 1.0 was released on 10-Apr-2019 and version 2.0 was released on 10-Feb-2022.
+
+- 30 months from 1.0 GA date is 10-Oct-2021
+- 18 months from 2.0 GA date is 10-Aug-2023
+- 1.x maintenance would end on 10-Aug-2023
 
 End-of-life dates for Beats can be found on the [Elastic product EOL dates page](https://www.elastic.co/support/eol).
 Support for various operating systems can also be found on the [Elastic support matrix page](https://www.elastic.co/support/matrix).

--- a/products/elasticsearch.md
+++ b/products/elasticsearch.md
@@ -57,17 +57,18 @@ Elasticsearch is part of the [Elastic Stack](https://www.elastic.co/elastic-stac
 [ELK Stack](https://www.elastic.co/what-is/elk-stack). It shares the same support policy as the
 other products in the Elastic Stack (Kibana, Logstash, Beats...).
 
-Elastic Stack product releases follow [Semantic Versioning](https://semver.org/). Elastic provides
-maintenance for each major release series for the longest of 30 months after the GA date of the
-major release or 18 months after the GA date of the following major release.
+Elastic Stack product releases follow [Semantic Versioning](https://semver.org/).
+Elastic provides maintenance for each major release series for the longest of 30 months after the GA date of the major release
+or 18 months after the GA date of the following major release.
+For example, if version 1.0 was released on 10-Apr-2019 and version 2.0 was released on 10-Feb-2022.
 
-Therefore:
-
-* **Elasticsearch 8** will receive updates for 18 months after the release date of 9.0 (TBD).
-* **Elasticsearch 7** will receive updates until the release date of 9.0 (TBD).
+- 30 months from 1.0 GA date is 10-Oct-2021
+- 18 months from 2.0 GA date is 10-Aug-2023
+- 1.x maintenance would end on 10-Aug-2023
 
 End-of-life dates for Elasticsearch can be found on the [Elastic product EOL dates page](https://www.elastic.co/support/eol).
 Support for various operating systems can also be found on the [Elastic support matrix page](https://www.elastic.co/support/matrix).
+License information can be found on the [Elastic license page](https://www.elastic.co/pricing/faq/licensing).
 
 *[GA]: General Availability
 *[EOL]: End Of Life

--- a/products/kibana.md
+++ b/products/kibana.md
@@ -54,12 +54,18 @@ Kibana is part of the [Elastic Stack](https://www.elastic.co/elastic-stack/), al
 [ELK Stack](https://www.elastic.co/what-is/elk-stack). It shares the same support policy as the
 other products in the Elastic Stack (Elasticsearch, Logstash, Beats...).
 
-Elastic Stack product releases follow [Semantic Versioning](https://semver.org/). Elastic provides
-maintenance for each major release series for the longest of 30 months after the GA date of the
-major release or 18 months after the GA date of the following major release.
+Elastic Stack product releases follow [Semantic Versioning](https://semver.org/).
+Elastic provides maintenance for each major release series for the longest of 30 months after the GA date of the major release
+or 18 months after the GA date of the following major release.
+For example, if version 1.0 was released on 10-Apr-2019 and version 2.0 was released on 10-Feb-2022.
+
+- 30 months from 1.0 GA date is 10-Oct-2021
+- 18 months from 2.0 GA date is 10-Aug-2023
+- 1.x maintenance would end on 10-Aug-2023
 
 End-of-life dates for Kibana can be found on the [Elastic product EOL dates page](https://www.elastic.co/support/eol).
 Support for various operating systems can also be found on the [Elastic support matrix page](https://www.elastic.co/support/matrix).
+License information can be found on the [Elastic license page](https://www.elastic.co/pricing/faq/licensing).
 
 *[GA]: General Availability
 *[EOL]: End Of Life

--- a/products/logstash.md
+++ b/products/logstash.md
@@ -53,9 +53,14 @@ Logstash is part of the [Elastic Stack](https://www.elastic.co/elastic-stack/), 
 [ELK Stack](https://www.elastic.co/what-is/elk-stack). It shares the same support policy as the
 other products in the Elastic Stack (Elasticsearch, Kibana, Beats...).
 
-Elastic Stack product releases follow [Semantic Versioning](https://semver.org/). Elastic provides
-maintenance for each major release series for the longest of 30 months after the GA date of the
-major release or 18 months after the GA date of the following major release.
+Elastic Stack product releases follow [Semantic Versioning](https://semver.org/).
+Elastic provides maintenance for each major release series for the longest of 30 months after the GA date of the major release
+or 18 months after the GA date of the following major release.
+For example, if version 1.0 was released on 10-Apr-2019 and version 2.0 was released on 10-Feb-2022.
+
+- 30 months from 1.0 GA date is 10-Oct-2021
+- 18 months from 2.0 GA date is 10-Aug-2023
+- 1.x maintenance would end on 10-Aug-2023
 
 End-of-life dates for Logstash can be found on the [Elastic product EOL dates page](https://www.elastic.co/support/eol).
 Support for various operating systems can also be found on the [Elastic support matrix page](https://www.elastic.co/support/matrix).


### PR DESCRIPTION
- Clarify support policy by giving an example,
- remove information for Elasticsearch 7/8 as it is now outdated,
- add link to the Elastic license page on Elasticsearch and Kibana.

Closes #5767.