### PR TITLE
[motorola-mobility] Remove repetitive Motorola part in model labels

### DIFF
--- a/products/motorola-mobility.md
+++ b/products/motorola-mobility.md
@@ -18,163 +18,163 @@ auto:
 
 releases:
 -   releaseCycle: "moto-e15"
-    releaseLabel: "Motorola Moto E15"
+    releaseLabel: "Moto E15"
     releaseDate: 2024-12-01
     eol: 2026-12-31 # until 12/2026, see https://www.motorola.com/gb/en/p/phones/moto-e/15/pmipmhk40mb?pn=PB6S0012GB
     link: https://en-us.support.motorola.com/app/software-security-update/g_id/7112/productid/12161
 
 -   releaseCycle: "moto-e14"
-    releaseLabel: "Motorola Moto E14"
+    releaseLabel: "Moto E14"
     releaseDate: 2024-04-01
     eol: 2026-04-30 # until 04/2026, see https://www.motorola.com/gb/en/p/phones/moto-e/14/pmipmhb38m2?pn=PB3C0002GB
     link: https://en-us.support.motorola.com/app/software-security-update/g_id/7112/productid/12029
 
 -   releaseCycle: "motorola-razr-40s"
-    releaseLabel: "Motorola Razr 40S"
+    releaseLabel: "Razr 40S"
     releaseDate: 2023-11-01
     eol: 2027-11-30
     link: https://en-us.support.motorola.com/app/software-security-update/g_id/7112/productid/11651
 
 -   releaseCycle: "moto-g84-5g"
-    releaseLabel: "Motorola Moto G84 5G"
+    releaseLabel: "Moto G84 5G"
     releaseDate: 2023-09-01
     eol: 2026-09-30
     link: https://en-us.support.motorola.com/app/software-security-update/g_id/7112/productid/11601
 
 -   releaseCycle: "moto-g54-5g"
-    releaseLabel: "Motorola Moto G54 5G"
+    releaseLabel: "Moto G54 5G"
     releaseDate: 2023-09-01
     eol: 2027-06-30
     link: https://en-us.support.motorola.com/app/software-security-update/g_id/7112/productid/11600
 
 -   releaseCycle: "motorola-edge-2023"
-    releaseLabel: "Motorola Edge (2023)"
+    releaseLabel: "Edge (2023)"
     releaseDate: 2023-09-01
     eol: 2026-09-30
     link: https://en-us.support.motorola.com/app/software-security-update/g_id/7112/productid/11576
 
 -   releaseCycle: "motorola-edge-40-neo"
-    releaseLabel: "Motorola Edge 40 Neo"
+    releaseLabel: "Edge 40 Neo"
     releaseDate: 2023-09-01
     eol: 2027-06-30
     link: https://en-us.support.motorola.com/app/software-security-update/g_id/7112/productid/11590
 
 -   releaseCycle: "motorola-razr-2023"
-    releaseLabel: "Motorola Razr (2023)"
+    releaseLabel: "Razr (2023)"
     releaseDate: 2023-09-01
     eol: 2027-09-30
     link: https://en-us.support.motorola.com/app/software-security-update/g_id/7112/productid/11592
 
 -   releaseCycle: "moto-g14"
-    releaseLabel: "Motorola Moto G14"
+    releaseLabel: "Moto G14"
     releaseDate: 2023-08-01
     eol: 2026-08-31
     link: https://en-us.support.motorola.com/app/software-security-update/g_id/7112/productid/11597
 
 -   releaseCycle: "motorola-razr-40"
-    releaseLabel: "Motorola Razr 40"
+    releaseLabel: "Razr 40"
     releaseDate: 2023-07-01
     eol: 2027-07-31
     link: https://en-us.support.motorola.com/app/software-security-update/g_id/7112/productid/11591
 
 -   releaseCycle: "moto-g-stylus-5g-2023"
-    releaseLabel: "Motorola Moto G Stylus 5G (2023)"
+    releaseLabel: "Moto G Stylus 5G (2023)"
     releaseDate: 2023-06-01
     eol: 2026-06-30
     link: https://en-us.support.motorola.com/app/software-security-update/g_id/7112/productid/11492
 
 -   releaseCycle: "moto-g53y-5g"
-    releaseLabel: "Motorola Moto G53Y 5G"
+    releaseLabel: "Moto G53Y 5G"
     releaseDate: 2023-06-01
     eol: 2026-12-31
     link: https://en-us.support.motorola.com/app/software-security-update/g_id/7112/productid/11599
 
 -   releaseCycle: "moto-g53j-5g"
