### PR TITLE
[oracle-jdk] Remove alternate_urls /java and /jdk

### DIFF
--- a/_redirects
+++ b/_redirects
@@ -16,6 +16,8 @@ layout: null
 # A few permanent redirects for removed pages / alternate URLs
 /advise                            /recommendations
 /advice                            /recommendations
+/java                              /tags/java-distribution
+/jdk                               /tags/java-distribution
 /tags/api-gateway                  /tags/web-server
 /tags/configuration-management     /
 /tags/db                           /tags/database

--- a/products/oracle-jdk.md
+++ b/products/oracle-jdk.md
@@ -7,8 +7,6 @@ iconSlug: oracle
 permalink: /oracle-jdk
 alternate_urls:
   - /oracle-java
-  - /java
-  - /jdk
 versionCommand: java -version
 releasePolicyLink: https://www.oracle.com/java/technologies/java-se-support-roadmap.html
 changelogTemplate: "https://www.oracle.com/java/technologies/javase/{{'__LATEST__'|replace:'.','-'}}-{% if '__RELEASE_CYCLE__'=='__LATEST__' %}relnote-issues{% else %}relnotes{% endif %}.html"


### PR DESCRIPTION
'java' and 'jdk' are too common to use for oracle-jdk. Redirect those to https://endoflife.date/tags/java-distribution.

Closes #4152.