### PR TITLE
[bitcoin-core] Switch to github_releases for automation

### DIFF
--- a/products/bitcoin-core.md
+++ b/products/bitcoin-core.md
@@ -9,7 +9,7 @@ changelogTemplate: https://bitcoincore.org/en/releases/__LATEST__/
 
 auto:
   methods:
-    - git: https://github.com/bitcoin/bitcoin.git
+    - github_releases: bitcoin/bitcoin
       regex: '^v?(?P<major>\d+)\.(?P<minor>\d+)(\.(?P<patch>\d+))?$'
     - release_table: https://bitcoincore.org/en/lifecycle/
       fields:


### PR DESCRIPTION
30.0 was tagged two days ago, but there is no github release yet nor news on https://bitcoin.org/en/version-history.