### PR TITLE
[New Product] Cisco IOS XE

### DIFF
--- a/products/cisco-ios-xe.md
+++ b/products/cisco-ios-xe.md
@@ -1,6 +1,6 @@
 ---
 title: Cisco IOS XE
-addedAt: 2025-11-03
+addedAt: 2025-11-08
 category: os
 tags: cisco
 iconSlug: cisco
@@ -11,131 +11,131 @@ eolColumn: Security Support
 latestColumn: false
 
 # For non-LTS:
-# - eoas(x) = releaseDate(x) (FCS) + 3 months (EoL announcement) + 3 months (EoS) + 6 months = releaseDate(x) + 12 months
-# - eol(x) = eoas(x) = releaseDate(x) + 12 months
+# - eoas(x) = releaseDate(x) + 12 months (FCS + 3 months (EoL announcement) + 3 months (EoS) + 6 months)
+# - eol(x) = eoas(x)
 # For LTS:
-# - eoas(x) = releaseDate(x) (FCS) + 12 months (EoL announcement) + 6 months (EoS) + 12 months = releaseDate(x) + 30 months
-# - eol(x) = releaseDate(x) + 12 months (EoL announcement) + 6 months (EoS) + 30 months = releaseDate(x) + 48 months
+# - eoas(x) = releaseDate(x) + 30 months (FCS + 12 months (EoL announcement) + 6 months (EoS) + 12 months)
+# - eol(x) = releaseDate(x) + 48 months (FCS + 12 months (EoL announcement) + 6 months (EoS) + 30 months)
 releases:
   - releaseCycle: "17.18"
     lts: true
     releaseDate: 2025-08-08
-    eoas: false
-    eol: false
+    eoas: 2028-02-08
+    eol: 2029-08-08
     link: https://www.cisco.com/c/en/us/support/ios-nx-os-software/ios-xe-17-18-1/model.html
 
   - releaseCycle: "17.17"
     releaseDate: 2025-03-31
-    eoas: false
-    eol: false
+    eoas: 2026-03-31
+    eol: 2026-03-31
     link: https://www.cisco.com/c/en/us/support/ios-nx-os-software/ios-xe-17-17-1/model.html
 
   - releaseCycle: "17.16"
     releaseDate: 2024-12-11
-    eoas: 2026-01-13
-    eol: 2026-01-13
+    eoas: 2025-12-11
+    eol: 2025-12-11
     link: https://www.cisco.com/c/en/us/products/collateral/ios-nx-os-software/ios-xe-17/ios-xe-17-16-x-eol.html
 
   - releaseCycle: "17.15"
     lts: true
     releaseDate: 2024-08-09
-    eoas: 2027-03-30
-    eol: 2028-09-30
+    eoas: 2027-02-09
+    eol: 2028-08-09
     link: https://www.cisco.com/c/en/us/products/collateral/ios-nx-os-software/ios-xe-17/ios-xe-17-15-x-eol.html
 
   - releaseCycle: "17.14"
     releaseDate: 2024-04-13
-    eoas: 2025-05-31
-    eol: 2025-05-31
+    eoas: 2025-04-13
+    eol: 2025-04-13
     link: https://www.cisco.com/c/en/us/products/collateral/ios-nx-os-software/ios-xe-17/ios-xe-17-14-x-eol.html
 
   - releaseCycle: "17.13"
     releaseDate: 2023-11-30
-    eoas: 2024-12-31
-    eol: 2024-12-31
+    eoas: 2024-11-30
+    eol: 2024-11-30
     link: https://www.cisco.com/c/en/us/products/collateral/ios-nx-os-software/ios-xe-17/ios-xe-17-13-x-eol.html
 
   - releaseCycle: "17.12"
     lts: true
     releaseDate: 2023-07-28
-    eoas: 2026-03-30
-    eol: 2027-09-30
+    eoas: 2026-01-28
+    eol: 2027-07-28
     link: https://www.cisco.com/c/en/us/products/collateral/ios-nx-os-software/ios-xe-17/ios-xe-17-12-x-eol.html
 
   - releaseCycle: "17.11"
     releaseDate: 2023-03-28
-    eoas: 2024-05-14
-    eol: 2024-05-14
+    eoas: 2024-03-28
+    eol: 2024-03-28
     link: https://www.cisco.com/c/en/us/products/collateral/ios-nx-os-software/ios-xe-17/ios-xe-17-11-x-eol.html
 
   - releaseCycle: "17.10"
     releaseDate: 2022-11-30
-    eoas: 2024-01-03
-    eol: 2024-01-03
+    eoas: 2023-11-30
+    eol: 2023-11-30
     link: https://www.cisco.com/c/en/us/products/collateral/ios-nx-os-software/ios-xe-17/ios-xe-17-10-x-eol.html
 
   - releaseCycle: "17.9"
     lts: true
     releaseDate: 2022-07-29
-    eoas: 2025-03-30
-    eol: 2026-09-30
+    eoas: 2025-01-29
+    eol: 2026-07-29
     link: https://www.cisco.com/c/en/us/products/collateral/ios-nx-os-software/ios-xe-17/ios-xe-17-9-x-eol.html
 
   - releaseCycle: "17.8"
     releaseDate: 2022-04-11
-    eoas: 2023-05-30
-    eol: 2023-05-30
+    eoas: 2023-04-11
+    eol: 2023-04-11
     link: https://www.cisco.com/c/en/us/products/collateral/ios-nx-os-software/ios-xe-17/ios-xe-17-8-x-eol.html
 
   - releaseCycle: "17.7"
     releaseDate: 2021-11-30
