### PR TITLE
[kong-gateway] Update EOL date for 2.8

### DIFF
--- a/products/kong-gateway.md
+++ b/products/kong-gateway.md
@@ -104,7 +104,7 @@ releases:
   - releaseCycle: "2.8"
     lts: true
     releaseDate: 2022-03-01
-    eol: false
+    eol: 2024-06-24
     eoes: 2025-03-01
     latest: "2.8.5"
     latestReleaseDate: 2024-06-24


### PR DESCRIPTION
There was no version for more than a year and the release has already reach its end of extended support.