### PR TITLE
Include release and discontinued dates in ics output

### DIFF
--- a/_plugins/create-icalendar-files.rb
+++ b/_plugins/create-icalendar-files.rb
@@ -58,7 +58,7 @@ def notification_message(product, cycle, type)
     message += ' will become End-of-life.'
   when 'eoas' then
     message += ' will end active development.'
-  when 'release' then
+  when 'releaseDate' then
     message += ' will be released.'
   when 'eoes' then
     message += ' will end extended support.'
@@ -71,7 +71,7 @@ def process_product(product)
   cal = Icalendar::Calendar.new
   product.release_cycles.each do |cycle|
     cycle.fetch('data').each do |key, item|
-      next if !['release', 'eoas', 'eol', 'eoes'].include?(key) || !item.instance_of?(Date)
+      next if !['releaseDate', 'eoas', 'eol', 'eoes'].include?(key) || !item.instance_of?(Date)
       event = cal.event
       event.dtstart = Icalendar::Values::Date.new(item)
       event.dtend = Icalendar::Values::Date.new(item + 1)

--- a/_plugins/create-icalendar-files.rb
+++ b/_plugins/create-icalendar-files.rb
@@ -62,6 +62,8 @@ def notification_message(product, cycle, type)
     message += ' will be released.'
   when 'eoes' then
     message += ' will end extended support.'
+  when 'discontinued' then
+    message += ' will be discontinued.'
   end
 end
 
@@ -71,7 +73,7 @@ def process_product(product)
   cal = Icalendar::Calendar.new
   product.release_cycles.each do |cycle|
     cycle.fetch('data').each do |key, item|
-      next if !['releaseDate', 'eoas', 'eol', 'eoes'].include?(key) || !item.instance_of?(Date)
+      next if !['releaseDate', 'eoas', 'eol', 'eoes', 'discontinued'].include?(key) || !item.instance_of?(Date)
       event = cal.event
       event.dtstart = Icalendar::Values::Date.new(item)
       event.dtend = Icalendar::Values::Date.new(item + 1)


### PR DESCRIPTION
The key for initial releases is `releaseDate`, not `release`. Release dates are present in the JSON API but not the calendar.

Note I intentionally left `latestReleaseDate` out, since it's a lossy update (as non-latest versions aren't kept between data updates).