### PR TITLE
[eclipse-jetty] Correct 12.1 release date

### DIFF
--- a/products/eclipse-jetty.md
+++ b/products/eclipse-jetty.md
@@ -44,7 +44,7 @@ auto:
 # Support, EOL and minJavaVersion can be found on https://jetty.org/download.html.
 releases:
   - releaseCycle: "12.1"
-    releaseDate: 2023-08-18
+    releaseDate: 2025-08-18
     minJvmVersion: "17"
     servletVersion: "3.1 - 6.1"
     jspVersion: "2.3 - 3.1"


### PR DESCRIPTION
- Fixing 12.1 release date from my past PR: https://github.com/endoflife-date/endoflife.date/pull/8463
- Release of jetty 12.1 was in 2025 and not 2023:https://github.com/jetty/jetty.project/releases/tag/jetty-12.1.0