-    releaseLabel: "Motorola Moto G53J 5G"
+    releaseLabel: "Moto G53J 5G"
     releaseDate: 2023-06-01
     eol: 2026-12-31
     link: https://en-us.support.motorola.com/app/software-security-update/g_id/7112/productid/11585
 
 -   releaseCycle: "motorola-razr-40-ultra"
-    releaseLabel: "Motorola Razr 40 Ultra"
+    releaseLabel: "Razr 40 Ultra"
     releaseDate: 2023-06-01
     eol: 2027-06-30
     link: https://en-us.support.motorola.com/app/software-security-update/g_id/7112/productid/11577
 
 -   releaseCycle: "motorola-razr+-2023"
-    releaseLabel: "Motorola Razr+ (2023)"
+    releaseLabel: "Razr+ (2023)"
     releaseDate: 2023-06-01
     eol: 2027-06-30
     link: https://en-us.support.motorola.com/app/software-security-update/g_id/7112/productid/11489
 
 -   releaseCycle: "moto-g-5g-2023"
-    releaseLabel: "Motorola Moto G 5G (2023)"
+    releaseLabel: "Moto G 5G (2023)"
     releaseDate: 2023-05-01
     eol: 2026-05-31
     link: https://en-us.support.motorola.com/app/software-security-update/g_id/7112/productid/11494
 
 -   releaseCycle: "motorola-edge+-2023"
-    releaseLabel: "Motorola Edge+ (2023)"
+    releaseLabel: "Edge+ (2023)"
     releaseDate: 2023-05-01
     eol: 2027-05-31
     link: https://en-us.support.motorola.com/app/software-security-update/g_id/7112/productid/11495
 
 -   releaseCycle: "motorola-edge-40"
-    releaseLabel: "Motorola Edge 40"
+    releaseLabel: "Edge 40"
     releaseDate: 2023-05-01
     eol: 2027-05-31
     link: https://en-us.support.motorola.com/app/software-security-update/g_id/7112/productid/11533
 
 -   releaseCycle: "moto-g-stylus-2023"
-    releaseLabel: "Motorola Moto G Stylus (2023)"
+    releaseLabel: "Moto G Stylus (2023)"
     releaseDate: 2023-04-01
     eol: 2026-04-30
     link: https://en-us.support.motorola.com/app/software-security-update/g_id/7112/productid/11493
 
 -   releaseCycle: "moto-g-power-5g-2023"
-    releaseLabel: "Motorola Moto G Power 5G (2023)"
+    releaseLabel: "Moto G Power 5G (2023)"
     releaseDate: 2023-04-01
     eol: 2026-04-30
     link: https://en-us.support.motorola.com/app/software-security-update/g_id/7112/productid/11490
 
 -   releaseCycle: "motorola-edge-40-pro"
-    releaseLabel: "Motorola Edge 40 Pro"
+    releaseLabel: "Edge 40 Pro"
     releaseDate: 2023-04-01
     eol: 2027-04-30
     link: https://en-us.support.motorola.com/app/software-security-update/g_id/7112/productid/11491
 
 -   releaseCycle: "moto-g-play-2023"
-    releaseLabel: "Motorola Moto G Play (2023)"
+    releaseLabel: "Moto G Play (2023)"
     releaseDate: 2023-01-01
     eol: 2025-12-31
     link: https://en-us.support.motorola.com/app/software-security-update/g_id/7112/productid/11403
 
 -   releaseCycle: "moto-g73-5g"
-    releaseLabel: "Motorola Moto G73 5G"
+    releaseLabel: "Moto G73 5G"
     releaseDate: 2023-01-01
     eol: 2026-01-31
     link: https://en-us.support.motorola.com/app/software-security-update/g_id/7112/productid/11431
 
 -   releaseCycle: "moto-g53-5g"
-    releaseLabel: "Motorola Moto G53 5G"
+    releaseLabel: "Moto G53 5G"
     releaseDate: 2023-01-01
     eol: 2026-01-31
     link: https://en-us.support.motorola.com/app/software-security-update/g_id/7112/productid/11426
 
 -   releaseCycle: "moto-g23"
-    releaseLabel: "Motorola Moto G23"
+    releaseLabel: "Moto G23"
     releaseDate: 2023-01-01
     eol: 2026-01-31
     link: https://en-us.support.motorola.com/app/software-security-update/g_id/7112/productid/11430
 
 -   releaseCycle: "moto-g13"
