### PR TITLE
[powershell] Add dotnet version to PowerShell releases

### DIFF
--- a/products/powershell.md
+++ b/products/powershell.md
@@ -18,6 +18,12 @@ identifiers:
   - purl: pkg:github/powershell/powershell
   - repology: powershell
 
+customFields:
+  - name: dotnetVersion
+    display: after-latest-column
+    label: ".NET Version"
+    description: Version of .NET that this PowerShell release is built on.
+
 auto:
   methods:
     - git: https://github.com/PowerShell/PowerShell.git
@@ -28,6 +34,7 @@ auto:
           regex: '^PowerShell (?P<value>\d+\.\d+)(?!.*\(preview\)).*$'
         releaseDate: "Release Date"
         eol: "End-of-support"
+        dotnetVersion: ".NET Version"
 
 releases:
   - releaseCycle: "7.5"
@@ -35,20 +42,23 @@ releases:
     releaseDate: 2025-01-23
     eol: 2026-05-12
     latest: "7.5.4"
-    latestReleaseDate: 2025-10-16
+    latestReleaseDate: 2025-10-20
+    dotnetVersion: ".NET 9.0"
 
   - releaseCycle: "7.4"
     lts: true
     releaseDate: 2023-11-16
     eol: 2026-11-10
     latest: "7.4.13"
-    latestReleaseDate: 2025-10-16
+    latestReleaseDate: 2025-10-20
+    dotnetVersion: ".NET 8.0"
 
   - releaseCycle: "7.3"
     releaseDate: 2022-11-09
     eol: 2024-05-08
     latest: "7.3.12"
     latestReleaseDate: 2024-04-11
+    dotnetVersion: ".NET 7.0"
 
   - releaseCycle: "7.2"
     lts: true
@@ -56,12 +66,14 @@ releases:
     eol: 2024-11-08
     latest: "7.2.24"
     latestReleaseDate: 2024-10-22
+    dotnetVersion: ".NET 6.0"
 
   - releaseCycle: "7.1"
     releaseDate: 2020-11-11
     eol: 2022-05-08
     latest: "7.1.7"
     latestReleaseDate: 2022-04-26
+    dotnetVersion: ".NET 5.0"
 
   - releaseCycle: "7.0"
     lts: true
@@ -69,24 +81,28 @@ releases:
     eol: 2022-12-03
     latest: "7.0.13"
     latestReleaseDate: 2022-10-20
+    dotnetVersion: ".NET Core 3.1"
 
   - releaseCycle: "6.2"
     releaseDate: 2019-03-29
     eol: 2020-09-04
     latest: "6.2.7"
     latestReleaseDate: 2020-07-16
+    dotnetVersion: ".NET Core 2.1"
 
   - releaseCycle: "6.1"
     releaseDate: 2018-09-13
     eol: 2019-09-28
     latest: "6.1.6"
     latestReleaseDate: 2019-09-12
+    dotnetVersion: ".NET Core 2.1"
 
   - releaseCycle: "6.0"
     releaseDate: 2018-01-20
     eol: 2019-02-13
     latest: "6.0.5"
     latestReleaseDate: 2018-11-13
+    dotnetVersion: ".NET Core 2.0"
 
 ---
 


### PR DESCRIPTION
Add dotnet version to PowerShell metadata

- Added `dotnetVersion` to `customFields` definition
- Added `dotnetVersion` version metadata to each release
