### PR TITLE
[mandrel] Set 25 is a LTS version

### DIFF
--- a/products/mandrel.md
+++ b/products/mandrel.md
@@ -22,6 +22,7 @@ releases:
     releaseLabel: "25.0 (JDK 25)"
     releaseDate: 2025-10-02
     eol: false
+    lts: true
     latest: "25.0.0.1"
     latestReleaseDate: 2025-09-29
 


### PR DESCRIPTION
# :grey_question: About

As per https://quarkus.io/blog/mandrel-25-released/ : 

<img width="1118" height="487" alt="image" src="https://github.com/user-attachments/assets/ff38e46c-18a2-4b90-a262-cbe28fa23f85" />


>  Mandrel 25 will be the next LTS 

:point_right: This PR fixes that (sorry for the miss in : 

- https://github.com/endoflife-date/endoflife.date/pull/8627

