### PR TITLE
logstash: convert to track minor versions

### DIFF
--- a/products/logstash.md
+++ b/products/logstash.md
@@ -21,17 +21,11 @@ auto:
 # For EOL, see https://www.elastic.co/support/eol
 releases:
   - releaseCycle: "9.1"
-    releaseDate: 2025-03-17
+    releaseDate: 2025-07-29
     eol: false # later of 2027-10-15 or 18 months after the release date of 10.0
     latest: "9.1.2"
     latestReleaseDate: 2025-08-07
     link: https://www.elastic.co/docs/release-notes/logstash#logstash-__LATEST__-release-notes
-
-  - releaseCycle: "9.0"
-    releaseDate: 2025-03-17
-    eol: false # later of 2027-10-15 or 18 months after the release date of 10.0
-    latest: "9.0.5"
-    latestReleaseDate: 2025-08-06
 
   - releaseCycle: "8.19"
     releaseDate: 2025-07-14
@@ -44,6 +38,12 @@ releases:
     eol: false # Until 9.2 is released
     latest: "8.18.5"
     latestReleaseDate: 2025-08-06
+
+  - releaseCycle: "9.0"
+    releaseDate: 2025-03-17
+    eol: false # later of 2027-10-15 or 18 months after the release date of 10.0
+    latest: "9.0.5"
+    latestReleaseDate: 2025-08-0
 
   - releaseCycle: "8.17"
     releaseDate: 2024-12-05

--- a/products/logstash.md
+++ b/products/logstash.md
@@ -43,7 +43,7 @@ releases:
     releaseDate: 2025-03-17
     eol: false # later of 2027-10-15 or 18 months after the release date of 10.0
     latest: "9.0.5"
-    latestReleaseDate: 2025-08-0
+    latestReleaseDate: 2025-08-06
 
   - releaseCycle: "8.17"
     releaseDate: 2024-12-05

--- a/products/logstash.md
+++ b/products/logstash.md
@@ -20,18 +20,36 @@ auto:
 
 # For EOL, see https://www.elastic.co/support/eol
 releases:
-  - releaseCycle: "9"
+  - releaseCycle: "9.1"
     releaseDate: 2025-03-17
     eol: false # later of 2027-10-15 or 18 months after the release date of 10.0
     latest: "9.1.2"
     latestReleaseDate: 2025-08-07
     link: https://www.elastic.co/docs/release-notes/logstash#logstash-__LATEST__-release-notes
 
-  - releaseCycle: "8"
-    releaseDate: 2022-02-10
+  - releaseCycle: "9.0"
+    releaseDate: 2025-03-17
+    eol: false # later of 2027-10-15 or 18 months after the release date of 10.0
+    latest: "9.0.5"
+    latestReleaseDate: 2025-08-06
+
+  - releaseCycle: "8.19"
+    releaseDate: 2025-07-14
     eol: 2027-07-15
     latest: "8.19.2"
-    latestReleaseDate: 2025-08-07
+    latestReleaseDate: 2025-08-06
+
+  - releaseCycle: "8.18"
+    releaseDate: 2025-04-09
+    eol: false # Until 9.2 is released
+    latest: "8.18.5"
+    latestReleaseDate: 2025-08-06
+
+  - releaseCycle: "8.17"
+    releaseDate: 2024-12-05
+    eol: false # Supposedly until 8.19 released, but they've released twice since
+    latest: "8.17.10"
+    latestReleaseDate: 2025-08-06
 
   - releaseCycle: "7"
     releaseDate: 2019-04-05


### PR DESCRIPTION
Similar to https://github.com/endoflife-date/endoflife.date/pull/8264

Logstash support multiple minor versions in parallel: https://github.com/elastic/logstash/tags