### PR TITLE
[ffmpeg] Fix latest for 8.0

### DIFF
--- a/products/ffmpeg.md
+++ b/products/ffmpeg.md
@@ -28,7 +28,7 @@ releases:
     codename: Huffman
     releaseDate: 2025-08-22
     eol: false
-    latest: "8.0.0"
+    latest: "8.0"
     latestReleaseDate: 2025-08-23
 
   - releaseCycle: "7.1"


### PR DESCRIPTION
First version of a cycle don't have the '.0' patch version, see https://ffmpeg.org/download.html#release_8.0.