### PR TITLE
[intel] Adds link and info about PCNs

### DIFF
--- a/products/intel-processors.md
+++ b/products/intel-processors.md
@@ -230,7 +230,7 @@ releases:
   with quality expectations per platform found [in the release notes](https://github.com/intel/compute-runtime/releases).
 - While a CPU may be under security support, it may not be supported on a specific Windows release.
   More information on this can be found [here](https://www.intel.com/content/www/us/en/support/articles/000032181/processors/intel-core-processors.html).
-- A CPU's iGPU may not be supported by the latest GPU driver branch even if still supported.
+- A CPU's iGPU may not be supported by the latest GPU driver branch even if the CPU is still supported.
 
 ## Determining product classification
 
@@ -242,4 +242,7 @@ your CPU belongs on:
 - macOS: `sysctl -n machdep.cpu.brand_string`
 - FreeBSD/OpenBSD: `sysctl -n hw.model`
 
-Then check product classification on <https://ark.intel.com/>.
+Then check product classification on <https://ark.intel.com/>. 
+
+Intel announces notifications via [Product Change Notifications](https://www.intel.com/content/www/us/en/collections/content-type/pcns.html).
+An third-party [PSN RSS/API Feed](https://intel.pcn.captnemo.in/) is available to subscribe to the same.


### PR DESCRIPTION
My Intel PCN project is finally functional (first commit was 2 years ago, but now it auto-updates, and publishes over RSS).

This PR adds 2 pieces of information:

1. Intel PCNs, and that they contain important information
2. How to subscribe to PCNs.