### PR TITLE
[Pixel] Mark Pixel 8 as discontinued

### DIFF
--- a/products/pixel.md
+++ b/products/pixel.md
@@ -119,7 +119,7 @@ releases:
     releaseDate: 2023-10-04
     eoas: 2030-10-01
     eol: 2030-10-01
-    discontinued: false
+    discontinued: true
     link: https://en.wikipedia.org/wiki/Pixel_8
     supportedAndroidVersions: "14 - 16" # https://www.gsmarena.com/google_pixel_8-12546.php
 


### PR DESCRIPTION
currently on Pixel 8 is marked as "No longer available"
<img width="438" height="582" alt="image" src="https://github.com/user-attachments/assets/2cc47a5c-f77e-4975-9760-0b2143f041b1" />


https://store.google.com/us/magazine/compare_pixel?hl=en-US&toggler0=Pixel+8&toggler1=Pixel+8+Pro&toggler2=Pixel+8a