### PR TITLE
[pan-gp]: update 6.2 latest release to 6.2.8-c317 (2025-09-09)

### DIFF
--- a/products/pan-gp.md
+++ b/products/pan-gp.md
@@ -41,8 +41,8 @@ releases:
     releaseDate: 2023-05-23
     eol: 2026-12-31
     eoas: 2026-12-31
-    latest: "6.2.8-c263"
-    latestReleaseDate: 2025-07-17
+    latest: "6.2.8-c317"
+    latestReleaseDate: 2025-09-09
     link: https://docs.paloaltonetworks.com/globalprotect/6-2/globalprotect-app-release-notes/globalprotect-addressed-issues
 
   - releaseCycle: "6.1"


### PR DESCRIPTION
Update GlobalProtect 6.2 release metadata:

- latest: 6.2.8-c263 → 6.2.8-c317
- latestReleaseDate: 2025-07-17 → 2025-09-09

Release Notes: https://docs.paloaltonetworks.com/globalprotect/6-2/globalprotect-app-release-notes/globalprotect-addressed-issues/globalprotect-6-2-8-h4-addressed-issues
