### PR TITLE
[intel-processors] Mark lakefield as EOL

### DIFF
--- a/products/intel-processors.md
+++ b/products/intel-processors.md
@@ -55,7 +55,7 @@ releases:
   - releaseCycle: "lakefield"
     releaseLabel: "Lakefield"
     releaseDate: 2020-06-19
-    discontinued: true
+    discontinued: 2021-07-07 # https://www.tomshardware.com/news/intel-retires-lakefield
     eol: 2023-06-30
     link: https://ark.intel.com/content/www/us/en/ark/products/codename/81657/products-formerly-lakefield.html
 

--- a/products/intel-processors.md
+++ b/products/intel-processors.md
@@ -56,7 +56,7 @@ releases:
     releaseLabel: "Lakefield"
     releaseDate: 2020-06-19
     discontinued: true
-    eol: false
+    eol: 2023-06-30
     link: https://ark.intel.com/content/www/us/en/ark/products/codename/81657/products-formerly-lakefield.html
 
   - releaseCycle: "ice-lake"


### PR DESCRIPTION
This processor is listed in the section "Products No Longer Receiving Interactive Support or Servicing Updates" on https://www.intel.com/content/www/us/en/support/articles/000022396/processors.html.

Using End of Servicing Updates Date from https://www.intel.com/content/www/us/en/products/sku/202777/intel-core-i5l16g7-processor-4m-cache-up-to-3-0ghz/specifications.html or https://www.intel.com/content/www/us/en/products/sku/202778/intel-core-i3l13g4-processor-4m-cache-up-to-2-8ghz/specifications.html.

Also update discontinued date based on https://www.tomshardware.com/news/intel-retires-lakefield.