### PR TITLE
[Python] Add PEP urls for python release information

### DIFF
--- a/products/python.md
+++ b/products/python.md
@@ -13,6 +13,13 @@ releasePolicyLink: https://devguide.python.org/versions/
 changelogTemplate: |
   https://www.python.org/downloads/release/python-{{"__LATEST__" | replace:'.',''}}/
 eoasColumn: true
+
+customFields:
+  - name: pep
+    display: after-release-column
+    label: PEP
+    description: Python Enhancement Proposal (PEP) document for this release
+
 identifiers:
   - purl: pkg:generic/python
   - purl: pkg:deb/ubuntu/python

--- a/products/python.md
+++ b/products/python.md
@@ -100,7 +100,7 @@ releases:
     eol: 2030-10-31
     latest: "3.14.0"
     latestReleaseDate: 2025-10-07
-    link: https://peps.python.org/pep-0745/
+    pep: https://peps.python.org/pep-0745/
 
   - releaseCycle: "3.13"
     releaseDate: 2024-10-07
@@ -108,7 +108,7 @@ releases:
     eol: 2029-10-31
     latest: "3.13.9"
     latestReleaseDate: 2025-10-14
-    link: https://peps.python.org/pep-0719/
+    pep: https://peps.python.org/pep-0719/
 
   - releaseCycle: "3.12"
     releaseDate: 2023-10-02
@@ -116,7 +116,7 @@ releases:
     eol: 2028-10-31
     latest: "3.12.12"
     latestReleaseDate: 2025-10-09
-    link: https://peps.python.org/pep-0693/
+    pep: https://peps.python.org/pep-0693/
 
   - releaseCycle: "3.11"
     releaseDate: 2022-10-24
@@ -124,7 +124,7 @@ releases:
     eol: 2027-10-31
     latest: "3.11.14"
     latestReleaseDate: 2025-10-09
-    link: https://peps.python.org/pep-0664/
+    pep: https://peps.python.org/pep-0664/
 
   - releaseCycle: "3.10"
     releaseDate: 2021-10-04
@@ -132,7 +132,7 @@ releases:
     eol: 2026-10-31
     latest: "3.10.19"
     latestReleaseDate: 2025-10-09
-    link: https://peps.python.org/pep-0619/
+    pep: https://peps.python.org/pep-0619/
 
   - releaseCycle: "3.9"
     releaseDate: 2020-10-05
@@ -140,7 +140,7 @@ releases:
     eol: 2025-10-31
     latest: "3.9.24"
     latestReleaseDate: 2025-10-09
-    link: https://peps.python.org/pep-0596/
+    pep: https://peps.python.org/pep-0596/
 
   - releaseCycle: "3.8"
     releaseDate: 2019-10-14
@@ -148,7 +148,7 @@ releases:
     eol: 2024-10-07
     latest: "3.8.20"
     latestReleaseDate: 2024-09-06
-    link: https://peps.python.org/pep-0569/
+    pep: https://peps.python.org/pep-0569/
 
   - releaseCycle: "3.7"
     releaseDate: 2018-06-27
@@ -156,7 +156,7 @@ releases:
     eol: 2023-06-27
     latest: "3.7.17"
     latestReleaseDate: 2023-06-05
-    link: https://peps.python.org/pep-0537/
+    pep: https://peps.python.org/pep-0537/
 
   - releaseCycle: "3.6"
     releaseDate: 2016-12-23
@@ -164,7 +164,7 @@ releases:
     eol: 2021-12-23
     latest: "3.6.15"
     latestReleaseDate: 2021-09-03
-    link: https://peps.python.org/pep-0494/
+    pep: https://peps.python.org/pep-0494/
 
   - releaseCycle: "3.5"
     releaseDate: 2015-09-13
@@ -172,7 +172,7 @@ releases:
     eol: 2020-09-30
     latest: "3.5.10"
     latestReleaseDate: 2020-09-05
-    link: https://peps.python.org/pep-0478/
+    pep: https://peps.python.org/pep-0478/
 
   - releaseCycle: "3.4"
     releaseDate: 2014-03-16
@@ -180,7 +180,7 @@ releases:
     eol: 2019-03-18
     latest: "3.4.10"
     latestReleaseDate: 2019-03-18
-    link: https://peps.python.org/pep-0429/
+    pep: https://peps.python.org/pep-0429/
 
   - releaseCycle: "3.3"
     releaseDate: 2012-09-29
@@ -188,7 +188,7 @@ releases:
     eol: 2017-09-29
     latest: "3.3.7"
     latestReleaseDate: 2017-09-19
