### PR TITLE
[nextjs] Add Lts tags for 16 ,15 and 14 cycles and fix eol dates

### DIFF
--- a/products/nextjs.md
+++ b/products/nextjs.md
@@ -29,7 +29,7 @@ releases:
 
   - releaseCycle: "15"
     releaseDate: 2024-10-21
-    eol: 2025-10-22
+    eol: false
     latest: "15.5.6"
     latestReleaseDate: 2025-10-17
 

--- a/products/nextjs.md
+++ b/products/nextjs.md
@@ -29,13 +29,13 @@ releases:
 
   - releaseCycle: "15"
     releaseDate: 2024-10-21
-    eol: false
+    eol: 2026-10-21
     latest: "15.5.6"
     latestReleaseDate: 2025-10-17
 
   - releaseCycle: "14"
     releaseDate: 2023-10-26
-    eol: false
+    eol: 2025-10-26
     latest: "14.2.33"
     latestReleaseDate: 2025-09-23
 

--- a/products/nextjs.md
+++ b/products/nextjs.md
@@ -23,18 +23,21 @@ auto:
 releases:
   - releaseCycle: "16"
     releaseDate: 2025-10-22
+    lts: true
     eol: false
     latest: "16.0.0"
     latestReleaseDate: 2025-10-22
 
   - releaseCycle: "15"
     releaseDate: 2024-10-21
+    lts: true
     eol: 2026-10-21
     latest: "15.5.6"
     latestReleaseDate: 2025-10-17
 
   - releaseCycle: "14"
     releaseDate: 2023-10-26
+    lts: true
     eol: 2025-10-26
     latest: "14.2.33"
     latestReleaseDate: 2025-09-23

--- a/products/nextjs.md
+++ b/products/nextjs.md
@@ -22,22 +22,22 @@ auto:
 # eol(x) = MAX(releaseDate(x+1), latestReleaseDate(x))
 releases:
   - releaseCycle: "16"
-    releaseDate: 2025-10-22
     lts: true
+    releaseDate: 2025-10-22
     eol: false
     latest: "16.0.0"
     latestReleaseDate: 2025-10-22
 
   - releaseCycle: "15"
-    releaseDate: 2024-10-21
     lts: true
+    releaseDate: 2024-10-21
     eol: 2026-10-21
     latest: "15.5.6"
     latestReleaseDate: 2025-10-17
 
   - releaseCycle: "14"
-    releaseDate: 2023-10-26
     lts: true
+    releaseDate: 2023-10-26
     eol: 2025-10-26
     latest: "14.2.33"
     latestReleaseDate: 2025-09-23


### PR DESCRIPTION
As per https://nextjs.org/support-policy

> Upon release of a new major, the previous major transitions to Maintenance LTS

This would promote 15 to Maintenance LTS, not End of Life.

Version 14 is still also in Maintenance LTS until this Sunday 26th of October 2025.