### PR TITLE
Rename releaseColumn to latestColumn

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -142,7 +142,7 @@ eoasColumn: Active Support
 
 # Whether the "Latest" column should be displayed (optional, default = true).
 # The value of this property can be set to any string to override the default column label.
-releaseColumn: Latest
+latestColumn: Latest
 
 # Whether the "Released" column should be displayed (optional, default = true).
 # The value of this property can be set to any string to override the default column label.
@@ -359,9 +359,9 @@ releases:
     #   and false otherwise.
     discontinued: true
 
-    # Latest release for the release cycle (optional if releaseColumn is false, else mandatory).
+    # Latest release for the release cycle (optional if latestColumn is false, else mandatory).
     # Usually this is the release cycle's latest "patch" release.
-    # It should be removed if releaseColumn is false.
+    # It should be removed if latestColumn is false.
     # Always add quotes around this value.
     latest: "1.2.3"
 

--- a/_config.yml
+++ b/_config.yml
@@ -83,8 +83,8 @@ defaults:
       alternate_urls: []
       identifiers: []
       auto: []
-      releaseColumn: true
-      releaseColumnLabel: "Latest"
+      latestColumn: true
+      latestColumnLabel: "Latest"
       releaseDateColumn: true
       releaseDateColumnLabel: "Released"
       discontinuedColumn: false

--- a/_layouts/product.html
+++ b/_layouts/product.html
@@ -45,7 +45,7 @@ layout: default
       {% if page.eolColumn %}<th>{{ page.eolColumnLabel }}</th>{% assign colCount = colCount | plus:1 %}{% endif %}
       {% if page.eoesColumn %}<th>{{ page.eoesColumnLabel }}</th>{% assign colCount = colCount | plus:1 %}{% endif %}
       {% for column in customColumnsBeforeLatest %}{% include custom-column-th.html column=column %}{% assign colCount = colCount | plus:1 %}{% endfor %}
-      {% if page.releaseColumn %}<th>{{ page.releaseColumnLabel }}</th>{% assign colCount = colCount | plus:1 %}{% endif %}
+      {% if page.latestColumn %}<th>{{ page.latestColumnLabel }}</th>{% assign colCount = colCount | plus:1 %}{% endif %}
       {% for column in customColumnsAfterLatest %}{% include custom-column-th.html column=column %}{% assign colCount = colCount | plus:1 %}{% endfor %}
     </tr>
   </thead>
@@ -58,7 +58,7 @@ layout: default
     {%- if r.is_eol %}{% assign cycleColumnClass = 'txt-linethrough' %}{% endif %}
     <td class="{{ cycleColumnClass }}">
       {% comment %}Only put a link in the version column if the release column is not shown{% endcomment %}
-      {% if page.releaseColumn == false and r.link  %}
+      {% if page.latestColumn == false and r.link  %}
         <a href="{{ r.link }}" title="Release Notes / Changelog for {{ r.label | strip_html }}">{{ r.label }}</a>
       {% else %}
         {{ r.label }}
@@ -133,10 +133,10 @@ layout: default
     {% include custom-column-td.html release=r column=column %}
     {%- endfor %}
 
-    {% if page.releaseColumn != false %}
-    {%- assign releaseColumnClass = '' %}
-    {%- if r.is_eol %}{% assign releaseColumnClass = 'txt-linethrough' %}{% endif %}
-    <td class="{{ releaseColumnClass }}">
+    {% if page.latestColumn != false %}
+    {%- assign latestColumnClass = '' %}
+    {%- if r.is_eol %}{% assign latestColumnClass = 'txt-linethrough' %}{% endif %}
+    <td class="{{ latestColumnClass }}">
       {% if r.link %}
         <a href="{{ r.link }}" title="Release Notes / Changelog">{{ r.latest }}</a>
       {% else %}
@@ -147,7 +147,7 @@ layout: default
     {% endif %}
 
     {%- for column in customColumnsAfterLatest %}
-    {% include custom-column-td.html release=r column=column cssClasses=releaseColumnClass %}
+    {% include custom-column-td.html release=r column=column cssClasses=latestColumnClass %}
     {%- endfor %}
   </tr>
 {% endfor %}
@@ -172,7 +172,7 @@ layout: default
 <p>More information is available on the <a href="{{page.releasePolicyLink}}">{{page.title}} website</a>.</p>
 {% endif %}
 
-{% if page.releaseColumn %}
+{% if page.latestColumn %}
 {% unless page.tags contains "discontinued" %}
 <p>You should be running one of the supported release numbers listed above in the rightmost column.</p>
 {% endunless %}

--- a/_plugins/generate-api-v1.rb
+++ b/_plugins/generate-api-v1.rb
@@ -321,7 +321,7 @@ module ApiV1
           json.delete(:eoesFrom)
         end
 
