### PR TITLE
[firefox] Fix eol date for ESR 115

### DIFF
--- a/products/firefox.md
+++ b/products/firefox.md
@@ -181,7 +181,7 @@ releases:
 -   releaseCycle: "115"
     lts: true
     releaseDate: 2023-07-04
-    eol: 2024-10-01 # estimated release day for 131 on https://whattrainisitnow.com/calendar/
+    eol: 2025-09-16 # extended becuase of support of Windows 7-8.1 and macOS 10.12-10.14 up to September 2025
     latest: "115.23.0"
     latestReleaseDate: 2025-04-29
 


### PR DESCRIPTION
We decided to extend support for ESR 115 only on Windows 7-8.1 and macOS 10.12-10.14 up to September 2025. We will re-evaluate this decision in August 2025 and announce any updates on ESR 115's end-of-life then source : https://whattrainisitnow.com/release/?version=esr