### PR TITLE
[opensearch] Update to use release creation date instead of tag commit date

### DIFF
--- a/products/opensearch.md
+++ b/products/opensearch.md
@@ -12,7 +12,7 @@ eolColumn: Maintenance Support
 
 auto:
   methods:
-    - git: https://github.com/opensearch-project/OpenSearch.git
+    - github_releases: opensearch-project/OpenSearch
     - release_table: https://opensearch.org/releases.html
       fields:
         releaseCycle: "Major Version"


### PR DESCRIPTION
Hi All,

This is a follow up PR to the discussion here:
* https://github.com/endoflife-date/endoflife.date/pull/7367#issuecomment-2855777433

The main OpenSearch core repo now has a dedicated github action to create release whenever a tag is cut.
Therefore, using release creation date is much more accurate than the commit date of the tag.

Please let me know if this is the correct way to update it.
I also wonder if I should send a PR to update dates here accordingly:
* https://github.com/endoflife-date/release-data/blob/main/releases/opensearch.json

Thanks.