### PR TITLE
[windows-powershell] Set staleReleaseThresholdYears to 10 years

### DIFF
--- a/products/windows-powershell.md
+++ b/products/windows-powershell.md
@@ -8,6 +8,7 @@ permalink: /windows-powershell
 versionCommand: powershell -Command "$PSVersionTable.PSVersion"
 releasePolicyLink: https://learn.microsoft.com/powershell/scripting/install/powershell-support-lifecycle?view=powershell-5.1#windows-powershell-release-history
 eolColumn: Support Status
+staleReleaseThresholdYears: 10
 
 releases:
   - releaseCycle: "5.1"


### PR DESCRIPTION
5.1 is still supported as part of Windows 10 Anniversary Update and Windows Server 2016, WMF 5.1. See https://github.com/endoflife-date/endoflife.date/pull/8531.