### PR TITLE
[ruby-on-rails] Update 8.0 cycle's eoas date

### DIFF
--- a/products/ruby-on-rails.md
+++ b/products/ruby-on-rails.md
@@ -35,7 +35,7 @@ releases:
 
   - releaseCycle: "8.0"
     releaseDate: 2024-11-07
-    eoas: 2025-11-07
+    eoas: 2026-05-07
     eol: 2026-11-07
     latest: "8.0.3"
     latestReleaseDate: 2025-09-22


### PR DESCRIPTION
Rails 8.0 support has been extended by 6 months.

https://rubyonrails.org/2025/10/29/new-rails-releases-and-end-of-support-announcement