### PR TITLE
[ipad] Update releases

### DIFF
--- a/products/ipad.md
+++ b/products/ipad.md
@@ -22,7 +22,7 @@ customFields:
 # All supported iPadOS versions can be found on https://en.wikipedia.org/wiki/List_of_iPad_models#iPad.
 releases:
   - releaseCycle: "11"
-    releaseLabel: "iPad (11th generation)"
+    releaseLabel: "iPad (A16)"
     releaseDate: 2025-03-12
     discontinued: false
     eol: false
@@ -30,7 +30,7 @@ releases:
     supportedIpadOsVersions: "18"
 
   - releaseCycle: "air-7"
-    releaseLabel: "iPad Air (7th generation)"
+    releaseLabel: "iPad Air (M3)"
     releaseDate: 2025-03-12
     discontinued: false
     eol: false
@@ -38,7 +38,7 @@ releases:
     supportedIpadOsVersions: "18"
 
   - releaseCycle: "mini-7"
-    releaseLabel: "iPad Mini (7th generation)"
+    releaseLabel: "iPad Mini (A17 Pro)"
     releaseDate: 2024-10-23
     discontinued: false
     eol: false
@@ -46,25 +46,17 @@ releases:
     supportedIpadOsVersions: "18"
 
   - releaseCycle: "pro-7"
-    releaseLabel: "iPad Pro (7th generation)"
+    releaseLabel: "iPad Pro (M4)"
     releaseDate: 2024-05-15
     discontinued: false
     eol: false
     link: https://support.apple.com/119891
     supportedIpadOsVersions: "17 - 18"
 
-  - releaseCycle: "air-6-m2"
-    releaseLabel: "iPad Air 11-inch (M2)"
-    releaseDate: 2024-05-15
-    discontinued: 2025-03-04
-    eol: false
-    link: https://support.apple.com/119894
-    supportedIpadOsVersions: "17 - 18"
-
   - releaseCycle: "air-6"
-    releaseLabel: "iPad Air (6th generation)"
+    releaseLabel: "iPad Air (M2)"
     releaseDate: 2024-05-15
-    discontinued: false
+    discontinued: 2025-03-04 # https://en.wikipedia.org/wiki/IPad_Air_(M2)
     eol: false
     link: https://support.apple.com/119893
     supportedIpadOsVersions: "17 - 18"
@@ -72,7 +64,7 @@ releases:
   - releaseCycle: "10"
     releaseLabel: "iPad (10th generation)"
     releaseDate: 2022-10-26
-    discontinued: false
+    discontinued: 2025-03-04 # https://en.wikipedia.org/wiki/IPad_(10th_generation)
     eol: false
     link: https://support.apple.com/kb/SP884
     supportedIpadOsVersions: "16 - 18"
@@ -80,7 +72,7 @@ releases:
   - releaseCycle: "pro-6"
     releaseLabel: "iPad Pro (6th generation)"
     releaseDate: 2022-10-26
-    discontinued: false
+    discontinued: 2024-05-07 # https://en.wikipedia.org/wiki/IPad_Pro_(6th_generation)
     eol: false
     link: https://support.apple.com/kb/SP844
     supportedIpadOsVersions: "16 - 18"
@@ -88,7 +80,7 @@ releases:
   - releaseCycle: "air-5"
     releaseLabel: "iPad Air (5th generation)"
     releaseDate: 2022-03-18
-    discontinued: false
+    discontinued: 2024-05-07 # https://en.wikipedia.org/wiki/IPad_Air_(5th_generation)
     eol: false
     link: https://support.apple.com/kb/SP866
     supportedIpadOsVersions: "15 - 18"
@@ -96,7 +88,7 @@ releases:
   - releaseCycle: "9"
     releaseLabel: "iPad (9th generation)"
     releaseDate: 2021-09-24
-    discontinued: false
+    discontinued: 2024-05-07 # https://en.wikipedia.org/wiki/IPad_(9th_generation)
     eol: false
     link: https://support.apple.com/kb/SP849
     supportedIpadOsVersions: "15 - 18"
@@ -104,7 +96,7 @@ releases:
   - releaseCycle: "mini-6"
     releaseLabel: "iPad Mini (6th generation)"
     releaseDate: 2021-09-24
-    discontinued: false
+    discontinued: 2024-10-15 # https://en.wikipedia.org/wiki/IPad_Mini_(6th_generation)
     eol: false
     link: https://support.apple.com/kb/SP850
     supportedIpadOsVersions: "15 - 18"


### PR DESCRIPTION
- set discontinued date for older models,
- update labels for newer models to use the commercial name,
- drop air-6-m2 release : all model sizes are always grouped in a single entry on this page.