### PR TITLE
[linux-kernel] 6.15 eol

### DIFF
--- a/products/linux-kernel.md
+++ b/products/linux-kernel.md
@@ -37,7 +37,7 @@ releases:
 
   - releaseCycle: "6.15"
     releaseDate: 2025-05-25
-    eol: false # not yet announced
+    eol: 2025-08-20 # announced https://lore.kernel.org/lkml/2025082012-jingling-alarm-7380@gregkh/
     latest: "6.15.11"
     latestReleaseDate: 2025-08-20
 


### PR DESCRIPTION
https://lore.kernel.org/lkml/2025082012-jingling-alarm-7380@gregkh/
https://lore.kernel.org/lkml/2025082012-jingling-alarm-7380@gregkh/
> Date: Wed, 20 Aug 2025 19:38:48 +0200
> this is the LAST 6.15.y kernel release, this branch is now
end-of-life