### PR TITLE
[pan-gp] Update GlobalProtect version to 6.2.8-c263 (2025-07-17)

### DIFF
--- a/products/pan-gp.md
+++ b/products/pan-gp.md
@@ -42,8 +42,8 @@ releases:
     releaseDate: 2023-05-23
     eol: 2026-12-31
     eoas: 2026-12-31
-    latest: "6.2.8-c243"
-    latestReleaseDate: 2025-06-23
+    latest: "6.2.8-c263"
+    latestReleaseDate: 2025-07-17
     link: https://docs.paloaltonetworks.com/globalprotect/6-2/globalprotect-app-release-notes/globalprotect-addressed-issues
 
 -   releaseCycle: "6.1"


### PR DESCRIPTION
This pull request updates the GlobalProtect version from 6.2.8-c243 (released on 2025-06-23) to 6.2.8-c263 (released on 2025-07-17).

[GlobalProtect 6.2.8-c263 Release Notes](https://docs.paloaltonetworks.com/globalprotect/6-2/globalprotect-app-release-notes/globalprotect-addressed-issues/globalprotect-app-6-2-8-h3-6-2-8-c263-windows-and-macos-addressed-issues)