### PR TITLE
[laravel] Fixes purl identifier

### DIFF
--- a/products/laravel.md
+++ b/products/laravel.md
@@ -17,7 +17,7 @@ customFields:
     description: Supported PHP versions
 
 identifiers:
-  - purl: pkg:composer/laravel/laravel
+  - purl: pkg:composer/laravel/framework
   - purl: pkg:docker/bitnami/laravel
   - purl: pkg:github/laravel/framework
   - repology: php:laravel-framework


### PR DESCRIPTION
Fix PURL for Laravel framework package

This patch corrects the package URL (purl) in `laravel.md` to reference the Laravel framework package rather than the starter application. 

The file now lists the composer package identifier as `pkg:composer/laravel/framework`, matching the author note on line ~130 that this page tracks the framework and not the laravel/laravel starter repository.