### PR TITLE
[nutanix-*] Update descriptions

### DIFF
--- a/products/nutanix-aos.md
+++ b/products/nutanix-aos.md
@@ -6,7 +6,7 @@ tags: nutanix
 iconSlug: nutanix
 permalink: /nutanix-aos
 versionCommand: ncli cluster version
-releasePolicyLink: "https://www.nutanix.com/support-services/product-support/support-policies-and-faqs"
+releasePolicyLink: https://www.nutanix.com/support-services/product-support/support-policies-and-faqs
 eoasColumn: End of Maintenance
 eolColumn: End of Support Life
 
@@ -176,21 +176,10 @@ releases:
 > system that provides the core functionality leveraged by workloads and services running on the
 > Nutanix platform.
 
-AOS releases and the associated policy is inclusive of software such as AHV, Foundation and Nutanix
-Cluster Check (NCC). Only the latest patch release in any given release cycle is supported.
+Nutanix AOS versions are designated using the following format: `X.Y.Z.n`, where `X` is the major version,
+`Y` is the minor version, `Z` is the maintenance version, and `n` is the patch version.
 
-## [Releases](https://portal.nutanix.com/page/documents/kbs/details?targetId=kA00e000000LIi9CAG)
-
-* **Short-Term Support (STS)** have new features, and also provide a regular upgrade path and are
-  released every 3–6 months. They receive security and phone support for three (3) months from the
-  next major/minor release.
-* **Long-Term Support (LTS)** which are maintained for a longer duration and provide primarily bug
-  fixes for an extended period of time on a particular release family. Each LTS Release is
-  maintained for 3 months after the next LTS major/minor release is made. Each LTS release will
-  then receive security and phone support for next 9 months.
-
-## Release Cadence
-
-* Major/Minor releases are typically made available every 6–9 months.
-* Maintenance releases are typically made available every 4–6 weeks.
-* Patch Releases are made available on an as-needed basis.
+Since AOS 7.0, Nutanix [transitioned](https://portal.nutanix.com/page/documents/kbs/details?targetId=kA00e000000LIi9CAG) from the LTS/STS/eSTS release model to a Unified 'NCI Release Model'.
+Under this model, major or minor releases are typically made available every 6–9 months.
+All releases are actively maintained with bug and security fixes for 15 months,
+followed by an additional 9 months of troubleshooting with only security fixes.

--- a/products/nutanix-files.md
+++ b/products/nutanix-files.md
@@ -15,10 +15,17 @@ auto:
 
 # Releases can be found on https://portal.nutanix.com/page/documents/eol/list?type=files.
 releases:
--   releaseCycle: "5.1"
-    releaseDate: 2024-12-16
+-   releaseCycle: "5.2"
+    releaseDate: 2025-07-30
     eoas: false # not yet documented on https://portal.nutanix.com/page/documents/eol/list?type=files
     eol: false # not yet documented on https://portal.nutanix.com/page/documents/eol/list?type=files
+    latest: "5.2.0.0"
+    latestReleaseDate: 2025-07-30
+
+-   releaseCycle: "5.1"
+    releaseDate: 2024-12-16
+    eoas: 2025-10-31
+    eol: 2026-07-31
     latest: "5.1.1.2"
     latestReleaseDate: 2025-07-03
 
@@ -97,19 +104,9 @@ releases:
 > [Nutanix Files](https://www.nutanix.com/uk/products/files) is a simple, scalable and smart
 > cloud-based file management platform.
 
-Only the latest release cycle is actively maintained (new features).
+Nutanix Files versions are designated using the following format: `X.Y.Z.n`, where `X` is the major version,
+`Y` is the minor version, `Z` is the maintenance version, and `n` is the patch version.
 
-* A release is supported (with workarounds and bug fixes) for 3 months after a new major/minor
-  version is released.
-* Troubleshooting (security fixes, phone support) is provided for 12 months after a new major/minor
-  version is released.
-
-For example, if Nutanix releases Files 3.1.0 on September 1, 2018 and Files 3.2.0 on November 1,
-2018 then Files 3.1.0 will be Maintained until February 28, 2019 and Troubleshooting for Files 3.1.0
-will be available until November 30, 2019.
-
-## Release Cadence
-
-* A new major/minor release is typically made every 6–9 months.
-* Maintenance releases are typically made every 6–8 weeks.
-* Patch releases are made on an as-needed basis.
+Major or minor releases are typically made available every 6–9 months.
+All releases are actively maintained with bug and security fixes until 3 months after the next major or minor release,
+followed by an additional 9 months of troubleshooting with only security fixes.

--- a/products/nutanix-prism.md
+++ b/products/nutanix-prism.md
@@ -20,6 +20,13 @@ auto:
 
 # Support and EOL dates can be found at https://portal.nutanix.com/page/documents/eol/list?type=pc.
 releases:
+-   releaseCycle: "pc.7.3"
+    releaseDate: 2025-06-24
+    eoas: 2026-09-30
+    eol: 2027-06-30
+    latest: "pc.7.3.0.0"
+    latestReleaseDate: 2025-06-24
+
 -   releaseCycle: "pc.2024.3"
     releaseDate: 2024-12-05
     eoas: 2026-03-31
@@ -193,18 +200,10 @@ releases:
 > [Nutanix Prism](https://www.nutanix.com/uk/products/prism) is the control plane that simplifies
 > and streamlines common workflows to make hypervisor and VM setup as easy as checking your email.
 
-Only the latest patch release in a release cycle is supported.
+Nutanix Prism versions are designated using the following format: `pc.X.Y.Z.n`, where `X` is the major version,
+`Y` is the minor version, `Z` is the maintenance version, and `n` is the patch version.
 
-Each release cycle (Upgrade) is maintained (with workarounds, bug fixes) for 2 months from the
-release date of the next release cycle. It then further receives Troubleshooting (phone support,
-security fixes) for another 3 months.
-
-For example, if Nutanix releases PC.2020.8 on Aug 1, 2020 and releases PC.2020.9 on Sep 1, 2020 then
-PC.2020.8 will be Maintained until Nov 30, 2020 and Troubleshooting for PC.2020.8 will be available
-until Feb 28, 2021.
-
-## Release Cadence
-
-* A new major/minor release is typically made every 6–9 months.
-* Maintenance releases are typically made every 4–6 weeks.
-* Patch releases are made available on an as-needed basis.
+Since Prism pc.2024.3, Nutanix [transitioned](https://portal.nutanix.com/page/documents/kbs/details?targetId=kA00e000000LIi9CAG) from the LTS/STS/eSTS release model to a Unified 'NCI Release Model'.
+Under this model, major or minor releases are typically made available every 6–9 months.
+All releases are actively maintained with bug and security fixes for 15 months,
+followed by an additional 9 months of troubleshooting with only security fixes.


### PR DESCRIPTION
With the introduction of AOS 7.0 and Prism Central (PC) version pc.2024.3, Nutanix transitioned from the LTS/STS/eSTS release model to a Unified 'NCI Release Model' (https://portal.nutanix.com/page/documents/kbs/details?targetId=kA00e000000LIi9CAG). Those updates are reflecting that.

This also update latest releases for Files and Prism.

Fixes #7405.