### PR TITLE
[openvpn] Mark 2.5 as EOL

### DIFF
--- a/products/openvpn.md
+++ b/products/openvpn.md
@@ -28,7 +28,7 @@ releases:
   - releaseCycle: "2.5"
     releaseDate: 2020-10-27
     eoas: 2024-07-18
-    eol: false
+    eol: 2025-07-31
     latest: "2.5.11"
     latestReleaseDate: 2024-07-18
 


### PR DESCRIPTION
As documented on https://community.openvpn.net/Pages/Supported%20versions.