### PR TITLE
[ubuntu] Add alternate link as `ubuntu-linux` 

### DIFF
--- a/products/ubuntu.md
+++ b/products/ubuntu.md
@@ -5,6 +5,8 @@ category: os
 tags: linux-distribution
 iconSlug: ubuntu
 permalink: /ubuntu
+alternate_urls:
+  - /ubuntu-linux
 versionCommand: cat /etc/os-release
 releasePolicyLink: https://wiki.ubuntu.com/Releases
 releaseImage: https://github.com/endoflife-date/endoflife.date/assets/1423115/c1d812cd-9179-4ff6-9607-520dbf37fa3e


### PR DESCRIPTION
To better match documention https://endoflife.date/docs/api/v1/#/Products/products

<img width="778" height="563" alt="image" src="https://github.com/user-attachments/assets/1182cd1f-4ada-40f7-896e-6c28a1ab398b" />
