### PR TITLE
[google-kubernetes-engine] Add 1.34

### DIFF
--- a/products/google-kubernetes-engine.md
+++ b/products/google-kubernetes-engine.md
@@ -25,6 +25,13 @@ auto:
 #
 # eoas:last-date-in-month(eol - 2months)
 releases:
+  - releaseCycle: "1.34"
+    releaseDate: 2025-09-30
+    eoas: 2026-08-30
+    eol: 2026-10-01
+    latest: "1.34.0-gke.1662000"
+    latestReleaseDate: 2025-10-01
+
   - releaseCycle: "1.33"
     releaseDate: 2025-06-03
     eoas: 2026-06-30


### PR DESCRIPTION
Kubernetes 1.34 has been available on the Regular channel for a couple of days

https://cloud.google.com/kubernetes-engine/docs/release-schedule

EOL is currently listed as `2026-Q4`. I set the `eol` value here to the first day in Q4, does that make sense?