### PR TITLE
[centreon] Update product

### DIFF
--- a/products/centreon.md
+++ b/products/centreon.md
@@ -7,13 +7,13 @@ permalink: /centreon
 releasePolicyLink: https://docs.centreon.com/docs/releases/lifecycle/
 releaseImage: https://docs.centreon.com/assets/images/lifecycle-from-24.10-de6e3693d62648fbe4760ab65fa21015.png
 changelogTemplate: "https://docs.centreon.com/docs/__RELEASE_CYCLE__/releases/centreon-os/#{{'__LATEST__'|replace:'.',''}}"
-eoasColumn: Phase 1 support
-eolColumn: Phase 2 support
+eolColumn: OSS Support
+eoesColumn: Commercial Support
 
 auto:
   methods:
     - git: https://github.com/centreon/centreon.git
-      regex: '^centreon-web-(?P<major>[0-9]+)\.(?P<minor>[0-9]+)\.(?P<patch>[0-9]+)$'
+      regex: '^centreon-web-(?P<major>[0-9]+)\.(?P<minor>04|10)\.(?P<patch>[0-9]+)$'
     - git: https://github.com/centreon/centreon-archived.git
     - release_table: https://docs.centreon.com/docs/releases/lifecycle/
       fields:
@@ -22,109 +22,107 @@ auto:
           regex: '^Centreon\s+(?P<value>\d+\.\d+).*$'
         eol: "End of support"
 
-# eoas(x) = releaseDate(x) + 1 year (rounded to the end of the month).
-# eol(x) = releaseDate(x) + 2 years (rounded to the end of the month).
+# eol(x) = releaseDate(x) + 18 months (rounded to the end of the month).
+# eoes(x) = releaseDate(x) + 18 months if x is odd, else + 36 months (rounded to the end of the month).
 # See also https://docs.centreon.com/docs/releases/lifecycle/
-# note: 24.10 will be an LTS release and should be treated differently
 releases:
   - releaseCycle: "24.10"
     releaseDate: 2024-10-31
-    lts: 2027-10-31
-    eoas: 2025-10-31
-    eol: 2027-10-31
+    eol: 2026-04-30
+    eoes: 2027-10-31
     latest: "24.10.12"
     latestReleaseDate: 2025-08-28
     link: https://docs.centreon.com/docs/releases/centreon-os/
 
   - releaseCycle: "24.04"
     releaseDate: 2024-04-22
-    eoas: 2025-04-30
     eol: 2026-04-30
+    eoes: 2026-04-30
     latest: "24.04.18"
     latestReleaseDate: 2025-09-24
 
   - releaseCycle: "23.10"
     releaseDate: 2023-10-30
-    eoas: 2024-10-31
     eol: 2025-10-31
+    eoes: 2025-10-31
     latest: "23.10.28"
     latestReleaseDate: 2025-09-24
 
   - releaseCycle: "23.04"
     releaseDate: 2023-04-26
-    eoas: 2024-04-30
     eol: 2025-04-30
+    eoes: 2025-04-30
     latest: "23.04.30"
     latestReleaseDate: 2025-06-16
 
   - releaseCycle: "22.10"
     releaseDate: 2022-10-26
-    eoas: 2023-10-31
     eol: 2024-10-31
+    eoes: 2024-10-31
     latest: "22.10.31"
     latestReleaseDate: 2025-07-24
 
   - releaseCycle: "22.04"
     releaseDate: 2022-05-18
-    eoas: 2023-05-31
     eol: 2024-05-31
+    eoes: 2024-05-31
     latest: "22.04.22"
     latestReleaseDate: 2024-03-14
     link: "https://docs.centreon.com/docs/__RELEASE_CYCLE__/releases/centreon-core/#{{'__LATEST__'|replace:'.',''}}"
 
   - releaseCycle: "21.10"
     releaseDate: 2021-11-02
-    eoas: 2022-11-30
     eol: 2023-11-30
+    eoes: 2023-11-30
     latest: "21.10.17"
     latestReleaseDate: 2023-11-17
     link: https://archives-docs.centreon.com/21.10/docs/releases/centreon-core/#211017
 
-  # 21.04 and older were supported for 18 months (eoas(x) = eol(x) - 1 year).
+  # 21.04 and older were supported for 18 months
   - releaseCycle: "21.04"
     releaseDate: 2021-04-21
-    eoas: 2021-10-31
     eol: 2022-10-31
+    eoes: 2022-10-31
     latest: "21.04.20"
     latestReleaseDate: 2022-10-12
     link: https://archives-docs.centreon.com/21.04/docs/releases/centreon-core/#210420
 
   - releaseCycle: "20.10"
     releaseDate: 2020-10-19