-    releaseLabel: "Motorola Moto G13"
+    releaseLabel: "Moto G13"
     releaseDate: 2023-01-01
     eol: 2026-01-31
     link: https://en-us.support.motorola.com/app/software-security-update/g_id/7112/productid/11429
 
 -   releaseCycle: "moto-e13"
-    releaseLabel: "Motorola Moto E13"
+    releaseLabel: "Moto E13"
     releaseDate: 2023-01-01
     eol: 2025-01-01
     link: https://en-us.support.motorola.com/app/software-security-update/g_id/7112/productid/11427
@@ -186,235 +186,235 @@ releases:
     link: https://en-us.support.motorola.com/app/software-security-update/g_id/7112/productid/11418
 
 -   releaseCycle: "moto-g72"
-    releaseLabel: "Motorola Moto G72"
+    releaseLabel: "Moto G72"
     releaseDate: 2022-10-01
     eol: 2025-10-31
     link: https://en-us.support.motorola.com/app/software-security-update/g_id/7112/productid/11372
 
 -   releaseCycle: "moto-e22s"
-    releaseLabel: "Motorola Moto E22S"
+    releaseLabel: "Moto E22S"
     releaseDate: 2022-10-01
     eol: 2024-10-01
     link: https://en-us.support.motorola.com/app/software-security-update/g_id/7112/productid/11369
 
 -   releaseCycle: "moto-e22i"
-    releaseLabel: "Motorola Moto E22I"
+    releaseLabel: "Moto E22I"
     releaseDate: 2022-10-01
     eol: 2024-10-01
     link: https://en-us.support.motorola.com/app/software-security-update/g_id/7112/productid/11356
 
 -   releaseCycle: "moto-e22"
-    releaseLabel: "Motorola Moto E22"
+    releaseLabel: "Moto E22"
     releaseDate: 2022-10-01
     eol: 2024-10-01
     link: https://en-us.support.motorola.com/app/software-security-update/g_id/7112/productid/11357
 
 -   releaseCycle: "motorola-razr-2022"
-    releaseLabel: "Motorola Razr (2022)"
+    releaseLabel: "Razr (2022)"
     releaseDate: 2022-10-01
     eol: 2025-10-31
     link: https://en-us.support.motorola.com/app/software-security-update/g_id/7112/productid/11371
 
 -   releaseCycle: "motorola-edge-30-ultra"
-    releaseLabel: "Motorola Edge 30 Ultra"
+    releaseLabel: "Edge 30 Ultra"
     releaseDate: 2022-09-01
     eol: 2026-09-30
     link: https://en-us.support.motorola.com/app/software-security-update/g_id/7112/productid/11368
 
 -   releaseCycle: "motorola-edge-30-neo"
-    releaseLabel: "Motorola Edge 30 Neo"
+    releaseLabel: "Edge 30 Neo"
     releaseDate: 2022-09-01
     eol: 2025-09-30
     link: https://en-us.support.motorola.com/app/software-security-update/g_id/7112/productid/11373
 
 -   releaseCycle: "motorola-edge-30-fusion"
-    releaseLabel: "Motorola Edge 30 Fusion"
+    releaseLabel: "Edge 30 Fusion"
     releaseDate: 2022-09-01
     eol: 2025-09-30
     link: https://en-us.support.motorola.com/app/software-security-update/g_id/7112/productid/11358
 
 -   releaseCycle: "moto-g32"
-    releaseLabel: "Motorola Moto G32"
+    releaseLabel: "Moto G32"
     releaseDate: 2022-08-01
     eol: 2025-08-31
     link: https://en-us.support.motorola.com/app/software-security-update/g_id/7112/productid/11354
 
 -   releaseCycle: "motorola-edge-2022"
-    releaseLabel: "Motorola Edge (2022)"
+    releaseLabel: "Edge (2022)"
     releaseDate: 2022-08-01
     eol: 2025-08-31
     link: https://en-us.support.motorola.com/app/software-security-update/g_id/7112/productid/11319
 
 -   releaseCycle: "moto-g62-5g"
-    releaseLabel: "Motorola Moto G62 5G"
+    releaseLabel: "Moto G62 5G"
     releaseDate: 2022-06-01
     eol: 2025-06-01
     link: https://en-us.support.motorola.com/app/software-security-update/g_id/7112/productid/11297
 
 -   releaseCycle: "moto-g52j-5g"
-    releaseLabel: "Motorola Moto G52J 5G"
+    releaseLabel: "Moto G52J 5G"
     releaseDate: 2022-06-01
     eol: 2025-06-01
     link: https://en-us.support.motorola.com/app/software-security-update/g_id/7112/productid/11299
 
 -   releaseCycle: "moto-g42"
