### PR TITLE
[couchbase-server] Use Firefox User-Agent

### DIFF
--- a/products/couchbase-server.md
+++ b/products/couchbase-server.md
@@ -23,6 +23,7 @@ auto:
   -   couchbase-server: https://docs.couchbase.com/server
       regex: '^Release (?P<version>\d+\.\d+(\.\d+)?) \((?P<date>.+)\)$'
   -   release_table: https://www.couchbase.com/support-policy/EOL/
+      user_agent: "Mozilla/5.0 (X11; Linux x86_64; rv:140.0) Gecko/20100101 Firefox/140.0"
       selector: "table"
       fields:
         releaseCycle:


### PR DESCRIPTION
Use Firefox User-Agent instead of endoflife.date-bot User-Agent. Using our user agent does not allow to load https://www.couchbase.com/support-policy/EOL/.

Relates to https://github.com/endoflife-date/release-data/pull/474.