### PR TITLE
Use categories for navigation

### DIFF
--- a/_plugins/end-of-life.rb
+++ b/_plugins/end-of-life.rb
@@ -1,0 +1,20 @@
+CATEGORIES = %w[app database device framework lang library os server-app service standard]
+
+def is_category?(name)
+  CATEGORIES.include?(name)
+end
+
+# Transform a category name to a title.
+# By default the name is just capitalized and an 's' is added at the end.
+# Override if something different is needed.
+def category_title(category_name)
+  case category_name
+  when 'app' then 'Applications'
+  when 'lang' then 'Languages'
+  when 'library' then 'Libraries'
+  when 'os' then 'Operating Systems'
+  when 'server-app' then 'Server Applications'
+  else
+    category_name.split('-').map(&:capitalize).join(' ') + 's'
+  end
+end

--- a/_plugins/generate-tag-pages.rb
+++ b/_plugins/generate-tag-pages.rb
@@ -1,6 +1,7 @@
 # This script create product pages for the website.
 
 require 'jekyll'
+require_relative 'end-of-life'
 
 module EndOfLife
 
@@ -70,12 +71,14 @@ module EndOfLife
         @dir = "tags"
         @name = "#{tag}.html"
 
+        is_category = is_category?(tag)
         @data = {
-          "title" => "Products tagged with '#{tag}'",
+          "title" => is_category ? category_title(tag) : "Products tagged with '#{tag}'",
           "layout" => "product-list",
           "permalink" => "/tags/#{tag}",
           "products" => products.sort_by { |product| product.data['title'] },
-          "nav_exclude"=> true
+          "is_category" => is_category,
+          "nav_exclude"=> !is_category
         }
 
         self.process(@name)

--- a/_plugins/product-data-enricher.rb
+++ b/_plugins/product-data-enricher.rb
@@ -23,6 +23,9 @@
 # - days_toward_eol (in cycles) : number of days toward the EOL of the cycle (optional, only if eol is set)
 # - days_toward_discontinued (in cycles) : number of days toward the discontinuation of the cycle (optional, only if discontinued is set)
 # - days_toward_eoes (in cycles) : number of days toward the end of extended support for the cycle (optional, only if eoes is set)
+
+require_relative 'end-of-life'
+
 module Jekyll
   class ProductDataEnricher
     class << self
@@ -35,6 +38,7 @@ module Jekyll
         set_id(page)
         set_description(page)
         set_icon_url(page)
+        set_parent(page)
         set_tags(page)
         set_identifiers(page)
         set_aliases(page)
@@ -69,6 +73,11 @@ module Jekyll
         if page['iconSlug']
           page.data['iconUrl'] = "https://cdn.jsdelivr.net/npm/simple-icons/icons/#{page['iconSlug']}.svg"
         end
+      end
+
+      # Set the parent page for navigation.
+      def set_parent(page)
+        page.data['parent'] = category_title(page.data['category'])
       end
 
       # Explode tags space-separated string to a list if necessary.

--- a/_plugins/product-data-validator.rb
+++ b/_plugins/product-data-validator.rb
@@ -10,12 +10,12 @@
 
 require 'jekyll'
 require 'open-uri'
+require_relative 'end-of-life'
 require_relative 'identifier-to-url'
 
 module EndOfLifeHooks
   VERSION = '1.0.0'
   TOPIC = 'Product Validator:'
-  VALID_CATEGORIES = %w[app database device framework lang library os server-app service standard]
   VALID_CUSTOM_FIELD_DISPLAY = %w[none api-only after-release-column before-latest-column after-latest-column]
 
   IGNORED_URL_PREFIXES = {
@@ -142,7 +142,7 @@ module EndOfLifeHooks
 
     error_if = Validator.new('product', product, product.data)
     error_if.is_not_a_string('title')
-    error_if.is_not_in('category', EndOfLifeHooks::VALID_CATEGORIES)
+    error_if.is_not_in('category', CATEGORIES)
     error_if.does_not_match('tags', /^[a-z0-9\-]+( [a-z0-9\-]+)*$/) if product.data.has_key?('tags')
     error_if.does_not_match('permalink', /^\/[a-z0-9-]+$/)
     error_if.does_not_match('alternate_urls', /^\/[a-z0-9\-_]+$/)

--- a/api_v1/swagger-ui.md
+++ b/api_v1/swagger-ui.md
@@ -3,4 +3,5 @@ title: EndOfLife API v1 Swagger UI
 permalink: /docs/api/v1/
 openapi_yml: /docs/api/v1/openapi.yml
 layout: swagger-ui
+nav_exclude: true
 ---


### PR DESCRIPTION
Products list is starting to become long, especially when loading the site on mobile. This improve navigation by declaring category pages as parent for product pages.

Using categories was the obvious choice because:

- All products already have a single category, so there was no need to create new pages.
- There are not many categories, which guarantee that the top-level navigation size will remain relatively small.
- The categories are strongly limited : adding a category requires an explicit declaration.

The only issue with relying on categories was their name. By default names are more suited for tags. This is why the tag names cannot be used as is, and must be transformed to something more suitable to use in menu entries, as seen in `end-of-life.rb`.

Closes #7949.