### PR TITLE
[kubernetes-csi-node-driver-registrar] Update product

### DIFF
--- a/products/kubernetes-csi-node-driver-registrar.md
+++ b/products/kubernetes-csi-node-driver-registrar.md
@@ -9,7 +9,6 @@ alternate_urls:
   - /node-driver-registrar
 versionCommand: |-
   csi-node-driver-registrar --version
-releasePolicyLink: https://kubernetes-csi.github.io/docs/node-driver-registrar.html#supported-versions
 changelogTemplate: https://github.com/kubernetes-csi/node-driver-registrar/releases/tag/v__LATEST__
 eolColumn: Support
 
@@ -22,7 +21,9 @@ identifiers:
   - purl: pkg:github/kubernetes-csi/node-driver-registrar
   - purl: pkg:golang/github.com/kubernetes-csi/node-driver-registrar
 
-# Supported versions are documented on https://kubernetes-csi.github.io/docs/node-driver-registrar.html#supported-versions.
+# eol(x) = releaseDate(x + 1)
+# Supported versions are documented on https://kubernetes-csi.github.io/docs/node-driver-registrar.html#supported-versions,
+# but the page is never up-to-date.
 releases:
   - releaseCycle: "2.15"
     releaseDate: 2025-09-12
@@ -32,97 +33,97 @@ releases:
 
   - releaseCycle: "2.14"
     releaseDate: 2025-05-30
-    eol: false
+    eol: 2025-09-12
     latest: "2.14.0"
     latestReleaseDate: 2025-05-30
 
   - releaseCycle: "2.13"
     releaseDate: 2024-12-19
-    eol: false
+    eol: 2025-05-30
     latest: "2.13.0"
     latestReleaseDate: 2024-12-19
 
   - releaseCycle: "2.12"
     releaseDate: 2024-08-22
-    eol: false
+    eol: 2024-12-19
     latest: "2.12.0"
     latestReleaseDate: 2024-08-22
 
   - releaseCycle: "2.11"
     releaseDate: 2024-05-22
-    eol: false
+    eol: 2024-08-22
     latest: "2.11.1"
     latestReleaseDate: 2024-07-16
 
   - releaseCycle: "2.10"
     releaseDate: 2024-01-04
-    eol: true
+    eol: 2024-05-22
     latest: "2.10.1"
     latestReleaseDate: 2024-03-20
 
   - releaseCycle: "2.9"
     releaseDate: 2023-09-11
-    eol: true
+    eol: 2024-01-04
     latest: "2.9.4"
     latestReleaseDate: 2024-03-20
 
   - releaseCycle: "2.8"
     releaseDate: 2023-04-27
-    eol: true
+    eol: 2023-09-11
     latest: "2.8.0"
     latestReleaseDate: 2023-04-27
 
   - releaseCycle: "2.7"
     releaseDate: 2022-12-28
-    eol: true
+    eol: 2023-04-27
     latest: "2.7.0"
     latestReleaseDate: 2022-12-28
 
   - releaseCycle: "2.6"
     releaseDate: 2022-10-20
-    eol: true
+    eol: 2022-12-28
     latest: "2.6.3"
     latestReleaseDate: 2023-01-23
 
   - releaseCycle: "2.5"
     releaseDate: 2022-02-02
-    eol: true
+    eol: 2022-10-20
     latest: "2.5.1"
     latestReleaseDate: 2022-05-06
 
   - releaseCycle: "2.4"
     releaseDate: 2021-11-09
-    eol: true
+    eol: 2021-11-09
     latest: "2.4.0"
     latestReleaseDate: 2021-11-09
 
   - releaseCycle: "2.3"
     releaseDate: 2021-08-11
-    eol: true
+    eol: 2021-11-09
     latest: "2.3.0"
     latestReleaseDate: 2021-08-11
 
   - releaseCycle: "2.2"
     releaseDate: 2021-04-27
-    eol: true
+    eol: 2021-08-11
     latest: "2.2.0"
     latestReleaseDate: 2021-04-27
 
   - releaseCycle: "2.1"
     releaseDate: 2020-12-17
-    eol: true
+    eol: 2021-04-27
     latest: "2.1.0"
     latestReleaseDate: 2020-12-17
 
   - releaseCycle: "2.0"
     releaseDate: 2020-08-28
-    eol: true
+    eol: 2020-12-17
     latest: "2.0.1"
     latestReleaseDate: 2020-09-03
 
   - releaseCycle: "1.2"
     releaseDate: 2019-09-09
-    eol: true
+    eol: 2020-08-28
     latest: "1.2.0"
     latestReleaseDate: 2019-09-09
 ---
@@ -130,3 +131,8 @@ releases:
 > The node-driver-registrar is a sidecar container for Kubernetes
 > that registers the [CSI](https://kubernetes-csi.github.io/docs/introduction.html) driver
 > with Kubelet using the kubelet plugin registration mechanism.
+
+A list of supported releases is available in [Kubernetes Container Storage Interface (CSI) Documentation](https://kubernetes-csi.github.io/docs/node-driver-registrar.html#supported-versions),
+but it doesn't seem to be updated regularly.
+
+Base on the latest versions, it seems that only the latest release is supported.


### PR DESCRIPTION
Apply a `eol(x) = releaseDate(x+1)` rule for all releases, as it works almost all the time and https://kubernetes-csi.github.io/docs/node-driver-registrar.html#supported-versions is never up-to-date.