### PR TITLE
[ros] Update product description

### DIFF
--- a/products/ros-2.md
+++ b/products/ros-2.md
@@ -90,7 +90,7 @@ releases:
 > support for real-time code and embedded system hardware. As ROS 1 will no longer be [supported past
 > May 2025](/ros), it is highly recommended for new projects to start using ROS 2.
 
-## Release Cadence
+Release Cadence:
 
 - There is a ROS 2 release every year on May 23rd.
 - Releases on even numbered years will be a LTS release, supported for five years.
@@ -104,5 +104,4 @@ Side effects of the release policy:
 - LTS releases will not share a common Ubuntu release with any previous releases.
 - ROS 2 releases will not add support for new Ubuntu distributions after their release date.
 
-These simplified rules and side effects are subject to change with changes to the underlying Ubuntu
-release policy.
+These simplified rules and side effects are subject to change with changes to the underlying Ubuntu release policy.

--- a/products/ros.md
+++ b/products/ros.md
@@ -11,61 +11,30 @@ releaseLabel: '__CODENAME__'
 releaseColumn: false
 eolColumn: End Of Life
 
-auto:
-  methods:
-  -   ros: https://wiki.ros.org/Distributions
-      regex: '^ROS (?P<name>(\w| )+)'
-      template: "{{name}}"
-
 releases:
 -   releaseCycle: 'noetic'
     codename: 'Noetic Ninjemys'
     releaseDate: 2020-05-23
     eol: 2025-05-01
-    latest: noetic
-    latestReleaseDate: 2020-05-23
 
 -   releaseCycle: 'melodic'
     codename: 'Melodic Morenia'
     releaseDate: 2018-05-23
     eol: 2023-04-01
-    latest: melodic
-    latestReleaseDate: 2018-05-23
 
 -   releaseCycle: 'lunar'
     codename: 'Lunar Loggerhead'
     releaseDate: 2017-05-23
     eol: 2019-05-01
-    latest: lunar
-    latestReleaseDate: 2017-05-23
 
 -   releaseCycle: 'kinetic'
     codename: 'Kinetic Kame'
     releaseDate: 2016-05-23
     eol: 2021-05-01
-    latest: kinetic
-    latestReleaseDate: 2016-05-23
 
 ---
 
 > ROS (Robot Operating System) provides libraries and tools to help software developers create robot
 > applications.
 
-Release rules:
-
-- There is a ROS release every year in May.
-- Releases on even numbered years will be a LTS release, supported for five years.
-- Releases on odd numbered years are normal ROS releases, supported for two years.
-- ROS releases will drop support for EOL Ubuntu distributions, even if the ROS release is still supported.
-
-Side effects of the release policy:
-
-- Every ROS release will be supported on exactly one Ubuntu LTS.
-- Releases on odd numbered years will share a common Ubuntu release with the LTS ROS release of the previous year.
-- LTS releases will not share a common Ubuntu release with any previous releases.
-- ROS releases will not add support for new Ubuntu distributions after their release date.
-
-These simplified rules and side effects are subject to change with changes to the underlying Ubuntu
-release policy.
-
-For more details see the official [Release Policy](https://wiki.ros.org/Distributions/ReleasePolicy).
+All ROS 1 distributions have reached end-of-life. You should use [ROS 2](/ros-2).


### PR DESCRIPTION
All Ros 1 version are now EOL: there is no need to explain the support policy and to keep the auto configuration.