### PR TITLE
[quarkus-framework]  Add Release Planning info

### DIFF
--- a/products/quarkus-framework.md
+++ b/products/quarkus-framework.md
@@ -363,6 +363,7 @@ releases:
 
 The Quarkus team releases a `major.minor` version every 4 to 6 weeks, and a fix version targeting the latest version every week in between.
 [Beginning with Quarkus 3.2](https://quarkus.io/blog/lts-releases/), a new LTS version is also published every 6 months.
+For up-to-date release planning informations, see [dedicated page](https://github.com/quarkusio/quarkus/wiki/Release-Planning).
 
 Quarkus releases an LTS (Long-Term Support) version every six months.
 LTS is designed for users who prioritize stability over new features.


### PR DESCRIPTION
# :grey_question: About

While trying to learn more about `quarkus` `3.29`, I found this very useful page : [Release Planning](https://github.com/quarkusio/quarkus/wiki/Release-Planning)

:point_right: Adding it to the webpage may help answer some questions about future releases, and automate reporting about it.