### PR TITLE
[bitcoin-core] Revert latest 29 to 29.1

### DIFF
--- a/products/bitcoin-core.md
+++ b/products/bitcoin-core.md
@@ -27,8 +27,8 @@ releases:
     releaseDate: 2025-04-14
     eoas: false
     eol: false
-    latest: "29.2"
-    latestReleaseDate: 2025-10-10
+    latest: "29.1"
+    latestReleaseDate: 2025-09-05
 
   - releaseCycle: "28"
     releaseDate: 2024-10-02


### PR DESCRIPTION
29.2 is not yet listed on https://github.com/bitcoin/bitcoin/releases nor https://bitcoincore.org/en/releases/.