### PR TITLE
[linuxmint] Add LMDE 6 EOL

### DIFF
--- a/products/linuxmint.md
+++ b/products/linuxmint.md
@@ -62,7 +62,7 @@ releases:
     releaseLabel: "LMDE 6 '__CODENAME__'"
     codename: Faye
     releaseDate: 2023-09-27
-    eol: false
+    eol: 2026-01-01
     link: https://blog.linuxmint.com/?p=4570
 
   - releaseCycle: "21.2"


### PR DESCRIPTION
Source: https://blog.linuxmint.com/?p=4936

> LMDE 6 EOL
> 
> LMDE 6 will reach End of Life on January 1st 2026.
> 
> Past that date the repositories will continue to work but the release will no longer receive bug fixes or security updates.
> 
> To upgrade the 64-bit version of LMDE 6 to LMDE 7 visit https://blog.linuxmint.com/?p=4571.
> 
> The 32-bit version will unfortunately not be upgradable. Proper support for 32-bit was dropped by many upstream projects (Debian, Ubuntu, Mozilla, Chromium) so we cannot continue to support this architecture anymore.