### PR TITLE
Update prometheus.md

### DIFF
--- a/products/prometheus.md
+++ b/products/prometheus.md
@@ -35,7 +35,7 @@ auto:
 releases:
 -   releaseCycle: "3.4"
     releaseDate: 2025-05-17
-    eol: 2025-07-05
+    eol: 2025-06-28
     latest: "3.4.2"
     latestReleaseDate: 2025-06-26
 


### PR DESCRIPTION
Updated EOL for release 3.4 from July 5th to June 28th, as the non LTS version is usually supported 6 weeks, not 7.