### PR TITLE
[pan-os]Update PAN-OS version(s)

### DIFF
--- a/products/pan-os.md
+++ b/products/pan-os.md
@@ -39,9 +39,9 @@ releases:
   - releaseCycle: "11.2"
     releaseDate: 2024-05-02
     eol: 2027-05-02
-    latest: "11.2.9"
-    latestReleaseDate: 2025-09-18
-    link: https://docs.paloaltonetworks.com/pan-os/11-2/pan-os-release-notes/pan-os-11-2-9-known-and-addressed-issues/pan-os-11-2-9-addressed-issues
+    latest: "11.2.10"
+    latestReleaseDate: 2025-11-05
+    link: https://docs.paloaltonetworks.com/pan-os/11-2/pan-os-release-notes/pan-os-11-2-10-known-and-addressed-issues/pan-os-11-2-10-addressed-issues
 
   - releaseCycle: "11.1"
     releaseDate: 2023-11-03


### PR DESCRIPTION
[panos] This PR updates the PAN-OS versions, Release dates and the Release Notes url.

Version: 11.2.10
Release Date: 2025-11-05
Release Notes    link: https://docs.paloaltonetworks.com/pan-os/11-2/pan-os-release-notes/pan-os-11-2-10-known-and-addressed-issues/pan-os-11-2-10-addressed-issues