-    link: https://peps.python.org/pep-0398/
+    pep: https://peps.python.org/pep-0398/
 
   - releaseCycle: "3.2"
     releaseDate: 2011-02-20
@@ -196,7 +196,7 @@ releases:
     eol: 2016-02-20
     latest: "3.2.6"
     latestReleaseDate: 2014-10-12
-    link: https://peps.python.org/pep-0392/
+    pep: https://peps.python.org/pep-0392/
 
   - releaseCycle: "2.7"
     releaseDate: 2010-07-03
@@ -204,7 +204,7 @@ releases:
     eol: 2020-01-01
     latest: "2.7.18"
     latestReleaseDate: 2020-04-19
-    link: https://peps.python.org/pep-0373/
+    pep: https://peps.python.org/pep-0373/
 
   - releaseCycle: "3.1"
     releaseDate: 2009-06-27
@@ -212,7 +212,7 @@ releases:
     eol: 2012-04-09
     latest: "3.1.5"
     latestReleaseDate: 2012-04-06
-    link: https://peps.python.org/pep-0375/
+    pep: https://peps.python.org/pep-0375/
 
   - releaseCycle: "3.0"
     releaseDate: 2008-12-03
@@ -220,7 +220,7 @@ releases:
     eol: 2009-06-27
     latest: "3.0.1"
     latestReleaseDate: 2009-02-12
-    link: https://peps.python.org/pep-0361/
+    pep: https://peps.python.org/pep-0361/
 
   - releaseCycle: "2.6"
     releaseDate: 2008-10-01
@@ -228,7 +228,7 @@ releases:
     eol: 2013-10-29
     latest: "2.6.9"
     latestReleaseDate: 2013-10-29
-    link: https://peps.python.org/pep-0361/
+    pep: https://peps.python.org/pep-0361/
 
 ---
 

--- a/products/python.md
+++ b/products/python.md
@@ -100,6 +100,7 @@ releases:
     eol: 2030-10-31
     latest: "3.14.0"
     latestReleaseDate: 2025-10-07
+    link: https://peps.python.org/pep-0745/
 
   - releaseCycle: "3.13"
     releaseDate: 2024-10-07
@@ -107,6 +108,7 @@ releases:
     eol: 2029-10-31
     latest: "3.13.9"
     latestReleaseDate: 2025-10-14
+    link: https://peps.python.org/pep-0719/
 
   - releaseCycle: "3.12"
     releaseDate: 2023-10-02
@@ -114,6 +116,7 @@ releases:
     eol: 2028-10-31
     latest: "3.12.12"
     latestReleaseDate: 2025-10-09
+    link: https://peps.python.org/pep-0693/
 
   - releaseCycle: "3.11"
     releaseDate: 2022-10-24
@@ -121,6 +124,7 @@ releases:
     eol: 2027-10-31
     latest: "3.11.14"
     latestReleaseDate: 2025-10-09
+    link: https://peps.python.org/pep-0664/
 
   - releaseCycle: "3.10"
     releaseDate: 2021-10-04
@@ -128,6 +132,7 @@ releases:
     eol: 2026-10-31
     latest: "3.10.19"
     latestReleaseDate: 2025-10-09
+    link: https://peps.python.org/pep-0619/
 
   - releaseCycle: "3.9"
     releaseDate: 2020-10-05
@@ -135,6 +140,7 @@ releases:
     eol: 2025-10-31
     latest: "3.9.24"
     latestReleaseDate: 2025-10-09
+    link: https://peps.python.org/pep-0596/
 
   - releaseCycle: "3.8"
     releaseDate: 2019-10-14
@@ -142,6 +148,7 @@ releases:
     eol: 2024-10-07
     latest: "3.8.20"
     latestReleaseDate: 2024-09-06
+    link: https://peps.python.org/pep-0569/
 
   - releaseCycle: "3.7"
     releaseDate: 2018-06-27
@@ -149,6 +156,7 @@ releases:
     eol: 2023-06-27
     latest: "3.7.17"
     latestReleaseDate: 2023-06-05
+    link: https://peps.python.org/pep-0537/
 
   - releaseCycle: "3.6"
     releaseDate: 2016-12-23
@@ -156,6 +164,7 @@ releases:
     eol: 2021-12-23
     latest: "3.6.15"
     latestReleaseDate: 2021-09-03
+    link: https://peps.python.org/pep-0494/
 
   - releaseCycle: "3.5"
     releaseDate: 2015-09-13
