### PR TITLE
[julia] Revert latest 1.11 to 1.11.6

### DIFF
--- a/products/julia.md
+++ b/products/julia.md
@@ -21,8 +21,8 @@ releases:
     releaseDate: 2024-10-07 # announcementLink: https://julialang.org/blog/2024/10/julia-1.11-highlights/
     lts: false
     eol: false
-    latest: "1.11.7"
-    latestReleaseDate: 2025-09-08
+    latest: "1.11.6"
+    latestReleaseDate: 2025-07-09
 
   - releaseCycle: "1.10"
     releaseDate: 2023-12-25


### PR DESCRIPTION
Looks like 1.11.7 tag was a mistake :

- it was added in https://github.com/endoflife-date/release-data/commit/85b33cc8347a9fa45f0d8df41f4e690aa5123550,
- and removed in https://github.com/endoflife-date/release-data/commit/240e477f1a7aef6f17c6c4ff6b8388bfe6480945.