### PR TITLE
[oneplus] Fix broken links

### DIFF
--- a/products/oneplus.md
+++ b/products/oneplus.md
@@ -7,7 +7,7 @@ iconSlug: oneplus
 permalink: /oneplus
 versionCommand: "Settings -> About device"
 releasePolicyLink: https://community.oneplus.com/thread/1462181
-changelogTemplate: "https://www.oneplus.com/oneplus-{{'__RELEASE_CYCLE__'|downcase}}"
+changelogTemplate: "https://www.oneplus.com/us/oneplus-{{'__RELEASE_CYCLE__'|downcase}}"
 releaseLabel: "OnePlus __RELEASE_CYCLE__"
 releaseColumn: false
 activeSupportColumn: Active Major Updates


### PR DESCRIPTION
Looks like they dont keep/mirror their all products in all locales so change links to us ones that will at least fix the 404 problem. For testing purposes :
https://www.oneplus.com/us/oneplus-11
vs
https://www.oneplus.com/fr/oneplus-11

if you are using a vpn than you will observe with that problem more obvious