@@ -163,6 +172,7 @@ releases:
     eol: 2020-09-30
     latest: "3.5.10"
     latestReleaseDate: 2020-09-05
+    link: https://peps.python.org/pep-0478/
 
   - releaseCycle: "3.4"
     releaseDate: 2014-03-16
@@ -170,6 +180,7 @@ releases:
     eol: 2019-03-18
     latest: "3.4.10"
     latestReleaseDate: 2019-03-18
+    link: https://peps.python.org/pep-0429/
 
   - releaseCycle: "3.3"
     releaseDate: 2012-09-29
@@ -177,6 +188,7 @@ releases:
     eol: 2017-09-29
     latest: "3.3.7"
     latestReleaseDate: 2017-09-19
+    link: https://peps.python.org/pep-0398/
 
   - releaseCycle: "3.2"
     releaseDate: 2011-02-20
@@ -184,6 +196,7 @@ releases:
     eol: 2016-02-20
     latest: "3.2.6"
     latestReleaseDate: 2014-10-12
+    link: https://peps.python.org/pep-0392/
 
   - releaseCycle: "2.7"
     releaseDate: 2010-07-03
@@ -191,6 +204,7 @@ releases:
     eol: 2020-01-01
     latest: "2.7.18"
     latestReleaseDate: 2020-04-19
+    link: https://peps.python.org/pep-0373/
 
   - releaseCycle: "3.1"
     releaseDate: 2009-06-27
@@ -198,6 +212,7 @@ releases:
     eol: 2012-04-09
     latest: "3.1.5"
     latestReleaseDate: 2012-04-06
+    link: https://peps.python.org/pep-0375/
 
   - releaseCycle: "3.0"
     releaseDate: 2008-12-03
@@ -205,6 +220,7 @@ releases:
     eol: 2009-06-27
     latest: "3.0.1"
     latestReleaseDate: 2009-02-12
+    link: https://peps.python.org/pep-0361/
 
   - releaseCycle: "2.6"
     releaseDate: 2008-10-01
@@ -212,6 +228,7 @@ releases:
     eol: 2013-10-29
     latest: "2.6.9"
     latestReleaseDate: 2013-10-29
+    link: https://peps.python.org/pep-0361/
 
 ---
 

--- a/products/python.md
+++ b/products/python.md
@@ -108,7 +108,7 @@ releases:
     eol: 2030-10-31
     latest: "3.14.0"
     latestReleaseDate: 2025-10-07
-    pep: https://peps.python.org/pep-0745/
+    pep: pep-0745
 
   - releaseCycle: "3.13"
     releaseDate: 2024-10-07
@@ -116,7 +116,7 @@ releases:
     eol: 2029-10-31
     latest: "3.13.9"
     latestReleaseDate: 2025-10-14
-    pep: https://peps.python.org/pep-0719/
+    pep: pep-0719
 
   - releaseCycle: "3.12"
     releaseDate: 2023-10-02
@@ -124,7 +124,7 @@ releases:
     eol: 2028-10-31
     latest: "3.12.12"
     latestReleaseDate: 2025-10-09
-    pep: https://peps.python.org/pep-0693/
+    pep: pep-0693
 
   - releaseCycle: "3.11"
     releaseDate: 2022-10-24
@@ -132,7 +132,7 @@ releases:
     eol: 2027-10-31
     latest: "3.11.14"
     latestReleaseDate: 2025-10-09
-    pep: https://peps.python.org/pep-0664/
+    pep: pep-0664
 
   - releaseCycle: "3.10"
     releaseDate: 2021-10-04
@@ -140,7 +140,7 @@ releases:
     eol: 2026-10-31
     latest: "3.10.19"
     latestReleaseDate: 2025-10-09
-    pep: https://peps.python.org/pep-0619/
+    pep: pep-0619
 
   - releaseCycle: "3.9"
     releaseDate: 2020-10-05
@@ -148,7 +148,7 @@ releases:
     eol: 2025-10-31
     latest: "3.9.24"
     latestReleaseDate: 2025-10-09
-    pep: https://peps.python.org/pep-0596/
+    pep: pep-0596
 
   - releaseCycle: "3.8"
     releaseDate: 2019-10-14
@@ -156,7 +156,7 @@ releases:
     eol: 2024-10-07
     latest: "3.8.20"
     latestReleaseDate: 2024-09-06
-    pep: https://peps.python.org/pep-0569/
+    pep: pep-0569
 
   - releaseCycle: "3.7"
     releaseDate: 2018-06-27
