### PR TITLE
[libreoffice] Ignore prereleases

### DIFF
--- a/products/libreoffice.md
+++ b/products/libreoffice.md
@@ -16,6 +16,8 @@ identifiers:
 auto:
   methods:
     - libreoffice: https://downloadarchive.documentfoundation.org/libreoffice/old/
+      prereleases_url: https://www.libreoffice.org/download/download-libreoffice/
+      prereleases_text: "LibreOffice is available in the following prerelease versions:"
       regex: '^(?P<version>\d+(\.\d+)*)/$'
       template: "{{version}}"
 


### PR DESCRIPTION
LibreOffice data may contain prerelease versions. Update auto-configuration to configure it.

Relates to https://github.com/endoflife-date/release-data/pull/517.