### PR TITLE
[freebsd] Add older releases

### DIFF
--- a/products/freebsd.md
+++ b/products/freebsd.md
@@ -7,7 +7,7 @@ iconSlug: freebsd
 permalink: /freebsd
 versionCommand: freebsd-version
 releasePolicyLink: https://www.freebsd.org/security/#sup
-changelogTemplate: https://www.freebsd.org/releases/{{"__RELEASE_CYCLE__" | split:'/' | last}}R/relnotes/
+changelogTemplate: https://www.freebsd.org/releases/__RELEASE_CYCLE__R/relnotes/
 releaseColumn: false
 
 identifiers:
@@ -17,6 +17,18 @@ identifiers:
 auto:
   methods:
     - freebsd-releases: https://www.freebsd.org/releases/
+    - release_table: https://www.freebsd.org/security/unsupported/
+      selector: "table"
+      fields:
+        releaseCycle:
+          column: "Branch"
+          regex: '^\w+\/(?P<value>\d+(\.\d+)?)$'
+        releaseDate: "Release Date"
+        eol: "EoL"
+    - declare: freebsd
+      releases:
+        - {name: "2.0", releaseDate: 1994-11-22}  # https://en.wikipedia.org/wiki/FreeBSD_version_history
+        - {name: "3.0", releaseDate: 1998-10-16}  # https://en.wikipedia.org/wiki/FreeBSD_version_history
 
 # eol(x) = releaseDate(x+1) + 3 months (rounded to the end of month)
 # See also https://lists.freebsd.org/archives/freebsd-announce/2024-July/000143.html
@@ -53,12 +65,12 @@ releases:
 
   - releaseCycle: "14.0"
     releaseLabel: "releng/14.0"
-    releaseDate: 2023-11-21
+    releaseDate: 2023-11-20
     eol: 2024-09-30
 
   - releaseCycle: "14"
     releaseLabel: "stable/14"
-    releaseDate: 2023-11-21
+    releaseDate: 2023-11-20
     eol: 2028-11-30
     link: null
 
@@ -80,7 +92,7 @@ releases:
   - releaseCycle: "12.3"
     releaseLabel: "releng/12.3"
     releaseDate: 2021-12-07
-    eol: 2023-03-05
+    eol: 2023-03-31
 
   - releaseCycle: "13.0"
     releaseLabel: "releng/13.0"
@@ -116,7 +128,7 @@ releases:
   - releaseCycle: "12.0"
     releaseLabel: "releng/12.0"
     releaseDate: 2018-12-11
-    eol: 2020-02-04
+    eol: 2020-02-29
 
   - releaseCycle: "12"
     releaseLabel: "stable/12"
@@ -245,7 +257,7 @@ releases:
 
   - releaseCycle: "7.2"
     releaseLabel: "releng/7.2"
-    releaseDate: 2009-03-04
+    releaseDate: 2009-05-04
     eol: 2010-06-30
 
   - releaseCycle: "7.1"
@@ -315,10 +327,91 @@ releases:
     releaseDate: 2004-11-06
     eol: 2006-10-31
 
+  - releaseCycle: '4.10'
+    releaseLabel: "releng/4.10"
+    releaseDate: 2004-05-27
+    eol: 2007-01-31
+
+  - releaseCycle: '5.2'
+    releaseLabel: "releng/5.2"
+    releaseDate: 2004-01-09
+    eol: 2005-02-28
+
+  - releaseCycle: '4.9'
+    releaseLabel: "releng/4.9"
+    releaseDate: 2003-10-28
+    eol: 2004-08-31
+
+  - releaseCycle: '5.1'
+    releaseLabel: "releng/5.1"
+    releaseDate: 2003-06-09
+    eol: 2004-04-30
+
+  - releaseCycle: '4.8'
+    releaseLabel: "releng/4.8"
+    releaseDate: 2003-04-03
+    eol: 2004-02-28
+
+  - releaseCycle: '5.0'
+    releaseLabel: "releng/5.0"
+    releaseDate: 2003-01-14
+    eol: 2003-09-30
+
   - releaseCycle: "5"
     releaseLabel: "stable/5"
