### PR TITLE
[kuma] Update auto configuration

### DIFF
--- a/products/kuma.md
+++ b/products/kuma.md
@@ -10,6 +10,7 @@ eolColumn: Support
 
 auto:
   methods:
+    - git: https://github.com/kumahq/kuma.git # a few versions are missing from releases
     - github_releases: kumahq/kuma
     - kuma: https://raw.githubusercontent.com/kumahq/kuma/master/versions.yml
 


### PR DESCRIPTION
Add git method together with the gith_release method: a few versions are missing from github releases.

Dates are more accurate in github releases, so also left the github_release configuration.