### PR TITLE
[amazon-linux] Fix regex

### DIFF
--- a/products/amazon-linux.md
+++ b/products/amazon-linux.md
@@ -21,8 +21,8 @@ identifiers:
 auto:
   methods:
     - docker_hub: library/amazonlinux
-      # TODO: Fix this regex to exclude RC releases
-      regex: ^(?:\d+(\.\d+){2,4})$
+      regex: '^(?P<version>\d+(\.\d+){2,4})$'
+      template: "{{version}}"
 
 releases:
   - releaseCycle: "2023"


### PR DESCRIPTION
So that version template can be used with the docker_hub auto method (https://github.com/endoflife-date/release-data/pull/504).