### PR TITLE
[elasticsearch] Add elastic as alternate url

### DIFF
--- a/products/elasticsearch.md
+++ b/products/elasticsearch.md
@@ -5,6 +5,8 @@ category: database
 tags: elastic java-runtime
 iconSlug: elasticsearch
 permalink: /elasticsearch
+alternate_urls:
+  - /elastic
 versionCommand: $ES_HOME/bin/elasticsearch -v
 releasePolicyLink: https://www.elastic.co/support_policy
 changelogTemplate: "https://www.elastic.co/guide/en/elasticsearch/reference/{{'__LATEST__'|split:'.'|pop|join:'.'}}/release-notes-__LATEST__.html"


### PR DESCRIPTION
# ❔ About

A lot of people call Elasticsearch by _"Elastic"_ so it could make sense and be useful to add this alternate url.