### PR TITLE
[apple-watch] Update stale release threshold to 6 years

### DIFF
--- a/products/apple-watch.md
+++ b/products/apple-watch.md
@@ -9,7 +9,7 @@ releasePolicyLink: https://support.apple.com/watch
 discontinuedColumn: true
 eolColumn: Supported
 latestColumn: false
-staleReleaseThresholdYears: 5
+staleReleaseThresholdYears: 6
 
 customFields:
   - name: supportedWatchOsVersions


### PR DESCRIPTION
apple-watch:6 has now been supported for more than 5 years.