### PR TITLE
Implement a retry mechanism for 429 when checking URLs

### DIFF
--- a/products/freebsd.md
+++ b/products/freebsd.md
@@ -407,6 +407,7 @@ releases:
     releaseLabel: releng/3.5
     releaseDate: 2000-06-30
     eol: 2001-06-30 # unknown, assumed to be 1 year after release
+    link: null
 
   - releaseCycle: "4.0"
     releaseLabel: "releng/4.0"


### PR DESCRIPTION
During [URL check](https://github.com/endoflife-date/endoflife.date/actions/workflows/check-links.yml) we may receive 429 errors. This is commonly the case when calling github.com.

This updates the `check_url` method to detect those errors and sleep for some time before retrying (up to `URL_CHECK_MAX_RETRY` times).