### PR TITLE
Fix a few markdown linting errors

### DIFF
--- a/.github/ISSUE_TEMPLATE/new_product_suggestion.md
+++ b/.github/ISSUE_TEMPLATE/new_product_suggestion.md
@@ -11,16 +11,13 @@ assignees: ''
 
 Let us know the long, full name and, if it has one, the short name (for example, PowerShell and pwsh).
 
-
 **Does this product have LTS versions? What are the intervals between each LTS version?**
 
 For example, a current release is a release that occurs between LTS releases. Current releases can contain critical fixes.
 
-
 **What is the website for the product and for its version information?**
 
-For example: https://github.com/PowerShell/PowerShell/tags
-
+For example: <https://github.com/PowerShell/PowerShell/tags>
 
 **Additional context**
 

--- a/.github/ISSUE_TEMPLATE/report_incorrect_details.md
+++ b/.github/ISSUE_TEMPLATE/report_incorrect_details.md
@@ -11,7 +11,6 @@ assignees: ''
 
 Let us know the URL of the product page on endoflife.date you found the incorrect details.
 
-
 **Details of incorrect and correct details you have found**
 
 For example, the active support date on endoflife.date is not the same as in the product documentation.
@@ -20,11 +19,9 @@ endoflife.date: 2021-02-02
 
 Product documentation: 2022-02-02
 
-
 **What is the source website for the product and for its version information?**
 
-For example: https://github.com/PowerShell/PowerShell/tags
-
+For example: <https://github.com/PowerShell/PowerShell/tags>
 
 **Additional context**
 

