### PR TITLE
[freebsd] Move 14/stable above 14.0

### DIFF
--- a/products/freebsd.md
+++ b/products/freebsd.md
@@ -51,16 +51,16 @@ releases:
     releaseDate: 2024-03-05
     eol: 2024-12-31
 
-  - releaseCycle: "14.0"
-    releaseLabel: "releng/14.0"
-    releaseDate: 2023-11-21
-    eol: 2024-09-30
-
   - releaseCycle: "14"
     releaseLabel: "stable/14"
     releaseDate: 2023-11-21
     eol: 2028-11-30
     link: null
+
+  - releaseCycle: "14.0"
+    releaseLabel: "releng/14.0"
+    releaseDate: 2023-11-20
+    eol: 2024-09-30
 
   - releaseCycle: "13.2"
     releaseLabel: "releng/13.2"


### PR DESCRIPTION
This fixes the following error:

Product Validator: Invalid releases '14' for freebsd.md, expecting release (released on 2023-11-21) to be before 14.0 (released on 2023-11-20).

Ref: https://github.com/endoflife-date/release-data/pull/498 which now picks this up automatically.