### PR TITLE
[pan-os]Update PAN-OS version(s)

### DIFF
--- a/products/pan-os.md
+++ b/products/pan-os.md
@@ -69,7 +69,7 @@ releases:
     eol: 2024-12-01
     latest: "10.1.14-h19"
     latestReleaseDate: 2025-11-03
-    link: https://docs.paloaltonetworks.com/ngfw/release-notes/10-1/pan-os-release-notes/pan-os-10-1-14-known-and-addressed-issues/pan-os-10-1-14-h19-addressed-issues
+    link: https://docs.paloaltonetworks.com/pan-os/10-1/pan-os-release-notes/pan-os-10-1-14-known-and-addressed-issues/pan-os-10-1-14-h19-addressed-issues
 
   - releaseCycle: "10.0"
     releaseDate: 2020-07-16

--- a/products/pan-os.md
+++ b/products/pan-os.md
@@ -67,9 +67,9 @@ releases:
   - releaseCycle: "10.1"
     releaseDate: 2021-05-31
     eol: 2024-12-01
-    latest: "10.1.14-h16"
-    latestReleaseDate: 2025-07-08
-    link: https://docs.paloaltonetworks.com/pan-os/10-1/pan-os-release-notes/pan-os-10-1-14-known-and-addressed-issues/pan-os-10-1-14-h16-addressed-issues
+    latest: "10.1.14-h19"
+    latestReleaseDate: 2025-11-03
+    link: https://docs.paloaltonetworks.com/ngfw/release-notes/10-1/pan-os-release-notes/pan-os-10-1-14-known-and-addressed-issues/pan-os-10-1-14-h19-addressed-issues
 
   - releaseCycle: "10.0"
     releaseDate: 2020-07-16


### PR DESCRIPTION
[panos] This PR updates the PAN-OS versions, Release dates and the Release Notes url.

Updated Pan-OS Version:  10.1.14-h19 

Released:                2025-11-03 

Release Notes:           https://docs.paloaltonetworks.com/pan-os/10-1/pan-os-release-notes/pan-os-10-1-14-known-and-addressed-issues/pan-os-10-1-14-h19-addressed-issues 
