### PR TITLE
[ibm-mq] Fix typo in releaseLabel

### DIFF
--- a/products/ibm-mq.md
+++ b/products/ibm-mq.md
@@ -28,7 +28,7 @@ auto:
 # or https://www.ibm.com/support/pages/space/product-lifecycle/ibm_product_lifecycle_list.csv.
 releases:
   - releaseCycle: "9.4"
-    releaseLabel: "IBM MQ 9.3 LTS"
+    releaseLabel: "IBM MQ 9.4 LTS"
     releaseDate: 2024-06-18
     eol: false
     eoes: false


### PR DESCRIPTION
The release label for IBM MQ 9.4 says 9.3. Fixed with this commit. 