-    releaseLabel: "Motorola Moto G42"
+    releaseLabel: "Moto G42"
     releaseDate: 2022-06-01
     eol: 2025-06-01
     link: https://en-us.support.motorola.com/app/software-security-update/g_id/7112/productid/11309
 
 -   releaseCycle: "moto-e32s"
-    releaseLabel: "Motorola Moto E32S"
+    releaseLabel: "Moto E32S"
     releaseDate: 2022-06-01
     eol: 2024-06-01
     link: https://en-us.support.motorola.com/app/software-security-update/g_id/7112/productid/11248
 
 -   releaseCycle: "moto-g82-5g"
-    releaseLabel: "Motorola Moto G82 5G"
+    releaseLabel: "Moto G82 5G"
     releaseDate: 2022-05-01
     eol: 2025-05-01
     link: https://en-us.support.motorola.com/app/software-security-update/g_id/7112/productid/11292
 
 -   releaseCycle: "moto-e32"
-    releaseLabel: "Motorola Moto E32"
+    releaseLabel: "Moto E32"
     releaseDate: 2022-05-01
     eol: 2024-05-01
     link: https://en-us.support.motorola.com/app/software-security-update/g_id/7112/productid/11249
 
 -   releaseCycle: "motorola-edge-30"
-    releaseLabel: "Motorola Edge 30"
+    releaseLabel: "Edge 30"
     releaseDate: 2022-05-01
     eol: 2025-05-01
     link: https://en-us.support.motorola.com/app/software-security-update/g_id/7112/productid/11247
 
 -   releaseCycle: "moto-g-stylus-5g-2022"
-    releaseLabel: "Motorola Moto G Stylus 5G (2022)"
+    releaseLabel: "Moto G Stylus 5G (2022)"
     releaseDate: 2022-04-01
     eol: 2025-04-30
     link: https://en-us.support.motorola.com/app/software-security-update/g_id/7112/productid/11246
 
 -   releaseCycle: "moto-g-5g-2022"
-    releaseLabel: "Motorola Moto G 5G (2022)"
+    releaseLabel: "Moto G 5G (2022)"
     releaseDate: 2022-04-01
     eol: 2025-04-01
     link: https://en-us.support.motorola.com/app/software-security-update/g_id/7112/productid/11241
 
 -   releaseCycle: "moto-g52"
-    releaseLabel: "Motorola Moto G52"
+    releaseLabel: "Moto G52"
     releaseDate: 2022-04-01
     eol: 2025-04-01
     link: https://en-us.support.motorola.com/app/software-security-update/g_id/7112/productid/11240
 
 -   releaseCycle: "moto-g22"
-    releaseLabel: "Motorola Moto G22"
+    releaseLabel: "Moto G22"
     releaseDate: 2022-03-01
     eol: 2025-03-01
     link: https://en-us.support.motorola.com/app/software-security-update/g_id/7112/productid/11235
 
 -   releaseCycle: "moto-g-stylus-2022"
-    releaseLabel: "Motorola Moto G Stylus (2022)"
+    releaseLabel: "Moto G Stylus (2022)"
     releaseDate: 2022-02-01
     eol: 2024-02-01
     link: https://en-us.support.motorola.com/app/software-security-update/g_id/7112/productid/11225
 
 -   releaseCycle: "motorola-edge-30-pro"
-    releaseLabel: "Motorola Edge 30 Pro"
+    releaseLabel: "Edge 30 Pro"
     releaseDate: 2022-02-01
     eol: 2025-02-01
     link: https://en-us.support.motorola.com/app/software-security-update/g_id/7112/productid/11220
 
 -   releaseCycle: "motorola-edge+-2022"
-    releaseLabel: "Motorola Edge+ (2022)"
+    releaseLabel: "Edge+ (2022)"
     releaseDate: 2022-02-01
     eol: 2025-02-01
     link: https://en-us.support.motorola.com/app/software-security-update/g_id/7112/productid/11221
 
 -   releaseCycle: "moto-g-power-2022"
-    releaseLabel: "Motorola Moto G Power (2022)"
+    releaseLabel: "Moto G Power (2022)"
     releaseDate: 2021-11-01
     eol: 2023-11-01
     link: https://en-us.support.motorola.com/app/software-security-update/g_id/7112/productid/11208
 
 -   releaseCycle: "moto-g200-5g"
