### PR TITLE
[vmware-esxi] Add 9.0

### DIFF
--- a/products/vmware-esxi.md
+++ b/products/vmware-esxi.md
@@ -27,6 +27,7 @@ releases:
   - releaseCycle: "9.0"
     releaseDate: 2025-06-17
     eol: false
+    technicalGuidance: 2032-06-17 # no source, calculated releaseDate(x)+7y
     latest: "9.0.0.0100"
     latestReleaseDate: 2025-07-15
     link: https://techdocs.broadcom.com/us/en/vmware-cis/vcf/vcf-9-0-and-later/9-0/release-notes/maintenance-releases/esx-update-and-patch-release-notes/esx-9-0-0-0100.html

--- a/products/vmware-esxi.md
+++ b/products/vmware-esxi.md
@@ -24,6 +24,13 @@ identifiers:
   - cpe: cpe:/o:vmware:esxi
 
 releases:
+  - releaseCycle: "9.0"
+    releaseDate: 2025-06-17
+    eol: false
+    latest: "9.0.0.0100"
+    latestReleaseDate: 2025-07-15
+    link: https://techdocs.broadcom.com/us/en/vmware-cis/vcf/vcf-9-0-and-later/9-0/release-notes/maintenance-releases/esx-update-and-patch-release-notes/esx-9-0-0-0100.html
+
   - releaseCycle: "8.0"
     releaseDate: 2022-10-11
     eol: 2027-10-11


### PR DESCRIPTION
From #8018

What I found so far:
https://knowledge.broadcom.com/external/article/316595/build-numbers-and-versions-of-vmware-esx.html
> [ESX 9.0 GA](https://techdocs.broadcom.com/us/en/vmware-cis/vcf/vcf-9-0-and-later/9-0/release-notes/vmware-cloud-foundation-90-release-notes.html)
> [ESX 9.0.0.0100](https://techdocs.broadcom.com/us/en/vmware-cis/vcf/vcf-9-0-and-later/9-0/release-notes/maintenance-releases/esx-update-and-patch-release-notes/esx-9-0-0-0100.html)

The links contains these details:
ESX 9.0 GA:
> VMware Cloud Foundation 9.0 | 17 JUN 2025 | Build 24755599

ESX 9.0.0.0100:
> VMware ESX 9.0.0.0100 | 15 JUL 2025 | Build 24813472

The [Lifecycle Page](https://support.broadcom.com/group/ecx/productlifecycle) needs a login now. We don't have details for `eol` and `technicalGuidance`.

https://blogs.vmware.com/cloud-foundation/2025/06/23/vsphere-in-vcf-9-0-whats-new/ has more details about the release.

It seems that ESX is more close to Cloud Foundation. As I don't work with the product I have no more insights.