### PR TITLE
[sles] Fix 15.6 eol and eoes dates

### DIFF
--- a/products/sles.md
+++ b/products/sles.md
@@ -42,8 +42,8 @@ releases:
 
   - releaseCycle: "15.6"
     releaseDate: 2024-06-26
-    eol: 2025-11-28
-    eoes: 2031-06-30
+    eol: 2025-12-17
+    eoes: 2028-12-17
 
   - releaseCycle: "15.5"
     releaseDate: 2023-06-20


### PR DESCRIPTION
According to https://www.suse.com/lifecycle/#suse-linux-enterprise-server-15, 15.6 general ends 6 months after SLES 15 SP7 release, and LTSS ends 42 months after SLES 15 SP7 release.