-    eoas: 2023-01-30
-    eol: 2023-01-30
+    eoas: 2022-11-30
+    eol: 2022-11-30
     link: https://www.cisco.com/c/en/us/products/collateral/ios-nx-os-software/ios-xe-17/ios-xe-17-7-x-eol.html
 
   - releaseCycle: "17.6"
     lts: true
     releaseDate: 2021-07-30
-    eoas: 2024-03-31
-    eol: 2024-09-30
+    eoas: 2023-01-30
+    eol: 2024-07-30
     link: https://www.cisco.com/c/en/us/products/collateral/ios-nx-os-software/ios-xe-17/ios-xe-17-6-x-eol.html
 
   - releaseCycle: "17.5"
     releaseDate: 2021-03-31
-    eoas: 2022-05-30
-    eol: 2022-05-30
+    eoas: 2022-03-31
+    eol: 2022-03-31
     link: https://www.cisco.com/c/en/us/products/collateral/ios-nx-os-software/ios-xe-17/ios-xe-17-5-x-eol.html
 
   - releaseCycle: "17.4"
     releaseDate: 2020-11-30
-    eol: 2022-01-28
-    eoas: 2022-01-28
+    eol: 2021-11-30
+    eoas: 2021-11-30
     link: https://www.cisco.com/c/en/us/products/collateral/ios-nx-os-software/ios-xe-17/eos-eol-notice-c51-2442351.html
 
   - releaseCycle: "17.3"
     lts: true
     releaseDate: 2020-07-31
-    eoas: 2023-03-31
-    eol: 2023-09-30
+    eoas: 2023-01-31
+    eol: 2024-07-31
     link: https://www.cisco.com/c/en/us/products/collateral/ios-nx-os-software/ios-xe-17/ios-xe-17-3-x-eol.html
 
   - releaseCycle: "17.2"
     releaseDate: 2020-03-30
-    eoas: 2021-07-15
-    eol: 2021-07-15
+    eoas: 2021-03-30
+    eol: 2021-03-30
     link: https://www.cisco.com/c/en/us/products/collateral/ios-nx-os-software/ios-xe-17/eos-eol-notice-c51-744388.html
 
   - releaseCycle: "17.1"
     releaseDate: 2019-11-21
-    eoas: 2020-12-30
-    eol: 2020-12-30
+    eoas: 2020-11-21
+    eol: 2020-11-21
     link: https://www.cisco.com/c/en/us/products/collateral/switches/catalyst-9200-series-switches/eos-eol-notice-c51-743638.html
 
   - releaseCycle: "16.12"
     lts: true
     releaseDate: 2019-07-31
-    eoas: 2022-02-17
-    eol: 2022-08-18
+    eoas: 2022-01-31
+    eol: 2023-07-31
     link: https://www.cisco.com/c/en/us/products/collateral/ios-nx-os-software/ios-xe-16/eos-eol-notice-c51-744154.html
 
 ---

--- a/products/cisco-ios-xe.md
+++ b/products/cisco-ios-xe.md
@@ -130,7 +130,7 @@ releases:
     eol: 2022-08-18
     eoas: 2022-02-17
     lts: true
-    changeLogReference: https://www.cisco.com/c/en/us/products/collateral/ios-nx-os-software/ios-xe-16/eos-eol-notice-c51-744154.html
+    link: https://www.cisco.com/c/en/us/products/collateral/ios-nx-os-software/ios-xe-16/eos-eol-notice-c51-744154.html
 
 ---
 

--- a/products/cisco-ios-xe.md
+++ b/products/cisco-ios-xe.md
@@ -1,6 +1,6 @@
 ---
 title: Cisco IOS XE
-addedAt: 2025-10-26
+addedAt: 2025-11-03
 category: os
 tags: cisco
 iconSlug: cisco
@@ -12,124 +12,124 @@ latestColumn: false
 
 releases:
   - releaseCycle: "17.18"
-    releaseDate: 2025-08-08
-    eol: false
-    eoas: false
     lts: true
+    releaseDate: 2025-08-08
+    eoas: false
+    eol: false
     link: https://www.cisco.com/c/en/us/support/ios-nx-os-software/ios-xe-17-18-1/model.html
 
   - releaseCycle: "17.17"
     releaseDate: 2025-03-31
-    eol: false
     eoas: false
+    eol: false
     link: https://www.cisco.com/c/en/us/support/ios-nx-os-software/ios-xe-17-17-1/model.html
 
   - releaseCycle: "17.16"
     releaseDate: 2024-12-11
-    eol: 2026-01-13
     eoas: 2026-01-13
+    eol: 2026-01-13
     link: https://www.cisco.com/c/en/us/products/collateral/ios-nx-os-software/ios-xe-17/ios-xe-17-16-x-eol.html
 
   - releaseCycle: "17.15"
-    releaseDate: 2024-08-09
-    eol: 2028-09-30
-    eoas: 2027-03-30
     lts: true
+    releaseDate: 2024-08-09
+    eoas: 2027-03-30
+    eol: 2028-09-30
     link: https://www.cisco.com/c/en/us/products/collateral/ios-nx-os-software/ios-xe-17/ios-xe-17-15-x-eol.html
 
   - releaseCycle: "17.14"
     releaseDate: 2024-04-13
