### PR TITLE
[haproxy] update EOL when a new version was released after EOL

### DIFF
--- a/products/haproxy.md
+++ b/products/haproxy.md
@@ -24,6 +24,7 @@ identifiers:
 
 # releaseCycle, releaseDate, lts, eol and latest are listed on https://www.haproxy.org/
 # eol dates noted as Q1-4 set to: Q1 -> YYYY-01-01, Q2 -> YYYY-04-01, Q3 -> YYYY-07-01, Q4 -> YYYY-10-01
+# eol(x) = max(fuzzyDate(x), latestReleaseDate(x))
 releases:
   - releaseCycle: "3.2"
     releaseDate: 2025-05-28

--- a/products/haproxy.md
+++ b/products/haproxy.md
@@ -47,7 +47,7 @@ releases:
 
   - releaseCycle: "2.9"
     releaseDate: 2023-12-05
-    eol: 2025-01-01
+    eol: 2025-03-21
     latest: "2.9.15"
     latestReleaseDate: 2025-03-21
 
@@ -60,7 +60,7 @@ releases:
 
   - releaseCycle: "2.7"
     releaseDate: 2022-12-01
-    eol: 2024-01-01
+    eol: 2024-04-05
     latest: "2.7.12"
     latestReleaseDate: 2024-04-05
 
@@ -73,7 +73,7 @@ releases:
 
   - releaseCycle: "2.5"
     releaseDate: 2021-11-23
-    eol: 2023-02-14
+    eol: 2023-05-02
     latest: "2.5.14"
     latestReleaseDate: 2023-05-02
 
@@ -86,14 +86,14 @@ releases:
 
   - releaseCycle: "2.3"
     releaseDate: 2020-11-05
-    eol: 2022-01-01
+    eol: 2022-07-27
     latest: "2.3.21"
     latestReleaseDate: 2022-07-27
 
   - releaseCycle: "2.2"
     releaseDate: 2020-07-07
     lts: true
-    eol: 2025-04-01
+    eol: 2025-04-23
     latest: "2.2.34"
     latestReleaseDate: 2025-04-23
 
@@ -105,7 +105,7 @@ releases:
 
   - releaseCycle: "2.0"
     releaseDate: 2019-06-16
-    eol: 2024-04-01
+    eol: 2024-04-05
     latest: "2.0.35"
     latestReleaseDate: 2024-04-05
 
@@ -117,13 +117,13 @@ releases:
 
   - releaseCycle: "1.8"
     releaseDate: 2017-11-26
-    eol: 2022-10-01
+    eol: 2022-12-09
     latest: "1.8.31"
     latestReleaseDate: 2022-12-09
 
   - releaseCycle: "1.7"
     releaseDate: 2016-11-25
-    eol: 2021-10-01
+    eol: 2021-03-31
     latest: "1.7.14"
     latestReleaseDate: 2021-03-31
 

--- a/products/haproxy.md
+++ b/products/haproxy.md
@@ -123,7 +123,7 @@ releases:
 
   - releaseCycle: "1.7"
     releaseDate: 2016-11-25
-    eol: 2021-03-31
+    eol: 2021-10-01
     latest: "1.7.14"
     latestReleaseDate: 2021-03-31
 


### PR DESCRIPTION
As stated in the last paragraph, the EOL dates of HAProxy are a bit fuzzy and a last version if often released past the EOL date. The last paragraph also says the eol date will be updated in this case. This commit updates the eol dates that were set before the last release date.

Alternatively, we could do the reverse: keep planned eol dates and remove the last sentence.