### PR TITLE
[splunk] Add cisco tag and disable auto update

### DIFF
--- a/products/splunk.md
+++ b/products/splunk.md
@@ -2,7 +2,7 @@
 title: Splunk
 addedAt: 2021-10-18
 category: server-app
-tag: cisco
+tags: cisco
 iconSlug: splunk
 permalink: /splunk
 versionCommand: splunk --version

--- a/products/splunk.md
+++ b/products/splunk.md
@@ -2,6 +2,7 @@
 title: Splunk
 addedAt: 2021-10-18
 category: server-app
+tag: cisco
 iconSlug: splunk
 permalink: /splunk
 versionCommand: splunk --version
@@ -12,6 +13,7 @@ identifiers:
   - repology: splunk
 
 auto:
+  disabled: true # there are anti-bot protection measures on https://docs.splunk.com
   methods:
     - splunk: https://docs.splunk.com/Documentation/Splunk
 


### PR DESCRIPTION
Cisco acquire Splunk last year: https://www.splunk.com/en_us/newsroom/press-releases/2024/cisco-completes-acquisition-of-splunk.html.

The website has been rebranded, and since then it looks like there are anti-bot protection measures in place preventing the auto-update.