### PR TITLE
[oracle-jdk] Use javascript for fetching https://www.java.com/releases/

### DIFF
--- a/products/oracle-jdk.md
+++ b/products/oracle-jdk.md
@@ -37,6 +37,7 @@ auto:
           regex: '^(?P<value>\w+ \d+).*'
   # Fix the release date, as only month-year dates are provided in the previous table.
   -   release_table: https://www.java.com/releases/
+      render_javascript: true
       selector: "table.releaselist"
       header_selector: "tbody#released tr:nth-of-type(3)"
       rows_selector: "tbody#released tr"


### PR DESCRIPTION
Despite working in local, not using javascript for fetching https://www.java.com/releases/ does not work on GHA runners.