--- a/CHANGELOG_API.md
+++ b/CHANGELOG_API.md
@@ -35,7 +35,7 @@ v1:
   WebComponent](https://github.com/stoplightio/elements/blob/main/docs/getting-started/elements/html.md) (#905),
 - but reverts #2425 due to incompatibilities in redirect rules.
 
-The API v1 is now generated using a Jekyll Generator (see https://jekyllrb.com/docs/plugins/generators/)
+The API v1 is now generated using a Jekyll Generator (see <https://jekyllrb.com/docs/plugins/generators/>)
 instead of a custom script.
 
 Note that the API v0 is still generated to give time to users to migrate to API v1. It will be

--- a/CODE-OF-CONDUCT.md
+++ b/CODE-OF-CONDUCT.md
@@ -60,7 +60,7 @@ representative at an online or offline event.
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
 reported to the community leaders responsible for enforcement at
-endoflife.date-coc@captnemo.in.
+<endoflife.date-coc@captnemo.in>.
 All complaints will be reviewed and investigated promptly and fairly.
 
 All community leaders are obligated to respect the privacy and security of the
@@ -130,4 +130,3 @@ For answers to common questions about this code of conduct, see the FAQ at
 [Mozilla CoC]: https://github.com/mozilla/diversity
 [FAQ]: https://www.contributor-covenant.org/faq/
 [translations]: https://www.contributor-covenant.org/translations/
-

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,7 +31,7 @@ Before you get started, get to know the project a little bit. Open [endoflife.da
 
 ## :pencil: About the codebase
 
-endoflife.date is built using [Jekyll](https://jekyllrb.com/) - the Ruby static site builder that powers GitHub Pages. The site is built and deployed to [Netlify](https://www.netlify.com/). Since the site is mostly informational, you _don't need programming skills to contribute to the project_.
+endoflife.date is built using [Jekyll](https://jekyllrb.com/) - the Ruby static site builder that powers GitHub Pages. The site is built and deployed to [Netlify](https://www.netlify.com/). Since the site is mostly informational, you *don't need programming skills to contribute to the project*.
 
 ## :new: Adding a new product
 
@@ -443,7 +443,7 @@ In `vim` you also could use the [yaml-language-server](https://github.com/redhat
 
 Once you file your Pull Request, Netlify will provide a list of checks for your changes. If one of the checks fails, you can click Details and see through the errors, or one of the Maintainers will be there to help you soon.
 
-If all of the checks pass, you can click the "Details" link on the "Deploy Preview" Status Check to see a preview of the website _with your changes_.
+If all of the checks pass, you can click the "Details" link on the "Deploy Preview" Status Check to see a preview of the website *with your changes*.
 
 ![image](https://user-images.githubusercontent.com/584253/134535142-7d1170b7-16f4-4cd3-987e-e890b76098d5.png)
 
@@ -473,7 +473,7 @@ docker run --rm \
 
 ## Testing API payload
 
-There is a GitHub workflow that already validates the OpenAPI specification (it can also be checked on https://pb33f.io/doctor/).
+There is a GitHub workflow that already validates the OpenAPI specification (it can also be checked on <https://pb33f.io/doctor/>).
 But to test the generated API payload you can do the following:
 
 ```sh
@@ -511,8 +511,8 @@ identifiers.
 We have the following documents which should help you get familiar with the project and the codebase. You don't need to read all of these, and we've linked these docs above in cases where you must read any of them.
 
 - [HACKING.md](https://github.com/endoflife-date/endoflife.date/blob/master/HACKING.md) contains instructions on setting up the codebase locally with Jekyll. Read this if you're planning to make complex changes or setting up the project locally.
-- [Guiding Principles](https://github.com/endoflife-date/endoflife.date/wiki/Guiding-Principles) - These help us make decisions around the content we have. If you'd like to make sure your PR gets speedy approval, please read these to ensure your changes are aligned with the rest of the content. This is _especially important if you are making non-trivial changes_ that deal with the content or add a new product.
-- [CONTRIBUTING.md](https://github.com/endoflife-date/endoflife.date/blob/master/CONTRIBUTING.md) - (This page). Also accessible at https://endoflife.date/contribute
+- [Guiding Principles](https://github.com/endoflife-date/endoflife.date/wiki/Guiding-Principles) - These help us make decisions around the content we have. If you'd like to make sure your PR gets speedy approval, please read these to ensure your changes are aligned with the rest of the content. This is *especially important if you are making non-trivial changes* that deal with the content or add a new product.
+- [CONTRIBUTING.md](https://github.com/endoflife-date/endoflife.date/blob/master/CONTRIBUTING.md) - (This page). Also accessible at <https://endoflife.date/contribute>
 
 ## :bookmark: Code of Conduct
 

--- a/HACKING.md
+++ b/HACKING.md
@@ -43,7 +43,7 @@ bundle exec jekyll --version
 Run the site locally:
 
 ```sh
-$ bundle exec jekyll serve --host localhost --port 4000
+bundle exec jekyll serve --host localhost --port 4000
 ```
 
 Browse to `http://localhost:4000` and you should see the site running locally. If you find any errors at this stage, check [Jekyll's troubleshooting page](https://jekyllrb.com/docs/troubleshooting/#configuration-problems) or [ask a question in the Q&A category](https://github.com/endoflife-date/endoflife.date/discussions/new/) on GitHub Discussions.
@@ -75,7 +75,6 @@ this configuration is for the current `main` branch, not for the version used by
 
 If you need to override some parts, take a look at
 [the customization section](https://just-the-docs.github.io/just-the-docs/docs/customization/) of the documentation.
-
 
 ## Logo
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ While participating in the project, you must abide by its [Code of Conduct](CODE
 
 ## API
 
-An API is available for integration with CI platforms. API documentation is available at https://endoflife.date/docs/api/v1/.
+An API is available for integration with CI platforms. API documentation is available at <https://endoflife.date/docs/api/v1/>.
 The API is currently in Beta, and breaking changes can happen.
 
 ## License

--- a/pages/help/identifiers-needed.md
+++ b/pages/help/identifiers-needed.md
@@ -22,7 +22,6 @@ We currently use the following identifiers:
 For any of the pages below, click the edit link, and add a new field in the YAML called `identifiers`. Here's some sample identifiers that
 we use across our various pages:
 
-
 ```yaml
 identifiers:
 # links the product to the https://repology.org/project/package-name/information
@@ -52,6 +51,7 @@ identifiers:
 -   purl: pkg:chocolatey/libericajdk
 -   purl: pkg:winget/BellSoft.LibericaJDK.8
 ```
+
 ## Pages without Identifiers
 
 <ul>

--- a/products/amazon-linux.md
+++ b/products/amazon-linux.md
@@ -224,7 +224,6 @@ Amazon Provides security advisories for all versions on the Amazon Linux Securit
 
 [al1-eol]: https://aws.amazon.com/blogs/aws/update-on-amazon-linux-ami-end-of-life/ "Update on Amazon Linux AMI end-of-life"
 
-[al1-faq]: https://aws.amazon.com/amazon-linux-ami/faqs/ "Amazon Linux AMI FAQ"
 [al2-faq]: https://aws.amazon.com/amazon-linux-2/faqs/#Long_Term_Support "Amazon Linux 2 FAQs"
 [al2023-faq]: https://aws.amazon.com/linux/amazon-linux-2023/faqs/#Long_Term_Support "Amazon Linux 2023 FAQs"
 

--- a/products/amazon-msk.md
+++ b/products/amazon-msk.md
@@ -111,7 +111,7 @@ with End-of-Support dates.
 
 ## [Upgrading](https://docs.aws.amazon.com/msk/latest/developerguide/version-upgrades.html)
 
-A cluster using a Kafka version after its end of support date is auto-upgraded to the recommended Kafka version. 
+A cluster using a Kafka version after its end of support date is auto-upgraded to the recommended Kafka version.
 Automatic upgrades can happen at any time after the end of support date. No notifications
 are sent before the upgrade.
 

--- a/products/centreon.md
+++ b/products/centreon.md
@@ -164,6 +164,7 @@ page, only major/critical bugs and security fixes are provided.
 > Upcoming Change
 >
 > [Starting with Centreon 24.10](https://www.centreon.com/new-centreon-release-cadence-and-version-lifecycle/) (expected in October 2024):
+>
 > - All Open Source major versions will be supported for 18 months.
 > - Commercial major versions released in even years will be designated as LTS versions and supported for 3 years.
 > - Commercial major versions released in odd years will be supported for 18 months.

--- a/products/citrix-vad.md
+++ b/products/citrix-vad.md
@@ -219,6 +219,7 @@ Citrix Virtual Apps and Desktops was previously known as XenApp and XenDesktop, 
 
 There are two release types for on-premises deployments, Current Releases and Long-Term Service
 Releases (LTSR):
+
 - Current Releases will reach end of active support 6 months after release and end of security
   support 18 months after release.
 - Long-Term Service Releases will reach end of active and security support 5 years after release.

--- a/products/firefox.md
+++ b/products/firefox.md
@@ -296,7 +296,7 @@ releases:
 > [Linux](https://support.mozilla.org/kb/install-firefox-linux), and
 > [ChromeOS](https://support.mozilla.org/kb/run-firefox-chromeos).
 
-## Firefox has two main release channels:
+## Firefox has two main release channels
 
 - **Firefox:** Simply named Firefox, this is the default channel and is the one recommended. It's
   the stable branch with the latest features available. Once a new release is out, the older release
@@ -308,7 +308,7 @@ releases:
   [with a planned release calendar for new ESR branches.](https://whattrainisitnow.com/calendar/)
   For more information you should review the [release cycle documentation.](https://support.mozilla.org/kb/firefox-esr-release-cycle)
 
-## Firefox also has three testing channels:
+## Firefox also has three testing channels
 
 - **Firefox Beta:** This branch is meant to reflect what the next **Firefox** release will look
   like. Every four weeks it gets cherry-picked changes from **Nightly**, then follows a three-weekly

--- a/products/freebsd.md
+++ b/products/freebsd.md
@@ -352,4 +352,3 @@ Branch tags have names like `releng/10.1`. The corresponding builds have names l
 > The support duration for individual point releases will remain until "next point release + 3 months".
 > A release cadence is being established so a new minor release from one of the supported
 > stable branches will happen most quarters.
-

--- a/products/ghc.md
+++ b/products/ghc.md
@@ -152,6 +152,7 @@ Because GHC is a *bootstrapping compiler* (meaning, it is written mostly in Hask
 itself), there're versioning considerations not quite covered with SemVer.
 
 GHC defines:
+
 * **Major release** - `x.y.1` where `y` is even.
 * **Minor release** - `x.y.z` where `y` is even and `z ≥ 2`.
 

--- a/products/gradle.md
+++ b/products/gradle.md
@@ -173,6 +173,7 @@ releases:
 
 Gradle follows [Semantic Versioning](https://semver.org/). The
 [support and EOL policy](https://docs.gradle.org/current/userguide/feature_lifecycle.html#eol_support) states that each major release causes:
+
 - The previous major version becomes maintenance only (end of active support). It will only receive critical bug fixes and security fixes.
 - The major version before the previous one to become end-of-life (EOL), and that release line will not receive any new fixes.
 

--- a/products/hashicorp-packer.md
+++ b/products/hashicorp-packer.md
@@ -67,11 +67,9 @@ releases:
 
 > [Hashicorp Packer](https://www.packer.io/) is a community tool for creating identical machine images for multiple platforms from a single source configuration.
 
-
 **Generally Available (GA)** releases of active products are supported under standard maintenance approximately
 for a year. The standard support period and end-of-life policy covers "N−2" versions,
 which means, at any given time, HashiCorp maintains the current version ("N") and the two previous versions ("N−2").
-
 
 ## Versioning and Release Cadence
 

--- a/products/intel-processors.md
+++ b/products/intel-processors.md
@@ -243,5 +243,4 @@ your CPU belongs on:
 - macOS: `sysctl -n machdep.cpu.brand_string`
 - FreeBSD/OpenBSD: `sysctl -n hw.model`
 
-Then check product classification on https://ark.intel.com/.
-
+Then check product classification on <https://ark.intel.com/>.

--- a/products/jhipster.md
+++ b/products/jhipster.md
@@ -80,5 +80,4 @@ releases:
 > JHipster is a development platform to quickly generate, develop, and deploy modern
 > web applications and microservice architectures.
 
-
 Only the latest release is supported, with active feature development, and security fixes.

--- a/products/ldap-account-manager.md
+++ b/products/ldap-account-manager.md
@@ -76,6 +76,7 @@ releases:
 
 LAM is published under the GNU General Public License; LAM Pro is a commercial extended version of
 LAM. Both follow the same release cycle:
+
 - there is a new minor release every 3 months
 - there are patch versions for the latest release cycle as needed
 - each new release cycle ends the previous one

--- a/products/nvidia-gpu.md
+++ b/products/nvidia-gpu.md
@@ -284,7 +284,7 @@ releases:
 There are multiple GPUs with the same name but part of a different architecture (therefore
 different support status length), and there are other cases to be careful of:
 
-### Desktop:
+### Desktop
 
 - `GT730`: Has a `GF108` (Fermi) and a `GK208` (Kepler) variant.
 - `GT625`: Has a `GF108` (Fermi) and a `GK107`/`GK208` (Kepler) variant.
@@ -297,7 +297,7 @@ different support status length), and there are other cases to be careful of:
 - All-in-one **desktops** are known to feature Mobile GPUs, which would make them fall under a
   different (and often shorter) support cycle.
 
-### Laptop:
+### Laptop
 
 - `GT810M`/`GT820M` are Fermi cards.
 - `GT825M`/`GT870M`/`GT880M` are Kepler cards.

--- a/products/openzfs.md
+++ b/products/openzfs.md
@@ -100,7 +100,7 @@ releases:
   the previous `MINOR` release will no longer be maintained (unless it is an LTS release). New
   `MINOR` releases are planned to occur roughly annually.
 
-## Officially supported distributions:
+## Officially supported distributions
 
 - [Fedora](https://openzfs.github.io/openzfs-docs/Getting%20Started/Fedora/index.html)
 - [RHEL-based distributions](https://openzfs.github.io/openzfs-docs/Getting%20Started/RHEL-based%20distro/index.html)
@@ -126,4 +126,5 @@ kernels. Point releases are tagged as needed in order to support the stable kern
   rows=collapsedCycles %}
 
 {: .note}
+>
 > - For FreeBSD 12.2, the last supported version is 2.2.6

--- a/products/oracle-linux.md
+++ b/products/oracle-linux.md
@@ -81,7 +81,7 @@ releases:
 - **Sustaining Support**: Available after Extended support ends. Does not include any new security
   fixes or alerts.
 
-## Differences with Upstream RHEL:
+## Differences with Upstream RHEL
 
 - Unlike RHEL, [Oracle Linux does not support point releases once a newer one is available](https://forums.oracle.com/ords/apexds/post/what-is-the-lifecycle-of-oracle-linux-for-minor-releases-2173).
   Once a new minor point release is available, the older one is immediately considered end of life

--- a/products/oracle-solaris.md
+++ b/products/oracle-solaris.md
@@ -73,7 +73,6 @@ releases:
 > renamed Oracle Solaris. It supports SPARC and x86-64 workstations and servers. It is known for
 > its stability, performance, scalability and innovative features such as DTrace or ZFS.
 
-
 The current Oracle Solaris support policy is based on _Oracle Lifetime Support Policy — Oracle and Sun
 System Software and Operating Systems_. This policy provides three stages of support: premier,
 extended and sustaining.

--- a/products/pci-dss.md
+++ b/products/pci-dss.md
@@ -51,4 +51,4 @@ releases:
   The new requirements introduced in PCI DSS v3.2 were considered best practices until 31 January 2018.
   Starting 1 February 2018 they are effective as requirements and must be used.
 
-[^1]: https://www.pcisecuritystandards.org/faq/articles/Frequently_Asked_Question/Does-an-entity-s-PCI-DSS-assessment-result-expire-when-the-standard-against-which-the-entity-was-assessed-is-retired/
+[^1]: <https://www.pcisecuritystandards.org/faq/articles/Frequently_Asked_Question/Does-an-entity-s-PCI-DSS-assessment-result-expire-when-the-standard-against-which-the-entity-was-assessed-is-retired/>

--- a/products/phoenix-framework.md
+++ b/products/phoenix-framework.md
@@ -90,6 +90,6 @@ releases:
 Bug fixes are made only to the latest minor branch. Security patches are available
 for the last 4 minor branches, including the latest one.
 
-New _minor_ versions (e.g. **1.8 → 1.9**) are released roughly every 18–24 months. The 
+New _minor_ versions (e.g. **1.8 → 1.9**) are released roughly every 18–24 months. The
 [Changelog](https://github.com/phoenixframework/phoenix/blob/main/CHANGELOG.md) lists
 breaking changes between releases.

--- a/products/redis.md
+++ b/products/redis.md
@@ -104,7 +104,6 @@ releases:
 > [Redis Sentinel](https://redis.io/docs/management/sentinel/) and automatic partitioning with
 > [Redis Cluster](https://docs.redis.com/latest/rc/concepts/clustering/).
 
-
 A new major version is planned for release once a year. Generally, every major release is followed
 by a minor version after six months. The latest stable release is always fully supported and
 maintained.

--- a/recommendations.md
+++ b/recommendations.md
@@ -61,7 +61,7 @@ Ubuntu has this information split between the (unmaintained) Ubuntu Wiki and the
 - <https://ubuntu.com/about/release-cycle>
 - <https://wiki.ubuntu.com/Releases>
 
-Make sure this information is hosted _alongside your end-user documentation_, not your developer or team documentation.
+Make sure this information is hosted *alongside your end-user documentation*, not your developer or team documentation.
 
 ### Bad - Python
 
@@ -169,7 +169,7 @@ However, your end-users shouldn't have to do the math. Make sure that all your r
 (I suggest `YYYY-MM-DD`) irrespective of how these dates are decided. You doing the math once will save your users much
 more time.
 
-### Bad:
+### Bad
 
 | K8s version | AKS GA   | End of life |
 |-------------|----------|-------------|
@@ -178,14 +178,14 @@ more time.
 
 (Source: [Azure Kubernetes Release Calendar][aks])
 
-### Bad:
+### Bad
 
 Some projects will often put a note instead of documenting absolute dates:
 
-Version|Release Date
----|---
-2.1|3rd March 2021
-2.0|1st March 2020
+| Version | Release Date   |
+|---------|----------------|
+| 2.1     | 3rd March 2021 |
+| 2.0     | 1st March 2020 |
 
 Release are supported for 2 years from the release date.
 
@@ -193,18 +193,17 @@ Release are supported for 2 years from the release date.
 
 Same as above, but we do the math:
 
-Version|Release Date|EoL Date
----|---|---
-2.1|3rd March 2021|3rd March 2023
-2.0|1st March 2020|1st March 2022
+| Version | Release Date   | EoL Date       |
+|---------|----------------|----------------|
+| 2.1     | 3rd March 2021 | 3rd March 2023 |
+| 2.0     | 1st March 2020 | 1st March 2022 |
 
+### Good
 
-### Good:
-
-|Kubernetes version|Upstream release|Amazon EKS release|Amazon EKS end of support|
-|------|-------------------|-------------------|--------------------|
-| 1.20 | December 8, 2020  | May 18, 2021      | July, 2022         |
-| 1.21 | April 8, 2021     | July 19, 2021     | September, 2022    |
+| Kubernetes version | Upstream release | Amazon EKS release | Amazon EKS end of support |
+|--------------------|------------------|--------------------|---------------------------|
+| 1.20               | December 8, 2020 | May 18, 2021       | July, 2022                |
+| 1.21               | April 8, 2021    | July 19, 2021      | September, 2022           |
 
 Source: [Amazon EKS Release Calendar][eks].
 


### PR DESCRIPTION
Those errors has been fixed using `markdownlint-cli2 --fix "**/*.md" "#node_modules"`.