### PR TITLE
[grails] Mark 5 as EOL

### DIFF
--- a/products/grails.md
+++ b/products/grails.md
@@ -31,7 +31,7 @@ releases:
   - releaseCycle: "5"
     releaseDate: 2021-10-12
     eoas: 2023-07-24
-    eol: false
+    eol: 2025-01-09 # more than 1 year without update, and not listed on https://grails.apache.org/download.html anymore
     latest: "5.3.6"
     latestReleaseDate: 2024-01-09
 


### PR DESCRIPTION
The was no release since 09 Jan 2024, no policy/documentation about it, and the release is not listed anymore on https://grails.apache.org/download.html.