-        if !product.data['releaseColumn']
+        if !product.data['latestColumn']
           json[:latest] = nil
         end
 

--- a/_plugins/product-data-enricher.rb
+++ b/_plugins/product-data-enricher.rb
@@ -117,7 +117,7 @@ module Jekyll
 
       # Set properly the column presence/label if it was overridden.
       def set_overridden_columns_label(page)
-        date_column_names = %w[releaseDateColumn releaseColumn discontinuedColumn eoasColumn eolColumn eoesColumn]
+        date_column_names = %w[releaseDateColumn latestColumn discontinuedColumn eoasColumn eolColumn eoesColumn]
         date_column_names.each { |date_column|
           if page.data[date_column].is_a? String
             page.data[date_column + 'Label'] = page.data[date_column]

--- a/_plugins/product-data-validator.rb
+++ b/_plugins/product-data-validator.rb
@@ -163,7 +163,7 @@ module EndOfLifeHooks
     error_if.is_not_a_string('LTSLabel')
     error_if.is_not_a_boolean_nor_a_string('eolColumn')
     error_if.is_not_a_boolean_nor_a_string('eoasColumn')
-    error_if.is_not_a_boolean_nor_a_string('releaseColumn')
+    error_if.is_not_a_boolean_nor_a_string('latestColumn')
     error_if.is_not_a_boolean_nor_a_string('releaseDateColumn')
     error_if.is_not_a_boolean_nor_a_string('discontinuedColumn')
     error_if.is_not_a_boolean_nor_a_string('eoesColumn')
@@ -203,9 +203,9 @@ module EndOfLifeHooks
       error_if.is_not_a_boolean_nor_a_date('discontinued') if product.data['discontinuedColumn']
       error_if.is_not_a_boolean_nor_a_date('eoes') if product.data['eoesColumn'] and release.has_key?('eoes')
       error_if.is_not_a_boolean_nor_a_date('lts') if release.has_key?('lts')
-      error_if.is_not_a_string('latest') if product.data['releaseColumn']
-      error_if.is_not_a_date('latestReleaseDate') if product.data['releaseColumn'] and release.has_key?('latestReleaseDate')
-      error_if.too_far_in_future('latestReleaseDate') if product.data['releaseColumn'] and release.has_key?('latestReleaseDate')
+      error_if.is_not_a_string('latest') if product.data['latestColumn']
+      error_if.is_not_a_date('latestReleaseDate') if product.data['latestColumn'] and release.has_key?('latestReleaseDate')
+      error_if.too_far_in_future('latestReleaseDate') if product.data['latestColumn'] and release.has_key?('latestReleaseDate')
       error_if.is_not_an_url('link') if release.has_key?('link') and release['link']
 
       error_if.is_not_before('releaseDate', 'eoas') if product.data['eoasColumn']

--- a/product-schema.json
+++ b/product-schema.json
@@ -444,7 +444,7 @@
           "type": "string",
           "format": "date"
         },
