### PR TITLE
[exim] Adds 4.99 release

### DIFF
--- a/products/exim.md
+++ b/products/exim.md
@@ -17,9 +17,17 @@ auto:
 
 # eol(x) = releaseDate(x+1)
 releases:
+
+  - releaseCycle: "4.99"
+    releaseDate: 2025-10-28
+    eol: false
+    latest: "4.99"
+    latestReleaseDate: 2025-10-28
+    link: https://lists.exim.org/lurker/message/20251028.114149.3bf19800.en.html
+
   - releaseCycle: "4.98"
     releaseDate: 2024-07-10
-    eol: false
+    eol: 2025-10-28
     latest: "4.98.2"
     latestReleaseDate: 2025-03-21
 

--- a/products/exim.md
+++ b/products/exim.md
@@ -17,7 +17,6 @@ auto:
 
 # eol(x) = releaseDate(x+1)
 releases:
-
   - releaseCycle: "4.99"
     releaseDate: 2025-10-28
     eol: false


### PR DESCRIPTION
Links to the announcement, since the tags are not annotated.