### PR TITLE
[Python] Add 3.14 and update 3.13

### DIFF
--- a/products/python.md
+++ b/products/python.md
@@ -90,7 +90,7 @@ releases:
     releaseDate: 2025-10-07
     eoas: 2027-10-01
     eol: 2030-10-31
-    latest: "3.14"
+    latest: "3.14.0"
     latestReleaseDate: 2025-10-07
 
   - releaseCycle: "3.13"

--- a/products/python.md
+++ b/products/python.md
@@ -86,12 +86,19 @@ auto:
         eol: "End of life"
 
 releases:
+  - releaseCycle: "3.14"
+    releaseDate: 2025-10-07
+    eoas: 2027-10-01
+    eol: 2030-10-31
+    latest: "3.14"
+    latestReleaseDate: 2025-10-07
+
   - releaseCycle: "3.13"
     releaseDate: 2024-10-07
     eoas: 2026-10-01
     eol: 2029-10-31
-    latest: "3.13.7"
-    latestReleaseDate: 2025-08-14
+    latest: "3.13.8"
+    latestReleaseDate: 2025-10-07
 
   - releaseCycle: "3.12"
     releaseDate: 2023-10-02


### PR DESCRIPTION
[Python 3.14 was released today](https://discuss.python.org/t/python-3-14-0-final-is-here/104210), and [so was 3.13.8](https://discuss.python.org/t/3-13-8-has-been-released/104211)!