-        "releaseColumn": {
+        "latestColumn": {
           "title": "Release column",
           "description": "Whether to show the release column, or a custom name for it.",
           "$ref": "#/$defs/boolOrString"
@@ -529,9 +529,9 @@
         },
         {
           "if": {
-            "required": ["releaseColumn"],
+            "required": ["latestColumn"],
             "properties": {
-              "releaseColumn": {
+              "latestColumn": {
                 "type": "string"
               }
             }

--- a/products/alibaba-ack.md
+++ b/products/alibaba-ack.md
@@ -9,7 +9,7 @@ alternate_urls:
   - /ack
 versionCommand: kubectl version
 releasePolicyLink: https://www.alibabacloud.com/help/en/ack/ack-managed-and-ack-dedicated/user-guide/support-for-kubernetes-versions
-releaseColumn: false
+latestColumn: false
 eolColumn: End of Support
 
 auto:

--- a/products/amazon-documentdb.md
+++ b/products/amazon-documentdb.md
@@ -5,7 +5,7 @@ category: service
 tags: amazon database
 iconSlug: amazondocumentdb
 permalink: /amazon-documentdb
-releaseColumn: false
+latestColumn: false
 eolColumn: End of Standard Support
 eoesColumn: End of Extended Support
 

--- a/products/amazon-glue.md
+++ b/products/amazon-glue.md
@@ -6,7 +6,7 @@ tags: amazon
 iconSlug: amazonaws
 permalink: /amazon-glue
 releasePolicyLink: https://docs.aws.amazon.com/glue/latest/dg/glue-version-support-policy.html
-releaseColumn: false
+latestColumn: false
 
 customFields:
   - name: pythonVersion

--- a/products/android.md
+++ b/products/android.md
@@ -11,7 +11,7 @@ alternate_urls:
 releasePolicyLink: https://developer.android.com/about/versions
 changelogTemplate: https://developer.android.com/about/versions/__RELEASE_CYCLE__
 releaseLabel: "__RELEASE_CYCLE__ '__CODENAME__'"
-releaseColumn: false
+latestColumn: false
 eolColumn: Security Support
 
 customFields:

--- a/products/apple-watch.md
+++ b/products/apple-watch.md
@@ -8,7 +8,7 @@ permalink: /apple-watch
 releasePolicyLink: https://support.apple.com/watch
 discontinuedColumn: true
 eolColumn: Supported
-releaseColumn: false
+latestColumn: false
 
 customFields:
   - name: supportedWatchOsVersions

--- a/products/aws-lambda.md
+++ b/products/aws-lambda.md
@@ -6,7 +6,7 @@ tags: amazon
 iconSlug: awslambda
 permalink: /aws-lambda
 releasePolicyLink: https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html
-releaseColumn: false
+latestColumn: false
 eoasColumn: Standard Support
 eolColumn: Deprecated Support
 

--- a/products/azure-kubernetes-service.md
+++ b/products/azure-kubernetes-service.md
@@ -9,7 +9,7 @@ alternate_urls:
 versionCommand: az aks show --resource-group myResourceGroup --name myAKSCluster
 releasePolicyLink: https://learn.microsoft.com/azure/aks/supported-kubernetes-versions
 releaseImage: https://learn.microsoft.com/en-us/azure/aks/media/supported-kubernetes-versions/kubernetes-versions-gantt.png
-releaseColumn: false
+latestColumn: false
 eolColumn: Support
 eoesColumn: LTS Support
 

--- a/products/centos-stream.md
+++ b/products/centos-stream.md
@@ -8,7 +8,7 @@ permalink: /centos-stream
 versionCommand: cat /etc/redhat-release
 releasePolicyLink: https://centos.org/stream9/
 eoasColumn: true
-releaseColumn: false
+latestColumn: false
 
 identifiers:
   - cpe: cpe:/o:centos:stream

--- a/products/chrome.md
+++ b/products/chrome.md
@@ -10,7 +10,7 @@ alternate_urls:
 versionCommand: google-chrome --version
 releasePolicyLink: https://developer.chrome.com/docs/web-platform/chrome-release-channels
 # no changelogTemplate : changelog is only available for the latest 10-20 releases, it's simpler to manage the links manually
-releaseColumn: false
+latestColumn: false
 
 identifiers:
   - repology: google-chrome

--- a/products/ckeditor.md
+++ b/products/ckeditor.md
@@ -7,7 +7,7 @@ permalink: /ckeditor
 releasePolicyLink: https://ckeditor.com/docs/ckeditor5/latest/updating/versioning-policy.html
 eolColumn: Support
 eoesColumn: true
-releaseColumn: false
+latestColumn: false
 
 identifiers:
   - repology: ckeditor

--- a/products/dotnetfx.md
+++ b/products/dotnetfx.md
@@ -11,7 +11,7 @@ alternative_urls:
 versionCommand: reg query "HKLM\SOFTWARE\Microsoft\Net Framework Setup\NDP" /s
 releasePolicyLink: https://dotnet.microsoft.com/download/dotnet-framework
 changelogTemplate: https://github.com/microsoft/dotnet/blob/main/releases/net{{"__RELEASE_CYCLE__"| replace:'.',''}}/README.md
-releaseColumn: false
+latestColumn: false
 eolColumn: Support Status
 
 auto:

--- a/products/fairphone.md
+++ b/products/fairphone.md
@@ -6,7 +6,7 @@ tags: mobile-phone
 iconSlug: fairphone
 permalink: /fairphone
 releasePolicyLink: https://forum.fairphone.com/t/fairphone-product-release-cycle/52652
-releaseColumn: false
+latestColumn: false
 eoasColumn: Active Major Updates
 discontinuedColumn: true
 eolColumn: Security Updates

--- a/products/fedora.md
+++ b/products/fedora.md
@@ -8,7 +8,7 @@ permalink: /fedora
 versionCommand: cat /etc/fedora-release
 releasePolicyLink: https://docs.fedoraproject.org/en-US/releases/lifecycle/
 changelogTemplate: https://fedoraproject.org/wiki/Releases/__RELEASE_CYCLE__/ChangeSet?rd=Releases/__RELEASE_CYCLE__
-releaseColumn: false
+latestColumn: false
 
 identifiers:
   - cpe: cpe:/o:fedoraproject:fedora

--- a/products/filemaker.md
+++ b/products/filemaker.md
@@ -4,7 +4,7 @@ addedAt: 2019-05-30
 category: app
 permalink: /filemaker
 releasePolicyLink: https://support.claris.com/s/article/Claris-support-policy
-releaseColumn: false
+latestColumn: false
 eolColumn: Support
 
 identifiers:

--- a/products/fortios.md
+++ b/products/fortios.md
@@ -9,7 +9,7 @@ alternate_urls:
   - /fortinet
 versionCommand: get system status
 changelogTemplate: https://docs.fortinet.com/product/fortigate/__RELEASE_CYCLE__
-releaseColumn: false
+latestColumn: false
 eolColumn: End of Support
 eoasColumn: End of Engineering Support
 

--- a/products/freebsd.md
+++ b/products/freebsd.md
@@ -8,7 +8,7 @@ permalink: /freebsd
 versionCommand: freebsd-version
 releasePolicyLink: https://www.freebsd.org/security/#sup
 changelogTemplate: https://www.freebsd.org/releases/__RELEASE_CYCLE__R/relnotes/
-releaseColumn: false
+latestColumn: false
 
 identifiers:
   - cpe: cpe:/o:freebsd:freebsd

--- a/products/google-nexus.md
+++ b/products/google-nexus.md
@@ -7,7 +7,7 @@ iconSlug: google
 permalink: /google-nexus
 versionCommand: "Settings -> About Phone -> Regulatory labels"
 releasePolicyLink: https://support.google.com/nexus/answer/11227897
-releaseColumn: false
+latestColumn: false
 discontinuedColumn: true
 eoasColumn: Android updates
 eolColumn: Security Updates

--- a/products/ibm-db2.md
+++ b/products/ibm-db2.md
@@ -8,7 +8,7 @@ permalink: /ibm-db2
 versionCommand: db2level
 releasePolicyLink: https://www.ibm.com/support/pages/db2-distributed-end-support-eos-dates
 changelogTemplate: https://www.ibm.com/docs/en/db2/__RELEASE_CYCLE__.0
-releaseColumn: false
+latestColumn: false
 eol: Base Support
 eoes: Extended Support
 

--- a/products/ibm-mq.md
+++ b/products/ibm-mq.md
@@ -8,7 +8,7 @@ permalink: /ibm-mq
 versionCommand: dspmqver
 releasePolicyLink: https://www.ibm.com/support/pages/ibm-mq-faq-long-term-support-and-continuous-delivery-releases
 changelogTemplate: https://www.ibm.com/docs/en/ibm-mq/__RELEASE_CYCLE__.x
-releaseColumn: false
+latestColumn: false
 eolColumn: Support
 eoesColumn: Extended Support
 

--- a/products/intel-processors.md
+++ b/products/intel-processors.md
@@ -5,7 +5,7 @@ category: device
 iconSlug: intel
 permalink: /intel-processors
 releasePolicyLink: https://www.intel.com/content/www/us/en/support/articles/000022396/processors.html
-releaseColumn: false
+latestColumn: false
 eolColumn: Active Support
 discontinuedColumn: true
 
@@ -242,7 +242,7 @@ your CPU belongs on:
 - macOS: `sysctl -n machdep.cpu.brand_string`
 - FreeBSD/OpenBSD: `sysctl -n hw.model`
 
-Then check product classification on <https://ark.intel.com/>. 
+Then check product classification on <https://ark.intel.com/>.
 
 Intel announces notifications via [Product Change Notifications](https://www.intel.com/content/www/us/en/collections/content-type/pcns.html).
 An third-party [PSN RSS/API Feed](https://intel.pcn.captnemo.in/) is available to subscribe to the same.

--- a/products/internet-explorer.md
+++ b/products/internet-explorer.md
@@ -10,7 +10,7 @@ alternate_urls:
   - /iexplore
 releasePolicyLink: https://learn.microsoft.com/lifecycle/faq/internet-explorer-microsoft-edge#what-is-the-lifecycle-policy-for-internet-explorer-
 changelogTemplate: https://learn.microsoft.com/lifecycle/products/internet-explorer-__RELEASE_CYCLE__
-releaseColumn: false
+latestColumn: false
 eolColumn: Security and technical support
 
 releases:

--- a/products/ipad.md
+++ b/products/ipad.md
@@ -8,7 +8,7 @@ permalink: /ipad
 releasePolicyLink: https://en.wikipedia.org/wiki/List_of_iPad_models#iPad
 discontinuedColumn: true
 eolColumn: Supported
-releaseColumn: false
+latestColumn: false
 
 customFields:
   - name: supportedIpadOsVersions

--- a/products/iphone.md
+++ b/products/iphone.md
@@ -8,7 +8,7 @@ permalink: /iphone
 releasePolicyLink: https://en.wikipedia.org/wiki/List_of_iPhone_models#Release_dates
 discontinuedColumn: true
 eolColumn: Supported
-releaseColumn: false
+latestColumn: false
 
 customFields:
   - name: supportedIosVersions

--- a/products/lineageos.md
+++ b/products/lineageos.md
@@ -6,7 +6,7 @@ iconSlug: lineageos
 permalink: /lineageos
 alternate_urls:
   - /lineage
-releaseColumn: false
+latestColumn: false
 
 customFields:
   - name: androidVersion

--- a/products/linuxmint.md
+++ b/products/linuxmint.md
@@ -8,7 +8,7 @@ permalink: /linuxmint
 alternate_urls:
   - /linux-mint
 versionCommand: cat /etc/linuxmint/info
-releaseColumn: false
+latestColumn: false
 releasePolicyLink: https://linuxmint.com/download_all.php
 releaseLabel: "__RELEASE_CYCLE__ '__CODENAME__'"
 

--- a/products/looker.md
+++ b/products/looker.md
@@ -8,7 +8,7 @@ permalink: /looker
 releasePolicyLink: https://cloud.google.com/looker/docs/release-overview
 LTSLabel: "<abbr title='Extended Support Release'>ESR</abbr>"
 eolColumn: Support Status
-releaseColumn: false
+latestColumn: false
 
 # Used only for detecting new minor releases.
 auto:

--- a/products/mageia.md
+++ b/products/mageia.md
@@ -7,7 +7,7 @@ permalink: /mageia
 versionCommand: cat /usr/lib/os-release
 releasePolicyLink: https://www.mageia.org/support/
 changelogTemplate: https://wiki.mageia.org/en/Archive:_Mageia___RELEASE_CYCLE___Release_Notes
-releaseColumn: false
+latestColumn: false
 eolColumn: Supported
 
 identifiers:

--- a/products/motorola-mobility.md
+++ b/products/motorola-mobility.md
@@ -9,7 +9,7 @@ alternate_urls:
   - /motorola
   - /motorolamobility
 releasePolicyLink: https://en-us.support.motorola.com/app/software-security-update
-releaseColumn: false
+latestColumn: false
 eolColumn: Security Updates
 
 auto:

--- a/products/netapp-ontap.md
+++ b/products/netapp-ontap.md
@@ -12,7 +12,7 @@ versionCommand: system-get-version
 releasePolicyLink: https://mysupport.netapp.com/site/info/version-support
 changelogTemplate: "https://docs.netapp.com/us-en/ontap/release-notes/whats-new-{{'__RELEASE_CYCLE__'|replace:'.',''}}.html"
 eolColumn: Full Support
-releaseColumn: false # no public access to the latest patches
+latestColumn: false # no public access to the latest patches
 
 # Releases are documented on https://mysupport.netapp.com/site/info/version-support.
 releases:

--- a/products/nixos.md
+++ b/products/nixos.md
@@ -11,7 +11,7 @@ versionCommand: cat /etc/os-release
 releasePolicyLink: https://nixos.org/blog/announcements.html
 changelogTemplate: https://nixos.org/manual/nixos/stable/release-notes.html#sec-release-__RELEASE_CYCLE__
 releaseLabel: "__RELEASE_CYCLE__ '__CODENAME__'"
-releaseColumn: false
+latestColumn: false
 
 identifiers:
   - cpe: cpe:/o:nixos:nixos

--- a/products/nokia.md
+++ b/products/nokia.md
@@ -9,7 +9,7 @@ alternate_urls:
   - /hmd
   - /nokiamobile
 releasePolicyLink: https://www.nokia.com/phones/en_int/security-updates
-releaseColumn: false
+latestColumn: false
 
 # EOL estimation if not explicitly announced by Nokia on the product page
 # - for C line: eol(x) = releaseDate(x) + 2 years

--- a/products/nvidia-gpu.md
+++ b/products/nvidia-gpu.md
@@ -9,7 +9,7 @@ alternate_urls:
   - /nvidia-products
   - /nvidia-gpus
 releasePolicyLink: https://www.nvidia.com/en-us/geforce/graphics-cards/
-releaseColumn: false
+latestColumn: false
 discontinuedColumn: true
 eoasColumn: true
 

--- a/products/office.md
+++ b/products/office.md
@@ -7,7 +7,7 @@ permalink: /office
 alternate_urls:
   - /msoffice
 releasePolicyLink: https://learn.microsoft.com/lifecycle/products/?terms=Office
-releaseColumn: false
+latestColumn: false
 eoasColumn: true
 
 identifiers:

--- a/products/oneplus.md
+++ b/products/oneplus.md
@@ -9,7 +9,7 @@ versionCommand: "Settings -> About device"
 releasePolicyLink: https://community.oneplus.com/thread/1462181
 changelogTemplate: "https://www.oneplus.com/us/oneplus-{{'__RELEASE_CYCLE__'|downcase}}"
 releaseLabel: "OnePlus __RELEASE_CYCLE__"
-releaseColumn: false
+latestColumn: false
 activeSupportColumn: Active Major Updates
 discontinuedColumn: true
 eoasColumn: Android Updates

--- a/products/openbsd.md
+++ b/products/openbsd.md
@@ -7,7 +7,7 @@ iconSlug: openbsd
 permalink: /openbsd
 versionCommand: uname -r
 changelogTemplate: "https://www.openbsd.org/{{'__RELEASE_CYCLE__'|replace:'.',''}}.html"
-releaseColumn: false
+latestColumn: false
 
 # eol(x) = releaseDate(x+2), Estimation releaseDate(x) + 1 year -> round to the first of next month
 releases:

--- a/products/opensuse.md
+++ b/products/opensuse.md
@@ -12,7 +12,7 @@ releasePolicyLink: https://en.opensuse.org/Lifetime
 releaseImage: https://upload.wikimedia.org/wikipedia/en/timeline/slucio84mdla0deffiv2vrszinbrlek.png
 changelogTemplate: https://doc.opensuse.org/release-notes/x86_64/openSUSE/Leap/__RELEASE_CYCLE__/
 releaseLabel: "Leap __RELEASE_CYCLE__"
-releaseColumn: false
+latestColumn: false
 eolColumn: End of Life
 
 identifiers:

--- a/products/oracle-apex.md
+++ b/products/oracle-apex.md
@@ -10,7 +10,7 @@ alternate_urls:
 versionCommand: SELECT VERSION_NO FROM APEX_RELEASE;
 releasePolicyLink: https://www.oracle.com/database/technologies/appdev/apex/collateral/#assistance
 changelogTemplate: https://apex.oracle.com/en/platform/features/whats-new-{{"__RELEASE_CYCLE__" | replace:".",""}}/
-releaseColumn: false
+latestColumn: false
 
 auto:
   methods:

--- a/products/oracle-database.md
+++ b/products/oracle-database.md
@@ -8,7 +8,7 @@ permalink: /oracle-database
 versionCommand: SELECT BANNER_FULL FROM V$VERSION;
 releasePolicyLink: https://support.oracle.com/knowledge/Oracle%20Database%20Products/742060_1.html
 LTSLabel: <abbr title="Long Term Release">LTR</abbr>
-releaseColumn: false
+latestColumn: false
 eolColumn: Premier Support
 eoesColumn: Extended Support
 

--- a/products/oracle-solaris.md
+++ b/products/oracle-solaris.md
@@ -9,7 +9,7 @@ alternate_urls:
   - /solaris
 versionCommand: cat /etc/release
 releasePolicyLink: https://www.oracle.com/support/lifetime-support/
-releaseColumn: false
+latestColumn: false
 eolColumn: Premier Support
 eoesColumn: Extended Support
 

--- a/products/pan-cortex-xdr.md
+++ b/products/pan-cortex-xdr.md
@@ -13,7 +13,7 @@ releasePolicyLink: https://www.paloaltonetworks.com/services/support/end-of-life
 changelogTemplate: https://docs-cortex.paloaltonetworks.com/r/Cortex-XDR/__RELEASE_CYCLE__/Cortex-XDR-Agent-Release-Notes/Cortex-XDR-Agent-__RELEASE_CYCLE__-Release-Information
 LTSLabel: CE
 iconSlug: paloaltonetworks
-releaseColumn: false
+latestColumn: false
 eolColumn: Support Status
 
 auto:

--- a/products/pci-dss.md
+++ b/products/pci-dss.md
@@ -7,7 +7,7 @@ alternate_urls:
   - /pci
 releasePolicyLink: https://blog.pcisecuritystandards.org/updated-pci-dss-v4.0-timeline
 releasePolicyImage: https://blog.pcisecuritystandards.org/hs-fs/hubfs/Development.png?width=750&name=Development.png
-releaseColumn: false
+latestColumn: false
 eolColumn: Acceptance
 
 releases:

--- a/products/pixel-watch.md
+++ b/products/pixel-watch.md
@@ -7,7 +7,7 @@ iconSlug: google
 permalink: /pixel-watch
 versionCommand: "Settings -> System -> About"
 releasePolicyLink: https://support.google.com/product-documentation/answer/12799779
-releaseColumn: false
+latestColumn: false
 discontinuedColumn: true
 eoasColumn: WearOS Updates
 eolColumn: Security Updates

--- a/products/pixel.md
+++ b/products/pixel.md
@@ -7,7 +7,7 @@ iconSlug: google
 permalink: /pixel
 versionCommand: "Settings -> About Phone -> Regulatory labels"
 releasePolicyLink: https://support.google.com/nexus/answer/4457705
-releaseColumn: false
+latestColumn: false
 discontinuedColumn: true
 eoasColumn: Android Updates
 eolColumn: Security Updates
@@ -50,7 +50,7 @@ releases:
     discontinued: false
     link: https://en.wikipedia.org/wiki/Pixel_10
     supportedAndroidVersions: "16" # https://www.gsmarena.com/google_pixel_10_5g-13979.php
-    
+
   - releaseCycle: "9a"
     releaseLabel: "Pixel 9a"
     releaseDate: 2025-04-10

--- a/products/pop-os.md
+++ b/products/pop-os.md
@@ -9,7 +9,7 @@ alternate_urls:
   - /popos
   - /pop_os
 versionCommand: cat /etc/os-release
-releaseColumn: false
+latestColumn: false
 eolColumn: General Support
 
 releases:

--- a/products/postmarketos.md
+++ b/products/postmarketos.md
@@ -6,7 +6,7 @@ tags: linux-distribution
 permalink: /postmarketos
 versionCommand: cat /etc/os-release
 releasePolicyLink: https://wiki.postmarketos.org/wiki/Releases
-releaseColumn: false
+latestColumn: false
 
 auto:
   methods:

--- a/products/raspberry-pi.md
+++ b/products/raspberry-pi.md
@@ -10,7 +10,7 @@ alternate_urls:
   - /rpi
 releasePolicyLink: https://en.wikipedia.org/wiki/Raspberry_Pi#Model_comparison
 eolColumn: Discontinued
-releaseColumn: false
+latestColumn: false
 
 releases:
   - releaseCycle: "5-500"

--- a/products/ros-2.md
+++ b/products/ros-2.md
@@ -10,7 +10,7 @@ versionCommand: printenv | grep -i ROS
 releasePolicyLink: https://docs.ros.org/en/rolling/Releases.html
 changelogTemplate: "https://docs.ros.org/en/__RELEASE_CYCLE__/Releases/Release-{{'__CODENAME__'|replace:' ','-'}}.html"
 releaseLabel: "__CODENAME__"
-releaseColumn: false
+latestColumn: false
 eolColumn: End Of Life
 
 auto:

--- a/products/ros.md
+++ b/products/ros.md
@@ -9,7 +9,7 @@ versionCommand: rosversion -d
 releasePolicyLink: https://wiki.ros.org/Distributions
 changelogTemplate: "https://wiki.ros.org/__RELEASE_CYCLE__"
 releaseLabel: "__CODENAME__"
-releaseColumn: false
+latestColumn: false
 eolColumn: End Of Life
 
 releases:

--- a/products/samsung-galaxy-tab.md
+++ b/products/samsung-galaxy-tab.md
@@ -6,7 +6,7 @@ tags: tablet
 iconSlug: samsung
 permalink: /samsung-galaxy-tab
 releasePolicyLink: https://security.samsungmobile.com/workScope.smsb
-releaseColumn: false
+latestColumn: false
 eoasColumn: Android Upgrades
 eolColumn: Security Updates
 

--- a/products/samsung-galaxy-watch.md
+++ b/products/samsung-galaxy-watch.md
@@ -6,7 +6,7 @@ tags: smartwatch
 iconSlug: samsung
 permalink: /samsung-galaxy-watch
 releasePolicyLink: https://security.samsungmobile.com/workScope.smsb
-releaseColumn: false
+latestColumn: false
 eoasColumn: Wear OS Upgrades
 eolColumn: Security Updates
 

--- a/products/samsung-mobile.md
+++ b/products/samsung-mobile.md
@@ -8,7 +8,7 @@ permalink: /samsung-mobile
 alternate_urls:
   - /samsungmobile
 releasePolicyLink: https://security.samsungmobile.com/workScope.smsb
-releaseColumn: false
+latestColumn: false
 eoasColumn: Android Upgrades
 eolColumn: Security Updates
 

--- a/products/slackware.md
+++ b/products/slackware.md
@@ -11,7 +11,7 @@ alternate_urls:
 versionCommand: cat /etc/os-release
 releasePolicyLink: http://www.slackware.com/faq/do_faq.php?faq=general#4
 changelogTemplate: http://www.slackware.com/announce/__RELEASE_CYCLE__.php
-releaseColumn: false
+latestColumn: false
 
 identifiers:
   - cpe: cpe:/o:slackware:slackware_linux

--- a/products/sles.md
+++ b/products/sles.md
@@ -12,7 +12,7 @@ alternate_urls:
 versionCommand: cat /etc/os-release
 releasePolicyLink: https://www.suse.com/lifecycle
 changelogTemplate: "https://www.suse.com/releasenotes/x86_64/SUSE-SLES/{{'__RELEASE_CYCLE__'|replace:'.','-SP'|replace:'-SP0',''}}/"
-releaseColumn: false
+latestColumn: false
 eolColumn: General Support
 eoesColumn: Long Term Service Pack Support
 

--- a/products/sns-firmware.md
+++ b/products/sns-firmware.md
@@ -5,7 +5,7 @@ category: os
 tags: stormshield
 permalink: /sns-firmware
 versionCommand: getversion
-releaseColumn: false
+latestColumn: false
 eoasColumn: End of Maintenance
 eolColumn: End of Life
 

--- a/products/sns-hardware.md
+++ b/products/sns-hardware.md
@@ -4,7 +4,7 @@ addedAt: 2025-08-27
 category: device
 tags: stormshield
 permalink: /sns-hardware
-releaseColumn: false
+latestColumn: false
 eoasColumn: End of Sales
 eolColumn: End of Life
 

--- a/products/sns-smc.md
+++ b/products/sns-smc.md
@@ -4,7 +4,7 @@ addedAt: 2025-09-09
 category: os
 tags: stormshield
 permalink: /sns-smc
-releaseColumn: false
+latestColumn: false
 eoasColumn: End of Maintenance
 eolColumn: End of Life
 

--- a/products/sony-xperia.md
+++ b/products/sony-xperia.md
@@ -7,7 +7,7 @@ iconSlug: sony
 permalink: /sony-xperia
 alternate_urls:
   - /xperia
-releaseColumn: false
+latestColumn: false
 
 customFields:
   - name: androidVersions

--- a/products/steamos.md
+++ b/products/steamos.md
@@ -6,7 +6,7 @@ tags: linux-distribution
 iconSlug: steam
 permalink: /steamos
 eolColumn: Support
-releaseColumn: false
+latestColumn: false
 
 identifiers:
   - cpe: cpe:/o:valvesoftware:steamos

--- a/products/surface.md
+++ b/products/surface.md
@@ -5,8 +5,7 @@ category: device
 tags: microsoft
 permalink: /surface
 releasePolicyLink: https://learn.microsoft.com/surface/surface-driver-firmware-lifecycle-support
-releaseColumn: false
-latestColumn: true
+latestColumn: false
 eolColumn: End of Servicing Date
 
 auto:

--- a/products/suse-linux-micro.md
+++ b/products/suse-linux-micro.md
@@ -10,7 +10,7 @@ alternate_urls:
 versionCommand: cat /etc/os-release
 releasePolicyLink: https://www.suse.com/lifecycle
 changelogTemplate: https://www.suse.com/releasenotes/x86_64/SL-Micro/__RELEASE_CYCLE__/
-releaseColumn: false
+latestColumn: false
 eolColumn: General Support
 
 identifiers:

--- a/products/tls.md
+++ b/products/tls.md
@@ -5,7 +5,7 @@ category: standard
 tags: ietf
 permalink: /tls
 releaseLabel: "TLS __RELEASE_CYCLE__"
-releaseColumn: false
+latestColumn: false
 
 releases:
   - releaseCycle: "1.3"

--- a/products/visual-cobol.md
+++ b/products/visual-cobol.md
@@ -5,7 +5,7 @@ category: lang
 permalink: /visual-cobol
 releasePolicyLink: "https://www.microfocus.com/productlifecycle/"
 changelogTemplate: "https://www.microfocus.com/documentation/visual-cobol/vc{{'__RELEASE_CYCLE__' | replace: '.','''}}/"
-releaseColumn: false
+latestColumn: false
 eolColumn: Support Status
 
 auto:

--- a/products/vmware-photon.md
+++ b/products/vmware-photon.md
@@ -10,7 +10,7 @@ alternate_urls:
   - /vmwarephoton
 versionCommand: cat /etc/os-release
 releasePolicyLink: https://blogs.vmware.com/vsphere/2023/05/announcing-photon-os-5-0-general-availability.html
-releaseColumn: false
+latestColumn: false
 eolColumn: Security Support
 
 customFields:

--- a/products/windows-embedded.md
+++ b/products/windows-embedded.md
@@ -9,7 +9,7 @@ alternate_urls:
 versionCommand: winver
 releasePolicyLink: https://learn.microsoft.com/lifecycle/products/?terms=Windows%20Embedded
 releaseLabel: "Windows Embedded __RELEASE_CYCLE__"
-releaseColumn: false
+latestColumn: false
 eoasColumn: true
 
 releases:

--- a/products/zentyal.md
+++ b/products/zentyal.md
@@ -5,7 +5,7 @@ category: os
 tags: linux-distribution
 permalink: /zentyal
 releasePolicyLink: https://zentyal.com/release-policy/
-releaseColumn: false
+latestColumn: false
 eolColumn: Development Edition Support
 eoesColumn: Commercial Support
 

--- a/products/zerto.md
+++ b/products/zerto.md
@@ -7,7 +7,7 @@ permalink: /zerto
 alternate_urls:
   - /hpe-zerto
 releasePolicyLink: https://help.zerto.com/bundle/Lifecycle.Matrix.HTML/page/product_version_lifecycle_matrix_for_zerto.html
-releaseColumn: false
+latestColumn: false
 eoasColumn: General Support
 eolColumn: Critical Support
 


### PR DESCRIPTION
`releaseColumn` can easily be confused with the `releaseDateColumn`. Renaming to `releaseColumn` to match the default column name: 'Latest'.