### PR TITLE
[quarkus-framework] Add 3.28 and 3.27 LTS

### DIFF
--- a/products/quarkus-framework.md
+++ b/products/quarkus-framework.md
@@ -33,9 +33,22 @@ auto:
 # - eol(x) = releaseDate(x)+1y for LTS
 # - For EOES see https://access.redhat.com/support/policy/updates/red_hat_build_of_quarkus_notes
 releases:
+  - releaseCycle: "3.28"
+    releaseDate: 2025-09-24
+    eol: false
+    latest: "3.28.1"
+    latestReleaseDate: 2025-09-24
+
+  - releaseCycle: "3.27"
+    releaseDate: 2025-09-24
+    eol: false
+    lts: true
+    latest: "3.27.0"
+    latestReleaseDate: 2025-09-24
+
   - releaseCycle: "3.26"
     releaseDate: 2025-08-28
-    eol: false
+    eol: 2025-09-24
     latest: "3.26.4"
     latestReleaseDate: 2025-09-17
 

--- a/products/quarkus-framework.md
+++ b/products/quarkus-framework.md
@@ -40,9 +40,9 @@ releases:
     latestReleaseDate: 2025-09-24
 
   - releaseCycle: "3.27"
-    releaseDate: 2025-09-24
-    eol: false
     lts: true
+    releaseDate: 2025-09-24
+    eol: 2026-09-24
     latest: "3.27.0"
     latestReleaseDate: 2025-09-24
 


### PR DESCRIPTION
According to [announce today](https://quarkus.io/blog/quarkus-3-28-released/) and [Tweet](https://x.com/QuarkusIO/status/1971275007943733649) : 

> Together with our new LTS stream, we released a new feature release, Quarkus 3.28. It comes with some additional features and improvements to the build performances.


<img width="603" height="669" alt="image" src="https://github.com/user-attachments/assets/3962b083-fa1d-464f-b462-d8bbd573da42" />
