### PR TITLE
[apache-flink] Clarify EOL policy

### DIFF
--- a/products/apache-flink.md
+++ b/products/apache-flink.md
@@ -7,8 +7,13 @@ iconSlug: apacheflink
 permalink: /apache-flink
 alternate_urls:
   - /flink
-releasePolicyLink: https://hub.docker.com/_/flink # This is the most conclusive resource
 changelogTemplate: https://nightlies.apache.org/flink/flink-docs-release-__RELEASE_CYCLE__/release-notes/flink-__RELEASE_CYCLE__/
+
+customFields:
+  - name: recommendedJavaVersion
+    display: after-release-column
+    label: Java version
+    description: Recommended Java version.
 
 identifiers:
   - repology: flink
@@ -24,39 +29,46 @@ auto:
       regex: '^release-(?P<version>[\d\.]+)$'
       template: "{{version}}"
 
-# eol(x) = releaseDate(x+3)
+# Only releases listed on https://flink.apache.org/downloads/ are supported.
 releases:
   - releaseCycle: "2.1"
+    recommendedJavaVersion: 17 # https://nightlies.apache.org/flink/flink-docs-release-2.1/docs/deployment/java_compatibility/
     releaseDate: 2025-07-29
     eol: false
     latest: "2.1.0"
     latestReleaseDate: 2025-07-29
 
   - releaseCycle: "2.0"
+    recommendedJavaVersion: 17 # https://nightlies.apache.org/flink/flink-docs-release-2.1/docs/deployment/java_compatibility/
     releaseDate: 2025-03-19
     eol: false
     latest: "2.0.0"
     latestReleaseDate: 2025-03-19
 
   - releaseCycle: "1.20"
+    recommendedJavaVersion: 11 # https://nightlies.apache.org/flink/flink-docs-release-1.20/docs/deployment/java_compatibility/
+    lts: true # See https://nightlies.apache.org/flink/flink-docs-lts/
     releaseDate: 2024-08-01
     eol: false
     latest: "1.20.2"
     latestReleaseDate: 2025-07-07
 
   - releaseCycle: "1.19"
+    recommendedJavaVersion: 11 # https://nightlies.apache.org/flink/flink-docs-release-1.19/docs/deployment/java_compatibility/
     releaseDate: 2024-03-15
-    eol: 2025-07-31
+    eol: false
     latest: "1.19.3"
     latestReleaseDate: 2025-07-07
 
   - releaseCycle: "1.18"
+    recommendedJavaVersion: 11 # https://nightlies.apache.org/flink/flink-docs-release-1.18/docs/deployment/java_compatibility/
     releaseDate: 2023-10-24
     eol: 2025-03-24
     latest: "1.18.1"
     latestReleaseDate: 2024-01-16
 
   - releaseCycle: "1.17"
+    recommendedJavaVersion: 11 # https://nightlies.apache.org/flink/flink-docs-release-1.18/docs/deployment/java_compatibility/
     releaseDate: 2023-03-23
     eol: 2024-08-01
     latest: "1.17.2"
@@ -67,12 +79,5 @@ releases:
 > framework designed for processing large-scale data streams in real-time with
 > high throughput and low latency.
 
-Apache Flink support policy is not defined. Given 3 releases [are listed on the download page](https://flink.apache.org/downloads/),
-backports seem to be maintained for the last 3 releases.
-
-## [Java Compatibility](https://nightlies.apache.org/flink/flink-docs-release-1.19/docs/deployment/java_compatibility/)
-
-- Java 8 is supported but deprecated (support dropped since 2.0).
-- Java 17 is the recommended version (since 2.0).
-- Java 17 is supported experimentally for Flink 1.18 and above.
-- Java 21 is supported for Flink 1.19 and above.
+Apache Flink support policy is not defined.
+Releases not listed [on the download page](https://flink.apache.org/downloads/) are considered EOL.

--- a/products/apache-flink.md
+++ b/products/apache-flink.md
@@ -32,21 +32,21 @@ auto:
 # Only releases listed on https://flink.apache.org/downloads/ are supported.
 releases:
   - releaseCycle: "2.1"
-    recommendedJavaVersion: 17 # https://nightlies.apache.org/flink/flink-docs-release-2.1/docs/deployment/java_compatibility/
+    recommendedJavaVersion: "17" # https://nightlies.apache.org/flink/flink-docs-release-2.1/docs/deployment/java_compatibility/
     releaseDate: 2025-07-29
     eol: false
     latest: "2.1.0"
     latestReleaseDate: 2025-07-29
 
   - releaseCycle: "2.0"
-    recommendedJavaVersion: 17 # https://nightlies.apache.org/flink/flink-docs-release-2.1/docs/deployment/java_compatibility/
+    recommendedJavaVersion: "17" # https://nightlies.apache.org/flink/flink-docs-release-2.1/docs/deployment/java_compatibility/
     releaseDate: 2025-03-19
     eol: false
     latest: "2.0.0"
     latestReleaseDate: 2025-03-19
 
   - releaseCycle: "1.20"
-    recommendedJavaVersion: 11 # https://nightlies.apache.org/flink/flink-docs-release-1.20/docs/deployment/java_compatibility/
+    recommendedJavaVersion: "11" # https://nightlies.apache.org/flink/flink-docs-release-1.20/docs/deployment/java_compatibility/
     lts: true # See https://nightlies.apache.org/flink/flink-docs-lts/
     releaseDate: 2024-08-01
     eol: false
@@ -54,21 +54,21 @@ releases:
     latestReleaseDate: 2025-07-07
 
   - releaseCycle: "1.19"
-    recommendedJavaVersion: 11 # https://nightlies.apache.org/flink/flink-docs-release-1.19/docs/deployment/java_compatibility/
+    recommendedJavaVersion: "11" # https://nightlies.apache.org/flink/flink-docs-release-1.19/docs/deployment/java_compatibility/
     releaseDate: 2024-03-15
     eol: false
     latest: "1.19.3"
     latestReleaseDate: 2025-07-07
 
   - releaseCycle: "1.18"
-    recommendedJavaVersion: 11 # https://nightlies.apache.org/flink/flink-docs-release-1.18/docs/deployment/java_compatibility/
+    recommendedJavaVersion: "11" # https://nightlies.apache.org/flink/flink-docs-release-1.18/docs/deployment/java_compatibility/
     releaseDate: 2023-10-24
     eol: 2025-03-24
     latest: "1.18.1"
     latestReleaseDate: 2024-01-16
 
   - releaseCycle: "1.17"
-    recommendedJavaVersion: 11 # https://nightlies.apache.org/flink/flink-docs-release-1.18/docs/deployment/java_compatibility/
+    recommendedJavaVersion: "11" # https://nightlies.apache.org/flink/flink-docs-release-1.18/docs/deployment/java_compatibility/
     releaseDate: 2023-03-23
     eol: 2024-08-01
     latest: "1.17.2"


### PR DESCRIPTION
There is no EOL policy documented for Apache Flink. Consider EOL all releases not listed on the download page.

Also document recommended Java version using a custom fields, instead of a paragraph in the description.

Closes #5579.