-    eol: 2025-05-31
     eoas: 2025-05-31
+    eol: 2025-05-31
     link: https://www.cisco.com/c/en/us/products/collateral/ios-nx-os-software/ios-xe-17/ios-xe-17-14-x-eol.html
 
   - releaseCycle: "17.13"
     releaseDate: 2023-11-30
-    eol: 2024-12-31
     eoas: 2024-12-31
+    eol: 2024-12-31
     link: https://www.cisco.com/c/en/us/products/collateral/ios-nx-os-software/ios-xe-17/ios-xe-17-13-x-eol.html
 
   - releaseCycle: "17.12"
-    releaseDate: 2023-07-28
-    eol: 2027-09-30
-    eoas: 2026-03-30
     lts: true
+    releaseDate: 2023-07-28
+    eoas: 2026-03-30
+    eol: 2027-09-30
     link: https://www.cisco.com/c/en/us/products/collateral/ios-nx-os-software/ios-xe-17/ios-xe-17-12-x-eol.html
 
   - releaseCycle: "17.11"
     releaseDate: 2023-03-28
-    eol: 2024-05-14
     eoas: 2024-05-14
+    eol: 2024-05-14
     link: https://www.cisco.com/c/en/us/products/collateral/ios-nx-os-software/ios-xe-17/ios-xe-17-11-x-eol.html
 
   - releaseCycle: "17.10"
     releaseDate: 2022-11-30
-    eol: 2024-01-03
     eoas: 2024-01-03
+    eol: 2024-01-03
     link: https://www.cisco.com/c/en/us/products/collateral/ios-nx-os-software/ios-xe-17/ios-xe-17-10-x-eol.html
 
   - releaseCycle: "17.9"
-    releaseDate: 2022-07-29
-    eol: 2026-09-30
-    eoas: 2025-03-30
     lts: true
+    releaseDate: 2022-07-29
+    eoas: 2025-03-30
+    eol: 2026-09-30
     link: https://www.cisco.com/c/en/us/products/collateral/ios-nx-os-software/ios-xe-17/ios-xe-17-9-x-eol.html
 
   - releaseCycle: "17.8"
     releaseDate: 2022-04-11
-    eol: 2023-05-30
     eoas: 2023-05-30
+    eol: 2023-05-30
     link: https://www.cisco.com/c/en/us/products/collateral/ios-nx-os-software/ios-xe-17/ios-xe-17-8-x-eol.html
 
   - releaseCycle: "17.7"
     releaseDate: 2021-11-30
-    eol: 2023-01-30
     eoas: 2023-01-30
+    eol: 2023-01-30
     link: https://www.cisco.com/c/en/us/products/collateral/ios-nx-os-software/ios-xe-17/ios-xe-17-7-x-eol.html
 
   - releaseCycle: "17.6"
-    releaseDate: 2021-07-30
-    eol: 2024-09-30
-    eoas: 2024-03-31
     lts: true
+    releaseDate: 2021-07-30
+    eoas: 2024-03-31
+    eol: 2024-09-30
     link: https://www.cisco.com/c/en/us/products/collateral/ios-nx-os-software/ios-xe-17/ios-xe-17-6-x-eol.html
 
   - releaseCycle: "17.5"
     releaseDate: 2021-03-31
-    eol: 2022-05-30
     eoas: 2022-05-30
+    eol: 2022-05-30
     link: https://www.cisco.com/c/en/us/products/collateral/ios-nx-os-software/ios-xe-17/ios-xe-17-5-x-eol.html
 
   - releaseCycle: "17.4"
     releaseDate: 2020-11-30
-    eoas: 2022-01-28
     eol: 2022-01-28
+    eoas: 2022-01-28
     link: https://www.cisco.com/c/en/us/products/collateral/ios-nx-os-software/ios-xe-17/eos-eol-notice-c51-2442351.html
 
   - releaseCycle: "17.3"
-    releaseDate: 2020-07-31
-    eol: 2023-09-30
-    eoas: 2023-03-31
     lts: true
+    releaseDate: 2020-07-31
+    eoas: 2023-03-31
+    eol: 2023-09-30
     link: https://www.cisco.com/c/en/us/products/collateral/ios-nx-os-software/ios-xe-17/ios-xe-17-3-x-eol.html
 
   - releaseCycle: "17.2"
     releaseDate: 2020-03-30
-    eol: 2021-07-15
     eoas: 2021-07-15
+    eol: 2021-07-15
     link: https://www.cisco.com/c/en/us/products/collateral/ios-nx-os-software/ios-xe-17/eos-eol-notice-c51-744388.html
 
   - releaseCycle: "17.1"
     releaseDate: 2019-11-21
-    eol: 2020-12-30
     eoas: 2020-12-30
+    eol: 2020-12-30
     link: https://www.cisco.com/c/en/us/products/collateral/switches/catalyst-9200-series-switches/eos-eol-notice-c51-743638.html
 
   - releaseCycle: "16.12"
-    releaseDate: 2019-07-31
-    eol: 2022-08-18
-    eoas: 2022-02-17
     lts: true
+    releaseDate: 2019-07-31
+    eoas: 2022-02-17
+    eol: 2022-08-18
     link: https://www.cisco.com/c/en/us/products/collateral/ios-nx-os-software/ios-xe-16/eos-eol-notice-c51-744154.html
 
 ---
@@ -137,7 +137,8 @@ releases:
 > Cisco IOS XE is a network operating system that is based on the Linux kernel.
 > It is used on a variety of Cisco products, including routers, switches, and wireless controllers.
 