@@ -164,7 +164,7 @@ releases:
     eol: 2023-06-27
     latest: "3.7.17"
     latestReleaseDate: 2023-06-05
-    pep: https://peps.python.org/pep-0537/
+    pep: pep-0537
 
   - releaseCycle: "3.6"
     releaseDate: 2016-12-23
@@ -172,7 +172,7 @@ releases:
     eol: 2021-12-23
     latest: "3.6.15"
     latestReleaseDate: 2021-09-03
-    pep: https://peps.python.org/pep-0494/
+    pep: pep-0494
 
   - releaseCycle: "3.5"
     releaseDate: 2015-09-13
@@ -180,7 +180,7 @@ releases:
     eol: 2020-09-30
     latest: "3.5.10"
     latestReleaseDate: 2020-09-05
-    pep: https://peps.python.org/pep-0478/
+    pep: pep-0478
 
   - releaseCycle: "3.4"
     releaseDate: 2014-03-16
@@ -188,7 +188,7 @@ releases:
     eol: 2019-03-18
     latest: "3.4.10"
     latestReleaseDate: 2019-03-18
-    pep: https://peps.python.org/pep-0429/
+    pep: pep-0429
 
   - releaseCycle: "3.3"
     releaseDate: 2012-09-29
@@ -196,7 +196,7 @@ releases:
     eol: 2017-09-29
     latest: "3.3.7"
     latestReleaseDate: 2017-09-19
-    pep: https://peps.python.org/pep-0398/
+    pep: pep-0398
 
   - releaseCycle: "3.2"
     releaseDate: 2011-02-20
@@ -204,7 +204,7 @@ releases:
     eol: 2016-02-20
     latest: "3.2.6"
     latestReleaseDate: 2014-10-12
-    pep: https://peps.python.org/pep-0392/
+    pep: pep-0392
 
   - releaseCycle: "2.7"
     releaseDate: 2010-07-03
@@ -212,7 +212,7 @@ releases:
     eol: 2020-01-01
     latest: "2.7.18"
     latestReleaseDate: 2020-04-19
-    pep: https://peps.python.org/pep-0373/
+    pep: pep-0373
 
   - releaseCycle: "3.1"
     releaseDate: 2009-06-27
@@ -220,7 +220,7 @@ releases:
     eol: 2012-04-09
     latest: "3.1.5"
     latestReleaseDate: 2012-04-06
-    pep: https://peps.python.org/pep-0375/
+    pep: pep-0375
 
   - releaseCycle: "3.0"
     releaseDate: 2008-12-03
@@ -228,7 +228,7 @@ releases:
     eol: 2009-06-27
     latest: "3.0.1"
     latestReleaseDate: 2009-02-12
-    pep: https://peps.python.org/pep-0361/
+    pep: pep-0361
 
   - releaseCycle: "2.6"
     releaseDate: 2008-10-01
@@ -236,7 +236,7 @@ releases:
     eol: 2013-10-29
     latest: "2.6.9"
     latestReleaseDate: 2013-10-29
-    pep: https://peps.python.org/pep-0361/
+    pep: pep-0361
 
 ---
 

--- a/products/python.md
+++ b/products/python.md
@@ -108,7 +108,7 @@ releases:
     eol: 2030-10-31
     latest: "3.14.0"
     latestReleaseDate: 2025-10-07
-    pep: pep-0745
+    pep: PEP-0745
 
   - releaseCycle: "3.13"
     releaseDate: 2024-10-07
@@ -116,7 +116,7 @@ releases:
     eol: 2029-10-31
     latest: "3.13.9"
     latestReleaseDate: 2025-10-14
-    pep: pep-0719
+    pep: PEP-0719
 
   - releaseCycle: "3.12"
     releaseDate: 2023-10-02
@@ -124,7 +124,7 @@ releases:
     eol: 2028-10-31
     latest: "3.12.12"
     latestReleaseDate: 2025-10-09
-    pep: pep-0693
+    pep: PEP-0693
 
   - releaseCycle: "3.11"
     releaseDate: 2022-10-24
@@ -132,7 +132,7 @@ releases:
     eol: 2027-10-31
     latest: "3.11.14"
     latestReleaseDate: 2025-10-09
-    pep: pep-0664
+    pep: PEP-0664
 
   - releaseCycle: "3.10"
     releaseDate: 2021-10-04
@@ -140,7 +140,7 @@ releases:
     eol: 2026-10-31
     latest: "3.10.19"
     latestReleaseDate: 2025-10-09
