### PR TITLE
[wordpress] Remove rapidfort purl for dockerhub

### DIFF
--- a/products/wordpress.md
+++ b/products/wordpress.md
@@ -32,7 +32,6 @@ identifiers:
   - purl: pkg:docker/library/wordpress
   - purl: pkg:docker/bitnami/wordpress
   - purl: pkg:docker/bitnami/wordpress-nginx
-  - purl: pkg:docker/rapidfort/wordpress
   - cpe: cpe:2.3:a:wordpress:wordpress
   - cpe: cpe:/a:wordpress:wordpress
 


### PR DESCRIPTION
rapidfort image doesnt exist anymore