### PR TITLE
[wagtail] add Wagtail 7 compatibility information

### DIFF
--- a/products/wagtail.md
+++ b/products/wagtail.md
@@ -292,7 +292,9 @@ The Wagtail team provides [official security support](https://docs.wagtail.org/e
 - The latest LTS release.
 
 ## [Compatible Django / Python versions](https://docs.wagtail.org/en/stable/releases/upgrading.html#compatible-django-python-versions)
+
 <!-- List supported releases, including minor ones -->
+
 | Wagtail release | Compatible Django versions | Compatible Python versions |
 | --------------- | -------------------------- | -------------------------- |
 | 7.1             | 4.2, 5.1, 5.2              | 3.9-3.13                   |

--- a/products/wagtail.md
+++ b/products/wagtail.md
@@ -295,6 +295,7 @@ The Wagtail team provides [official security support](https://docs.wagtail.org/e
 
 | Wagtail release | Compatible Django versions | Compatible Python versions |
 | --------------- | -------------------------- | -------------------------- |
+| 7               | 4.2, 5.1, 5.2              | 3.9-3.13                   |
 | 6               | 4.2, 5.0                   | 3.8-3.12                   |
 | 5               | 3.2, 4.1, 4.2, 5.0         | 3.8-3.12                   |
 | 4               | 3.2, 4.0, 4.1              | 3.7-3.11                   |

--- a/products/wagtail.md
+++ b/products/wagtail.md
@@ -298,7 +298,7 @@ The Wagtail team provides [official security support](https://docs.wagtail.org/e
 | Wagtail release | Compatible Django versions | Compatible Python versions |
 | --------------- | -------------------------- | -------------------------- |
 | 7.1             | 4.2, 5.1, 5.2              | 3.9-3.13                   |
-| 7.0             | 4.2, 5.1, 5.2              | 3.9-3.13                   |
-| 6.3             | 4.2, 5.0, 5.1, 5.2         | 3.9-3.12                   |
+| 7.0 LTS         | 4.2, 5.1, 5.2              | 3.9-3.13                   |
+| 6.3 LTS         | 4.2, 5.0, 5.1, 5.2         | 3.9-3.12                   |
 
 *[LTS]: Long-Term Support

--- a/products/wagtail.md
+++ b/products/wagtail.md
@@ -292,14 +292,11 @@ The Wagtail team provides [official security support](https://docs.wagtail.org/e
 - The latest LTS release.
 
 ## [Compatible Django / Python versions](https://docs.wagtail.org/en/stable/releases/upgrading.html#compatible-django-python-versions)
-
+<!-- List supported releases, including minor ones -->
 | Wagtail release | Compatible Django versions | Compatible Python versions |
 | --------------- | -------------------------- | -------------------------- |
-| 7               | 4.2, 5.1, 5.2              | 3.9-3.13                   |
-| 6               | 4.2, 5.0                   | 3.8-3.12                   |
-| 5               | 3.2, 4.1, 4.2, 5.0         | 3.8-3.12                   |
-| 4               | 3.2, 4.0, 4.1              | 3.7-3.11                   |
-| 3               | 3.2, 4.0                   | 3.7-3.10                   |
-| 2.15 LTS        | 3.0, 3.1, 3.2              | 3.6-3.10                   |
+| 7.1             | 4.2, 5.1, 5.2              | 3.9-3.13                   |
+| 7.0             | 4.2, 5.1, 5.2              | 3.9-3.13                   |
+| 6.3             | 4.2, 5.0, 5.1, 5.2         | 3.9-3.12                   |
 
 *[LTS]: Long-Term Support


### PR DESCRIPTION
Hello, Wagtail core team member here. I use this website quite a lot and noticed the compatibility table entry for Wagtail 7 is missing. This PR adds that.

---

Could I ask why the compatibility table only shows the major version of Wagtail (`5 series`, `6 series` and so on)? The [compatibility table in the Wagtail documentation](https://docs.wagtail.org/en/stable/releases/upgrading.html#compatible-django-python-versions) shows the Django/Python compatibility per release. As you can see, Django 5.1 and 5.2 compatibility was added to Wagtail 6.3. As was Python 3.13 support. That is not reflected in the Wagtail 6 table entry in this repository.