### PR TITLE
[pan-os]Update PAN-OS version(s)

### DIFF
--- a/products/pan-os.md
+++ b/products/pan-os.md
@@ -32,9 +32,9 @@ releases:
   - releaseCycle: "12.1"
     releaseDate: 2025-08-28
     eol: 2028-08-28
-    latest: "12.1.2"
-    latestReleaseDate: 2025-08-28
-    link: https://docs.paloaltonetworks.com/ngfw/release-notes/12-1/pan-os-12-1-2-known-and-addressed-issues/pan-os-12-1-2-addressed-issues
+    latest: "12.1.3"
+    latestReleaseDate: 2025-09-25
+    link: https://docs.paloaltonetworks.com/pan-os/12-1/pan-os-release-notes/pan-os-12-1-3-known-and-addressed-issues/pan-os-12-1-3-addressed-issues
 
   - releaseCycle: "11.2"
     releaseDate: 2024-05-02
@@ -60,9 +60,9 @@ releases:
   - releaseCycle: "10.2"
     releaseDate: 2022-02-27
     eol: 2025-08-27
-    latest: "10.2.16-h1"
-    latestReleaseDate: 2025-07-02
-    link: https://docs.paloaltonetworks.com/pan-os/10-2/pan-os-release-notes/pan-os-10-2-16-known-and-addressed-issues/pan-os-10-2-16-h1-addressed-issues
+    latest: "10.2.16-h4"
+    latestReleaseDate: 2025-09-25
+    link: https://docs.paloaltonetworks.com/pan-os/10-2/pan-os-release-notes/pan-os-10-2-16-known-and-addressed-issues/pan-os-10-2-16-h4-addressed-issues
 
   - releaseCycle: "10.1"
     releaseDate: 2021-05-31


### PR DESCRIPTION
[panos] This PR updates the PAN-OS versions, Release dates and the Release Notes url.

Updated Pan-OS Version:  12.1.3 

Released:                2025-09-25 

Release Notes:           https://docs.paloaltonetworks.com/ngfw/release-notes/12-1/pan-os-12-1-3-known-and-addressed-issues/pan-os-12-1-3-addressed-issues 

Updated Pan-OS Version:  10.2.16-h4 

Released:                2025-09-25 

Release Notes:           https://docs.paloaltonetworks.com/pan-os/10-2/pan-os-release-notes/pan-os-10-2-16-known-and-addressed-issues/pan-os-10-2-16-h4-addressed-issues 
