### PR TITLE
[couchbase-server] Add 1.8 to 5.5

### DIFF
--- a/products/couchbase-server.md
+++ b/products/couchbase-server.md
@@ -29,18 +29,29 @@ auto:
         releaseCycle:
           column: "Release"
           regex: '^Couchbase Server (?P<value>[0-9.]+)$'
+        releaseDate: "General Availability"
         eol: "End of Full Maintenance"
   -   declare: couchbase-server
-      versions:
-        # Dates are not available for all versions, so they must be set manually in some cases.
-        -   { name: "6.0.0", date: 2018-10-31 } # https://www.couchbase.com/blog/announcing-couchbase-6-0/
-        -   { name: "6.0.1", date: 2019-02-15 } # https://web.archive.org/web/20190307191211/https://docs.couchbase.com/server/6.0/release-notes/relnotes.html
-        -   { name: "6.6.0", date: 2020-08-12 } # https://www.couchbase.com/blog/whats-new-and-improved-in-couchbase-server-6-6/
-        -   { name: "7.2.0", date: 2023-06-01 } # https://www.couchbase.com/blog/couchbase-capella-spring-release-72/
+      releases:
+      -   {name: "7.6", releaseDate: 2024-03-25} # https://www.couchbase.com/blog/announcing-couchbase-6-0/
+      -   {name: "7.2", releaseDate: 2023-06-01} # https://www.couchbase.com/blog/couchbase-capella-spring-release-72/
+      -   {name: "7.1", releaseDate: 2022-05-10} # https://www.couchbase.com/blog/whats-new-in-couchbase-server-7-1/
+      -   {name: "7.0", releaseDate: 2021-07-29} # https://www.couchbase.com/blog/couchbase-server-7-0-release/
+      -   {name: "6.6", releaseDate: 2020-08-12} # https://www.couchbase.com/blog/whats-new-and-improved-in-couchbase-server-6-6/
+      -   {name: "6.5", releaseDate: 2020-01-21} # https://www.couchbase.com/blog/announcing-couchbase-server-6-5-0-whats-new-and-improved/
+      -   {name: "6.0", releaseDate: 2018-10-31} # https://www.couchbase.com/blog/announcing-couchbase-6-0/
+      -   {name: "5.5", releaseDate: 2018-07-23} # https://www.couchbase.com/blog/couchbase-server-5-5-beta-2/
+      -   {name: "5.0", releaseDate: 2017-10-26} # https://www.couchbase.com/blog/announcing-couchbase-server-5-0/
+      -   {name: "4.6", releaseDate: 2017-02-16} # https://www.couchbase.com/blog/announcing-couchbase-server-4-6-whats-new-improved/
+      -   {name: "4.5", releaseDate: 2016-06-27} # https://www.couchbase.com/blog/announcing-couchbase-server-4.5/
+      -   {name: "4.1", releaseDate: 2015-12-10} # https://www.couchbase.com/blog/introducing-couchbase-server-4.1/
+      -   {name: "4.0", releaseDate: 2015-10-06} # https://www.couchbase.com/blog/announcing-couchbase-server-4-0/
+      -   {name: "3.0", releaseDate: 2014-12-17} # https://www.couchbase.com/blog/announcing-release-couchbase-server-30-0/
+      -   {name: "2.1", releaseDate: 2013-06-26} # https://www.couchbase.com/press-releases/couchbase-announces-availability-of-couchbase-server-2-1-nosql-document-database/
 
 releases:
 -   releaseCycle: "7.6"
-    releaseDate: 2024-03-31
+    releaseDate: 2024-03-25
     eol: 2026-07-31
     latest: "7.6.6"
     latestReleaseDate: 2025-05-31
@@ -52,13 +63,13 @@ releases:
     latestReleaseDate: 2025-03-31
 
 -   releaseCycle: "7.1"
-    releaseDate: 2022-05-31
+    releaseDate: 2022-05-10
     eol: 2024-01-31
     latest: "7.1.6"
     latestReleaseDate: 2023-11-30
 
 -   releaseCycle: "7.0"
-    releaseDate: 2021-07-31
+    releaseDate: 2021-07-29
     eol: 2023-01-31
     latest: "7.0.5"
     latestReleaseDate: 2022-12-31
@@ -70,18 +81,116 @@ releases:
     latestReleaseDate: 2023-01-15
 
 -   releaseCycle: "6.5"
-    releaseDate: 2020-01-15
+    releaseDate: 2020-01-21
     eol: 2021-02-28
-    link: https://web.archive.org/web/20230519160357/https://docs.couchbase.com/server/6.5/release-notes/relnotes.html
     latest: "6.5.2"
     latestReleaseDate: 2021-02-15
+    link: https://web.archive.org/web/20230519160357/https://docs.couchbase.com/server/6.5/release-notes/relnotes.html
 
 -   releaseCycle: "6.0"
     releaseDate: 2018-10-31
     eol: 2020-07-31
