### PR TITLE
[gitlab] Update automation

### DIFF
--- a/products/gitlab.md
+++ b/products/gitlab.md
@@ -20,13 +20,6 @@ auto:
   methods:
     - git: https://gitlab.com/gitlab-org/gitlab.git
       regex: '^v?(?P<major>[1-9]\d*)\.(?P<minor>\d+)\.(?P<patch>\d+)-ee?$'
-    - release_table: https://about.gitlab.com/releases/
-      fields:
-        releaseCycle: "Version"
-        releaseDate:
-          column: "Release Date"
-          regex: '^(?P<month>\w+) (?P<day>\d+)(st|nd|rd|th)?,? (?P<year>\d{4}).*$'
-          template: "{{month}} {{day}} {{year}}"
 
 # eoas(x) = releaseDate(x+1)
 # eol(x) = releaseDate(x+3)


### PR DESCRIPTION
Drop automation based on https://about.gitlab.com/releases/. It now redirects to https://about.gitlab.com/releases/categories/releases/ which don't contain the release table.