### PR TITLE
Manually declare missing or erroneous version

### DIFF
--- a/products/artifactory.md
+++ b/products/artifactory.md
@@ -15,6 +15,10 @@ identifiers:
 auto:
   methods:
   -   artifactory: https://jfrog.com/help/r/jfrog-release-information/artifactory-end-of-life
+  -   declare:
+        versions:
+          # release date is wrong on https://jfrog.com/help/r/jfrog-release-information/artifactory-end-of-life.
+          -   { name: "7.71.23", date: 2024-08-05 }
 
 # EOL documented on https://jfrog.com/help/r/jfrog-release-information/artifactory-end-of-life.
 releases:

--- a/products/aws-lambda.md
+++ b/products/aws-lambda.md
@@ -12,6 +12,11 @@ eolColumn: Deprecated Support
 auto:
   methods:
   -   aws-lambda: https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html
+  -   declare: aws-lambda
+      versions:
+      # there is a mistake on https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html:
+      # block function update date cannot be before the deprecation date
+      -   { name: "nodejs4.3-edge", date: 2020-04-30 }
 
 # The custom script will only detect new releases and update support and eol dates based on dates found on https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html.
 # The release dates must be retrieved from announcement blog posts on https://aws.amazon.com/blogs/compute/category/compute/aws-lambda/.

--- a/products/coldfusion.md
+++ b/products/coldfusion.md
@@ -13,7 +13,7 @@ identifiers:
 -   cpe: cpe:2.3:a:adobe:coldfusion
 -   cpe: cpe:/a:adobe:coldfusion
 
-# Disabled, as the Adobe ColdFusion website is now protected by anti-bot measures.
+# Disabled: helpx.adobe.com time out when running from a GHA runner.
 #auto:
 #  methods:
 #  -   coldfusion: https://helpx.adobe.com/coldfusion/kb/coldfusion-10-updates.html
@@ -23,6 +23,15 @@ identifiers:
 #  -   coldfusion: https://helpx.adobe.com/coldfusion/kb/coldfusion-2021-updates.html
 #  -   coldfusion: https://helpx.adobe.com/coldfusion/kb/coldfusion-2023-updates.html
 #  -   coldfusion: https://helpx.adobe.com/coldfusion/kb/coldfusion-2025-updates.html
+#  -   declare: coldfusion
+#      versions: # .0 release dates are not available in the release notes
+#      -   { name: "10.0.0", date: 2012-05-15 } # https://en.wikipedia.org/wiki/Adobe_ColdFusion#Adobe_ColdFusion_10
+#      -   { name: "11.0.0", date: 2014-04-29 } # https://en.wikipedia.org/wiki/Adobe_ColdFusion#Adobe_ColdFusion_11
+#      -   { name: "2016.0.0", date: 2016-02-16 } # https://en.wikipedia.org/wiki/Adobe_ColdFusion#Adobe_ColdFusion_(2016_Release)
+#      -   { name: "2018.0.0", date: 2018-07-12 } # https://coldfusion.adobe.com/2018/07/new-coldfusion-release-adds-performance-monitoring-toolset-for-measuring-monitoring-and-managing-high-performing-web-apps/
+#      -   { name: "2021.0.0", date: 2020-11-11 } # https://community.adobe.com/t5/coldfusion-discussions/introducing-adobe-coldfusion-2021-release/m-p/11585468
+#      -   { name: "2023.0.0", date: 2022-05-16 } # https://coldfusion.adobe.com/2023/05/coldfusion2023-release/
+#      -   { name: "2025.0.0", date: 2025-02-25 } # https://community.adobe.com/t5/coldfusion-discussions/now-live-adobe-coldfusion-2025-release/td-p/15176421
 
 # When adding a cycle, remember to add its release note URL in
 # https://github.com/endoflife-date/release-data/blob/main/src/coldfusion.py

--- a/products/couchbase-server.md
+++ b/products/couchbase-server.md
@@ -28,6 +28,13 @@ auto:
           column: "Release"
           regex: '^Couchbase Server (?P<value>[0-9.]+)$'
         eol: "End of Full Maintenance"
+  -   declare: couchbase-server
+      versions:
+        # Dates are not available for all versions, so they must be set manually in some cases.
+        -   { name: "6.0.0", date: 2018-10-31 } # https://www.couchbase.com/blog/announcing-couchbase-6-0/
+        -   { name: "6.0.1", date: 2019-02-15 } # https://web.archive.org/web/20190307191211/https://docs.couchbase.com/server/6.0/release-notes/relnotes.html
+        -   { name: "6.6.0", date: 2020-08-12 } # https://www.couchbase.com/blog/whats-new-and-improved-in-couchbase-server-6-6/
+        -   { name: "7.2.0", date: 2023-06-01 } # https://www.couchbase.com/blog/couchbase-capella-spring-release-72/
 
 releases:
 -   releaseCycle: "7.6"


### PR DESCRIPTION
Use the new `declare` auto method for that.

This must be merged before https://github.com/endoflife-date/release-data/pull/461.