### PR TITLE
[opensearch] Add 3.3.0

### DIFF
--- a/products/opensearch.md
+++ b/products/opensearch.md
@@ -34,8 +34,8 @@ releases:
     releaseDate: 2025-05-06
     eoas: false
     eol: false
-    latest: "3.2.0"
-    latestReleaseDate: 2025-08-08
+    latest: "3.3.0"
+    latestReleaseDate: 2025-10-14
 
   - releaseCycle: "2"
     releaseDate: 2022-05-26


### PR DESCRIPTION
# :grey_question: About

According to the [announce below](https://x.com/OpenSearchProj/status/1978225745362121060), OpenSearch 3.3 is [available for download](https://opensearch.org/downloads/), with a number of new features designed to help your search, observability, and AI-powered applications ([see detailed Blog Post for more](https://opensearch.org/blog/explore-opensearch-3-3/)): 

<img width="607" height="768" alt="image" src="https://github.com/user-attachments/assets/0923020c-dbd6-4020-a09c-a415d8dfd78c" />
