### PR TITLE
workflows/lint: remove explicit ruby-version tag

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -22,7 +22,6 @@ jobs:
       - name: Setup ruby
         uses: ruby/setup-ruby@0481980f17b760ef6bca5e8c55809102a0af1e5a # v1
         with:
-          ruby-version: 3.4
           bundler-cache: true
 
       - name: Build site

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Setup ruby
         uses: ruby/setup-ruby@0481980f17b760ef6bca5e8c55809102a0af1e5a # v1
         with:
-          ruby-version: 3.3
+          ruby-version: 3.4
           bundler-cache: true
 
       - name: Build site


### PR DESCRIPTION
Right now the [setup-ruby does not support `ruby-version-file`](https://github.com/ruby/setup-ruby/issues/813), so we have to manually bump when updating the ruby-version file (https://github.com/endoflife-date/endoflife.date/pull/8600)