### PR TITLE
[New Product] Oreon Linux

### DIFF
--- a/products/oreon.md
+++ b/products/oreon.md
@@ -1,0 +1,52 @@
+---
+title: Oreon Linux
+addedAt: 2025-10-30
+category: os
+tags: linux-distribution
+iconSlug: oreon
+permalink: /oreon
+alternate_urls:
+  - /oreon-linux
+  - /oreon-os
+versionCommand: cat /etc/oreon-release
+releasePolicyLink: https://wiki.oreonproject.org/docs/Support-Timelines/
+changelogTemplate: https://wiki.oreonproject.org/docs/Support-Timelines/oreon-10-support-timeline
+eoasColumn: true
+
+identifiers:
+  - cpe: cpe:/o:oreon:oreon
+  - cpe: cpe:2.3:o:oreon:oreon
+
+auto:
+  methods:
+    - distrowatch: oreon
+      regex: '^Distribution Release: Oreon (?P<major>\d+)-(?P<build>\d+)$'
+
+releases:
+  - releaseCycle: "10"
+    releaseLabel: "Oreon 10"
+    releaseDate: 2024-12-12
+    eoas: 2030-08-20
+    eol: 2035-06-01
+    latest: "2510"
+    latestReleaseDate: 2025-10-12
+    link: https://wiki.oreonproject.org/docs/Support-Timelines/oreon-10-support-timeline
+
+  - releaseCycle: "Lime R2"
+    releaseLabel: "Oreon Lime (R2)"
+    releaseDate: 2024-02-18
+    eoas: 2027-06-01
+    eol: 2032-05-31
+    latest: "2504"
+    latestReleaseDate: 2025-04-19
+    link: https://wiki.oreonproject.org/docs/Support-Timelines/oreon-lime-r2-support-timeline
+---
+
+> [Oreon Linux](https://oreonproject.org/) is a free and open-source Linux distribution dedicated to making Enterprise Linux more suitable for desktops and laptops, providing the best user experience right out of the gate.
+> Oreon is in the process of becoming independent.
+
+Oreon Linux aims to provide predictable, well-documented support timelines for enterprise and community environments alike.  
+Support lifecycles and changelogs for each release are publicly maintained on the [Oreon Wiki](https://wiki.oreonproject.org/).
+
+### Support
+The Oreon Project has several support options on [their website](https://oreonproject.org/help).

--- a/products/oreon.md
+++ b/products/oreon.md
@@ -8,8 +8,7 @@ alternate_urls:
   - /oreon-linux
   - /oreon-os
 versionCommand: cat /etc/oreon-release
-releasePolicyLink: https://wiki.oreonproject.org/docs/Support-Timelines/
-changelogTemplate: https://wiki.oreonproject.org/docs/Support-Timelines/oreon-10-support-timeline
+releasePolicyLink: https://wiki.oreonproject.org/docs/Support-Timelines/oreon-10-support-timeline
 eoasColumn: true
 
 identifiers:
@@ -29,7 +28,7 @@ releases:
     eol: 2035-06-01
     latest: "2510"
     latestReleaseDate: 2025-10-12
-    link: https://wiki.oreonproject.org/docs/Support-Timelines/oreon-10-support-timeline
+    link: https://oreonproject.org/docs/releases/oreon-10
 
   - releaseCycle: "lime-r2"
     releaseLabel: "Oreon Lime (R2)"
@@ -38,7 +37,7 @@ releases:
     eol: 2032-05-31
     latest: "2504"
     latestReleaseDate: 2025-04-19
-    link: https://wiki.oreonproject.org/docs/Support-Timelines/oreon-lime-r2-support-timeline
+    link: 
 ---
 
 > [Oreon Linux](https://oreonproject.org/) is a free and open-source Linux distribution dedicated to making Enterprise Linux more suitable for desktops and laptops, providing the best user experience right out of the gate.

--- a/products/oreon.md
+++ b/products/oreon.md
@@ -32,7 +32,7 @@ releases:
     latestReleaseDate: 2025-10-12
     link: https://wiki.oreonproject.org/docs/Support-Timelines/oreon-10-support-timeline
 
-  - releaseCycle: "Lime R2"
+  - releaseCycle: "lime-r2"
     releaseLabel: "Oreon Lime (R2)"
     releaseDate: 2024-02-18
     eoas: 2027-06-01

--- a/products/oreon.md
+++ b/products/oreon.md
@@ -1,9 +1,8 @@
 ---
 title: Oreon Linux
-addedAt: 2025-10-30
+addedAt: 2026-01-12
 category: os
 tags: linux-distribution
-iconSlug: oreon
 permalink: /oreon
 alternate_urls:
   - /oreon-linux
@@ -45,8 +44,4 @@ releases:
 > [Oreon Linux](https://oreonproject.org/) is a free and open-source Linux distribution dedicated to making Enterprise Linux more suitable for desktops and laptops, providing the best user experience right out of the gate.
 > Oreon is in the process of becoming independent.
 
-Oreon Linux aims to provide predictable, well-documented support timelines for enterprise and community environments alike.  
-Support lifecycles and changelogs for each release are publicly maintained on the [Oreon Wiki](https://wiki.oreonproject.org/).
-
-### Support
-The Oreon Project has several support options on [their website](https://oreonproject.org/help).
+Oreon follows the support timeline of its base RHEL version, with security updates provided throughout the entire support period.


### PR DESCRIPTION
Added detailed information about Oreon Linux, including its support timelines, release cycles, and links to relevant documentation.

Oreon currently has a smaller-ish community when compared to most distros, but after we release Oreon 11, we will likely gain a lot more popularity with the features we are planning to ship. Oreon 11 will also be independent so we will be predicting the lifecycle and support timelines for that version, not AlmaLinux.

Let me know if this needs any modification.