### PR TITLE
 [debian] Update News links for 12.11 and 13.0

### DIFF
--- a/products/debian.md
+++ b/products/debian.md
@@ -35,7 +35,7 @@ releases:
     releaseDate: 2025-08-09
     eol: false # not announced yet
     eoes: false # not announced yet
-    link: https://www.debian.org/releases/trixie/release-notes/
+    link: https://www.debian.org/News/2025/20250809
     latest: "13.0"
     latestReleaseDate: 2025-08-09
 
@@ -44,7 +44,7 @@ releases:
     releaseDate: 2023-06-10
     eol: 2026-06-10
     eoes: 2028-06-10
-    link: https://www.debian.org/News/2025/20250111
+    link: https://www.debian.org/News/2025/20250517
     latest: "12.11"
     latestReleaseDate: 2025-05-17
 


### PR DESCRIPTION
To keep consistency with precedent releases
https://www.debian.org/News/2025/20250517
https://www.debian.org/News/2025/20250809