### PR TITLE
[pan-os]Update PAN-OS version(s)

### DIFF
--- a/products/pan-os.md
+++ b/products/pan-os.md
@@ -32,9 +32,9 @@ releases:
   - releaseCycle: "11.2"
     releaseDate: 2024-05-02
     eol: 2027-05-02
-    latest: "11.2.7-h2"
-    latestReleaseDate: 2025-08-07
-    link: https://docs.paloaltonetworks.com/pan-os/11-2/pan-os-release-notes/pan-os-11-2-7-known-and-addressed-issues/pan-os-11-2-7-h2-addressed-issues
+    latest: "11.2.8"
+    latestReleaseDate: 2025-08-21
+    link: https://docs.paloaltonetworks.com/pan-os/11-2/pan-os-release-notes/pan-os-11-2-8-known-and-addressed-issues/pan-os-11-2-8-addressed-issues
 
   - releaseCycle: "11.1"
     releaseDate: 2023-11-03


### PR DESCRIPTION
[panos] This PR updates the PAN-OS versions, Release dates and the Release Notes url.

Updated Pan-OS Version:  11.2.8 

Released:                2025-08-21 

Release Notes:           https://docs.paloaltonetworks.com/pan-os/11-2/pan-os-release-notes/pan-os-11-2-8-known-and-addressed-issues/pan-os-11-2-8-addressed-issues 
