### PR TITLE
[python]: add cpe and github purl identifiers

### DIFF
--- a/products/python.md
+++ b/products/python.md
@@ -114,7 +114,10 @@ identifiers:
   - purl: pkg:docker/library/python
   - purl: pkg:docker/circleci/python
   - purl: pkg:docker/bitnami/python
+  - purl: pkg:github/python/cpython
   - repology: python
+  - cpe: cpe:/a:python:python
+  - cpe: cpe:2.3:a:python:python
 
 auto:
   methods:


### PR DESCRIPTION
Adds CPEs and the github package URL identifier for python