### PR TITLE
[jenkins] Add 2.528 LTS

### DIFF
--- a/products/jenkins.md
+++ b/products/jenkins.md
@@ -37,10 +37,17 @@ releases:
     latest: "2.532"
     latestReleaseDate: 2025-10-14
 
+  - releaseCycle: "2.528"
+    releaseDate: 2025-09-17
+    lts: 2025-10-15
+    eol: false
+    latest: "2.528.1"
+    latestReleaseDate: 2025-10-15
+
   - releaseCycle: "2.516"
     releaseDate: 2025-06-24
     lts: 2025-07-23
-    eol: false
+    eol: 2025-10-15
     latest: "2.516.3"
     latestReleaseDate: 2025-09-15
 


### PR DESCRIPTION
See [Upgrading to Jenkins LTS 2.528.x](https://www.jenkins.io/doc/upgrade-guide/2.528/)