### PR TITLE
[eclipse-jetty] add 12.1

### DIFF
--- a/products/eclipse-jetty.md
+++ b/products/eclipse-jetty.md
@@ -38,10 +38,23 @@ identifiers:
 
 auto:
   methods:
-    - maven: org.eclipse.jetty/jetty-server
+    - github_releases: jetty/jetty.project
+      regex: ^jetty-(?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)$
+      template: "{major}.{minor}.{patch}"
 
-# Support, EOL and minJavaVersion can be found on https://eclipse.dev/jetty/download.php.
+# Support, EOL and minJavaVersion can be found on https://jetty.org/download.html.
 releases:
+  - releaseCycle: "12.1"
+    releaseDate: 2023-08-07
+    minJvmVersion: "17"
+    servletVersion: "3.1 - 6.1"
+    jspVersion: "2.3 - 3.1"
+    eoas: false
+    eol: false
+    eoes: false
+    latest: "12.1.1"
+    latestReleaseDate: 2025-09-08
+
   - releaseCycle: "12"
     releaseDate: 2023-08-07
     minJvmVersion: "17"
@@ -50,8 +63,8 @@ releases:
     eoas: false
     eol: false
     eoes: false
-    latest: "12.0.21"
-    latestReleaseDate: 2025-05-09
+    latest: "12.0.27"
+    latestReleaseDate: 2025-09-11
 
   - releaseCycle: "11"
     minJvmVersion: "11"
@@ -111,8 +124,8 @@ releases:
     servletVersion: "3.1"
     jspVersion: "2.3"
     releaseDate: 2013-11-15
-    eoas: 2014-12-31 # only year provided on https://eclipse.dev/jetty/download.php, used end of the year
-    eol: 2014-12-31 # only year provided on https://eclipse.dev/jetty/download.php, used end of the year
+    eoas: 2014-12-31 # only year provided on https://jetty.org/download.html, used end of the year
+    eol: 2014-12-31 # only year provided on https://jetty.org/download.html, used end of the year
     latest: "9.1.6.v20160112"
     latestReleaseDate: 2016-01-12
 
@@ -121,8 +134,8 @@ releases:
     servletVersion: "3.1-beta"
     jspVersion: "2.3"
     releaseDate: 2013-03-08
-    eoas: 2013-12-31 # only year provided on https://eclipse.dev/jetty/download.php, used end of the year
-    eol: 2013-12-31 # only year provided on https://eclipse.dev/jetty/download.php, used end of the year
+    eoas: 2013-12-31 # only year provided on https://jetty.org/download.html, used end of the year
+    eol: 2013-12-31 # only year provided on https://jetty.org/download.html, used end of the year
     latest: "9.0.7.v20131107"
     latestReleaseDate: 2013-11-07
 
@@ -131,8 +144,8 @@ releases:
     servletVersion: "3.0"
     jspVersion: "2.2"
     releaseDate: 2011-09-01
-    eoas: 2014-12-31 # only year provided on https://eclipse.dev/jetty/download.php, used end of the year
-    eol: 2014-12-31 # only year provided on https://eclipse.dev/jetty/download.php, used end of the year
+    eoas: 2014-12-31 # only year provided on https://jetty.org/download.html, used end of the year
+    eol: 2014-12-31 # only year provided on https://jetty.org/download.html, used end of the year
     latest: "8.2.0.v20160908"
     latestReleaseDate: 2016-09-08
 
@@ -141,8 +154,8 @@ releases:
     servletVersion: "2.5"
     jspVersion: "2.1"
     releaseDate: 2009-10-05
-    eoas: 2014-12-31 # only year provided on https://eclipse.dev/jetty/download.php, used end of the year
-    eol: 2014-12-31 # only year provided on https://eclipse.dev/jetty/download.php, used end of the year
+    eoas: 2014-12-31 # only year provided on https://jetty.org/download.html, used end of the year
+    eol: 2014-12-31 # only year provided on https://jetty.org/download.html, used end of the year
     latest: "7.6.21.v20160908"
     latestReleaseDate: 2016-09-08
 ---

--- a/products/eclipse-jetty.md
+++ b/products/eclipse-jetty.md
@@ -44,7 +44,7 @@ auto:
 # Support, EOL and minJavaVersion can be found on https://jetty.org/download.html.
 releases:
   - releaseCycle: "12.1"
-    releaseDate: 2023-08-07
+    releaseDate: 2023-08-18
     minJvmVersion: "17"
     servletVersion: "3.1 - 6.1"
     jspVersion: "2.3 - 3.1"

--- a/products/eclipse-jetty.md
+++ b/products/eclipse-jetty.md
@@ -40,7 +40,6 @@ auto:
   methods:
     - github_releases: jetty/jetty.project
       regex: ^jetty-(?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)$
-      template: "{major}.{minor}.{patch}"
 
 # Support, EOL and minJavaVersion can be found on https://jetty.org/download.html.
 releases:


### PR DESCRIPTION
1. Version updates:
    - Add **Jetty 12.1 branch** - new stable release series
    - Update 12.0.21 → **12.0.27** (latest in 12.0.x series)

2. Switch data source from [maven central API ](https://search.maven.org/solrsearch/select?q=g:org.eclipse.jetty+AND+a:jetty-project&core=gav&wt=json)to [GitHub releases](https://github.com/jetty/jetty.project/releases) since the Maven Central API returns outdated information for jetty. 

3. Update documentation links from `https://eclipse.dev/jetty/download.php` to the current `https://jetty.org/download.html`