### PR TITLE
[openbao] Fix Bad eol for openbao 2.2

### DIFF
--- a/products/openbao.md
+++ b/products/openbao.md
@@ -44,7 +44,7 @@ releases:
 
   - releaseCycle: "2.2"
     releaseDate: 2025-03-06
-    eol: 2025-09-26
+    eol: 2025-06-26
     latest: "2.2.2"
     latestReleaseDate: 2025-05-30
 


### PR DESCRIPTION
Based on the EOL strategy of open-bao, there's a little bug I did not see while pushing the data : 

<img width="762" height="602" alt="image" src="https://github.com/user-attachments/assets/a8006f39-fe75-4e9d-a3ed-39f04791db86" />
