### PR TITLE
Remove deprecated ignore_empty_releases's release_table option

### DIFF
--- a/products/bazel.md
+++ b/products/bazel.md
@@ -21,7 +21,6 @@ auto:
   methods:
   -   git: https://github.com/bazelbuild/bazel.git
   -   release_table: https://bazel.build/release
-      ignore_empty_releases: true # so that future releases are ignored
       selector: "table"
       fields:
         releaseCycle:

--- a/products/containerd.md
+++ b/products/containerd.md
@@ -18,7 +18,6 @@ auto:
   methods:
   -   git: https://github.com/containerd/containerd.git
   -   release_table: https://containerd.io/releases/
-      ignore_empty_releases: true # ignore future releases
       selector: "table"
       fields:
         releaseCycle: "Release"

--- a/products/debian.md
+++ b/products/debian.md
@@ -18,7 +18,6 @@ auto:
   methods:
   -   debian: https://salsa.debian.org/webmaster-team/webwml.git
   -   release_table: https://wiki.debian.org/DebianReleases
-      ignore_empty_releases: true # so that future releases are ignored
       selector: "table"
       header_selector: "tr:nth-of-type(1)"
       # 'EOL LTS' cannot be mapped because it would exclude rows with no EOL LTS date because cells missing LTS dates

--- a/products/eclipse-temurin.md
+++ b/products/eclipse-temurin.md
@@ -56,7 +56,6 @@ auto:
       regex: '^jdk-(?P<version>[\d\.+]+)$'
       template: '{{version}}'
   -   release_table: https://adoptium.net/support/
-      ignore_empty_releases: true # avoid listing upcoming releases in auto-update PRs
       selector: "table"
       fields:
         releaseCycle:

--- a/products/envoy.md
+++ b/products/envoy.md
@@ -31,7 +31,6 @@ auto:
   -   git: https://github.com/envoyproxy/envoy.git
   -   release_table: https://github.com/envoyproxy/envoy/blob/main/RELEASES.md
       render_javascript: true
-      ignore_empty_releases: true # ignore future releases
       selector: "table"
       fields:
         releaseCycle:

--- a/products/linuxmint.md
+++ b/products/linuxmint.md
@@ -14,7 +14,6 @@ releaseLabel: "__RELEASE_CYCLE__ '__CODENAME__'"
 auto:
   methods:
   -   release_table: https://linuxmint.com/download_all.php
-      ignore_empty_releases: true
       selector: "table"
       fields:
         releaseCycle: "Version"

--- a/products/mariadb.md
+++ b/products/mariadb.md
@@ -50,7 +50,6 @@ auto:
   -   release_table: https://mariadb.org/about/#maintenance-policy
       selector: "table"
       header_selector: "tbody tr:nth-of-type(1)"
-      ignore_empty_releases: true # Ignore future releases
       fields:
         releaseCycle: "Release"
         releaseDate: "GA release date"

--- a/products/nuxt.md
+++ b/products/nuxt.md
@@ -18,7 +18,6 @@ auto:
   methods:
   -   npm: nuxt
   -   release_table: https://nuxt.com/docs/community/roadmap
-      ignore_empty_releases: true # Ignore future releases
       selector: "table"
       fields:
         releaseCycle:

--- a/products/redis.md
+++ b/products/redis.md
@@ -28,7 +28,6 @@ auto:
   -   git: https://github.com/redis/redis.git
   -   release_table: https://redis.io/docs/latest/operate/rs/installing-upgrading/product-lifecycle/
       selector: "table"
-      ignore_empty_releases: true
       fields:
         releaseCycle:
           column: "Version - Release date"


### PR DESCRIPTION
It is now done by default.

It was removed in https://github.com/endoflife-date/release-data/pull/466.