-    pep: pep-0619
+    pep: PEP-0619
 
   - releaseCycle: "3.9"
     releaseDate: 2020-10-05
@@ -148,7 +148,7 @@ releases:
     eol: 2025-10-31
     latest: "3.9.24"
     latestReleaseDate: 2025-10-09
-    pep: pep-0596
+    pep: PEP-0596
 
   - releaseCycle: "3.8"
     releaseDate: 2019-10-14
@@ -156,7 +156,7 @@ releases:
     eol: 2024-10-07
     latest: "3.8.20"
     latestReleaseDate: 2024-09-06
-    pep: pep-0569
+    pep: PEP-0569
 
   - releaseCycle: "3.7"
     releaseDate: 2018-06-27
@@ -164,7 +164,7 @@ releases:
     eol: 2023-06-27
     latest: "3.7.17"
     latestReleaseDate: 2023-06-05
-    pep: pep-0537
+    pep: PEP-0537
 
   - releaseCycle: "3.6"
     releaseDate: 2016-12-23
@@ -172,7 +172,7 @@ releases:
     eol: 2021-12-23
     latest: "3.6.15"
     latestReleaseDate: 2021-09-03
-    pep: pep-0494
+    pep: PEP-0494
 
   - releaseCycle: "3.5"
     releaseDate: 2015-09-13
@@ -180,7 +180,7 @@ releases:
     eol: 2020-09-30
     latest: "3.5.10"
     latestReleaseDate: 2020-09-05
-    pep: pep-0478
+    pep: PEP-0478
 
   - releaseCycle: "3.4"
     releaseDate: 2014-03-16
@@ -188,7 +188,7 @@ releases:
     eol: 2019-03-18
     latest: "3.4.10"
     latestReleaseDate: 2019-03-18
-    pep: pep-0429
+    pep: PEP-0429
 
   - releaseCycle: "3.3"
     releaseDate: 2012-09-29
@@ -196,7 +196,7 @@ releases:
     eol: 2017-09-29
     latest: "3.3.7"
     latestReleaseDate: 2017-09-19
-    pep: pep-0398
+    pep: PEP-0398
 
   - releaseCycle: "3.2"
     releaseDate: 2011-02-20
@@ -204,7 +204,7 @@ releases:
     eol: 2016-02-20
     latest: "3.2.6"
     latestReleaseDate: 2014-10-12
-    pep: pep-0392
+    pep: PEP-0392
 
   - releaseCycle: "2.7"
     releaseDate: 2010-07-03
@@ -212,7 +212,7 @@ releases:
     eol: 2020-01-01
     latest: "2.7.18"
     latestReleaseDate: 2020-04-19
-    pep: pep-0373
+    pep: PEP-0373
 
   - releaseCycle: "3.1"
     releaseDate: 2009-06-27
@@ -220,7 +220,7 @@ releases:
     eol: 2012-04-09
     latest: "3.1.5"
     latestReleaseDate: 2012-04-06
-    pep: pep-0375
+    pep: PEP-0375
 
   - releaseCycle: "3.0"
     releaseDate: 2008-12-03
@@ -228,7 +228,7 @@ releases:
     eol: 2009-06-27
     latest: "3.0.1"
     latestReleaseDate: 2009-02-12
-    pep: pep-0361
+    pep: PEP-0361
 
   - releaseCycle: "2.6"
     releaseDate: 2008-10-01
@@ -236,7 +236,7 @@ releases:
     eol: 2013-10-29
     latest: "2.6.9"
     latestReleaseDate: 2013-10-29
-    pep: pep-0361
+    pep: PEP-0361
 
 ---
 

--- a/products/python.md
+++ b/products/python.md
@@ -16,7 +16,7 @@ eoasColumn: true
 
 customFields:
   - name: pep
-    display: after-release-column
+    display: api-only
     label: PEP
     description: Python Enhancement Proposal (PEP) document for this release
     link: https://peps.python.org/topic/release/

--- a/products/python.md
+++ b/products/python.md
@@ -19,6 +19,7 @@ customFields:
     display: after-release-column
     label: PEP
     description: Python Enhancement Proposal (PEP) document for this release
+    link: https://peps.python.org/topic/release/
 
 identifiers:
   - purl: pkg:generic/python


### PR DESCRIPTION
I was looking for a source of python release information and ran across endoflife.date and it's 99% of what I needed. One of the things I was planning to include were links to the PEP's that defined the release timelines. It seemed like `link` might be the appropriate key to use for them based on some poking around in other products, but lmk if that's not the case or if this doesn't make sense at all.