### PR TITLE
:label: `consul` (as `etcd`) could/should be in the `database` category :grey_question: 

### DIFF
--- a/products/consul.md
+++ b/products/consul.md
@@ -1,7 +1,7 @@
 ---
 title: Hashicorp Consul
 addedAt: 2021-10-20
-category: server-app
+category: server-app database
 tags: hashicorp
 iconSlug: consul
 permalink: /consul

--- a/products/consul.md
+++ b/products/consul.md
@@ -1,7 +1,7 @@
 ---
 title: Hashicorp Consul
 addedAt: 2021-10-20
-category: server-app database
+category: database
 tags: hashicorp
 iconSlug: consul
 permalink: /consul


### PR DESCRIPTION
# :grey_question: About

As [`etcd`](https://endoflife.date/etcd), [`consul`](https://endoflife.date/consul) (a `key/value` datbase like system) should also have the `database` label.

<img width="1111" height="740" alt="image" src="https://github.com/user-attachments/assets/fd7eeed3-6517-4ca9-8910-2993c4a333e8" />


:point_right: This PR fixes that