### PR TITLE
[pan-os]Update PAN-OS version(s)

### DIFF
--- a/products/pan-os.md
+++ b/products/pan-os.md
@@ -32,8 +32,8 @@ releases:
 -   releaseCycle: "11.2"
     releaseDate: 2024-05-02
     eol: 2027-05-02
-    latest: "11.2.7"
-    latestReleaseDate: 2025-06-18
+    latest: "11.2.7-h1"
+    latestReleaseDate: 2025-07-23
     link: https://docs.paloaltonetworks.com/pan-os/11-2/pan-os-release-notes/pan-os-11-2-7-known-and-addressed-issues/pan-os-11-2-7-addressed-issues
 
 -   releaseCycle: "11.1"

--- a/products/pan-os.md
+++ b/products/pan-os.md
@@ -34,7 +34,7 @@ releases:
     eol: 2027-05-02
     latest: "11.2.7-h1"
     latestReleaseDate: 2025-07-23
-    link: https://docs.paloaltonetworks.com/pan-os/11-2/pan-os-release-notes/pan-os-11-2-7-known-and-addressed-issues/pan-os-11-2-7-addressed-issues
+    link: https://docs.paloaltonetworks.com/pan-os/11-2/pan-os-release-notes/pan-os-11-2-7-known-and-addressed-issues/pan-os-11-2-7-h1-addressed-issues
 
 -   releaseCycle: "11.1"
     releaseDate: 2023-11-03


### PR DESCRIPTION
[panos] This PR updates the PAN-OS versions, Release dates and the Release Notes url.

Updated Pan-OS Version:  11.2.7-h1 

Released:                2025-07-23 

Release Notes:         https://docs.paloaltonetworks.com/pan-os/11-2/pan-os-release-notes/pan-os-11-2-7-known-and-addressed-issues/pan-os-11-2-7-h1-addressed-issues