-    link: https://web.archive.org/web/20230519162206/https://docs.couchbase.com/server/6.0/release-notes/relnotes.html
     latest: "6.0.5"
     latestReleaseDate: 2022-04-30
+    link: https://web.archive.org/web/20230519162206/https://docs.couchbase.com/server/6.0/release-notes/relnotes.html
+
+-   releaseCycle: '5.5'
+    releaseDate: 2018-07-23
+    eol: 2020-07-31
+    latest: "5.5.6"
+    latestReleaseDate: 2019-11-15 # approximate date from https://web.archive.org/web/20211016022911/https://docs.couchbase.com/server/5.5/release-notes/relnotes.html
+    link: https://web.archive.org/web/20211016022911/https://docs.couchbase.com/server/5.5/release-notes/relnotes.html
+
+-   releaseCycle: '5.1'
+    releaseDate: 2018-02-28
+    eol: 2019-01-31
+    latest: "5.1.3"
+    latestReleaseDate: 2018-11-15 # approximate date from https://web.archive.org/web/20211021103137/https://docs.couchbase.com/server/5.1/release-notes/relnotes.html
+    link: https://web.archive.org/web/20211021103137/https://docs.couchbase.com/server/5.1/release-notes/relnotes.html
+
+-   releaseCycle: '5.0'
+    releaseDate: 2017-10-26
+    eol: 2018-08-31
+    latest: "5.0.1"
+    latestReleaseDate: 2017-12-15 # approximate date from https://web.archive.org/web/20211207070105/https://docs.couchbase.com/server/5.0/release-notes/relnotes.html
+    link: https://web.archive.org/web/20211207070105/https://docs.couchbase.com/server/5.0/release-notes/relnotes.html
+
+-   releaseCycle: '4.6'
+    releaseDate: 2017-02-16 # https://www.couchbase.com/blog/announcing-couchbase-server-4-6-whats-new-improved/
+    eol: 2018-08-31
+    latest: "5.0.1"
+    latestReleaseDate: 2017-12-15 # approximate date from https://web.archive.org/web/20211207070105/https://docs.couchbase.com/server/5.0/release-notes/relnotes.html
+    link: null
+
+-   releaseCycle: '4.5'
+    releaseDate: 2016-06-27
+    eol: 2018-04-30
+    latest: "4.5.1"
+    latestReleaseDate: 2016-10-05
+    link: https://www.couchbase.com/blog/announcing-couchbase-server-4-5-1/
+
+-   releaseCycle: '4.1'
+    releaseDate: 2015-12-10
+    eol: 2018-04-30
+    latest: "4.1.2"
+    latestReleaseDate: 2016-08-15
+    link: https://www.couchbase.com/blog/announcing-couchbase-server-4-1-2/
+
+-   releaseCycle: '4.0'
+    releaseDate: 2015-10-06
+    eol: 2017-04-30
+    latest: "4.0.0" # could not find any information
+    latestReleaseDate: 2015-10-06
+    link: null
+
+-   releaseCycle: '3.1'
+    releaseDate: 2015-08-31
+    eol: 2017-02-28
+    latest: "3.1.3"
+    latestReleaseDate: 2016-05-16
+    link: https://www.couchbase.com/blog/couchbase-3.1.3-ce-is-now-available/
+
+-   releaseCycle: '3.0'
+    releaseDate: 2014-12-17
+    eol: 2016-04-30
+    latest: "3.0.3"
+    latestReleaseDate: 2015-03-30
+    link: https://www.couchbase.com/blog/announcing-couchbase-server-3.0.3/
+
+-   releaseCycle: '2.5'
+    releaseDate: 2014-02-28
+    eol: 2015-12-31
+    latest: "2.5.0" # could not find any information
+    latestReleaseDate: 2014-02-28
+    link: null
+
+-   releaseCycle: '2.2'
+    releaseDate: 2013-09-30
+    eol: 2015-03-31
+    latest: "2.2.0" # could not find any information
+    latestReleaseDate: 2013-09-30
+    link: null
+
+-   releaseCycle: '2.1'
+    releaseDate: 2013-06-26
+    eol: 2014-12-31
+    latest: "2.1.0" # could not find any information
+    latestReleaseDate: 2013-06-26
+    link: null
+
+-   releaseCycle: '2.0'
+    releaseDate: 2012-12-31
+    eol: 2014-06-30
+    latest: "2.0.0" # could not find any information
+    latestReleaseDate: 2012-12-31
+    link: null
+
+-   releaseCycle: '1.8'
+    releaseDate: 2012-07-31
+    eol: 2014-01-31
+    latest: "1.8.0" # could not find any information
+    latestReleaseDate: 2012-07-31
+    link: null
 
 ---
 


### PR DESCRIPTION
Based on information from https://github.com/endoflife-date/endoflife.date/pull/7995#issuecomment-3146883647.

Also updated the auto configuration so the approximate release dates are also retrieved from https://www.couchbase.com/support-policy/EOL/.