### PR TITLE
Update API v0 description to reflect deprecation

### DIFF
--- a/assets/openapi.yml
+++ b/assets/openapi.yml
@@ -3,7 +3,7 @@ info:
   title: endoflife.date
   version: 0.0.1
   summary: endoflife.date API
-  description: "Documentation for the endoflife.date API. The API is currently in Alpha. Additional information about the API can be found on the [endoflife.date wiki](https://github.com/endoflife-date/endoflife.date/wiki)."
+  description: "The endoflife.date v0 API is currently deprecated, please [use the endoflife.date v1 API](https://endoflife.date/docs/api/v1/)."
   license:
     name: MIT
     url: "https://github.com/endoflife-date/endoflife.date/blob/master/LICENSE"


### PR DESCRIPTION
Make it explicit that the v0 API is deprecated, as it is not clear enough, see https://github.com/endoflife-date/endoflife.date/discussions/7888#discussioncomment-14682357.