### PR TITLE
[pan-gp] GlobalProtect 6.0: bump latest to 6.0.12 (2025-09-02)

### DIFF
--- a/products/pan-gp.md
+++ b/products/pan-gp.md
@@ -57,8 +57,8 @@ releases:
     releaseDate: 2022-02-22
     eol: 2025-12-31
     eoas: 2025-12-31
-    latest: "6.0.11"
-    latestReleaseDate: 2024-11-25
+    latest: "6.0.12"
+    latestReleaseDate: 2025-09-02
     link: https://docs.paloaltonetworks.com/globalprotect/6-0/globalprotect-app-release-notes/globalprotect-addressed-issues
 
   - releaseCycle: "5.3"


### PR DESCRIPTION
[pan-gp] GlobalProtect 6.0: bump latest to 6.0.12 (2025-09-02)

- Update `latest` from 6.0.11 → 6.0.12
- Set `latestReleaseDate` to 2025-09-02
- No changes to `releaseDate` (2022-02-22), `eol`/`eoas` (2025-12-31)
- Source: https://docs.paloaltonetworks.com/globalprotect/6-0/globalprotect-app-release-notes/globalprotect-addressed-issues