### PR TITLE
[pan-os]: add release cycle 12.1 with latest version 12.1.2

### DIFF
--- a/products/pan-os.md
+++ b/products/pan-os.md
@@ -29,6 +29,13 @@ auto:
         eol: "End-of-Life Date"
 
 releases:
+  - releaseCycle: "12.1"
+    releaseDate: 2025-08-28
+    eol: 2028-08-28
+    latest: "12.1.2"
+    latestReleaseDate: 2025-08-28
+    link: https://docs.paloaltonetworks.com/ngfw/release-notes/12-1/pan-os-12-1-2-known-and-addressed-issues/pan-os-12-1-2-addressed-issues
+
   - releaseCycle: "11.2"
     releaseDate: 2024-05-02
     eol: 2027-05-02


### PR DESCRIPTION
This PR updates pan-os.md with the new 12.1 release cycle:

Added release cycle 12.1

Release date: 2025-08-28

End of life: 2028-08-28

Latest version: 12.1.2 (released 2025-08-28)

Included link to addressed issues: [PAN-OS 12.1.2 Release Notes](https://docs.paloaltonetworks.com/ngfw/release-notes/12-1/pan-os-12-1-2-known-and-addressed-issues/pan-os-12-1-2-addressed-issues?utm_source=chatgpt.com)