### PR TITLE
[pan-os] Fix 12.1 link

### DIFF
--- a/products/pan-os.md
+++ b/products/pan-os.md
@@ -34,7 +34,7 @@ releases:
     eol: 2028-08-28
     latest: "12.1.3"
     latestReleaseDate: 2025-09-25
-    link: https://docs.paloaltonetworks.com/pan-os/12-1/pan-os-release-notes/pan-os-12-1-3-known-and-addressed-issues/pan-os-12-1-3-addressed-issues
+    link: https://docs.paloaltonetworks.com/ngfw/release-notes/12-1/pan-os-12-1-3-known-and-addressed-issues
 
   - releaseCycle: "11.2"
     releaseDate: 2024-05-02


### PR DESCRIPTION
Current link, https://docs.paloaltonetworks.com/pan-os/12-1/pan-os-release-notes/pan-os-12-1-3-known-and-addressed-issues/pan-os-12-1-3-addressed-issues, returns a 404.