### PR TITLE
[tomcat] Update auto configuration

### DIFF
--- a/products/tomcat.md
+++ b/products/tomcat.md
@@ -23,7 +23,7 @@ identifiers:
 
 auto:
   methods:
-    - maven: org.apache.tomcat/tomcat
+    - git: https://github.com/apache/tomcat.git
 
 # EOL can be seen on https://tomcat.apache.org/whichversion.html
 releases:


### PR DESCRIPTION
Use git instead of maven to retrieve versions. The maven auto method is very unstable and often fails, especially on projects with a lot of versions.