### PR TITLE
[hbase] Mark 2.4 as EOL

### DIFF
--- a/products/hbase.md
+++ b/products/hbase.md
@@ -38,7 +38,7 @@ releases:
 
   - releaseCycle: "2.4"
     releaseDate: 2020-12-15
-    eol: false
+    eol: 2025-05-25 # more than 1 year without update, and not listed on https://hbase.apache.org/downloads.html anymore
     latest: "2.4.18"
     latestReleaseDate: 2024-05-25
 


### PR DESCRIPTION
It's been more than one year there are no new version, and this release is not listed on https://hbase.apache.org/downloads.html anymore.