### PR TITLE
[fairphone] Remove Android versions that aren't yet released on the FP6

### DIFF
--- a/products/fairphone.md
+++ b/products/fairphone.md
@@ -21,7 +21,7 @@ customFields:
 releases:
 -   releaseCycle: "6"
     releaseLabel: "Fairphone 6"
-    supportedAndroidVersions: "15 - 22" # https://support.fairphone.com/hc/en-us/articles/24463093338898-The-Fairphone-Gen-6-FAQ
+    supportedAndroidVersions: "15" # https://support.fairphone.com/hc/en-us/articles/24463093338898-The-Fairphone-Gen-6-FAQ
     releaseDate: 2025-06-25 # https://support.fairphone.com/hc/en-us/articles/24463093338898-The-Fairphone-Gen-6-FAQ
     discontinued: false
     eoas: false

--- a/products/fairphone.md
+++ b/products/fairphone.md
@@ -21,7 +21,7 @@ customFields:
 releases:
 -   releaseCycle: "6"
     releaseLabel: "Fairphone 6"
-    supportedAndroidVersions: "15" # https://support.fairphone.com/hc/en-us/articles/24463093338898-The-Fairphone-Gen-6-FAQ
+    supportedAndroidVersions: "15" # https://support.fairphone.com/hc/en-us/articles/24463713641234-The-Fairphone-Gen-6-Release-Notes
     releaseDate: 2025-06-25 # https://support.fairphone.com/hc/en-us/articles/24463093338898-The-Fairphone-Gen-6-FAQ
     discontinued: false
     eoas: false


### PR DESCRIPTION
The "Supported Android" column does not include potential future Android releases, only those that are effectively shipped.
"15 - 22" here would mean "this phone released with Android 15 and is upgradable up to Android 22 right now"