### PR TITLE
[julia] Add 1.12 and mark 1.11 as eoled

### DIFF
--- a/products/julia.md
+++ b/products/julia.md
@@ -18,7 +18,7 @@ identifiers:
 
 releases:
   - releaseCycle: "1.12"
-    releaseDate: 2025-10-07 # announcementLink: https://julialang.org/blog/2025/10/julia-1.12-highlights/
+    releaseDate: 2025-10-08 # announcementLink: https://julialang.org/blog/2025/10/julia-1.12-highlights/
     eol: false
     latest: "1.12.0"
     latestReleaseDate: 2025-10-07

--- a/products/julia.md
+++ b/products/julia.md
@@ -19,7 +19,6 @@ identifiers:
 releases:
   - releaseCycle: "1.12"
     releaseDate: 2025-10-07 # announcementLink: https://julialang.org/blog/2025/10/julia-1.12-highlights/
-    lts: false
     eol: false
     latest: "1.12.0"
     latestReleaseDate: 2025-10-07

--- a/products/julia.md
+++ b/products/julia.md
@@ -17,10 +17,16 @@ identifiers:
   - repology: julia
 
 releases:
-  - releaseCycle: "1.11"
-    releaseDate: 2024-10-07 # announcementLink: https://julialang.org/blog/2024/10/julia-1.11-highlights/
+  - releaseCycle: "1.12"
+    releaseDate: 2025-10-07 # announcementLink: https://julialang.org/blog/2025/10/julia-1.12-highlights/
     lts: false
     eol: false
+    latest: "1.12.0"
+    latestReleaseDate: 2025-10-07
+
+  - releaseCycle: "1.11"
+    releaseDate: 2024-10-07 # announcementLink: https://julialang.org/blog/2024/10/julia-1.11-highlights/
+    eol: 2025-10-07 # https://discourse.julialang.org/t/julia-v1-12-0-has-been-released/132990
     latest: "1.11.7"
     latestReleaseDate: 2025-09-08
 

--- a/products/julia.md
+++ b/products/julia.md
@@ -25,7 +25,7 @@ releases:
 
   - releaseCycle: "1.11"
     releaseDate: 2024-10-07 # announcementLink: https://julialang.org/blog/2024/10/julia-1.11-highlights/
-    eol: 2025-10-07 # https://discourse.julialang.org/t/julia-v1-12-0-has-been-released/132990
+    eol: 2025-10-08 # https://discourse.julialang.org/t/julia-v1-12-0-has-been-released/132990
     latest: "1.11.7"
     latestReleaseDate: 2025-09-08
 


### PR DESCRIPTION
Source : https://discourse.julialang.org/t/julia-v1-12-0-has-been-released/132990