### PR TITLE
[Pixel Watch] set discontinued for Pixel Watch and Pixel Watch 2

### DIFF
--- a/products/pixel-watch.md
+++ b/products/pixel-watch.md
@@ -34,7 +34,7 @@ releases:
     releaseDate: 2023-10-12
     eoas: 2026-10-01
     eol: 2026-10-01
-    discontinued: false
+    discontinued: true
     link: https://en.wikipedia.org/wiki/Pixel_Watch_2
     supportedAndroidVersions: "4 - 5" # https://www.gsmarena.com/google_pixel_watch_2-12547.php
 
@@ -43,7 +43,7 @@ releases:
     releaseDate: 2022-10-13
     eoas: 2025-10-01
     eol: 2025-10-01
-    discontinued: false
+    discontinued: true
     link: https://en.wikipedia.org/wiki/Pixel_Watch
     supportedAndroidVersions: "3.5 - 5" # https://www.gsmarena.com/google_pixel_watch-11546.php
 ---


### PR DESCRIPTION
as listed on [google store website](https://store.google.com/us/magazine/google_pixel_watch_compare?hl=en-US&selections=eyJwcm9kdWN0RmFtaWx5IjoiY21WbWRYSmlhWE5vWldSZmNHbDRaV3hmTjJFPSIsInZhcmlhbnRzIjpbWyIyIiwiTXc9PSJdXX0%3D&toggler0=Google+Pixel+Watch+4+%2841mm%29&toggler1=Google+Pixel+Watch&toggler2=Google+Pixel+Watch+2)



<img width="846" height="696" alt="image" src="https://github.com/user-attachments/assets/77a97c23-088c-459a-9788-a930d740acb8" />
