### PR TITLE
[micronaut] Update page

### DIFF
--- a/products/micronaut.md
+++ b/products/micronaut.md
@@ -7,7 +7,6 @@ permalink: /micronaut
 alternate_urls:
   - /micronaut-framework
   - /mn
-releasePolicyLink: https://micronaut.io/support-schedule/
 changelogTemplate: "https://github.com/micronaut-projects/micronaut-core/releases/tag/v__LATEST__"
 eoasColumn: Active Development
 eolColumn: Active Maintenance
@@ -19,29 +18,29 @@ auto:
 releases:
   - releaseCycle: "4"
     releaseDate: 2023-07-11
-    eol: false
     eoas: false
+    eol: false
     latest: "4.10.7"
     latestReleaseDate: 2025-10-20
 
   - releaseCycle: "3"
     releaseDate: 2021-08-18
-    eol: false
     eoas: 2023-07-11
+    eol: 2025-03-23 # latestReleaseDate + 1 year
     latest: "3.10.4"
     latestReleaseDate: 2024-03-23
 
   - releaseCycle: "2"
     releaseDate: 2020-06-26
-    eol: 2023-03-01
     eoas: 2021-08-18
+    eol: 2023-03-01
     latest: "2.5.13"
     latestReleaseDate: 2021-09-03
 
   - releaseCycle: "1"
     releaseDate: 2018-10-23
+    eoas: 2020-06-26
     eol: 2021-12-31
-    eoas: true
     latest: "1.3.7"
     latestReleaseDate: 2020-07-10
 
@@ -50,11 +49,9 @@ releases:
 > [Micronaut](https://micronaut.io/) is a modern, JVM-based, full-stack framework for building
 > modular, easily testable microservice and serverless applications.
 
-Versions of the Micronaut framework may fall into one of three lifecycle stages:
+The Micronaut framework adheres to [semantic versioning](https://semver.org).
+While its release, support, and end-of-life policies [were previously documented](https://web.archive.org/web/20230703052603/https://micronaut.io/support-schedule/), this information is no longer publicly available.
+Recently, it appears that only the latest major release receives new features, bug fixes, and security updates.
 
-- Active Development: those versions receive regular updates.
-- Active Maintenance: those versions receive limited bug fixes and patches, mostly focused around
-  the resolution of critical security advisories.
-
-The Micronaut Foundation offers [commercial support](https://micronaut.io/support/). This typically
-lasts a few years after active maintenance ends.
+Commercial support for the Micronaut Framework is provided by several companies,
+which are listed on [the official Micronaut support page](https://micronaut.io/support/).


### PR DESCRIPTION
- Mark 3 as EOL : there were no version in more than a year.
- Update description.
- Drop releasePolicyLink as it's not available anymore.