### PR TITLE
[OpenBao] > Add `bao` as alternate url

### DIFF
--- a/products/openbao.md
+++ b/products/openbao.md
@@ -7,6 +7,7 @@ iconSlug: null
 permalink: /openbao
 alternate_urls:
   - /open-bao
+  - /bao
 releasePolicyLink: https://openbao.org/docs/policies/support/
 changelogTemplate: https://github.com/openbao/openbao/releases/tag/v__LATEST__
 eolColumn: Standard Maintenance


### PR DESCRIPTION
# :grey_question: About

As `open-tofu` has the `tofu` https://endoflife.date/tofu alternate, its makes sense to port it to bao too... which is also shorter to write for the ones who use `eol` `CLI`