-Releases are time-based, each with a fixed release date. The schedule specifies 3 minor releases per year at 4 month intervals.
+Releases are time-based, each with a fixed release date.
+The schedule specifies 3 minor releases per year at 4 month intervals.
 Every subsequent first and second release (e.g. 17.1, 17.2, 17.4, 17.5...) receive standard support.
 Every subsequent third release (e.g. 17.3, 17.6...) receive extended support.
 

--- a/products/cisco-ios-xe.md
+++ b/products/cisco-ios-xe.md
@@ -1,5 +1,6 @@
 ---
 title: Cisco IOS XE
+addedAt: 2025-10-26
 category: os
 tags: cisco
 iconSlug: cisco

--- a/products/cisco-ios-xe.md
+++ b/products/cisco-ios-xe.md
@@ -6,8 +6,8 @@ tags: cisco
 iconSlug: cisco
 permalink: /cisco-ios-xe
 releasePolicyLink: https://www.cisco.com/c/en/us/products/collateral/ios-nx-os-software/ios-xe-16/bulletin-c25-2378701.html
-eolColumn: Last Date of Support
-eoasColumn: End of Vulnerability/Security Support
+eolColumn: End of Vulnerability/Security Support
+eoasColumn: End of SW Maintenance Releases Date
 latestColumn: false
 
 releases:
@@ -26,14 +26,14 @@ releases:
 
   - releaseCycle: "17.16"
     releaseDate: 2024-12-11
-    eol: 2028-06-30
+    eol: 2026-01-13
     eoas: 2026-01-13
     link: https://www.cisco.com/c/en/us/products/collateral/ios-nx-os-software/ios-xe-17/ios-xe-17-16-x-eol.html
 
   - releaseCycle: "17.15"
     releaseDate: 2024-08-09
-    eol: 2029-03-30
-    eoas: 2028-09-30
+    eol: 2028-09-30
+    eoas: 2027-03-30
     lts: true
     link: https://www.cisco.com/c/en/us/products/collateral/ios-nx-os-software/ios-xe-17/ios-xe-17-15-x-eol.html
 
@@ -45,90 +45,90 @@ releases:
 
   - releaseCycle: "17.13"
     releaseDate: 2023-11-30
-    eol: 2027-07-31
+    eol: 2024-12-31
     eoas: 2024-12-31
     link: https://www.cisco.com/c/en/us/products/collateral/ios-nx-os-software/ios-xe-17/ios-xe-17-13-x-eol.html
 
   - releaseCycle: "17.12"
     releaseDate: 2023-07-28
-    eol: 2029-03-31
-    eoas: 2027-09-30
+    eol: 2027-09-30
+    eoas: 2026-03-30
     lts: true
     link: https://www.cisco.com/c/en/us/products/collateral/ios-nx-os-software/ios-xe-17/ios-xe-17-12-x-eol.html
 
   - releaseCycle: "17.11"
     releaseDate: 2023-03-28
-    eol: 2026-11-30
+    eol: 2024-05-14
     eoas: 2024-05-14
     link: https://www.cisco.com/c/en/us/products/collateral/ios-nx-os-software/ios-xe-17/ios-xe-17-11-x-eol.html
 
   - releaseCycle: "17.10"
     releaseDate: 2022-11-30
-    eol: 2026-07-31
+    eol: 2024-01-03
     eoas: 2024-01-03
     link: https://www.cisco.com/c/en/us/products/collateral/ios-nx-os-software/ios-xe-17/ios-xe-17-10-x-eol.html
 
   - releaseCycle: "17.9"
     releaseDate: 2022-07-29
-    eol: 2027-03-31
-    eoas: 2026-09-30
+    eol: 2026-09-30
+    eoas: 2025-03-30
     lts: true
     link: https://www.cisco.com/c/en/us/products/collateral/ios-nx-os-software/ios-xe-17/ios-xe-17-9-x-eol.html
 
   - releaseCycle: "17.8"
     releaseDate: 2022-04-11
-    eol: 2027-11-30
+    eol: 2023-05-30
     eoas: 2023-05-30
     link: https://www.cisco.com/c/en/us/products/collateral/ios-nx-os-software/ios-xe-17/ios-xe-17-8-x-eol.html
 
   - releaseCycle: "17.7"
     releaseDate: 2021-11-30
-    eol: 2027-07-31
+    eol: 2023-01-30
     eoas: 2023-01-30
     link: https://www.cisco.com/c/en/us/products/collateral/ios-nx-os-software/ios-xe-17/ios-xe-17-7-x-eol.html
 
   - releaseCycle: "17.6"
     releaseDate: 2021-07-30
-    eol: 2026-03-31
-    eoas: 2024-09-30
+    eol: 2024-09-30
+    eoas: 2024-03-31
     lts: true
     link: https://www.cisco.com/c/en/us/products/collateral/ios-nx-os-software/ios-xe-17/ios-xe-17-6-x-eol.html
 
   - releaseCycle: "17.5"
     releaseDate: 2021-03-31
-    eol: 2026-11-30
+    eol: 2022-05-30
     eoas: 2022-05-30
     link: https://www.cisco.com/c/en/us/products/collateral/ios-nx-os-software/ios-xe-17/ios-xe-17-5-x-eol.html
 
   - releaseCycle: "17.4"
     releaseDate: 2020-11-30
     eoas: 2022-01-28
