### PR TITLE
[Shopware] Add supported PHP versions info for 6.7 cycle

### DIFF
--- a/products/shopware.md
+++ b/products/shopware.md
@@ -30,7 +30,7 @@ auto:
 # PHP support is documented on https://docs.shopware.com/en/shopware-6-en/first-steps/system-requirements.
 releases:
 -   releaseCycle: "6.7"
-    supportedPhpVersions: N/A
+    supportedPhpVersions: 8.2 - 8.4
     releaseDate: 2025-06-17
     eoas: false
     eol: false # still listed on https://developer.shopware.com/release-notes/

--- a/products/shopware.md
+++ b/products/shopware.md
@@ -30,7 +30,7 @@ auto:
 # PHP support is documented on https://docs.shopware.com/en/shopware-6-en/first-steps/system-requirements.
 releases:
 -   releaseCycle: "6.7"
-    supportedPhpVersions: 8.2 - 8.4
+    supportedPhpVersions: 8.2 - 8.4 # https://github.com/shopware/shopware/blob/v6.7.0.0/composer.json#L64
     releaseDate: 2025-06-17
     eoas: false
     eol: false # still listed on https://developer.shopware.com/release-notes/


### PR DESCRIPTION
https://github.com/shopware/shopware/blob/v6.7.0.0/composer.json#L64

Actually Shopware 6.6.10.x are also compatible with PHP 8.4 but earlier versions not. Not sure how (or if) that should be added.