### PR TITLE
[kubernetes] Add missing eol date for 1.34

### DIFF
--- a/products/kubernetes.md
+++ b/products/kubernetes.md
@@ -26,8 +26,8 @@ auto:
 releases:
   - releaseCycle: "1.34"
     releaseDate: 2025-08-27
-    eoas: false # not yet documented on https://kubernetes.io/releases/patch-releases/#detailed-release-history-for-active-branches
-    eol: false # not yet documented on https://kubernetes.io/releases/patch-releases/#detailed-release-history-for-active-branches
+    eoas: 2026-08-27
+    eol: 2026-10-27
     latest: "1.34.1"
     latestReleaseDate: 2025-09-09
 


### PR DESCRIPTION
EOL and EOAS dates for Kubernets 1.34 are now documented on https://kubernetes.io/releases/patch-releases/#detailed-release-history-for-active-branches

Follow on to #8289