### PR TITLE
elasticsearch: convert to track minor versions

### DIFF
--- a/products/elasticsearch.md
+++ b/products/elasticsearch.md
@@ -30,18 +30,43 @@ auto:
 
 # For EOL, see https://www.elastic.co/support/eol
 releases:
-  - releaseCycle: "9"
-    releaseDate: 2025-04-08
-    eol: false # later of 2027-10-15 or 18 months after the release date of 10.0
+  - releaseCycle: "9.1"
+    releaseDate: 2025-07-29
+    eol: false
     latest: "9.1.2"
     latestReleaseDate: 2025-08-11
-    link: https://www.elastic.co/docs/release-notes/elasticsearch#elasticsearch-9.0.1-release-notes
+    link: https://www.elastic.co/docs/release-notes/elasticsearch#elasticsearch-9.1.2-release-notes
 
-  - releaseCycle: "8"
-    releaseDate: 2022-02-10
+  - releaseCycle: "8.19"
+    releaseDate: 2025-07-29
     eol: 2027-07-15
     latest: "8.19.2"
     latestReleaseDate: 2025-08-11
+
+  - releaseCycle: "8.18"
+    releaseDate: 2025-04-15
+    eol: false  # Until 9.2 is released
+    latest: "8.18.5"
+    latestReleaseDate: 2025-08-12
+
+  - releaseCycle: "9.0"
+    releaseDate: 2025-04-08
+    eol: false
+    latest: "9.0.5"
+    latestReleaseDate: 2025-08-12
+    link: https://www.elastic.co/docs/release-notes/elasticsearch#elasticsearch-9.0.5-release-notes
+
+  - releaseCycle: "8.17"
+    releaseDate: 2024-12-12
+    eol: false  # Supposedly until 8.19 released, but they've released twice since
+    latest: "8.17.10"
+    latestReleaseDate: 2025-08-12
+
+  - releaseCycle: "8.16"
+    releaseDate: 2024-11-12
+    eol: 2025-04-15
+    latest: "8.16.6"
+    latestReleaseDate: 2025-03-25
 
   - releaseCycle: "7"
     releaseDate: 2019-04-10


### PR DESCRIPTION
Elastic support multiple minor versions in parallel.  Minor versions are the granularity of release that people are most likely to deploy at, and so the better granularity to track the EOL status of.

I've left the major versions without multiple minor versions to track intact: potentially once 8.17 and 8.18 are EOL, 8 could be similarly generalised.

Fixes: #6542 