### PR TITLE
[rust] Adds 1.91

### DIFF
--- a/products/rust.md
+++ b/products/rust.md
@@ -22,9 +22,15 @@ identifiers:
 
 # eol(x) = releaseDate(x+1)
 releases:
+  - releaseCycle: "1.91"
+    releaseDate: 2025-10-30
+    eol: false
+    latest: "1.91.0"
+    latestReleaseDate: 2025-10-30
+
   - releaseCycle: "1.90"
     releaseDate: 2025-09-18
-    eol: false
+    eol: 2025-10-30
     latest: "1.90.0"
     latestReleaseDate: 2025-09-18
 
@@ -410,6 +416,7 @@ Editions are a mechanism for opt-in changes that may otherwise pose a backwards 
 Since editions are opt-in, existing crates won't use the changes unless they explicitly migrate to the new edition.
 Each crate chooses its edition within its Cargo.toml file.
 Editions are skin-deep, and as a result - you can always use an older edition alongside a supported version of the compiler.
+Editions are expected to be [released every three years](https://rust-lang.github.io/rfcs/3501-edition-2024.html).
 
 The following Rust editions exist:
 


### PR DESCRIPTION
Adds rust 1.91 release, and notes
the 3-yr cadence for editions.