### PR TITLE
[unity] Add 2022.2.23f1 , 2022.1.25f1 , 2021.1.29f1 , 2021.2.20f1 and 2021.3.45f2

### DIFF
--- a/products/unity.md
+++ b/products/unity.md
@@ -91,8 +91,8 @@ releases:
   - releaseCycle: "2021.1"
     releaseDate: 2021-03-22
     eol: 2022-11-04
-    latest: "2021.1.28f1"
-    latestReleaseDate: 2022-11-04
+    latest: "2021.1.29f1"
+    latestReleaseDate: 2025-10-03
 
   - releaseCycle: "2020"
     lts: true

--- a/products/unity.md
+++ b/products/unity.md
@@ -79,8 +79,8 @@ releases:
   - releaseCycle: "2021.3"
     releaseDate: 2022-04-11
     eol: 2025-02-18
-    latest: "2021.3.45f1"
-    latestReleaseDate: 2024-10-16
+    latest: "2021.3.45f2"
+    latestReleaseDate: 2025-10-03
 
   - releaseCycle: "2021.2"
     releaseDate: 2021-10-25

--- a/products/unity.md
+++ b/products/unity.md
@@ -60,14 +60,14 @@ releases:
   - releaseCycle: "2022.2"
     releaseDate: 2022-12-07
     eol: 2023-06-12
-    latest: "2022.2.21f1"
-    latestReleaseDate: 2023-05-24
+    latest: "2022.2.23f1"
+    latestReleaseDate: 2025-10-03
 
   - releaseCycle: "2022.1"
     releaseDate: 2022-05-09
     eol: 2022-12-06
-    latest: "2022.1.24f1"
-    latestReleaseDate: 2022-12-06
+    latest: "2022.1.25f1"
+    latestReleaseDate: 2025-10-03
 
   - releaseCycle: "2021"
     lts: true

--- a/products/unity.md
+++ b/products/unity.md
@@ -73,8 +73,8 @@ releases:
     lts: true
     releaseDate: 2022-04-11
     eol: 2025-02-18
-    latest: "2021.3.45f1"
-    latestReleaseDate: 2024-10-16
+    latest: "2021.3.45f2"
+    latestReleaseDate: 2025-10-03
 
   - releaseCycle: "2021.3"
     releaseDate: 2022-04-11
@@ -85,8 +85,8 @@ releases:
   - releaseCycle: "2021.2"
     releaseDate: 2021-10-25
     eol: 2022-04-05
-    latest: "2021.2.19f1"
-    latestReleaseDate: 2022-04-05
+    latest: "2021.2.20f1"
+    latestReleaseDate: 2025-10-03
 
   - releaseCycle: "2021.1"
     releaseDate: 2021-03-22


### PR DESCRIPTION
Those are the ones which got important security fixes even though they already eoled.

https://unity.com/releases/editor/whats-new/2022.1.25f1#notes

https://unity.com/releases/editor/whats-new/2022.2.23f1#notes

https://unity.com/releases/editor/whats-new/2021.3.45f2#notes

https://unity.com/releases/editor/whats-new/2021.1.29f1#notes

https://unity.com/releases/editor/whats-new/2021.2.20f1#notes


