### PR TITLE
[eclipse-jetty]: rename release cycle 12 to 12.0 to fix conflicts

### DIFF
--- a/products/eclipse-jetty.md
+++ b/products/eclipse-jetty.md
@@ -54,7 +54,7 @@ releases:
     latest: "12.1.1"
     latestReleaseDate: 2025-09-08
 
-  - releaseCycle: "12"
+  - releaseCycle: "12.0"
     releaseDate: 2023-08-07
     minJvmVersion: "17"
     servletVersion: "3.1 - 6.0"
@@ -62,8 +62,8 @@ releases:
     eoas: false
     eol: false
     eoes: false
-    latest: "12.1.1"
-    latestReleaseDate: 2025-09-08
+    latest: "12.0.27"
+    latestReleaseDate: 2025-09-11
 
   - releaseCycle: "11"
     minJvmVersion: "11"


### PR DESCRIPTION
Jetty has two stable versions: 12.0 and 12.1. Currently, version 12.0 is labeled as just "12", which causes automation to incorrectly update it with 12.1 data ([reference commit](https://github.com/endoflife-date/endoflife.date/commit/92ddc948ef27b66ce8f01c14370dd1c3fb4f21be#diff-b54555f170b7fb6e917cb0a69572242ea3a3356135f90cb5de80b90dbbf4491e)). This PR changes "12" to "12.0" to fix the ambiguity.

Sorry I missed this the first time. 