### PR TITLE
[magento] Set staleReleaseThresholdYears to 3 years

### DIFF
--- a/products/magento.md
+++ b/products/magento.md
@@ -13,6 +13,7 @@ changelogTemplate: "https://experienceleague.adobe.com/docs/commerce-operations/
 eoasColumn: Bug fix maintenance
 eolColumn: Security maintenance
 eoesColumn: Adobe Commerce end of software support
+staleReleaseThresholdYears: 3
 
 customFields:
   - name: supportedPhpVersions


### PR DESCRIPTION
It's been more than two years that  2.4.6 were released, and the date is still not documented on https://www.adobe.com/content/dam/cc/en/legal/terms/enterprise/pdfs/Magento-Open-Source-Software-Maintenance-Policy.pdf.