### PR TITLE
[apache-apisix] Add 3.14

### DIFF
--- a/products/apache-apisix.md
+++ b/products/apache-apisix.md
@@ -20,9 +20,15 @@ auto:
 #
 # Official releases dates and git tag dates always differ by a few days.
 releases:
+  - releaseCycle: "3.14"
+    releaseDate: 2025-10-10
+    eol: false
+    latest: "3.14.0"
+    latestReleaseDate: 2025-10-10
+
   - releaseCycle: "3.13"
     releaseDate: 2025-06-27
-    eol: false
+    eol: 2025-10-10
     latest: "3.13.0"
     latestReleaseDate: 2025-06-27
 


### PR DESCRIPTION
See https://apisix.apache.org/blog/2025/10/10/release-apache-apisix-3.14.0/.