### PR TITLE
feat(apache-airflow): change latest v3 version from v3.0.5 to v3.0.4

### DIFF
--- a/products/apache-airflow.md
+++ b/products/apache-airflow.md
@@ -36,8 +36,8 @@ releases:
     releaseDate: 2025-04-22
     eoas: false
     eol: false
-    latest: "3.0.5"
-    latestReleaseDate: 2025-08-20
+    latest: "3.0.4"
+    latestReleaseDate: 2025-08-06
 
   - releaseCycle: "2"
     releaseDate: 2020-12-17


### PR DESCRIPTION
Apache Airflow v3.0.5 has been yanked by upstream due to https://github.com/apache/airflow/issues/54768

Refs:

- https://pypi.org/project/apache-airflow/3.0.5/
- https://github.com/apache/airflow/issues/54768#issuecomment-3210308683
- https://github.com/apache/airflow/issues/54781#issuecomment-3215573190