-    eol: 2026-07-31
+    eol: 2022-01-28
     link: https://www.cisco.com/c/en/us/products/collateral/ios-nx-os-software/ios-xe-17/eos-eol-notice-c51-2442351.html
 
   - releaseCycle: "17.3"
     releaseDate: 2020-07-31
-    eol: 2027-03-31
-    eoas: 2023-09-30
+    eol: 2023-09-30
+    eoas: 2023-03-31
     lts: true
     link: https://www.cisco.com/c/en/us/products/collateral/ios-nx-os-software/ios-xe-17/ios-xe-17-3-x-eol.html
 
   - releaseCycle: "17.2"
     releaseDate: 2020-03-30
-    eol: 2026-01-31
+    eol: 2021-07-15
     eoas: 2021-07-15
     link: https://www.cisco.com/c/en/us/products/collateral/ios-nx-os-software/ios-xe-17/eos-eol-notice-c51-744388.html
 
   - releaseCycle: "17.1"
     releaseDate: 2019-11-21
-    eol: 2025-06-30
-    eoas: 2021-03-31
-    link: https://www.cisco.com/c/en/us/support/ios-nx-os-software/ios-xe-amsterdam-17-1-1/model.html
+    eol: 2020-12-30
+    eoas: 2020-12-30
+    link: https://www.cisco.com/c/en/us/products/collateral/switches/catalyst-9200-series-switches/eos-eol-notice-c51-743638.html
 
   - releaseCycle: "16.12"
     releaseDate: 2019-07-31
-    eol: 2026-02-28
-    eoas: 2022-08-18
+    eol: 2022-08-18
+    eoas: 2022-02-17
     lts: true
     changeLogReference: https://www.cisco.com/c/en/us/products/collateral/ios-nx-os-software/ios-xe-16/eos-eol-notice-c51-744154.html
 

--- a/products/cisco-ios-xe.md
+++ b/products/cisco-ios-xe.md
@@ -6,10 +6,16 @@ tags: cisco
 iconSlug: cisco
 permalink: /cisco-ios-xe
 releasePolicyLink: https://www.cisco.com/c/en/us/products/collateral/ios-nx-os-software/ios-xe-16/bulletin-c25-2378701.html
-eolColumn: End of Vulnerability/Security Support
-eoasColumn: End of SW Maintenance Releases Date
+eoasColumn: Maintenance Support
+eolColumn: Security Support
 latestColumn: false
 
+# For non-LTS:
+# - eoas(x) = releaseDate(x) (FCS) + 3 months (EoL announcement) + 3 months (EoS) + 6 months = releaseDate(x) + 12 months
+# - eol(x) = eoas(x) = releaseDate(x) + 12 months
+# For LTS:
+# - eoas(x) = releaseDate(x) (FCS) + 12 months (EoL announcement) + 6 months (EoS) + 12 months = releaseDate(x) + 30 months
+# - eol(x) = releaseDate(x) + 12 months (EoL announcement) + 6 months (EoS) + 30 months = releaseDate(x) + 48 months
 releases:
   - releaseCycle: "17.18"
     lts: true
@@ -138,9 +144,11 @@ releases:
 > It is used on a variety of Cisco products, including routers, switches, and wireless controllers.
 
 Releases are time-based, each with a fixed release date.
-The schedule specifies 3 minor releases per year at 4 month intervals.
-Every subsequent first and second release (e.g. 17.1, 17.2, 17.4, 17.5...) receive standard support.
-Every subsequent third release (e.g. 17.3, 17.6...) receive extended support.
+The schedule specifies 3 minor releases per year at 4-month intervals.
 
-Standard-Support means, that the release has a sustaining support lifetime of 12 months from First Customer Shipment (FCS) with scheduled rebuilds.
-Extended-Support means, that the release has a sustaining support lifetime of 48 months from First Customer Shipment (FCS) with scheduled rebuilds.
+Every subsequent first and second release (e.g. 17.1, 17.2, 17.4, 17.5...) receive standard support.
+With standard support, releases are supported 12 months with critical bug fixes and security updates.
+
+Every subsequent third release (e.g. 17.3, 17.6...) receive extended support.
+With extended support, releases are supported 30 months with critical bug fixes and security updates,
+followed by an additional 18 months of security updates only.

--- a/products/cisco-ios-xe.md
+++ b/products/cisco-ios-xe.md
@@ -9,7 +9,6 @@ releasePolicyLink: https://www.cisco.com/c/en/us/products/collateral/ios-nx-os-s
 eolColumn: Last Date of Support
 eoasColumn: End of Vulnerability/Security Support
 latestColumn: false
-releaseLabel: "__RELEASE_CYCLE__"
 
 releases:
   - releaseCycle: "17.18"

--- a/products/cisco-ios-xe.md
+++ b/products/cisco-ios-xe.md
@@ -119,6 +119,12 @@ releases:
     eoas: 2021-03-31
     link: https://www.cisco.com/c/en/us/support/ios-nx-os-software/ios-xe-amsterdam-17-1-1/model.html
 
+  - releaseCycle: "16.12"
+    releaseDate: 2019-07-31
+    eol: 2026-02-28
+    eoas: 2022-08-18
+    changeLogReference: https://www.cisco.com/c/en/us/products/collateral/ios-nx-os-software/ios-xe-16/eos-eol-notice-c51-744154.html
+
 ---
 
 > Cisco IOS XE is a network operating system that is based on the Linux kernel.