-    eoas: 2021-05-31
     eol: 2022-05-31
+    eoes: 2022-05-31
     latest: "20.10.18"
     latestReleaseDate: 2022-06-09
     link: https://archives-docs.centreon.com/20.10/docs/releases/centreon-core/#201018
 
   - releaseCycle: "20.04"
     releaseDate: 2020-04-20
-    eoas: 2020-10-31
     eol: 2021-10-31
+    eoes: 2021-10-31
     latest: "20.04.20"
     latestReleaseDate: 2021-11-19
     link: https://archives-docs.centreon.com/20.04/docs/releases/centreon-core/#200420
 
   - releaseCycle: "19.10"
     releaseDate: 2019-10-15
-    eoas: 2020-04-30
     eol: 2021-04-30
+    eoes: 2021-04-30
     latest: "19.10.23"
     latestReleaseDate: 2021-05-04
     link: https://docs-older.centreon.com/docs/centreon/en/latest/release_notes/centreon-19.10.html
 
   - releaseCycle: "19.04"
     releaseDate: 2019-04-24
-    eoas: 2019-10-31
     eol: 2020-10-31
+    eoes: 2020-10-31
     latest: "19.04.20"
     latestReleaseDate: 2020-11-19
     link: https://docs-older.centreon.com/docs/centreon/en/latest/release_notes/centreon-19.04.html
 
   - releaseCycle: "18.10"
     releaseDate: 2018-10-24
-    eoas: 2019-04-30
     eol: 2020-04-30
+    eoes: 2020-04-30
     latest: "18.10.12"
     latestReleaseDate: 2020-02-24
     link: https://docs-older.centreon.com/docs/centreon/en/latest/release_notes/centreon-18.10.html
@@ -134,42 +132,11 @@ releases:
 > [Centreon](https://www.centreon.com/) is a software platform used to monitor IT infrastructure.
 > It can track the health of systems, applications, and networks, notifying IT staff of any problems.
 
-{: .warning }
+Centreon delivers one major release per year in October, named after the year and month of delivery.
+All modules and components of the Centreon software suite use the same version numbers.
 
-> Centreon is composed of many components, each with its own minor version number.
-> The version numbers tracked here are for the Centreon Web interface.
+Open Source major versions are supported for 18 months.
 
-## Release Cadence
-
-Centreon delivers two releases per year, and releases are named according to the year and period of
-delivery: `XX.04` for the spring release, and `XX.10` for the fall release. All modules and
-components of the Centreon software suite use the same release numbers.
-
-{: .note-title }
-
-> Upcoming Change
->
-> [Starting with Centreon 24.10](https://www.centreon.com/new-centreon-release-cadence-and-version-lifecycle/)
-> (expected in October 2024), Centreon will have one major release
-> in October every year. Minor versions, with bug fixes and minor improvements will be released monthly.
-> A Service Pack version, cumulating all minor versions changes, is typically delivered after six months.
-
-## Support Lifecycle
-
-Releases are supported for two years divided into two phases of 12 months each.
-During the first phase, named _Phase 1 support_ on this page, releases are supported with bugs of
-all severity levels and security fixes. During the second phase, named _Phase 2 support_ on this
-page, only major/critical bugs and security fixes are provided.
-
-{: .note-title }
-
-> Upcoming Change
->
-> [Starting with Centreon 24.10](https://www.centreon.com/new-centreon-release-cadence-and-version-lifecycle/) (expected in October 2024):
->
-> - All Open Source major versions will be supported for 18 months.
-> - Commercial major versions released in even years will be designated as LTS versions and supported for 3 years.
-> - Commercial major versions released in odd years will be supported for 18 months.
-
-[Paid support](https://www.centreon.com/centreon-editions/) is available for
-Commercial Editions.
+[Commercial editions offering longer support are available](https://www.centreon.com/centreon-editions/).
+Commercial major versions released in odd years (2025, 2027...) are supported for 18 months,
+while those released in even years are designated LTS and supported for 3 years.


### PR DESCRIPTION
Simplify description, focusing on the 24.10+ support policy and on major releases. With this change, the eoas column was dropped (it is meaningless now) and the eoes column was added to document commercial support, i.e. LTS releases. Note that LTS releases are only for commercial support and has no meaning for OSS, so it was dropped from 24.10.

There are minor releases between x.10.z releases, but those does not have a clearly defined policy and are not listed on the download page nor [on-prem documentation](https://docs.centreon.com/docs/getting-started/welcome/), so those were completely ignored.