### PR TITLE
[watchos] Drop eoas column

### DIFF
--- a/products/watchos.md
+++ b/products/watchos.md
@@ -6,10 +6,7 @@ tags: apple smartwatch
 iconSlug: apple
 permalink: /watchos
 releasePolicyLink: https://en.wikipedia.org/wiki/WatchOS#Version_history
-# Release notes are not published for all minor or patch versions, so using only the major version.
-# Other release notes are easily accessible from that page, if available.
-changelogTemplate: "https://developer.apple.com/documentation/watchos-release-notes/watchos-__RELEASE_CYCLE__-release-notes"
-eoasColumn: true
+changelogTemplate: https://developer.apple.com/documentation/watchos-release-notes/watchos-__RELEASE_CYCLE__-release-notes
 
 identifiers:
   - cpe: cpe:/o:apple:watch_os
@@ -24,86 +21,75 @@ auto:
         - 'watchOS\s+(?P<version>\d+)'
         - 'watchOS\s+(?P<version>\d+(?:\.\d+)+)'
 
+# eol(x) = releaseDate(x+1)
 releases:
   - releaseCycle: "26"
     releaseDate: 2025-09-15
-    eoas: false
     eol: false
     latest: "26.0.0"
     latestReleaseDate: 2025-09-15
 
   - releaseCycle: "11"
     releaseDate: 2024-09-16
-    eoas: 2025-09-15
     eol: 2025-09-15
     latest: "11.6.1"
     latestReleaseDate: 2025-08-14
-    link: https://support.apple.com/en-us/121163
 
   - releaseCycle: "10"
     releaseDate: 2023-09-18
-    eoas: 2024-09-16
     eol: 2024-09-16
     latest: "10.6.1"
     latestReleaseDate: 2024-08-19
 
   - releaseCycle: "9"
     releaseDate: 2022-09-12
-    eoas: 2023-09-18
-    eol: 2023-09-22
-    latestReleaseDate: 2023-09-21
+    eol: 2023-09-18
     latest: "9.6.3"
+    latestReleaseDate: 2023-09-21
 
   - releaseCycle: "8"
     releaseDate: 2021-09-20
-    eoas: 2022-09-12
-    eol: 2022-09-22
-    latestReleaseDate: 2023-06-21
+    eol: 2022-09-12
     latest: "8.8.1"
+    latestReleaseDate: 2023-06-21
 
   - releaseCycle: "7"
     releaseDate: 2020-09-16
-    eoas: 2021-09-20
-    eol: 2021-10-11
-    latestReleaseDate: 2021-09-13
+    eol: 2021-09-20
     latest: "7.6.2"
+    latestReleaseDate: 2021-09-13
 
   - releaseCycle: "6"
     releaseDate: 2019-09-19
-    eoas: 2020-09-16
     eol: 2020-09-16
-    latestReleaseDate: 2020-12-14
     latest: "6.3"
+    latestReleaseDate: 2020-12-14
 
   - releaseCycle: "5"
     releaseDate: 2018-09-17
-    eoas: 2019-09-19
-    eol: 2019-09-30
-    latestReleaseDate: 2020-11-05
+    eol: 2019-09-19
     latest: "5.3.9"
+    latestReleaseDate: 2020-11-05
 
   - releaseCycle: "4"
     releaseDate: 2017-09-19
-    eoas: 2018-09-17
-    eol: 2018-09-27
-    latestReleaseDate: 2018-07-09
+    eol: 2018-09-17
     latest: "4.3.2"
+    latestReleaseDate: 2018-07-09
     link: https://support.apple.com/HT208071
 
   - releaseCycle: "3"
     releaseDate: 2016-09-13
-    eoas: 2017-09-19
-    eol: 2017-10-04
-    latestReleaseDate: 2017-07-19
+    eol: 2017-09-19
     latest: "3.2.3"
+    latestReleaseDate: 2017-07-19
     link: https://support.apple.com/kb/DL1894
 
 ---
 
-> [watchOS](https://www.apple.com/watchos/) is Apple's mobile operating system for its Apple
-> Watches. It is based on iOS, and introduced in 2015.
+> [watchOS](https://www.apple.com/watchos/) is Apple's mobile operating system for its Apple Watches.
+> It is based on iOS, and introduced in 2015.
 
 Major versions of watchOS are released annually, with the previous major version losing support.
 
-Apple publishes a [Compatibility Table](https://support.apple.com/118490) for supported combinations
-of iPhone, iOS, watchOS.
+Apple publishes a [Compatibility Table](https://support.apple.com/118490) for supported combinations of iPhone, iOS, watchOS.


### PR DESCRIPTION
Documented support policy is `eol(x) = releaseDate(x+1)`. This may be false for a few releases, but overall that's correct and it is safe to assume that Apple does not guarantee anything for all but the last release.

Considering this:

- drop the eoas column: a release is either supported or not,
- apply the `eol(x) = releaseDate(x+1)` rule on all releases.

Also took this opportunity to reformat and cleanup things a bit.