### PR TITLE
[godot Fix latest for 4.3

### DIFF
--- a/products/godot.md
+++ b/products/godot.md
@@ -49,7 +49,7 @@ releases:
     releaseDate: 2024-08-15
     eoas: false
     eol: false
-    latest: "4.3.0"
+    latest: "4.3"
     latestReleaseDate: 2024-08-15
 
   - releaseCycle: "4.2"


### PR DESCRIPTION
First version of a cycle don't have the '.0' patch version, see https://github.com/godotengine/godot/releases/tag/4.3-stable.