### PR TITLE
Add a workaround to fix Autofocus to search-input

### DIFF
--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -3,3 +3,19 @@ layout: default
 ---
 
 {{content}}
+
+<script>
+// Automatically focus the #search-input element once it appears in the DOM.
+// Fixes #367 can be removed whenever upstream/just-the-docs brings a better solution
+document.addEventListener('DOMContentLoaded', function() {
+  const observer = new MutationObserver((mutations, obs) => {
+    const searchInput = document.getElementById('search-input');
+    if (searchInput) {
+      searchInput.focus();
+      obs.disconnect();
+    }
+  });
+
+  observer.observe(document.body, { childList: true, subtree: true });
+});
+</script>


### PR DESCRIPTION
Fixes #367

tested on local machine on the other hand  it might not work on preview page so we can observe it after merge ( if you think it is not working we can always revert back , but as my test this was working perfect on my localmachine copy )