### PR TITLE
[pan-os]Update PAN-OS version(s)

### DIFF
--- a/products/pan-os.md
+++ b/products/pan-os.md
@@ -59,9 +59,9 @@ releases:
 -   releaseCycle: "10.1"
     releaseDate: 2021-05-31
     eol: 2024-12-01
-    latest: "10.1.14-h15"
-    latestReleaseDate: 2025-06-10
-    link: https://docs.paloaltonetworks.com/pan-os/10-1/pan-os-release-notes/pan-os-10-1-14-known-and-addressed-issues/pan-os-10-1-14-h15-addressed-issues
+    latest: "10.1.14-h16"
+    latestReleaseDate: 2025-07-08
+    link: https://docs.paloaltonetworks.com/pan-os/10-1/pan-os-release-notes/pan-os-10-1-14-known-and-addressed-issues/pan-os-10-1-14-h16-addressed-issues
 
 -   releaseCycle: "10.0"
     releaseDate: 2020-07-16


### PR DESCRIPTION
This update includes the latest patch for PAN-OS 10.1:

- Added version `10.1.14-h16`, released on `2025-07-08`
- Updated corresponding documentation link
- Replaced previous entry (`10.1.14-h15`) where applicable
- No changes to release cycle or EOL date (`2024-12-01`)

Release Notes:
https://docs.paloaltonetworks.com/pan-os/10-1/pan-os-release-notes/pan-os-10-1-14-known-and-addressed-issues/pan-os-10-1-14-h16-addressed-issues
