### PR TITLE
[unity] Add 6.2 cycle

### DIFF
--- a/products/unity.md
+++ b/products/unity.md
@@ -15,6 +15,12 @@ auto:
     - unity: https://unity.com/releases/editor/qa/lts-releases
 
 releases:
+  - releaseCycle: "6.2"
+    releaseDate: 2025-08-12
+    eol: false
+    latest: "6000.2.0f1"
+    latestReleaseDate: 2025-08-12
+
   - releaseCycle: "6.1"
     releaseDate: 2025-04-23
     eol: false


### PR DESCRIPTION
https://unity.com/releases/editor/whats-new/6000.2.0#notes

Looks like this doesnt made 6.1 eol yet because it got a release just 1 day later then 6.2 released. I will modify eol date within 2 weeks ( just after being sure )