### PR TITLE
[openwrt] 23.05 is EOL

### DIFF
--- a/products/openwrt.md
+++ b/products/openwrt.md
@@ -29,7 +29,7 @@ releases:
   - releaseCycle: "23.05"
     releaseDate: 2023-10-11
     eoas: 2025-02-04
-    eol: 2025-08-04
+    eol: 2025-08-16
     latest: "23.05.6"
     latestReleaseDate: 2025-08-16
 


### PR DESCRIPTION
https://openwrt.org/releases/23.05/notes-23.05.6#openwrt_2305_is_eol

> The OpenWrt 23.05 series is end of life according to the OpenWrt security policy. The last release from the OpenWrt 23.05 series is 23.05.6, after this date we will not provide any updates for OpenWrt 23.05, not even for severe security problems. We encourage everyone to upgrade to OpenWrt 24.10 which will be supported till 2026.