### PR TITLE
[consul] Remove Brew package identifier

### DIFF
--- a/products/consul.md
+++ b/products/consul.md
@@ -12,7 +12,6 @@ staleReleaseThresholdYears: 1.5
 
 identifiers:
   - repology: consul
-  - purl: pkg:brew/consul
   - purl: pkg:docker/library/consul
   - purl: pkg:github/hashicorp/consul
   - purl: pkg:golang/github.com/hashicorp/consul


### PR DESCRIPTION
https://formulae.brew.sh/formula/consul is 404.