### PR TITLE
Add bot page

### DIFF
--- a/bot.md
+++ b/bot.md
@@ -6,27 +6,27 @@ title: About the endoflife.date bot
 description: Some information about the endoflife.date bot - what it is and why it exists.
 ---
 
-If you are on this page, this means you have noticed our user agent, `endoflife.date-bot/1.0 (endoflife.date automation; +https://endoflife.date/bot)` in your server logs.
-We understand that seeing an unfamiliar bot can raise questions, and this page is intended to clarify our bot's purpose and practices.
+If you are reading this page, you have likely noticed our user agent, `endoflife.date-bot/1.0 (endoflife.date automation; +https://endoflife.date/bot)`, in your server logs.
+We understand that seeing an unfamiliar bot can raise questions. This page clarifies our bot's purpose and practices.
 
 endoflife.date is an open-source community website dedicated to documenting End-of-Life (EOL) dates and support lifecycles for various products.
 Our goal is to provide accurate and up-to-date information to help users and organizations plan their software and hardware upgrades effectively.
 
-To help us achieve this goal, we have developed a bot that automates the collection of information from various websites, including yours.
+To help achieve this, we have developed a bot that automates the collection of information from various websites, including yours.
 We want to assure you that our bot is designed to be as respectful and non-intrusive as possible.
 Here are some key points about our scraping practices:
 
-- Selective Scraping: Our bot only scrapes a few selected pages that are relevant to our mission.
-  We do not indiscriminately crawl entire websites.
-- Respect for Cache Directives: We respect the cache directives set by your server.
-  If a cache directive is not set, we keep the website page in our cache for one day to minimize the number of requests to your server.
+- **Selective Scraping:** Our bot only scrapes a few selected pages relevant to our mission; it does not indiscriminately crawl entire websites.
+- **Respect for Cache Directives:** We respect the cache directives set by your server.
+  If none are set, we keep the website page in our cache for one day to minimize requests.
 
-We kindly ask you to keep authorizing our user agent to access your site.
-Your cooperation will help us maintain accurate and up-to-date information for the benefit of the entire community.
+We kindly ask that you continue authorizing our user agent to access your site.
+Your cooperation helps us maintain accurate and up-to-date information for the benefit of the entire community.
 
-If, for any reason, it is not possible to authorize our bot, we understand and respect your decision.
-In such cases, we would appreciate it if you could let us know by opening an issue on our GitHub repository: [endoflife-date/endoflife.date/issues](https://github.com/endoflife-date/endoflife.date/issues).
-This will allow us to deactivate the automation for your site and explore alternative ways to collect the necessary information.
+If you are unable to authorize our bot, we understand and respect your decision.
+In such cases, please let us know by opening an issue on our GitHub repository: [endoflife-date/endoflife.date/issues](https://github.com/endoflife-date/endoflife.date/issues).
+This will allow us to deactivate our bot for your site and explore alternative ways to collect the necessary information.
 
-Thank you for your understanding and support,
+Thank you for your understanding and support.
+
 The endoflife.date Team

--- a/bot.md
+++ b/bot.md
@@ -1,0 +1,32 @@
+---
+layout: page
+nav_exclude: true
+permalink: /bot
+title: About the endoflife.date bot
+description: Some information about the endoflife.date bot - what it is and why it exists.
+---
+
+If you are on this page, this means you have noticed our user agent, `endoflife.date-bot/1.0 (endoflife.date automation; +https://endoflife.date/bot)` in your server logs.
+We understand that seeing an unfamiliar bot can raise questions, and this page is intended to clarify our bot's purpose and practices.
+
+endoflife.date is an open-source community website dedicated to documenting End-of-Life (EOL) dates and support lifecycles for various products.
+Our goal is to provide accurate and up-to-date information to help users and organizations plan their software and hardware upgrades effectively.
+
+To help us achieve this goal, we have developed a bot that automates the collection of information from various websites, including yours.
+We want to assure you that our bot is designed to be as respectful and non-intrusive as possible.
+Here are some key points about our scraping practices:
+
+- Selective Scraping: Our bot only scrapes a few selected pages that are relevant to our mission.
+  We do not indiscriminately crawl entire websites.
+- Respect for Cache Directives: We respect the cache directives set by your server.
+  If a cache directive is not set, we keep the website page in our cache for one day to minimize the number of requests to your server.
+
+We kindly ask you to keep authorizing our user agent to access your site.
+Your cooperation will help us maintain accurate and up-to-date information for the benefit of the entire community.
+
+If, for any reason, it is not possible to authorize our bot, we understand and respect your decision.
+In such cases, we would appreciate it if you could let us know by opening an issue on our GitHub repository: [endoflife-date/endoflife.date/issues](https://github.com/endoflife-date/endoflife.date/issues).
+This will allow us to deactivate the automation for your site and explore alternative ways to collect the necessary information.
+
+Thank you for your understanding and support,
+The endoflife.date Team


### PR DESCRIPTION
We're planning to update our user agent so that it can be recognized easily, see https://github.com/endoflife-date/release-data/pull/470. This page will helps us explain to site maintainers why they should keep authorizing our bot.