--- a/products/cisco-ios-xe.md
+++ b/products/cisco-ios-xe.md
@@ -31,9 +31,9 @@ releases:
 
   - releaseCycle: "17.15"
     releaseDate: 2024-08-09
-    eol: false
-    eoas: false
-    link: https://www.cisco.com/c/en/us/support/ios-nx-os-software/ios-xe-17-15-1/model.html
+    eol: 2029-03-30
+    eoas: 2028-09-30
+    link: https://www.cisco.com/c/en/us/products/collateral/ios-nx-os-software/ios-xe-17/ios-xe-17-15-x-eol.html
 
   - releaseCycle: "17.14"
     releaseDate: 2024-04-13

--- a/products/cisco-ios-xe.md
+++ b/products/cisco-ios-xe.md
@@ -15,6 +15,7 @@ releases:
     releaseDate: 2025-08-08
     eol: false
     eoas: false
+    lts: true
     link: https://www.cisco.com/c/en/us/support/ios-nx-os-software/ios-xe-17-18-1/model.html
 
   - releaseCycle: "17.17"
@@ -33,6 +34,7 @@ releases:
     releaseDate: 2024-08-09
     eol: 2029-03-30
     eoas: 2028-09-30
+    lts: true
     link: https://www.cisco.com/c/en/us/products/collateral/ios-nx-os-software/ios-xe-17/ios-xe-17-15-x-eol.html
 
   - releaseCycle: "17.14"
@@ -51,6 +53,7 @@ releases:
     releaseDate: 2023-07-28
     eol: 2029-03-31
     eoas: 2027-09-30
+    lts: true
     link: https://www.cisco.com/c/en/us/products/collateral/ios-nx-os-software/ios-xe-17/ios-xe-17-12-x-eol.html
 
   - releaseCycle: "17.11"
@@ -69,6 +72,7 @@ releases:
     releaseDate: 2022-07-29
     eol: 2027-03-31
     eoas: 2026-09-30
+    lts: true
     link: https://www.cisco.com/c/en/us/products/collateral/ios-nx-os-software/ios-xe-17/ios-xe-17-9-x-eol.html
 
   - releaseCycle: "17.8"
@@ -87,6 +91,7 @@ releases:
     releaseDate: 2021-07-30
     eol: 2026-03-31
     eoas: 2024-09-30
+    lts: true
     link: https://www.cisco.com/c/en/us/products/collateral/ios-nx-os-software/ios-xe-17/ios-xe-17-6-x-eol.html
 
   - releaseCycle: "17.5"
@@ -105,6 +110,7 @@ releases:
     releaseDate: 2020-07-31
     eol: 2027-03-31
     eoas: 2023-09-30
+    lts: true
     link: https://www.cisco.com/c/en/us/products/collateral/ios-nx-os-software/ios-xe-17/ios-xe-17-3-x-eol.html
 
   - releaseCycle: "17.2"
@@ -123,12 +129,15 @@ releases:
     releaseDate: 2019-07-31
     eol: 2026-02-28
     eoas: 2022-08-18
+    lts: true
     changeLogReference: https://www.cisco.com/c/en/us/products/collateral/ios-nx-os-software/ios-xe-16/eos-eol-notice-c51-744154.html
 
 ---
 
 > Cisco IOS XE is a network operating system that is based on the Linux kernel.
 > It is used on a variety of Cisco products, including routers, switches, and wireless controllers.
+
+Releases are time-based, each with a fixed release date. The schedule specifies 3 individual software releases per year at 4 month intervals.
 
 Cisco has various dates which mark different phases of the EOL cycle. The dates are as follows:
 

