### PR TITLE
[oracle-jdk] Stop using javascript for fetching https://www.java.com/releases/

### DIFF
--- a/products/oracle-jdk.md
+++ b/products/oracle-jdk.md
@@ -37,8 +37,6 @@ auto:
           regex: '^(?P<value>\w+ \d+).*'
   # Fix the release date, as only month-year dates are provided in the previous table.
   -   release_table: https://www.java.com/releases/
-      render_javascript: true
-      render_javascript_wait_until: networkidle
       selector: "table.releaselist"
       header_selector: "tbody#released tr:nth-of-type(3)"
       rows_selector: "tbody#released tr"


### PR DESCRIPTION
It's not needed, and started failing : https://github.com/endoflife-date/release-data/actions/runs/16085523550.