-    releaseDate: 2004-11-06
+    releaseDate: 2003-01-14
     eol: 2008-05-31
+    link: null
+
+  - releaseCycle: '4.7'
+    releaseLabel: "releng/4.7"
+    releaseDate: 2002-10-10
+    eol: 2003-07-31
+
+  - releaseCycle: '4.6'
+    releaseLabel: "releng/4.6"
+    releaseDate: 2002-06-15
+    eol: 2003-01-31
+
+  - releaseCycle: '4.5'
+    releaseLabel: "releng/4.5"
+    releaseDate: 2002-01-29
+    eol: 2002-09-30
+    link: null
+
+  - releaseCycle: '4.4'
+    releaseLabel: "releng/4.4"
+    releaseDate: 2001-09-20
+    eol: 2002-04-30
+    link: null
+
+  - releaseCycle: '4.3'
+    releaseLabel: "releng/4.3"
+    releaseDate: 2001-04-20
+    eol: 2001-12-31
+    link: null
+
+  - releaseCycle: '4.2'
+    releaseLabel: "releng/4.2"
+    releaseDate: 2000-11-21
+    eol: 2001-07-31
+    link: null
+
+  - releaseCycle: '4.1'
+    releaseLabel: "releng/4.1"
+    releaseDate: 2000-07-27
+    eol: 2001-02-28
+    link: null
+
+  - releaseCycle: '3.5'
+    releaseLabel: releng/3.5
+    releaseDate: 2000-06-30
+    eol: 2001-06-30 # unknown, assumed to be 1 year after release
+
+  - releaseCycle: '4.0'
+    releaseLabel: "releng/4.0"
+    releaseDate: 2000-03-14
+    eol: 2000-10-31
     link: null
 
   - releaseCycle: "4"
@@ -326,6 +419,67 @@ releases:
     releaseDate: 2000-03-14
     eol: 2007-01-31
     link: null
+
+  - releaseCycle: '3.4'
+    releaseLabel: releng/3.4
+    releaseDate: 1999-12-31
+    eol: 2000-09-30
+    link: null
+
+  - releaseCycle: '3.3'
+    releaseLabel: releng/3.3
+    releaseDate: 1999-09-30
+    eol: 2000-02-29
+    link: null
+
+  - releaseCycle: '3.2'
+    releaseLabel: releng/3.2
+    releaseDate: 1999-05-31
+    eol: 1999-12-31
+    link: null
+
+  - releaseCycle: '3.1'
+    releaseLabel: releng/3.1
+    releaseDate: 1999-02-28
+    eol: 1999-08-31
+    link: null
+
+  - releaseCycle: '3.0'
+    releaseLabel: releng/3.0
+    releaseDate: 1998-10-16
+    eol: 1999-05-31
+    link: null
+
+  - releaseCycle: '2.2'
+    releaseLabel: releng/2.2
+    releaseDate: 1997-03-31
+    eol: 1998-03-31 # unknown, assumed to be 1 year after release
+    link: null
+
+  - releaseCycle: '2.1'
+    releaseLabel: releng/2.1
+    releaseDate: 1995-11-30
+    eol: 1997-06-30
+    link: null
+
+  - releaseCycle: '2.0'
+    releaseLabel: releng/2.0
+    releaseDate: 1994-11-22
+    eol: 1996-02-28
+    link: null
+
+  - releaseCycle: '1.1'
+    releaseLabel: releng/1.1
+    releaseDate: 1994-05-31
+    eol: 1995-05-31 # unknown, assumed to be 1 year after release
+    link: null
+
+  - releaseCycle: '1.0'
+    releaseLabel: releng/1.0
+    releaseDate: 1993-11-30
+    eol: 1994-08-31
+    link: null
+
 ---
 
 > [FreeBSD](https://www.freebsd.org) is an operating system used to power modern servers, desktops,


### PR DESCRIPTION
Following https://github.com/endoflife-date/endoflife.date/pull/8175.
Based on https://www.freebsd.org/security/unsupported/ and https://www.freebsd.org/releases/.

Also simplified the `changelogTemplate` : the computation is not needed anymore since the name normalization.