### PR TITLE
[ipad] Update iPad OS 26 support for iPad Pro 11in Gen 1 & Gen 2

### DIFF
--- a/products/ipad.md
+++ b/products/ipad.md
@@ -138,7 +138,7 @@ releases:
     releaseLabel: "iPad Pro 11-inch (2nd generation)"
     releaseDate: 2020-03-01
     discontinued: 2021-04-01
-    eol: 2027-09-15 # 3-year support expected for iPadOS 18
+    eol: false
     link: https://support.apple.com/en-us/118452
     supportedIpadOsVersions: "10 - 26"
 
@@ -178,7 +178,7 @@ releases:
     releaseLabel: "iPad Pro 11-inch (1st generation)"
     releaseDate: 2018-11-01
     discontinued: 2020-03-01
-    eol: 2027-09-15 # 3-year support expected for iPadOS 18
+    eol: false
     link: https://support.apple.com/en-us/111974
     supportedIpadOsVersions: "9 - 26"
 

--- a/products/ipad.md
+++ b/products/ipad.md
@@ -140,7 +140,7 @@ releases:
     discontinued: 2021-04-01
     eol: 2027-09-15 # 3-year support expected for iPadOS 18
     link: https://support.apple.com/en-us/118452
-    supportedIpadOsVersions: "10 - 18"
+    supportedIpadOsVersions: "10 - 26"
 
   - releaseCycle: "7"
     releaseLabel: "iPad (7th generation)"
@@ -180,7 +180,7 @@ releases:
     discontinued: 2020-03-01
     eol: 2027-09-15 # 3-year support expected for iPadOS 18
     link: https://support.apple.com/en-us/111974
-    supportedIpadOsVersions: "9 - 18"
+    supportedIpadOsVersions: "9 - 26"
 
   - releaseCycle: "6"
     releaseLabel: "iPad (6th generation)"


### PR DESCRIPTION
Looks like these iPad models were missed during a previous PR - https://github.com/endoflife-date/endoflife.date/pull/8542

