### PR TITLE
beats: convert to track minor versions

### DIFF
--- a/products/beats.md
+++ b/products/beats.md
@@ -36,13 +36,6 @@ releases:
     latestReleaseDate: 2025-08-11
     link: https://www.elastic.co/docs/release-notes/beats#beats-9.1.2-release-notes
 
-  - releaseCycle: "9.0"
-    releaseDate: 2025-04-08
-    eol: false # later of 2027-10-15 or 18 months after the release date of 10.0
-    latest: "9.0.5"
-    latestReleaseDate: 2025-08-06
-    link: https://www.elastic.co/docs/release-notes/beats#beats-9.0.5-release-notes
-
   - releaseCycle: "8.19"
     releaseDate: 2025-07-23
     eol: 2027-07-15
@@ -54,6 +47,13 @@ releases:
     eol: false # Until 9.2 is released
     latest: "8.18.5"
     latestReleaseDate: 2025-08-06
+   
+  - releaseCycle: "9.0"
+    releaseDate: 2025-04-08
+    eol: false # later of 2027-10-15 or 18 months after the release date of 10.0
+    latest: "9.0.5"
+    latestReleaseDate: 2025-08-06
+    link: https://www.elastic.co/docs/release-notes/beats#beats-9.0.5-release-notes
 
   - releaseCycle: "8.17"
     releaseDate: 2024-12-11

--- a/products/beats.md
+++ b/products/beats.md
@@ -29,18 +29,43 @@ auto:
 
 # For EOL, see https://www.elastic.co/support/eol
 releases:
-  - releaseCycle: "9"
-    releaseDate: 2025-04-08
+  - releaseCycle: "9.1"
+    releaseDate: 2025-07-23
     eol: false # later of 2027-10-15 or 18 months after the release date of 10.0
     latest: "9.1.2"
     latestReleaseDate: 2025-08-11
-    link: https://www.elastic.co/docs/release-notes/beats#beats-9.0.1-release-notes
+    link: https://www.elastic.co/docs/release-notes/beats#beats-9.1.2-release-notes
 
-  - releaseCycle: "8"
-    releaseDate: 2022-02-10
+  - releaseCycle: "9.0"
+    releaseDate: 2025-04-08
+    eol: false # later of 2027-10-15 or 18 months after the release date of 10.0
+    latest: "9.0.5"
+    latestReleaseDate: 2025-08-06
+    link: https://www.elastic.co/docs/release-notes/beats#beats-9.0.5-release-notes
+
+  - releaseCycle: "8.19"
+    releaseDate: 2025-07-23
     eol: 2027-07-15
     latest: "8.19.2"
     latestReleaseDate: 2025-08-08
+
+  - releaseCycle: "8.18"
+    releaseDate: 2025-04-09
+    eol: false # Until 9.2 is released
+    latest: "8.18.5"
+    latestReleaseDate: 2025-08-06
+
+  - releaseCycle: "8.17"
+    releaseDate: 2024-12-11
+    eol: false # Supposedly until 8.19 released, but they've released twice since
+    latest: "8.17.10"
+    latestReleaseDate: 2025-08-08
+
+  - releaseCycle: "8.16"
+    releaseDate: 2024-11-07
+    eol: 2025-04-18
+    latest: "8.16.6"
+    latestReleaseDate: 2025-03-18
 
   - releaseCycle: "7"
     releaseDate: 2019-04-05


### PR DESCRIPTION
Similar to https://github.com/endoflife-date/endoflife.date/pull/8264

Beats support multiple minor versions in parallel: https://github.com/elastic/beats/tags