--- a/products/cisco-ios-xe.md
+++ b/products/cisco-ios-xe.md
@@ -1,0 +1,139 @@
+---
+title: Cisco IOS XE
+category: os
+tags: cisco
+permalink: /cisco-ios-xe
+releasePolicyLink: https://www.cisco.com/c/en/us/products/collateral/ios-nx-os-software/ios-xe-16/bulletin-c25-2378701.html
+eolColumn: Last Date of Support
+eoasColumn: End of Vulnerability/Security Support
+latestColumn: false
+iconSlug: cisco
+releaseLabel: "__RELEASE_CYCLE__"
+
+releases:
+  - releaseCycle: "17.18"
+    releaseDate: 2025-08-08
+    eol: false
+    eoas: false
+    link: https://www.cisco.com/c/en/us/support/ios-nx-os-software/ios-xe-17-18-1/model.html
+
+  - releaseCycle: "17.17"
+    releaseDate: 2025-03-31
+    eol: false
+    eoas: false
+    link: https://www.cisco.com/c/en/us/support/ios-nx-os-software/ios-xe-17-17-1/model.html
+
+  - releaseCycle: "17.16"
+    releaseDate: 2024-12-11
+    eol: 2028-06-30
+    eoas: 2026-01-13
+    link: https://www.cisco.com/c/en/us/products/collateral/ios-nx-os-software/ios-xe-17/ios-xe-17-16-x-eol.html
+
+  - releaseCycle: "17.15"
+    releaseDate: 2024-08-09
+    eol: false
+    eoas: false
+    link: https://www.cisco.com/c/en/us/support/ios-nx-os-software/ios-xe-17-15-1/model.html
+
+  - releaseCycle: "17.14"
+    releaseDate: 2024-04-13
+    eol: 2025-05-31
+    eoas: 2025-05-31
+    link: https://www.cisco.com/c/en/us/products/collateral/ios-nx-os-software/ios-xe-17/ios-xe-17-14-x-eol.html
+
+  - releaseCycle: "17.13"
+    releaseDate: 2023-11-30
+    eol: 2027-07-31
+    eoas: 2024-12-31
+    link: https://www.cisco.com/c/en/us/products/collateral/ios-nx-os-software/ios-xe-17/ios-xe-17-13-x-eol.html
+
+  - releaseCycle: "17.12"
+    releaseDate: 2023-07-28
+    eol: 2029-03-31
+    eoas: 2027-09-30
+    link: https://www.cisco.com/c/en/us/products/collateral/ios-nx-os-software/ios-xe-17/ios-xe-17-12-x-eol.html
+
+  - releaseCycle: "17.11"
+    releaseDate: 2023-03-28
+    eol: 2026-11-30
+    eoas: 2024-05-14
+    link: https://www.cisco.com/c/en/us/products/collateral/ios-nx-os-software/ios-xe-17/ios-xe-17-11-x-eol.html
+
+  - releaseCycle: "17.10"
+    releaseDate: 2022-11-30
+    eol: 2026-07-31
+    eoas: 2024-01-03
+    link: https://www.cisco.com/c/en/us/products/collateral/ios-nx-os-software/ios-xe-17/ios-xe-17-10-x-eol.html
+
+  - releaseCycle: "17.9"
+    releaseDate: 2022-07-29
+    eol: 2027-03-31
+    eoas: 2026-09-30
+    link: https://www.cisco.com/c/en/us/products/collateral/ios-nx-os-software/ios-xe-17/ios-xe-17-9-x-eol.html
+
+  - releaseCycle: "17.8"
+    releaseDate: 2022-04-11
+    eol: 2027-11-30
+    eoas: 2023-05-30
+    link: https://www.cisco.com/c/en/us/products/collateral/ios-nx-os-software/ios-xe-17/ios-xe-17-8-x-eol.html
+
+  - releaseCycle: "17.7"
+    releaseDate: 2021-11-30
+    eol: 2027-07-31
+    eoas: 2023-01-30
+    link: https://www.cisco.com/c/en/us/products/collateral/ios-nx-os-software/ios-xe-17/ios-xe-17-7-x-eol.html
+
+  - releaseCycle: "17.6"
+    releaseDate: 2021-07-30
+    eol: 2026-03-31
+    eoas: 2024-09-30
+    link: https://www.cisco.com/c/en/us/products/collateral/ios-nx-os-software/ios-xe-17/ios-xe-17-6-x-eol.html
+
+  - releaseCycle: "17.5"
+    releaseDate: 2021-03-31
+    eol: 2026-11-30
+    eoas: 2022-05-30
+    link: https://www.cisco.com/c/en/us/products/collateral/ios-nx-os-software/ios-xe-17/ios-xe-17-5-x-eol.html
+
+  - releaseCycle: "17.4"
+    releaseDate: 2020-11-30
+    eoas: 2022-01-28
+    eol: 2026-07-31
+    link: https://www.cisco.com/c/en/us/products/collateral/ios-nx-os-software/ios-xe-17/eos-eol-notice-c51-2442351.html
+
+  - releaseCycle: "17.3"
+    releaseDate: 2020-07-31
+    eol: 2027-03-31
+    eoas: 2023-09-30
+    link: https://www.cisco.com/c/en/us/products/collateral/ios-nx-os-software/ios-xe-17/ios-xe-17-3-x-eol.html
+
+  - releaseCycle: "17.2"
+    releaseDate: 2020-03-30
+    eol: 2026-01-31
+    eoas: 2021-07-15
+    link: https://www.cisco.com/c/en/us/products/collateral/ios-nx-os-software/ios-xe-17/eos-eol-notice-c51-744388.html
+
+  - releaseCycle: "17.1"
+    releaseDate: 2019-11-21
+    eol: 2025-06-30
+    eoas: 2021-03-31
+    link: https://www.cisco.com/c/en/us/support/ios-nx-os-software/ios-xe-amsterdam-17-1-1/model.html
+
+---
+
+> Cisco IOS XE is a network operating system that is based on the Linux kernel. It is used on a variety of Cisco products, including routers, switches, and wireless controllers.
+
+Cisco has various dates which mark different phases of the EOL cycle. The dates are as follows:
+
+* Last Date of Support: This is also referenced as EOL. The last date to receive applicable service and support for the product as entitled by active service contracts or by warranty terms and conditions.
+* End of SW Maintenance Releases Date: The last date that Cisco Engineering may release any final software maintenance releases or bug fixes for. After this date, Cisco Engineering will no longer develop, repair, maintain, or test the product software. The only exception is Vulnerability/Security issues that will be addressed as shown in the End of Vulnerability/Security Support milestone below.
+* End of Vulnerability/Security Support: The last date that Cisco Engineering may release bug fixes for Vulnerability or Security issues for. After this date, bug fixes for Vulnerability or Security issues identified in may be provided through later supported software releases.
+
+Cisco has two support types:
+
+* Standard-Support Release Details: A sustaining support lifetime of 12 months from First Customer Shipment (FCS) with scheduled rebuilds.
+* Extended-Support release Details: A sustaining support lifetime of 48 months from First Customer Shipment (FCS) with scheduled rebuilds.
+
+Standard Support release versions: 17.1, 17.2, 17.4, 17.5, 17.7, 17.8, 17.10, 17.11 etc.
+
+Extended Support release versions: 17.3, 17.6, 17.9, 17.12, 17.13, 17.14, 17.15, etc.

