### PR TITLE
[unity] Revert mixed Enterprise and Industry only versions

### DIFF
--- a/products/unity.md
+++ b/products/unity.md
@@ -69,14 +69,14 @@ releases:
     lts: true
     releaseDate: 2022-04-11
     eol: 2025-02-18
-    latest: "2021.3.49f1"
-    latestReleaseDate: 2025-02-18
+    latest: "2021.3.45f1"
+    latestReleaseDate: 2024-10-16
 
   - releaseCycle: "2021.3"
     releaseDate: 2022-04-11
     eol: 2025-02-18
-    latest: "2021.3.50f1"
-    latestReleaseDate: 2025-03-19
+    latest: "2021.3.45f1"
+    latestReleaseDate: 2024-10-16
 
   - releaseCycle: "2021.2"
     releaseDate: 2021-10-25


### PR DESCRIPTION
Those shouldnt be listed within related cycle. Probably I made a mistake or they have changed its support cycle.