### PR TITLE
[graalvm-ce] : Java 25 is LTS

### DIFF
--- a/products/graalvm-ce.md
+++ b/products/graalvm-ce.md
@@ -24,6 +24,7 @@ releases:
   - releaseCycle: "25"
     releaseDate: 2025-09-16
     eol: false
+    lts: true
     latest: "25"
     latestReleaseDate: 2025-09-16
     


### PR DESCRIPTION
Looks like it's a LTS, but nore the graalvm CE implements it 

- https://linuxiac.com/jdk-25-lts-released-with-tls-key-exporters-improved-debugging/
<img width="1024" height="576" alt="image" src="https://github.com/user-attachments/assets/ff9687a6-263e-4786-ac3b-3d6f32e1591f" />
