### PR TITLE
[ruby-on-rails] Update eol/eoas dates for 8.1 cycle

### DIFF
--- a/products/ruby-on-rails.md
+++ b/products/ruby-on-rails.md
@@ -28,38 +28,38 @@ auto:
 releases:
   - releaseCycle: "8.1"
     releaseDate: 2025-10-22
-    eoas: 2026-10-22
-    eol: 2027-10-22
-    latest: "8.1.0"
-    latestReleaseDate: 2025-10-22
+    eoas: 2026-10-10
+    eol: 2027-10-10
+    latest: "8.1.1"
+    latestReleaseDate: 2025-10-28
 
   - releaseCycle: "8.0"
     releaseDate: 2024-11-07
-    eoas: 2025-11-07
+    eoas: 2026-05-07
     eol: 2026-11-07
-    latest: "8.0.3"
-    latestReleaseDate: 2025-09-22
+    latest: "8.0.4"
+    latestReleaseDate: 2025-10-28
 
   - releaseCycle: "7.2"
     releaseDate: 2024-08-09
     eoas: 2025-08-09
     eol: 2026-08-09
-    latest: "7.2.2.2"
-    latestReleaseDate: 2025-08-13
+    latest: "7.2.3"
+    latestReleaseDate: 2025-10-28
 
   - releaseCycle: "7.1"
     releaseDate: 2023-10-05
     eoas: 2024-10-01
     eol: 2025-10-01 # see https://rubyonrails.org/maintenance
-    latest: "7.1.5.2"
-    latestReleaseDate: 2025-08-13
+    latest: "7.1.6"
+    latestReleaseDate: 2025-10-28
 
   - releaseCycle: "7.0"
     releaseDate: 2021-12-15
     eoas: 2023-10-15
     eol: 2025-04-01 # see https://rubyonrails.org/maintenance
-    latest: "7.0.8.7"
-    latestReleaseDate: 2024-12-10
+    latest: "7.0.10"
+    latestReleaseDate: 2025-10-28
 
   - releaseCycle: "6.1"
     releaseDate: 2020-12-09


### PR DESCRIPTION
I didn't see a PR template so hope this is right.

I verified the gem versions with this command:
```shell
versions="8.1.1 8.0.4 7.2.3 7.1.6 7.0.10"
curl -s "https://rubygems.org/api/v1/versions/rails.json" | \
  jq -r --arg versions "$versions" '
    .[] |
    select(.number as $num | $versions | split(" ") | index($num) != null) |
    "Rails \(.number): \(.created_at[:10])"
  '
```

AI Disclaimer: I used Claude Code to help generate this PR.

## Summary

Updates Rails versions and support dates based on the [official announcement from October 29, 2025](https://rubyonrails.org/2025/10/29/new-rails-releases-and-end-of-support-announcement).

## Changes

- **Rails 8.1**: Corrected support end dates from October 22 to October 10 (both active and security support), updated to version 8.1.1
- **Rails 8.0**: Extended active support to May 7, 2026 (6-month extension due to delayed 8.1 release), updated to version 8.0.4
- **Rails 7.2**: Updated to version 7.2.3
- **Rails 7.1**: Updated to version 7.1.6 (final release, now EOL)
- **Rails 7.0**: Updated to version 7.0.10 (final release, now EOL)

All release dates updated to October 28, 2025 to match rubygems.org.

## References

- https://rubyonrails.org/2025/10/29/new-rails-releases-and-end-of-support-announcement