### PR TITLE
[nvidia-gpu] add end of support dates for maxwell, pascal, and volta gpus

### DIFF
--- a/products/nvidia-gpu.md
+++ b/products/nvidia-gpu.md
@@ -122,64 +122,64 @@ releases:
 -   releaseCycle: "professional-volta"
     releaseLabel: "Professional Volta (GV100)"
     releaseDate: 2017-12-07
-    eoas: false
-    eol: false
+    eoas: 2025-11-01
+    eol: 2028-11-01
     discontinued: true
 
 -   releaseCycle: "mobile-professional-pascal"
     releaseLabel: "Mobile Professional Pascal (GP10x)"
     releaseDate: 2017-02-06
-    eoas: false
-    eol: false
+    eoas: 2025-11-01
+    eol: 2028-11-01
     discontinued: true
 
 -   releaseCycle: "mobile-consumer-pascal"
     releaseLabel: "Mobile Consumer Pascal (GP10x)"
-    eoas: false
-    eol: false
+    eoas: 2025-11-01
+    eol: 2028-11-01
     discontinued: true
     releaseDate: 2016-08-15
 
 -   releaseCycle: "consumer-pascal"
     releaseLabel: "Consumer Pascal (GP10x)"
     releaseDate: 2016-05-27
-    eoas: false
-    eol: false
+    eoas: 2025-11-01
+    eol: 2028-11-01
     discontinued: true
 
 -   releaseCycle: "professional-pascal"
     releaseLabel: "Professional Pascal (GP10x)"
     releaseDate: 2016-04-05
-    eoas: false
-    eol: false
+    eoas: 2025-11-01
+    eol: 2028-11-01
     discontinued: true
 
 -   releaseCycle: "mobile-professional-maxwell"
     releaseLabel: "Mobile Professional Maxwell (GMxxx)"
     releaseDate: 2015-08-18
-    eoas: false
-    eol: false
+    eoas: 2025-11-01
+    eol: 2028-11-01
     discontinued: true
 
 -   releaseCycle: "professional-maxwell"
     releaseLabel: "Professional Maxwell (GMxxx)"
     releaseDate: 2015-06-29
-    eoas: false
-    eol: false
+    eoas: 2025-11-01
+    eol: 2028-11-01
     discontinued: true
 
 -   releaseCycle: "mobile-consumer-maxwell"
     releaseLabel: "Mobile Consumer Maxwell (GMxxx)"
     releaseDate: 2014-10-07
-    eoas: false
-    eol: false
+    eoas: 2025-11-01
+    eol: 2028-11-01
     discontinued: true
 
 -   releaseCycle: "consumer-maxwell"
     releaseLabel: "Consumer Maxwell (GMxxx)"
     releaseDate: 2014-09-19
-    eoas: false
-    eol: false
+    eoas: 2025-11-01
+    eol: 2028-11-01
     discontinued: true
 
 -   releaseCycle: "professional-kepler"

--- a/products/nvidia-gpu.md
+++ b/products/nvidia-gpu.md
@@ -122,64 +122,64 @@ releases:
 -   releaseCycle: "professional-volta"
     releaseLabel: "Professional Volta (GV100)"
     releaseDate: 2017-12-07
-    eoas: 2025-11-01
-    eol: 2028-11-01
+    eoas: 2025-10-31
+    eol: 2028-10-31
     discontinued: true
 
 -   releaseCycle: "mobile-professional-pascal"
     releaseLabel: "Mobile Professional Pascal (GP10x)"
     releaseDate: 2017-02-06
-    eoas: 2025-11-01
-    eol: 2028-11-01
+    eoas: 2025-10-31
+    eol: 2028-10-31
     discontinued: true
 
 -   releaseCycle: "mobile-consumer-pascal"
     releaseLabel: "Mobile Consumer Pascal (GP10x)"
-    eoas: 2025-11-01
-    eol: 2028-11-01
+    eoas: 2025-10-31
+    eol: 2028-10-31
     discontinued: true
     releaseDate: 2016-08-15
 
 -   releaseCycle: "consumer-pascal"
     releaseLabel: "Consumer Pascal (GP10x)"
     releaseDate: 2016-05-27
-    eoas: 2025-11-01
-    eol: 2028-11-01
+    eoas: 2025-10-31
+    eol: 2028-10-31
     discontinued: true
 
 -   releaseCycle: "professional-pascal"
     releaseLabel: "Professional Pascal (GP10x)"
     releaseDate: 2016-04-05
-    eoas: 2025-11-01
-    eol: 2028-11-01
+    eoas: 2025-10-31
+    eol: 2028-10-31
     discontinued: true
 
 -   releaseCycle: "mobile-professional-maxwell"
     releaseLabel: "Mobile Professional Maxwell (GMxxx)"
     releaseDate: 2015-08-18
-    eoas: 2025-11-01
-    eol: 2028-11-01
+    eoas: 2025-10-31
+    eol: 2028-10-31
     discontinued: true
 
 -   releaseCycle: "professional-maxwell"
     releaseLabel: "Professional Maxwell (GMxxx)"
     releaseDate: 2015-06-29
-    eoas: 2025-11-01
-    eol: 2028-11-01
+    eoas: 2025-10-31
+    eol: 2028-10-31
     discontinued: true
 
 -   releaseCycle: "mobile-consumer-maxwell"
     releaseLabel: "Mobile Consumer Maxwell (GMxxx)"
     releaseDate: 2014-10-07
-    eoas: 2025-11-01
-    eol: 2028-11-01
+    eoas: 2025-10-31
+    eol: 2028-10-31
     discontinued: true
 
 -   releaseCycle: "consumer-maxwell"
     releaseLabel: "Consumer Maxwell (GMxxx)"
     releaseDate: 2014-09-19
-    eoas: 2025-11-01
-    eol: 2028-11-01
+    eoas: 2025-10-31
+    eol: 2028-10-31
     discontinued: true
 
 -   releaseCycle: "professional-kepler"


### PR DESCRIPTION
Sourced from:
https://www.nvidia.com/en-us/geforce/news/mafia-the-old-country-geforce-game-ready-driver/

https://nvidia.custhelp.com/app/answers/detail/a_id/5676/kw/end%20of%20support

Not 100% sure if the "professional" cards should be included here or not, but I marked them as such anyways.

There also isn't exact dates, but as it's mentioned "through October 2028" for the security support, I'm interpreting both of the October dates as including the entire month of October, therefore the first day of no support at all would be November 1st.