### PR TITLE
Only compute identifiers URLs once during build

### DIFF
--- a/_includes/identifiers.html
+++ b/_includes/identifiers.html
@@ -6,7 +6,7 @@
     {% assign type_and_identifier = identifier_hash|first %}
     {% assign identifier_type = type_and_identifier[0] %}
     {% assign identifier = type_and_identifier[1] %}
-    {% assign identifier_url = (identifier_hash|identifier_to_url) %}
+    {% assign identifier_url = identifier_hash.url %}
 
     <li>
       {{ identifier_type }}:

--- a/_plugins/end-of-life-filters.rb
+++ b/_plugins/end-of-life-filters.rb
@@ -1,5 +1,4 @@
 require 'nokogiri'
-require_relative 'identifier-to-url'
 
 # Various custom filters used by endoflife.date.
 #
@@ -127,10 +126,6 @@ module EndOfLifeFilter
       # Assuming it's a date
       return end_color(days_from_now(input))
     end
-  end
-
-  def identifier_to_url(input)
-    IdentifierToUrl.new.render(input)
   end
 end
 

--- a/_plugins/product-data-enricher.rb
+++ b/_plugins/product-data-enricher.rb
@@ -25,6 +25,7 @@
 # - days_toward_eoes (in cycles) : number of days toward the end of extended support for the cycle (optional, only if eoes is set)
 
 require_relative 'end-of-life'
+require_relative 'identifier-to-url'
 
 module Jekyll
   class ProductDataEnricher
@@ -40,7 +41,7 @@ module Jekyll
         set_icon_url(page)
         set_parent(page)
         set_tags(page)
-        set_identifiers(page)
+        set_identifiers_url(page)
         set_aliases(page)
         set_overridden_columns_label(page)
 
@@ -105,10 +106,12 @@ module Jekyll
         end
       end
 
-      # Set identifiers to empty if it's not present.
-      def set_identifiers(page)
-        if !page.data['identifiers']
-          page.data['identifiers'] = []
+      # Set each identifiers URL.
+      def set_identifiers_url(page)
+        for identifier in page.data['identifiers']
+          unless identifier['url']
+            identifier['url'] = IdentifierToUrl.new.render(identifier)
+          end
         end
       end
 


### PR DESCRIPTION
Identifier's URL is computed two times during build : during validation and during rendering. This moves the computation of identifier's URL in product-data-enricher so that the URL is computed just once per build.

With this the URL identifiers URLs are now also checked in product-data-validator when the MUST_CHECK_URLS environment variable is set.