### PR TITLE
Add per-product event feed

### DIFF
--- a/_includes/head_custom.html
+++ b/_includes/head_custom.html
@@ -3,6 +3,10 @@ Favicons were generated from the SVG icons with https://realfavicongenerator.net
 
 The SVG favicon supports dark mode (https://blog.tomayac.com/2019/09/21/prefers-color-scheme-in-svg-favicons-for-dark-mode-icons/).
 {% endcomment %}
+{% if page.layout == "product" %}
+<link rel="alternate" type="text/calendar" title="{{ page.title }} events calendar" href="webcal://{{site.url | split: '://' | last}}/calendar{{page.permalink}}.ics" />
+<link rel="alternate" type="application/atom+xml" title="{{ page.title }} events feed" href="{{ page.permalink | relative_url }}.atom" />
+{% endif %}
 <link rel="apple-touch-icon" sizes="180x180" href="{{ '/assets/apple-touch-icon.png' | relative_url }}">
 <link rel="icon" type="image/svg+xml" href="{{ '/assets/favicon.svg' | relative_url }}">
 <link rel="icon alternate" type="image/png" sizes="32x32" href="{{ '/assets/favicon-32x32.png' | relative_url }}">

--- a/_layouts/product-feed.atom
+++ b/_layouts/product-feed.atom
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="utf-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom">
+  <id>{{ page.product_link }}</id>
+  <title>endoflife.date: {{ page.product_label }} events</title>
+  <subtitle>{{ page.product_label }} release and end-of-life events</subtitle>
+  <link href="{{ page.url | absolute_url }}" rel="self" />
+  <link href="{{ page.product_link }}"/>
+  <updated>{{ page.last_updated | date_to_xmlschema }}</updated>
+  <author><name>endoflife.date</name></author>
+{%- assign sorted_events = page.events | sort: "occurred_at" -%}
+{%- for event in sorted_events %}
+  <entry>
+    <id>{{ page.product_link }}/{{ event.release_name }}/{{ event.type }}</id>
+    <link href="{{ page.product_link }}"/>
+    <updated>{{ event.occurred_at | date_to_xmlschema }}</updated>
+{%- if event.type == "release" %}
+    <title>{{ page.product_label }} {{ event.release_label }} released</title>
+    <summary>{{ page.product_label }} {{ event.release_label }} has been released.</summary>
+{% elsif event.type == "eoas" %}
+    <title>{{ page.product_label }} {{ event.release_label }} end of active support</title>
+    <summary>{{ page.product_label }} {{ event.release_label }} active support ended.</summary>
+{% elsif event.type == "eol-7d" %}
+    <title>{{ page.product_label }} {{ event.release_label }} upcoming end of life</title>
+    <summary>{{ page.product_label }} {{ event.release_label }} will be end-of-life in 7 days.</summary>
+{% elsif event.type == "eol" %}
+    <title>{{ page.product_label }} {{ event.release_label }} end of life</title>
+    <summary>{{ page.product_label }} {{ event.release_label }} is end-of-life.</summary>
+{% elsif event.type == "eoes" %}
+    <title>{{ page.product_label }} {{ event.release_label }} end of extended support</title>
+    <summary>{{ page.product_label }} {{ event.release_label }} extended support ended.</summary>
+{% endif -%}
+  </entry>
+{% endfor -%}
+</feed>

--- a/_layouts/product.html
+++ b/_layouts/product.html
@@ -202,5 +202,6 @@ layout: default
 <p>
   A JSON version of this page is available at <a href="/api/v1/products{{page.permalink}}/">/api/v1/products{{page.permalink}}/</a>.
   See the <a href="/docs/api/v1/">API Documentation</a> for more information.
-  You can subscribe to the iCalendar feed at <a href="webcal://{{site.url | split: '://' | last}}/calendar{{page.permalink}}.ics">/calendar{{page.permalink}}.ics</a>.
+  You can subscribe to the RSS feed at <a href="{{page.permalink}}.atom" aria-label="Product events feed">{{page.permalink}}.atom</a>
+  or to the iCalendar feed at <a href="webcal://{{site.url | split: '://' | last}}/calendar{{page.permalink}}.ics" aria-label="Product events calendar">/calendar{{page.permalink}}.ics</a>.
 </p>

--- a/_plugins/generate-product-feeds.rb
+++ b/_plugins/generate-product-feeds.rb
@@ -1,0 +1,102 @@
+# This script create product pages for the website.
+
+require 'jekyll'
+
+module EndOfLife
+
+  def self.site_url(site, path)
+    "#{site.config['url']}#{path}"
+  end
+
+  class ProductFeedsGenerator < Jekyll::Generator
+    safe true
+    priority :lowest
+
+    TOPIC = "Product feeds:"
+
+    def generate(site)
+      @site = site
+      start = Time.now
+      Jekyll.logger.info TOPIC, "Generating..."
+
+      site.pages.select { |page| page.data['layout'] == 'product' }.each do |product|
+        site.pages << ProductFeed.new(site, product)
+      end
+
+      Jekyll.logger.info TOPIC, "Done in #{(Time.now - start).round(3)} seconds."
+    end
+  end
+
+  class ProductFeed < Jekyll::Page
+      def initialize(site, product)
+        @site = site
+        @base = site.source
+        @dir = ""
+        @name = "#{product.data['id']}.atom"
+
+        events = []
+        product.data['releases'].each do |release|
+          release_name = release['releaseCycle']
+          release_label = release['label']
+
+          release_date = release['releaseDate']
+          events << {
+            "type" => "release",
+            "release_name" => release_name,
+            "release_label" => release_label,
+            "occurred_at" => release_date&.to_datetime&.beginning_of_day,
+          }
+
+          eoas_date = release['eoas']
+          if eoas_date && eoas_date.is_a?(Date) then
+            events << {
+              "type" => "eoas",
+              "release_name" => release_name,
+              "release_label" => release_label,
+              "occurred_at" => eoas_date&.to_datetime&.end_of_day,
+            }
+          end
+
+          eol_date = release['eol']
+          if eol_date && eol_date.is_a?(Date) then
+            events << {
+              "type" => "eol",
+              "release_name" => release_name,
+              "release_label" => release_label,
+              "occurred_at" => eol_date&.to_datetime&.end_of_day,
+            }
+
+            eol_date_7d = release['eol'] - 7
+            events << {
+              "type" => "eol-7d",
+              "release_name" => release_name,
+              "release_label" => release_label,
+              "occurred_at" => eol_date_7d&.to_datetime&.end_of_day,
+            }
+          end
+
+          eoes_date = release['eoes']
+          if eoes_date && eoes_date.is_a?(Date) then
+            events << {
+              "type" => "eoes",
+              "release_name" => release_name,
+              "release_label" => release_label,
+              "occurred_at" => eoes_date&.to_datetime&.end_of_day,
+            }
+          end
+        end
+
+        @data = {
+          "layout" => "product-feed",
+          "product_id" => product.data['id'],
+          "product_label" => product.data['title'],
+          "product_link" => EndOfLife.site_url(site, product.data['permalink']),
+          "last_updated" => product.data['last_modified_at'],
+          "events" => events.select { |event| event["occurred_at"] <= Time.now },
+          "nav_exclude"=> true
+        }
+
+        self.process(@name)
+      end
+    end
+end

--- a/_plugins/generate-product-feeds.rb
+++ b/_plugins/generate-product-feeds.rb
@@ -28,75 +28,75 @@ module EndOfLife
   end
 
   class ProductFeed < Jekyll::Page
-      def initialize(site, product)
-        @site = site
-        @base = site.source
-        @dir = ""
-        @name = "#{product.data['id']}.atom"
+    def initialize(site, product)
+      @site = site
+      @base = site.source
+      @dir = ""
+      @name = "#{product.data['id']}.atom"
 
-        events = []
-        product.data['releases'].each do |release|
-          release_name = release['releaseCycle']
-          release_label = release['label']
+      events = []
+      product.data['releases'].each do |release|
+        release_name = release['releaseCycle']
+        release_label = release['label']
 
-          release_date = release['releaseDate']
-          events << {
-            "type" => "release",
-            "release_name" => release_name,
-            "release_label" => release_label,
-            "occurred_at" => release_date&.to_datetime&.beginning_of_day,
-          }
-
-          eoas_date = release['eoas']
-          if eoas_date && eoas_date.is_a?(Date) then
-            events << {
-              "type" => "eoas",
-              "release_name" => release_name,
-              "release_label" => release_label,
-              "occurred_at" => eoas_date&.to_datetime&.end_of_day,
-            }
-          end
-
-          eol_date = release['eol']
-          if eol_date && eol_date.is_a?(Date) then
-            events << {
-              "type" => "eol",
-              "release_name" => release_name,
-              "release_label" => release_label,
-              "occurred_at" => eol_date&.to_datetime&.end_of_day,
-            }
-
-            eol_date_7d = release['eol'] - 7
-            events << {
-              "type" => "eol-7d",
-              "release_name" => release_name,
-              "release_label" => release_label,
-              "occurred_at" => eol_date_7d&.to_datetime&.end_of_day,
-            }
-          end
-
-          eoes_date = release['eoes']
-          if eoes_date && eoes_date.is_a?(Date) then
-            events << {
-              "type" => "eoes",
-              "release_name" => release_name,
-              "release_label" => release_label,
-              "occurred_at" => eoes_date&.to_datetime&.end_of_day,
-            }
-          end
-        end
-
-        @data = {
-          "layout" => "product-feed",
-          "product_id" => product.data['id'],
-          "product_label" => product.data['title'],
-          "product_link" => EndOfLife.site_url(site, product.data['permalink']),
-          "last_updated" => product.data['last_modified_at'],
-          "events" => events.select { |event| event["occurred_at"] <= Time.now },
-          "nav_exclude"=> true
+        release_date = release['releaseDate']
+        events << {
+          "type" => "release",
+          "release_name" => release_name,
+          "release_label" => release_label,
+          "occurred_at" => release_date&.to_datetime&.beginning_of_day,
         }
 
-        self.process(@name)
+        eoas_date = release['eoas']
+        if eoas_date && eoas_date.is_a?(Date) then
+          events << {
+            "type" => "eoas",
+            "release_name" => release_name,
+            "release_label" => release_label,
+            "occurred_at" => eoas_date&.to_datetime&.end_of_day,
+          }
+        end
+
+        eol_date = release['eol']
+        if eol_date && eol_date.is_a?(Date) then
+          events << {
+            "type" => "eol",
+            "release_name" => release_name,
+            "release_label" => release_label,
+            "occurred_at" => eol_date&.to_datetime&.end_of_day,
+          }
+
+          eol_date_7d = release['eol'] - 7
+          events << {
+            "type" => "eol-7d",
+            "release_name" => release_name,
+            "release_label" => release_label,
+            "occurred_at" => eol_date_7d&.to_datetime&.end_of_day,
+          }
+        end
+
+        eoes_date = release['eoes']
+        if eoes_date && eoes_date.is_a?(Date) then
+          events << {
+            "type" => "eoes",
+            "release_name" => release_name,
+            "release_label" => release_label,
+            "occurred_at" => eoes_date&.to_datetime&.end_of_day,
+          }
+        end
       end
+
+      @data = {
+        "layout" => "product-feed",
+        "product_id" => product.data['id'],
+        "product_label" => product.data['title'],
+        "product_link" => EndOfLife.site_url(site, product.data['permalink']),
+        "last_updated" => product.data['last_modified_at'],
+        "events" => events.select { |event| event["occurred_at"] <= Time.now },
+        "nav_exclude" => true
+      }
+
+      self.process(@name)
     end
+  end
 end

--- a/_plugins/generate-product-feeds.rb
+++ b/_plugins/generate-product-feeds.rb
@@ -1,4 +1,4 @@
-# This script create product pages for the website.
+# This script creates product pages for the website.
 
 require 'jekyll'
 

--- a/_redirects
+++ b/_redirects
@@ -35,6 +35,7 @@ layout: null
 /api{{page.permalink}}                  /api{{page.permalink}}.json
 {%- for alternate_url in page.alternate_urls %}
 {{alternate_url}}                       {{page.permalink}}
+{{alternate_url}}.atom                  {{page.permalink}}.atom
 /calendar{{alternate_url}}.ics          /calendar{{page.permalink}}.ics
 /api{{alternate_url}}.json              /api{{page.permalink}}.json
 /api{{alternate_url}}/*                 /api{{page.permalink}}/:splat


### PR DESCRIPTION
Each product has its own Atom feed wich contains the following events:

- a new release appear,
- a release reach end of active support,
- a release will reach end of life in 7 days,
- a release reached end of life,
- a release reached end of extended support.

Future events are not in the feed : this is not a calendar.

Having a 7-days, 30-days and 90-days event was considered but this is challenging, as it won't work for products which have a relatively short release cycles (bi-monthly, monthly, or even quarterly). So for now only the 7-days event has been implemented.

Relates to: #48, #238, #2368, #6138.