### PR TITLE
[linuxmint] Increase stale release threshold from 2 to 3 years

### DIFF
--- a/products/linuxmint.md
+++ b/products/linuxmint.md
@@ -11,7 +11,7 @@ versionCommand: cat /etc/linuxmint/info
 latestColumn: false
 releasePolicyLink: https://linuxmint.com/download_all.php
 releaseLabel: "__RELEASE_CYCLE__ '__CODENAME__'"
-staleReleaseThresholdYears: 2
+staleReleaseThresholdYears: 3
 
 auto:
   methods:


### PR DESCRIPTION
LMDE 6 EOL date is still not documented on https://linuxmint.com/download_all.php.