### PR TITLE
[oracle-jdk] Set 25 as an LTS release

### DIFF
--- a/products/oracle-jdk.md
+++ b/products/oracle-jdk.md
@@ -55,6 +55,7 @@ auto:
 # for non-LTS, eol(x) = releaseDate(x+1).
 releases:
   - releaseCycle: "25"
+    lts: true
     releaseDate: 2025-09-16
     eol: 2030-09-30
     eoes: 2033-09-30


### PR DESCRIPTION
Hi,

Java JDK 25 is an LTS release - see https://openjdk.org/projects/jdk/25/ for confirmation. This PR sets the LTS flag on this release.

Thanks,
Andrew