--- a/products/cisco-ios-xe.md
+++ b/products/cisco-ios-xe.md
@@ -137,22 +137,9 @@ releases:
 > Cisco IOS XE is a network operating system that is based on the Linux kernel.
 > It is used on a variety of Cisco products, including routers, switches, and wireless controllers.
 
-Releases are time-based, each with a fixed release date. The schedule specifies 3 individual software releases per year at 4 month intervals.
+Releases are time-based, each with a fixed release date. The schedule specifies 3 minor releases per year at 4 month intervals.
+Every subsequent first and second release (e.g. 17.1, 17.2, 17.4, 17.5...) receive standard support.
+Every subsequent third release (e.g. 17.3, 17.6...) receive extended support.
 
-Cisco has various dates which mark different phases of the EOL cycle. The dates are as follows:
-
-* Last Date of Support: This is also referenced as EOL.
-  The last date to receive applicable service and support for the product as entitled by active service contracts or by warranty terms and conditions.
-* End of SW Maintenance Releases Date: The last date that Cisco Engineering may release any final software maintenance releases or bug fixes for.
-  After this date, Cisco Engineering will no longer develop, repair, maintain, or test the product software. The only exception is Vulnerability/Security issues that will be addressed as shown in the End of Vulnerability/Security Support milestone below.
-* End of Vulnerability/Security Support: The last date that Cisco Engineering may release bug fixes for Vulnerability or Security issues for.
-  After this date, bug fixes for Vulnerability or Security issues identified in may be provided through later supported software releases.
-
-Cisco has two support types:
-
-* Standard-Support Release Details: A sustaining support lifetime of 12 months from First Customer Shipment (FCS) with scheduled rebuilds.
-* Extended-Support release Details: A sustaining support lifetime of 48 months from First Customer Shipment (FCS) with scheduled rebuilds.
-
-Standard Support release versions: 17.1, 17.2, 17.4, 17.5, 17.7, 17.8, 17.10, 17.11 etc.
-
-Extended Support release versions: 17.3, 17.6, 17.9, 17.12, 17.13, 17.14, 17.15, etc.
+Standard-Support means, that the release has a sustaining support lifetime of 12 months from First Customer Shipment (FCS) with scheduled rebuilds.
+Extended-Support means, that the release has a sustaining support lifetime of 48 months from First Customer Shipment (FCS) with scheduled rebuilds.

--- a/products/cisco-ios-xe.md
+++ b/products/cisco-ios-xe.md
@@ -2,12 +2,12 @@
 title: Cisco IOS XE
 category: os
 tags: cisco
+iconSlug: cisco
 permalink: /cisco-ios-xe
 releasePolicyLink: https://www.cisco.com/c/en/us/products/collateral/ios-nx-os-software/ios-xe-16/bulletin-c25-2378701.html
 eolColumn: Last Date of Support
 eoasColumn: End of Vulnerability/Security Support
 latestColumn: false
-iconSlug: cisco
 releaseLabel: "__RELEASE_CYCLE__"
 
 releases:
@@ -121,13 +121,17 @@ releases:
 
 ---
 
-> Cisco IOS XE is a network operating system that is based on the Linux kernel. It is used on a variety of Cisco products, including routers, switches, and wireless controllers.
+> Cisco IOS XE is a network operating system that is based on the Linux kernel.
+> It is used on a variety of Cisco products, including routers, switches, and wireless controllers.
 
 Cisco has various dates which mark different phases of the EOL cycle. The dates are as follows:
 
-* Last Date of Support: This is also referenced as EOL. The last date to receive applicable service and support for the product as entitled by active service contracts or by warranty terms and conditions.
-* End of SW Maintenance Releases Date: The last date that Cisco Engineering may release any final software maintenance releases or bug fixes for. After this date, Cisco Engineering will no longer develop, repair, maintain, or test the product software. The only exception is Vulnerability/Security issues that will be addressed as shown in the End of Vulnerability/Security Support milestone below.
-* End of Vulnerability/Security Support: The last date that Cisco Engineering may release bug fixes for Vulnerability or Security issues for. After this date, bug fixes for Vulnerability or Security issues identified in may be provided through later supported software releases.
+* Last Date of Support: This is also referenced as EOL.
+  The last date to receive applicable service and support for the product as entitled by active service contracts or by warranty terms and conditions.
+* End of SW Maintenance Releases Date: The last date that Cisco Engineering may release any final software maintenance releases or bug fixes for.
+  After this date, Cisco Engineering will no longer develop, repair, maintain, or test the product software. The only exception is Vulnerability/Security issues that will be addressed as shown in the End of Vulnerability/Security Support milestone below.
+* End of Vulnerability/Security Support: The last date that Cisco Engineering may release bug fixes for Vulnerability or Security issues for.
+  After this date, bug fixes for Vulnerability or Security issues identified in may be provided through later supported software releases.
 
 Cisco has two support types:
 


### PR DESCRIPTION
Adds EOL data for Cisco IOS XE 17 releases.

The data is gathered from these Cisco sites:

https://www.cisco.com/c/en/us/support/ios-nx-os-software/ios-xe-17/series.html

https://www.cisco.com/c/en/us/products/ios-nx-os-software/ios-xe-17/eos-eol-notice-listing.html