-    releaseLabel: "Motorola Moto G200 5G"
+    releaseLabel: "Moto G200 5G"
     releaseDate: 2021-11-01
     eol: 2023-11-01
     link: https://en-us.support.motorola.com/app/software-security-update/g_id/7112/productid/11210
 
 -   releaseCycle: "moto-g71-5g"
-    releaseLabel: "Motorola Moto G71 5G"
+    releaseLabel: "Moto G71 5G"
     releaseDate: 2021-11-01
     eol: 2023-11-01
     link: https://en-us.support.motorola.com/app/software-security-update/g_id/7112/productid/11207
 
 -   releaseCycle: "moto-g51-5g"
-    releaseLabel: "Motorola Moto G51 5G"
+    releaseLabel: "Moto G51 5G"
     releaseDate: 2021-11-01
     eol: 2023-11-01
     link: https://en-us.support.motorola.com/app/software-security-update/g_id/7112/productid/11211
 
 -   releaseCycle: "moto-g41"
-    releaseLabel: "Motorola Moto G41"
+    releaseLabel: "Moto G41"
     releaseDate: 2021-11-01
     eol: 2023-11-01
     link: https://en-us.support.motorola.com/app/software-security-update/g_id/7112/productid/11198
 
 -   releaseCycle: "moto-g31"
-    releaseLabel: "Motorola Moto G31"
+    releaseLabel: "Moto G31"
     releaseDate: 2021-11-01
     eol: 2023-11-01
     link: https://en-us.support.motorola.com/app/software-security-update/g_id/7112/productid/11197
 
 -   releaseCycle: "moto-g-pure-2021"
-    releaseLabel: "Motorola Moto G Pure (2021)"
+    releaseLabel: "Moto G Pure (2021)"
     releaseDate: 2021-11-01
     eol: 2023-11-01
     link: https://en-us.support.motorola.com/app/software-security-update/g_id/7112/productid/11179
 
 -   releaseCycle: "moto-g-pure"
-    releaseLabel: "Motorola Moto G Pure"
+    releaseLabel: "Moto G Pure"
     releaseDate: 2021-09-01
     eol: 2023-09-01
     link: https://en-us.support.motorola.com/app/software-security-update/g_id/7112/productid/11179
 
 -   releaseCycle: "moto-e40"
-    releaseLabel: "Motorola Moto E40"
+    releaseLabel: "Moto E40"
     releaseDate: 2021-09-01
     eol: 2023-09-01
     link: https://en-us.support.motorola.com/app/software-security-update/g_id/7112/productid/11178
 
 -   releaseCycle: "moto-e30"
-    releaseLabel: "Motorola Moto E30"
+    releaseLabel: "Moto E30"
     releaseDate: 2021-09-01
     eol: 2023-09-01
     link: https://en-us.support.motorola.com/app/software-security-update/g_id/7112/productid/11177
 
 -   releaseCycle: "moto-e20"
-    releaseLabel: "Motorola Moto E20"
+    releaseLabel: "Moto E20"
     releaseDate: 2021-09-01
     eol: 2023-09-01
     link: https://en-us.support.motorola.com/app/software-security-update/g_id/7112/productid/11168
 
 -   releaseCycle: "motorola-edge-20-lite"
-    releaseLabel: "Motorola Edge 20 Lite"
+    releaseLabel: "Edge 20 Lite"
     releaseDate: 2021-08-01
     eol: 2023-07-01
     link: https://en-us.support.motorola.com/app/software-security-update/g_id/7112/productid/11166
 
 -   releaseCycle: "motorola-edge-20-fusion"
-    releaseLabel: "Motorola Edge 20 Fusion"
+    releaseLabel: "Edge 20 Fusion"
     releaseDate: 2021-08-01
     eol: 2023-08-01
     link: https://en-us.support.motorola.com/app/software-security-update/g_id/7112/productid/11166
 
 -   releaseCycle: "motorola-edge-20"
-    releaseLabel: "Motorola Edge 20"
+    releaseLabel: "Edge 20"
     releaseDate: 2021-08-01
     eol: 2023-08-01
     link: https://en-us.support.motorola.com/app/software-security-update/g_id/7112/productid/11167
 
 -   releaseCycle: "motorola-edge-2021"
-    releaseLabel: "Motorola Edge (2021)"
+    releaseLabel: "Edge (2021)"
     releaseDate: 2021-08-01
     eol: 2023-08-01
     link: https://en-us.support.motorola.com/app/software-security-update/g_id/7112/productid/11170


### PR DESCRIPTION
Even motorola itself doesnt mention their products with Motorola prefix. If we plan to keep Motorola part we also need to add Samsung too all Samsung phones too [which we are not doing]