### PR TITLE
Move 'All tags' page to the main navigation

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -34,8 +34,6 @@ search:
 
 # https://just-the-docs.com/docs/configuration/#aux-links
 aux_links:
-  Tags:
-    - /tags/
   Recommendations:
     - /recommendations
   Contribute:

--- a/_plugins/end-of-life.rb
+++ b/_plugins/end-of-life.rb
@@ -1,20 +1,31 @@
+# All categories on endoflife.date.
+# This also defines the order in which they appear in the navigation, so keep ordered alphabetically.
 CATEGORIES = %w[app database device framework lang library os server-app service standard]
 
 def is_category?(name)
   CATEGORIES.include?(name)
 end
 
-# Transform a category name to a title.
-# By default the name is just capitalized and an 's' is added at the end.
-# Override if something different is needed.
-def category_title(category_name)
-  case category_name
+# Transform a tag name to a title.
+# By default the name is used as the title and this is overridden for tags that are categories so that
+# so that the navigation is more user-friendly.
+def tag_title(tag_name)
+  case tag_name
   when 'app' then 'Applications'
+  when 'database' then 'Databases'
+  when 'device' then 'Devices'
+  when 'framework' then 'Frameworks'
   when 'lang' then 'Languages'
   when 'library' then 'Libraries'
   when 'os' then 'Operating Systems'
   when 'server-app' then 'Server Applications'
+  when 'service' then 'Services'
+  when 'standard' then 'Standards'
   else
-    category_name.split('-').map(&:capitalize).join(' ') + 's'
+    tag_name
   end
+end
+
+def category_index(category_name)
+  CATEGORIES.index(category_name)
 end

--- a/_plugins/generate-tag-pages.rb
+++ b/_plugins/generate-tag-pages.rb
@@ -53,11 +53,12 @@ module EndOfLife
 
       tags = products_by_tag.map { |tag, value| "#{tag}|#{value.size()}" }.sort
       @data = {
-        "title" => "Product tags",
+        "title" => "All tags",
         "layout" => "product-tags",
         "permalink" => "/tags/",
-        "tags" => tags,
-        "nav_exclude"=> true
+        "has_toc" => false,
+        "nav_order"=> 9999, # Ensure this page appears last in the navigation
+        "tags" => tags
       }
 
       self.process(@name)
@@ -73,12 +74,14 @@ module EndOfLife
 
         is_category = is_category?(tag)
         @data = {
-          "title" => is_category ? category_title(tag) : "Products tagged with '#{tag}'",
+          "title" => tag_title(tag),
           "layout" => "product-list",
           "permalink" => "/tags/#{tag}",
-          "products" => products.sort_by { |product| product.data['title'] },
+          "has_toc" => false,
+          "parent" => is_category ? nil: "All tags",
+          "nav_order"=> is_category ? category_index(tag) : nil, # Ensure category pages appears first in the navigation, order by their name
           "is_category" => is_category,
-          "nav_exclude"=> !is_category
+          "products" => products.sort_by { |product| product.data['title'] }
         }
 
         self.process(@name)

--- a/_plugins/product-data-enricher.rb
+++ b/_plugins/product-data-enricher.rb
@@ -77,7 +77,7 @@ module Jekyll
 
       # Set the parent page for navigation.
       def set_parent(page)
-        page.data['parent'] = category_title(page.data['category'])
+        page.data['parent'] = tag_title(page.data['category'])
       end
 
       # Explode tags space-separated string to a list if necessary.


### PR DESCRIPTION
Move 'All tags' page to the main navigation, and list tag pages (that are not category) as children.

This also disable the TOC that is added by default by just-the-doc on all parent pages.