### PR TITLE
[apache-camel] Update auto-configuration

### DIFF
--- a/products/apache-camel.md
+++ b/products/apache-camel.md
@@ -24,7 +24,8 @@ identifiers:
 
 auto:
   methods:
-    - maven: org.apache.camel/camel
+    - git: https://github.com/apache/camel.git
+      regex: '^camel-(?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)$'
 
 # For LTS: eol = releaseDate + 1 year
 # For non-LTS : eol(x) = releaseDate(x+1)


### PR DESCRIPTION
Use git instead of maven to retrieve versions. The maven auto method is very unstable and often fails, especially on projects with a lot of versions.