### PR TITLE
[SUSE Manager] Update  4.3, 5.0 and 5.1 patch releases and rename product title

### DIFF
--- a/products/suse-manager.md
+++ b/products/suse-manager.md
@@ -4,7 +4,10 @@ addedAt: 2024-08-02
 category: server-app
 tags: suse
 iconSlug: suse
-permalink: /suse-manager
+permalink: /suse-multi-linux-manager
+alternate_urls:
+  - /suse-manager
+  - /suse-mlm
 versionCommand: zypper info mgradm
 releasePolicyLink: https://www.suse.com/lifecycle
 changelogTemplate: https://www.suse.com/releasenotes/x86_64/SUSE-MANAGER/__RELEASE_CYCLE__/

--- a/products/suse-manager.md
+++ b/products/suse-manager.md
@@ -32,7 +32,6 @@ releases:
   - releaseCycle: "4.3"
     releaseDate: 2022-06-20
     eol: 2025-07-23
-    lts: 2026-07-31
     latest: "4.3.16"
     latestReleaseDate: 2025-07-01
 

--- a/products/suse-manager.md
+++ b/products/suse-manager.md
@@ -13,17 +13,24 @@ eolColumn: General Support
 # Release dates are documented in each release note in the "Version revision history" paragraph.
 # EOL dates can be found on https://www.suse.com/lifecycle.
 releases:
+  - releaseCycle: "5.1"
+    releaseDate: 2024-07-31
+    eol: false
+    latest: "5.1"
+    latestReleaseDate: 2025-07-31
+
   - releaseCycle: "5.0"
     releaseDate: 2024-07-16
     eol: 2026-06-30
-    latest: "5.0.4"
-    latestReleaseDate: 2025-04-16
+    latest: "5.0.5"
+    latestReleaseDate: 2025-07-01
 
   - releaseCycle: "4.3"
     releaseDate: 2022-06-20
-    eol: 2025-06-30
-    latest: "4.3.15.1"
-    latestReleaseDate: 2024-04-16
+    eol: 2025-07-23
+    lts: 2026-07-31
+    latest: "4.3.16"
+    latestReleaseDate: 2025-07-01
 
   - releaseCycle: "4.2"
     releaseDate: 2021-06-21

--- a/products/suse-manager.md
+++ b/products/suse-manager.md
@@ -4,9 +4,9 @@ addedAt: 2024-08-02
 category: server-app
 tags: suse
 iconSlug: suse
-permalink: /suse-multi-linux-manager
+permalink: /suse-manager
 alternate_urls:
-  - /suse-manager
+  - /suse-multi-linux-manager
   - /suse-mlm
 versionCommand: zypper info mgradm
 releasePolicyLink: https://www.suse.com/lifecycle

--- a/products/suse-manager.md
+++ b/products/suse-manager.md
@@ -85,7 +85,7 @@ releases:
     latestReleaseDate: 2013-08-26
 ---
 
-> [SUSE Multi-Linux Manager](https://www.suse.com/products/multi-linux-manager/) is an open source infrastructure management solution designed to simplify and secure a mixed Linux environment.
+> [SUSE Multi-Linux Manager](https://www.suse.com/products/multi-linux-manager/), formerly known as SUSE Manager, is an open source infrastructure management solution designed to simplify and secure a mixed Linux environment.
 > It uses the Salt configuration management system to manage clients, deploy patches and packages, and report changes at scale.
 
 {: .warning }

--- a/products/suse-manager.md
+++ b/products/suse-manager.md
@@ -11,7 +11,6 @@ alternate_urls:
 versionCommand: zypper info mgradm
 releasePolicyLink: https://www.suse.com/lifecycle
 changelogTemplate: https://www.suse.com/releasenotes/x86_64/SUSE-MANAGER/__RELEASE_CYCLE__/
-# beginning with 5.1: https://www.suse.com/releasenotes/x86_64/multi-linux-manager/__RELEASE_CYCLE__
 eolColumn: General Support
 
 # Release dates are documented in each release note in the "Version revision history" paragraph.
@@ -22,6 +21,7 @@ releases:
     eol: false
     latest: "5.1"
     latestReleaseDate: 2025-07-31
+    link: https://www.suse.com/releasenotes/x86_64/multi-linux-manager/__RELEASE_CYCLE__
 
   - releaseCycle: "5.0"
     releaseDate: 2024-07-16

--- a/products/suse-manager.md
+++ b/products/suse-manager.md
@@ -1,13 +1,14 @@
 ---
-title: SUSE Manager
+title: SUSE Multi-Linux Manager
 addedAt: 2024-08-02
 category: server-app
 tags: suse
 iconSlug: suse
 permalink: /suse-manager
-versionCommand: zypper info SUSE-Manager-Server-release
+versionCommand: zypper info mgradm
 releasePolicyLink: https://www.suse.com/lifecycle
 changelogTemplate: https://www.suse.com/releasenotes/x86_64/SUSE-MANAGER/__RELEASE_CYCLE__/
+# beginning with 5.1: https://www.suse.com/releasenotes/x86_64/multi-linux-manager/__RELEASE_CYCLE__
 eolColumn: General Support
 
 # Release dates are documented in each release note in the "Version revision history" paragraph.
@@ -81,14 +82,14 @@ releases:
     latestReleaseDate: 2013-08-26
 ---
 
-> [SUSE Manager](https://www.suse.com/products/suse-manager/) is an open source infrastructure management solution designed to simplify and secure a mixed Linux environment.
+> [SUSE Multi-Linux Manager](https://www.suse.com/products/multi-linux-manager/) is an open source infrastructure management solution designed to simplify and secure a mixed Linux environment.
 > It uses the Salt configuration management system to manage clients, deploy patches and packages, and report changes at scale.
 
 {: .warning }
 
-> This page tracks SUSE Manager, which is a SUSE product based on the [open-source Uyuni project](https://uyuni-project.org).
+> This page tracks SUSE Multi-Linux Manager, which is a SUSE product based on the [open-source Uyuni project](https://uyuni-project.org).
 > Uyuni offers the same functionality but follows a rolling release — bugfixes are only available on the latest version.
 
-SUSE Manager is usually released every 12 months.
+SUSE Multi-Linux Manager is usually released every 12 months.
 The current release is usually supported for an additional 12 months once after the next release, resulting in a 24-month support cycle.
-SUSE Manager Proxy follows the same lifecycle as SUSE Manager Server.
+SUSE Multi-Linux Manager Proxy follows the same lifecycle as SUSE Multi-Linux Manager Server.


### PR DESCRIPTION
Updated versions in accordance with the release notes:

- https://www.suse.com/releasenotes/x86_64/SUSE-MANAGER/4.3/index.html#_version_revision_history
- https://www.suse.com/releasenotes/x86_64/SUSE-MANAGER/5.0/index.html#_version_revision_history
- https://www.suse.com/releasenotes/x86_64/multi-linux-manager/5.1/index.html#_version_revision_history

With version 5.1, SUSE renamed the product to `SUSE Multi-Linux Manager` so I changed the references.

Should we also change the permalink to `/multi-linux-manager`, what do you think?