### PR TITLE
[guzzle] Fix latest for 3

### DIFF
--- a/products/guzzle.md
+++ b/products/guzzle.md
@@ -49,8 +49,8 @@ releases:
   - releaseCycle: "3"
     eol: 2016-10-31
     supportedPHPVersions: ">=5.3.3, <7.0"
-    latest: "3.9.3"
-    releaseDate: 2012-10-15
+    latest: "3.8.1"
+    releaseDate: 2014-01-28
 
 ---
 


### PR DESCRIPTION
Latest is 3.8.1, not 3.9.3. See https://github.com/guzzle/guzzle/tags?after=4.0.0.