### PR TITLE
[erlang] Fix missing 26 end of active support date

### DIFF
--- a/products/erlang.md
+++ b/products/erlang.md
@@ -38,7 +38,7 @@ releases:
 
   - releaseCycle: "26"
     releaseDate: 2023-05-15
-    eoas: false
+    eoas: 2024-05-17
     eol: 2026-05-15 # projected
     latest: "26.2.5.14"
     latestReleaseDate: 2025-07-16


### PR DESCRIPTION
Active support for Erlang/OTP 26 ended with the release of OTP 27, as described here:
https://www.erlang.org/doc/system/misc.html#supported-releases

```
In general, bugs are only fixed on the latest release, and new features are introduced in the upcoming release that is under development.
```

It was properly taken into account for OTP 27 with the release of OTP 28, as another reference.

Thanks,
Jérôme