### PR TITLE
Fix header anchors in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,14 +6,14 @@ description: Some information on how to contribute to https://endoflife.date.
 permalink: /contribute
 ---
 
-- [<img class="emoji" title=":octocat:" alt=":octocat:" src="https://github.githubassets.com/images/icons/emoji/octocat.png" width="20" height="20"> Hacktoberfest](#img-classemoji-titleoctocat-altoctocat-srchttpsgithubgithubassetscomimagesiconsemojioctocatpng-width20-height20-hacktoberfest)
+- [<img class="emoji" title=":octocat:" alt=":octocat:" src="https://github.githubassets.com/images/icons/emoji/octocat.png" width="20" height="20"> Hacktoberfest](#-hacktoberfest)
 - [🕐 What's this project?](#-whats-this-project)
-- [✏️ About the codebase](#pencil-about-the-codebase)
-- [➕ Adding a new product](#new-adding-a-new-product)
+- [✏️ About the codebase](#️-about-the-codebase)
+- [➕ Adding a new product](#-adding-a-new-product)
 - [✅ Validating your changes](#-validating-your-changes)
 - [🆔 Adding Identifiers](#-adding-identifiers)
 - [📑 Suggested Reading](#-suggested-reading)
-- [⚖️ Code of Conduct](#bookmark-code-of-conduct)
+- [⚖️ Code of Conduct](#️-code-of-conduct)
 
 ## 🎲 Hacktoberfest
 


### PR DESCRIPTION
Some links in TOC did not link to the specific section. This PR should fix this

`✏️` and `⚖️` emojis are created using `%EF%B8%8F` variation selector character and it exists as a part of URL. It is invisible but it makes the pound symbol look kinda odd:

<img width="217" height="40" alt="image" src="https://github.com/user-attachments/assets/8cf126db-d416-4a4e-bf2e-e28a52436ed9" />

Not sure if it can be trimmed