### PR TITLE
Improve stale release warnings

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -95,7 +95,7 @@ defaults:
       eolColumnLabel: "Security Support"
       eoesColumn: false
       eoesColumnLabel: "Extended Support"
-      staleReleaseThresholdYears: 1
+      staleReleaseThresholdDays: 365
       customFields: []
       LTSLabel: '<abbr title="Long Term Support">LTS</abbr>'
 

--- a/_plugins/product-data-validator.rb
+++ b/_plugins/product-data-validator.rb
@@ -403,7 +403,7 @@ module EndOfLifeHooks
     def undeclared_custom_field(property)
       releases = @data[property]
 
-      standard_fields = %w[releaseCycle releaseLabel codename releaseDate eoas eol eoes discontinued latest latestReleaseDate link lts outOfOrder]
+      standard_fields = %w[releaseCycle releaseLabel codename releaseDate eoas eol eoes discontinued latest latestReleaseDate link lts outOfOrder staleReleaseThresholdDays]
       custom_fields = @product["customFields"].map { |column| column["name"] }
 
       releases.each do |release|

--- a/products/amazon-documentdb.md
+++ b/products/amazon-documentdb.md
@@ -8,7 +8,7 @@ permalink: /amazon-documentdb
 latestColumn: false
 eolColumn: End of Standard Support
 eoesColumn: End of Extended Support
-staleReleaseThresholdYears: 5
+staleReleaseThresholdDays: 2000
 
 auto:
   methods:

--- a/products/amazon-glue.md
+++ b/products/amazon-glue.md
@@ -7,7 +7,7 @@ iconSlug: amazonaws
 permalink: /amazon-glue
 releasePolicyLink: https://docs.aws.amazon.com/glue/latest/dg/glue-version-support-policy.html
 latestColumn: false
-staleReleaseThresholdYears: 5
+staleReleaseThresholdDays: 2000
 
 customFields:
   - name: pythonVersion

--- a/products/amazon-msk.md
+++ b/products/amazon-msk.md
@@ -12,8 +12,9 @@ alternate_urls:
 releasePolicyLink: https://docs.aws.amazon.com/msk/latest/developerguide/version-support.html
 changelogTemplate: "https://docs.aws.amazon.com/msk/latest/developerguide/supported-kafka-versions.html#{{'__LATEST__' | replace:'.x',''}}"
 eolColumn: Support
-staleReleaseThresholdYears: 3
+staleReleaseThresholdDays: 1000 # confirmed on https://docs.aws.amazon.com/msk/latest/developerguide/supported-kafka-versions.html
 
+# eol are documented on https://docs.aws.amazon.com/msk/latest/developerguide/supported-kafka-versions.html.
 releases:
   - releaseCycle: "4.0"
     releaseDate: 2025-05-16

--- a/products/android.md
+++ b/products/android.md
@@ -13,7 +13,7 @@ changelogTemplate: https://developer.android.com/about/versions/__RELEASE_CYCLE_
 releaseLabel: "__RELEASE_CYCLE__ '__CODENAME__'"
 latestColumn: false
 eolColumn: Security Support
-staleReleaseThresholdYears: 4
+staleReleaseThresholdDays: 1095 # 3 years seems a minimum
 
 customFields:
   - name: apiVersion

--- a/products/apache-ant.md
+++ b/products/apache-ant.md
@@ -9,7 +9,6 @@ alternate_urls:
   - /apache-ant
 changelogTemplate: https://ant.apache.org/antnews.html
 versionCommand: ant -version
-staleReleaseThresholdYears: 2
 
 identifiers:
   - cpe: cpe:/a:apache:ant
@@ -22,6 +21,7 @@ auto:
 
 releases:
   - releaseCycle: "1.10"
+    staleReleaseThresholdDays: 700 # confirmed on https://ant.apache.org/antnews.html
     releaseDate: 2016-12-27
     eol: false
     latest: "1.10.15"

--- a/products/apache-apisix.md
+++ b/products/apache-apisix.md
@@ -8,7 +8,6 @@ permalink: /apache-apisix
 alternate_urls:
   - /apisix
 changelogTemplate: https://github.com/apache/apisix/releases/tag/__LATEST__
-staleReleaseThresholdYears: 3
 
 auto:
   methods:
@@ -93,9 +92,10 @@ releases:
     latestReleaseDate: 2023-05-04
 
   - releaseCycle: "3.2"
+    staleReleaseThresholdDays: 1000 # status is unclear, https://github.com/apache/apisix/issues/11759
     lts: true
     releaseDate: 2023-03-06
-    eol: false # https://github.com/apache/apisix/issues/11759
+    eol: false
     latest: "3.2.2"
     latestReleaseDate: 2023-07-22
 

--- a/products/apache-couchdb.md
+++ b/products/apache-couchdb.md
@@ -28,8 +28,8 @@ releases:
   - releaseCycle: "3.5"
     releaseDate: 2025-05-05
     eol: false
-    latest: "3.5.0"
-    latestReleaseDate: 2025-05-05
+    latest: "3.5.1"
+    latestReleaseDate: 2025-11-09
 
   - releaseCycle: "3.4"
     releaseDate: 2024-09-20
@@ -48,6 +48,7 @@ releases:
     eol: 2024-09-20
     latest: "3.2.3"
     latestReleaseDate: 2023-04-24
+
 ---
 
 > [Apache CouchDB](https://couchdb.apache.org/) is an open-source, document-oriented NoSQL database implemented

--- a/products/apache-groovy.md
+++ b/products/apache-groovy.md
@@ -13,7 +13,6 @@ releasePolicyLink: https://groovy.apache.org/versioning.html
 changelogTemplate: https://groovy-lang.org/changelogs/changelog-__LATEST__.html
 eoasColumn: true
 eolColumn: Bug and Security Fixes
-staleReleaseThresholdYears: 3
 
 identifiers:
   - repology: groovy
@@ -53,9 +52,10 @@ releases:
     latestReleaseDate: 2025-05-27
 
   - releaseCycle: "2.5"
+    staleReleaseThresholdDays: 1000 # still listed on https://groovy.apache.org/download.html
     releaseDate: 2018-05-30
     eoas: true
-    eol: false # still listed on https://groovy.apache.org/download.html
+    eol: false
     latest: "2.5.23"
     latestReleaseDate: 2023-08-22
 

--- a/products/apache-hadoop.md
+++ b/products/apache-hadoop.md
@@ -11,7 +11,6 @@ changelogTemplate: https://hadoop.apache.org/release/__LATEST__.html
 eolColumn: Support
 # https://stackoverflow.com/a/33936569/374236
 versionCommand: hadoop version
-staleReleaseThresholdYears: 5
 
 identifiers:
   - repology: hadoop
@@ -35,12 +34,14 @@ releases:
     latestReleaseDate: 2025-08-29
 
   - releaseCycle: "3.3"
+    staleReleaseThresholdDays: 1000 # still on https://cwiki.apache.org/confluence/display/HADOOP/Hadoop+Active+Release+Lines
     releaseDate: 2020-07-15
     eol: false
     latest: "3.3.6"
     latestReleaseDate: 2023-06-26
 
   - releaseCycle: "2.10"
+    staleReleaseThresholdDays: 1500 # still on https://cwiki.apache.org/confluence/display/HADOOP/Hadoop+Active+Release+Lines
     releaseDate: 2019-10-29
     eol: false
     latest: "2.10.2"

--- a/products/apple-watch.md
+++ b/products/apple-watch.md
@@ -9,7 +9,7 @@ releasePolicyLink: https://support.apple.com/watch
 discontinuedColumn: true
 eolColumn: Supported
 latestColumn: false
-staleReleaseThresholdYears: 6
+staleReleaseThresholdDays: 2000
 
 customFields:
   - name: supportedWatchOsVersions
@@ -44,7 +44,7 @@ releases:
     eol: false
     link: https://support.apple.com/en-us/125095
     supportedWatchOsVersions: "26"
-    
+
   - releaseCycle: "series-10"
     releaseLabel: "Series 10"
     releaseDate: 2024-09-20

--- a/products/cachet.md
+++ b/products/cachet.md
@@ -6,7 +6,6 @@ tags: php-runtime
 iconSlug: cachet
 permalink: /cachet
 changelogTemplate: https://github.com/cachethq/cachet/releases/tag/v__LATEST__
-staleReleaseThresholdYears: 3
 
 auto:
   methods:
@@ -15,6 +14,7 @@ auto:
 # eol(x) = releaseDate(x+1)
 releases:
   - releaseCycle: "2.4"
+    staleReleaseThresholdDays: 1000 # team is working on v3 - https://github.com/orgs/cachethq/discussions/4342#discussioncomment-11714831
     releaseDate: 2023-10-27
     eol: false
     latest: "2.4.1"

--- a/products/cakephp.md
+++ b/products/cakephp.md
@@ -12,7 +12,6 @@ versionCommand: php bin/cake.php version
 releasePolicyLink: https://github.com/cakephp/cakephp/wiki
 changelogTemplate: https://github.com/cakephp/cakephp/releases/__LATEST__
 eoasColumn: true
-staleReleaseThresholdYears: 2
 
 customFields:
   - name: supportedPhpVersions
@@ -75,6 +74,7 @@ releases:
 
   - releaseCycle: "5.0"
     codename: "Chiffon"
+    staleReleaseThresholdDays: 500 # not EOL on https://github.com/cakephp/cakephp/wiki
     releaseDate: 2023-09-09
     supportedPhpVersions: 8.1+
     eoas: 2024-09-14

--- a/products/chef-infra-server.md
+++ b/products/chef-infra-server.md
@@ -11,7 +11,6 @@ versionCommand: chef-server-ctl version
 releasePolicyLink: https://docs.chef.io/versions/
 changelogTemplate: https://docs.chef.io/release_notes_server/#__LATEST__
 eoasColumn: true
-staleReleaseThresholdYears: 4
 
 identifiers:
   - repology: chef-server
@@ -33,6 +32,7 @@ releases:
     latestReleaseDate: 2025-11-03
 
   - releaseCycle: "14"
+    staleReleaseThresholdDays: 1500 # deprecated, but no EOL on https://docs.chef.io/versions/
     releaseDate: 2020-06-08
     eoas: 2022-06-13
     eol: false

--- a/products/ckeditor.md
+++ b/products/ckeditor.md
@@ -7,7 +7,7 @@ permalink: /ckeditor
 releasePolicyLink: https://ckeditor.com/docs/ckeditor5/latest/updating/versioning-policy.html
 eolColumn: Support
 eoesColumn: true
-staleReleaseThresholdYears: 0.1 # so that maintainers are reminded to manually update the latest version frequently
+staleReleaseThresholdDays: 30 # so that maintainers are reminded to manually update the latest version frequently
 
 identifiers:
   - repology: ckeditor

--- a/products/consul.md
+++ b/products/consul.md
@@ -8,7 +8,6 @@ permalink: /consul
 versionCommand: consul --version
 releasePolicyLink: https://support.hashicorp.com/hc/en-us/articles/360021185113-Support-Period-and-End-of-Life-EOL-Policy
 changelogTemplate: https://github.com/hashicorp/consul/blob/v__LATEST__/CHANGELOG.md
-staleReleaseThresholdYears: 1.5
 
 identifiers:
   - repology: consul

--- a/products/dotnetfx.md
+++ b/products/dotnetfx.md
@@ -13,7 +13,7 @@ releasePolicyLink: https://dotnet.microsoft.com/download/dotnet-framework
 changelogTemplate: https://github.com/microsoft/dotnet/blob/main/releases/net{{"__RELEASE_CYCLE__"| replace:'.',''}}/README.md
 latestColumn: false
 eolColumn: Support Status
-staleReleaseThresholdYears: 10
+staleReleaseThresholdDays: 3650 # linked to their corresponding Windows version
 
 auto:
   methods:

--- a/products/dovecot.md
+++ b/products/dovecot.md
@@ -9,7 +9,6 @@ releasePolicyLink: https://dovecot.org/mailman3/archives/list/dovecot-news@dovec
 changelogTemplate: https://github.com/dovecot/core/releases/tag/__LATEST__
 eolColumn: Security Support
 eoasColumn: Active Support
-staleReleaseThresholdYears: 2
 
 identifiers:
   - repology: dovecot
@@ -29,6 +28,7 @@ releases:
     latestReleaseDate: 2025-10-28
 
   - releaseCycle: "2.3"
+    staleReleaseThresholdDays: 500 # mentioned recently on https://dovecot.org/mailman3/archives/list/dovecot-news@dovecot.org/thread/3P45L76DOC3NKUNSSPIXQNKINGOCYH5K/
     releaseDate: 2017-12-22
     eoas: 2025-01-24
     eol: false

--- a/products/drush.md
+++ b/products/drush.md
@@ -9,7 +9,6 @@ versionCommand: drush --version
 releasePolicyLink: https://www.drush.org/latest/install/#drupal-compatibility
 changelogTemplate: https://github.com/drush-ops/drush/releases/tag/__LATEST__
 eolColumn: Support
-staleReleaseThresholdYears: 2
 
 customFields:
   - name: supportedPhpVersions
@@ -53,6 +52,7 @@ releases:
     latestReleaseDate: 2025-08-04
 
   - releaseCycle: "12"
+    staleReleaseThresholdDays: 500 # EOL is TBD on https://www.drush.org/13.x/install/#drupal-compatibility
     releaseDate: 2023-06-03
     eol: false
     supportedPhpVersions: "8.1+"

--- a/products/elixir.md
+++ b/products/elixir.md
@@ -8,7 +8,7 @@ versionCommand: elixir --version
 releasePolicyLink: https://hexdocs.pm/elixir/compatibility-and-deprecations.html
 changelogTemplate: https://github.com/elixir-lang/elixir/blob/v__RELEASE_CYCLE__/CHANGELOG.md
 eoasColumn: true
-staleReleaseThresholdYears: 3
+staleReleaseThresholdDays: 1000 # expected given https://hexdocs.pm/elixir/compatibility-and-deprecations.html
 
 identifiers:
   - repology: elixir

--- a/products/ffmpeg.md
+++ b/products/ffmpeg.md
@@ -9,7 +9,6 @@ releasePolicyLink: https://ffmpeg.org/
 changelogTemplate: https://ffmpeg.org/download.html#release_{{"__RELEASE_CYCLE__"}}
 releaseLabel: "__RELEASE_CYCLE__ '__CODENAME__'"
 eolColumn: Supported
-staleReleaseThresholdYears: 2
 
 identifiers:
   - repology: ffmpeg
@@ -148,8 +147,9 @@ releases:
 
   - releaseCycle: "2.8"
     codename: "Feynman"
+    staleReleaseThresholdDays: 1000 # still listed on https://ffmpeg.org/download.html
     releaseDate: 2015-09-09
-    eol: false # still listed on https://ffmpeg.org/download.html
+    eol: false
     latest: "2.8.22"
     latestReleaseDate: 2023-10-29
 

--- a/products/font-awesome.md
+++ b/products/font-awesome.md
@@ -8,7 +8,6 @@ alternate_urls:
   - /fontawesome
 changelogTemplate: https://github.com/FortAwesome/Font-Awesome/releases/tag/__LATEST__
 releasePolicyLink: https://fontawesome.com/versions
-staleReleaseThresholdYears: 5
 
 auto:
   methods:
@@ -29,9 +28,10 @@ releases:
     latestReleaseDate: 2024-12-16
 
   - releaseCycle: "5"
+    staleReleaseThresholdDays: 1750 # still listed on https://fontawesome.com/versions with "This version will continue to receive patch releases"
     lts: true
     releaseDate: 2018-02-05
-    eol: false # still listed on https://fontawesome.com/versions with "This version will continue to receive patch releases"
+    eol: false
     latest: "5.15.4"
     latestReleaseDate: 2021-08-04
 

--- a/products/godot.md
+++ b/products/godot.md
@@ -11,7 +11,6 @@ releasePolicyLink: https://docs.godotengine.org/en/latest/about/release_policy.h
 changelogTemplate: "https://github.com/godotengine/godot/releases/tag/{{'__LATEST__'|drop_zero_patch}}-stable"
 eolColumn: Critical, Security and Platform support
 eoasColumn: true
-staleReleaseThresholdYears: 3
 
 identifiers:
   - repology: godot

--- a/products/gorilla.md
+++ b/products/gorilla.md
@@ -6,7 +6,6 @@ iconSlug: go
 permalink: /gorilla
 releasePolicyLink: https://github.com/gorilla/
 eolColumn: Support
-staleReleaseThresholdYears: 5
 
 identifiers:
   - repology: go:github-gorilla-context

--- a/products/grunt.md
+++ b/products/grunt.md
@@ -9,7 +9,6 @@ releasePolicyLink: https://github.com/gruntjs/grunt
 changelogTemplate: https://github.com/gruntjs/grunt/releases/tag/v__LATEST__
 eolColumn: Community Support
 eoesColumn: Commercial Support
-staleReleaseThresholdYears: 3
 
 auto:
   methods:

--- a/products/ibm-aix.md
+++ b/products/ibm-aix.md
@@ -12,7 +12,6 @@ releasePolicyLink: https://www.ibm.com/support/pages/aix-support-lifecycle-infor
 releaseLabel: "{{'__RELEASE_CYCLE__'|split:'.'|pop|join:'.'}} TL{{'__RELEASE_CYCLE__'|split:'.'|last}}"
 changelogTemplate: "https://www.ibm.com/docs/aix/{{'__RELEASE_CYCLE__'|split:'.'|pop|join:'.'}}?topic=notes-aix-{{'__RELEASE_CYCLE__'|replace:'.',''}}-release"
 eolColumn: End of Service Pack Support (<abbr title="End of Service Pack Support">EoSPS</abbr>)
-staleReleaseThresholdYears: 6
 
 identifiers:
   - cpe: cpe:/o:ibm:aix
@@ -59,6 +58,7 @@ releases:
     link: https://www.ibm.com/docs/aix/7.3?topic=notes-aix-73-release
 
   - releaseCycle: "7.2.5"
+    staleReleaseThresholdDays: 2000 # see https://www.ibm.com/support/pages/aix-support-lifecycle-information
     releaseDate: 2020-11-30
     eol: false
     latest: "7.2.5"

--- a/products/ibm-db2.md
+++ b/products/ibm-db2.md
@@ -11,7 +11,6 @@ changelogTemplate: https://www.ibm.com/docs/en/db2/__RELEASE_CYCLE__.0
 latestColumn: false
 eol: Base Support
 eoes: Extended Support
-staleReleaseThresholdYears: 7
 
 identifiers:
   - cpe: cpe:/a:ibm:db2

--- a/products/ibm-i.md
+++ b/products/ibm-i.md
@@ -17,7 +17,6 @@ versionCommand: DSPJOB OUTPUT(*PRINT)
 releasePolicyLink: https://www.ibm.com/support/pages/release-life-cycle # https://www.ibm.com/support/pages/ibm-i-release-support
 eolColumn: End of Service Pack Support (<abbr title="End of Service Pack Support">EoSPS</abbr>)
 eoesColumn: Extended Life Cycle Support
-staleReleaseThresholdYears: 7
 
 auto:
   methods:
@@ -40,6 +39,7 @@ releases:
     link: https://www.ibm.com/docs/i/7.6.0
 
   - releaseCycle: "7.5"
+    staleReleaseThresholdDays: 1500 # see https://www.ibm.com/support/pages/release-life-cycle
     releaseDate: 2022-05-10
     eol: false
     latest: "7.5.0"

--- a/products/ibm-mq.md
+++ b/products/ibm-mq.md
@@ -11,7 +11,7 @@ changelogTemplate: https://www.ibm.com/docs/en/ibm-mq/__RELEASE_CYCLE__.x
 latestColumn: false
 eolColumn: Support
 eoesColumn: Extended Support
-staleReleaseThresholdYears: 4
+staleReleaseThresholdDays: 1500 # the product seems very stable
 
 identifiers:
   - cpe: cpe:/a:ibm:mq

--- a/products/intel-processors.md
+++ b/products/intel-processors.md
@@ -8,7 +8,7 @@ releasePolicyLink: https://www.intel.com/content/www/us/en/support/articles/0000
 latestColumn: false
 eolColumn: Active Support
 discontinuedColumn: true
-staleReleaseThresholdYears: 7
+staleReleaseThresholdDays: 2555 # 7 years, processors has a very long support window
 
 releases:
   - releaseCycle: "arrow-lake"
@@ -24,7 +24,7 @@ releases:
     discontinued: false
     eol: false
     link: https://www.intel.com/content/www/us/en/ark/products/codename/213792/products-formerly-lunar-lake.html
-  
+
   - releaseCycle: "meteor-lake"
     releaseLabel: "Meteor Lake"
     releaseDate: 2023-12-14

--- a/products/ipad.md
+++ b/products/ipad.md
@@ -9,7 +9,7 @@ releasePolicyLink: https://en.wikipedia.org/wiki/List_of_iPad_models#iPad
 discontinuedColumn: true
 eolColumn: Supported
 latestColumn: false
-staleReleaseThresholdYears: 8
+staleReleaseThresholdDays: 2920 # 8 years, ipad 6 is still supported with ipados 17, see https://en.wikipedia.org/wiki/List_of_iPad_models#iPad
 
 customFields:
   - name: supportedIpadOsVersions

--- a/products/iphone.md
+++ b/products/iphone.md
@@ -9,7 +9,7 @@ releasePolicyLink: https://en.wikipedia.org/wiki/List_of_iPhone_models#Release_d
 discontinuedColumn: true
 eolColumn: Supported
 latestColumn: false
-staleReleaseThresholdYears: 8
+staleReleaseThresholdDays: 2920 # 8 years, iphone xs is still supported with ios 18, see https://en.wikipedia.org/wiki/List_of_iPhone_models#Not_supporting_latest_iOS_version
 
 customFields:
   - name: supportedIosVersions

--- a/products/jekyll.md
+++ b/products/jekyll.md
@@ -9,7 +9,6 @@ releasePolicyLink: https://jekyllrb.com/docs/security/
 changelogTemplate: https://github.com/jekyll/jekyll/releases/tag/v__LATEST__
 eoasColumn: Active Development
 eolColumn: Active Maintenance
-staleReleaseThresholdYears: 2
 
 customFields:
   - name: minRubyVersion
@@ -37,6 +36,7 @@ releases:
     latestReleaseDate: 2025-01-29
 
   - releaseCycle: "3"
+    staleReleaseThresholdDays: 730 # still used on GitHub pages
     minRubyVersion: "2.0+" # https://web.archive.org/web/20160103225823/https://jekyllrb.com/docs/installation/
     releaseDate: 2015-10-26
     eoas: true

--- a/products/jquery-ui.md
+++ b/products/jquery-ui.md
@@ -19,10 +19,11 @@ auto:
 
 releases:
   - releaseCycle: "1.14"
+    staleReleaseThresholdDays: 730 # see https://github.com/jquery/jquery-ui?tab=security-ov-file#supported-versions
     releaseDate: 2024-08-05
     eol: false
     latest: "1.14.1"
-    link: https://blog.jqueryui.com/2024/08/jquery-ui-1-14-0-released/
+    link: https://blog.jqueryui.com/2024/10/jquery-ui-1-14-1-released/
 
     latestReleaseDate: 2024-10-30
   - releaseCycle: "1.13"

--- a/products/jquery.md
+++ b/products/jquery.md
@@ -7,7 +7,6 @@ iconSlug: jquery
 permalink: /jquery
 changelogTemplate: https://github.com/jquery/jquery/releases/tag/__LATEST__
 eoesColumn: Commercial Support
-staleReleaseThresholdYears: 4
 
 identifiers:
   - purl: pkg:github/jquery/jquery
@@ -25,6 +24,7 @@ auto:
 
 releases:
   - releaseCycle: "3"
+    staleReleaseThresholdDays: 1095 # see https://github.com/jquery/jquery?tab=security-ov-file#supported-versions
     releaseDate: 2016-06-09
     eol: false
     latest: "3.7.1"

--- a/products/kong-gateway.md
+++ b/products/kong-gateway.md
@@ -11,7 +11,6 @@ alternate_urls:
 changelogTemplate: https://github.com/Kong/kong/releases/tag/__LATEST__
 eolColumn: Support
 eoesColumn: Enterprise Support
-staleReleaseThresholdYears: 3
 
 auto:
   methods:
@@ -67,6 +66,7 @@ releases:
     latestReleaseDate: 2023-11-08
 
   - releaseCycle: "3.4"
+    staleReleaseThresholdDays: 1095 # LTS, still supported for enterprise, see https://developer.konghq.com/gateway/version-support-policy/
     lts: true
     releaseDate: 2023-08-09
     eol: false

--- a/products/lineageos.md
+++ b/products/lineageos.md
@@ -7,7 +7,7 @@ permalink: /lineageos
 alternate_urls:
   - /lineage
 latestColumn: false
-staleReleaseThresholdYears: 2
+staleReleaseThresholdDays: 730 # OSes have a longer support window
 
 customFields:
   - name: androidVersion

--- a/products/linuxmint.md
+++ b/products/linuxmint.md
@@ -11,7 +11,6 @@ versionCommand: cat /etc/linuxmint/info
 latestColumn: false
 releasePolicyLink: https://linuxmint.com/download_all.php
 releaseLabel: "__RELEASE_CYCLE__ '__CODENAME__'"
-staleReleaseThresholdYears: 3
 
 auto:
   methods:

--- a/products/magento.md
+++ b/products/magento.md
@@ -13,7 +13,7 @@ changelogTemplate: "https://experienceleague.adobe.com/docs/commerce-operations/
 eoasColumn: Bug fix maintenance
 eolColumn: Security maintenance
 eoesColumn: Adobe Commerce end of software support
-staleReleaseThresholdYears: 3
+staleReleaseThresholdDays: 1095 # still not documented on https://www.adobe.com/content/dam/cc/en/legal/terms/enterprise/pdfs/Magento-Open-Source-Software-Maintenance-Policy.pdf
 
 customFields:
   - name: supportedPhpVersions

--- a/products/mule-runtime.md
+++ b/products/mule-runtime.md
@@ -107,7 +107,7 @@ releases:
     eoas: 2024-10-08
     eol: 2025-10-08
     latest: "4.4.0-20250919"
-    latestReleaseDate: 2025-10-03
+    latestReleaseDate: 2025-11-04
 
   - releaseCycle: "4.3"
     releaseDate: 2020-04-30
@@ -129,7 +129,7 @@ releases:
     eoas: 2020-11-02
     eol: 2022-11-02
     latest: "4.1.6-20240112"
-    latestReleaseDate: 2024-06-07
+    latestReleaseDate: 2024-08-10
     link: https://archive.docs.mulesoft.com/release-notes/mule-runtime/mule-4.1.6-release-notes
 
   - releaseCycle: "3.9"

--- a/products/netbsd.md
+++ b/products/netbsd.md
@@ -9,7 +9,7 @@ versionCommand: uname -r
 releasePolicyLink: https://www.netbsd.org/releases/
 changelogTemplate: https://www.netbsd.org/releases/formal-__RELEASE_CYCLE__/NetBSD-__LATEST__.html
 eoasColumn: true
-staleReleaseThresholdYears: 2
+staleReleaseThresholdDays: 1095 # OSes have a longer support window
 
 identifiers:
   - cpe: cpe:/o:netbsd:netbsd

--- a/products/nvidia-gpu.md
+++ b/products/nvidia-gpu.md
@@ -12,7 +12,7 @@ releasePolicyLink: https://www.nvidia.com/en-us/geforce/graphics-cards/
 latestColumn: false
 discontinuedColumn: true
 eoasColumn: true
-staleReleaseThresholdYears: 8
+staleReleaseThresholdDays: 2920 # GPUs have a long support window, and https://en.wikipedia.org/wiki/Turing_(microarchitecture) not EOL yet
 
 # Support can be found on Wikipedia.
 # Example of a documented deprecated architecture (support status): https://en.wikipedia.org/wiki/Pascal_(microarchitecture).

--- a/products/openvpn.md
+++ b/products/openvpn.md
@@ -7,7 +7,6 @@ permalink: /openvpn
 releasePolicyLink: https://community.openvpn.net/openvpn/wiki/SupportedVersions
 changelogTemplate: https://github.com/OpenVPN/openvpn/blob/release/__RELEASE_CYCLE__/ChangeLog
 eoasColumn: Full Stable Support
-staleReleaseThresholdYears: 2
 
 auto:
   methods:

--- a/products/ovirt.md
+++ b/products/ovirt.md
@@ -6,7 +6,7 @@ tags: java-runtime
 permalink: /ovirt
 releasePolicyLink: https://blogs.ovirt.org/2022/04/ovirt-4-4-end-of-life/
 changelogTemplate: https://github.com/oVirt/ovirt-engine/releases/tag/ovirt-engine-__LATEST__
-staleReleaseThresholdYears: 2
+staleReleaseThresholdDays: 730 # looks like there are not much releases
 
 auto:
   methods:

--- a/products/pci-dss.md
+++ b/products/pci-dss.md
@@ -9,7 +9,7 @@ releasePolicyLink: https://blog.pcisecuritystandards.org/updated-pci-dss-v4.0-ti
 releasePolicyImage: https://blog.pcisecuritystandards.org/hs-fs/hubfs/Development.png?width=750&name=Development.png
 latestColumn: false
 eolColumn: Acceptance
-staleReleaseThresholdYears: 3
+staleReleaseThresholdDays: 1095 # standards have a long lifespan
 
 releases:
   - releaseCycle: "4.0.1"

--- a/products/phoenix-framework.md
+++ b/products/phoenix-framework.md
@@ -7,10 +7,10 @@ permalink: /phoenix-framework
 alternate_urls:
   - /phoenix
   - /phoenixframework
-changelogTemplate: https://github.com/phoenixframework/phoenix/releases/tag/v__LATEST__
 releasePolicyLink: https://github.com/phoenixframework/phoenix/security
+changelogTemplate: https://github.com/phoenixframework/phoenix/releases/tag/v__LATEST__
 eoasColumn: Bug Fixes
-staleReleaseThresholdYears: 4
+staleReleaseThresholdDays: 1500 # https://github.com/phoenixframework/phoenix/security
 
 identifiers:
   - purl: pkg:hex/phoenix

--- a/products/phpmyadmin.md
+++ b/products/phpmyadmin.md
@@ -8,7 +8,6 @@ permalink: /phpmyadmin
 releasePolicyLink: https://www.phpmyadmin.net/downloads/#support
 changelogTemplate: "https://github.com/phpmyadmin/phpmyadmin/blob/QA_{{'__RELEASE_CYCLE__'|replace:'.','_'}}/ChangeLog"
 eoasColumn: true
-staleReleaseThresholdYears: 3
 
 auto:
   methods:
@@ -49,6 +48,7 @@ releases:
     latestReleaseDate: 2020-10-15
 
   - releaseCycle: "4.9"
+    staleReleaseThresholdDays: 1100 # https://www.phpmyadmin.net/downloads/#support
     lts: true
     releaseDate: 2019-06-04
     eoas: 2019-12-31

--- a/products/pigeonhole.md
+++ b/products/pigeonhole.md
@@ -7,7 +7,6 @@ permalink: /pigeonhole
 alternate_urls:
   - /dovecot-pigeonhole
 changelogTemplate: https://github.com/dovecot/pigeonhole/releases/tag/__LATEST__
-staleReleaseThresholdYears: 2
 
 identifiers:
   - repology: dovecot-pigeonhole
@@ -26,6 +25,7 @@ releases:
     latestReleaseDate: 2025-10-28
 
   - releaseCycle: "0.5"
+    staleReleaseThresholdDays: 730 # Dovecot 2.3 still receive security support
     releaseDate: 2017-12-24
     eol: false
     latest: "0.5.21.1"
@@ -60,8 +60,6 @@ releases:
 > [Pigeonhole](https://pigeonhole.dovecot.org/) is the project that adds support for the Sieve
 > language and the ManageSieve protocol to the [Dovecot](https://dovecot.org/) Secure IMAP Server.
 
-Pigeonhole does not follow a documented release policy for its own. It follows the same cycle as
-[Dovecot](/dovecot) does, even if that means to do a release without changes to keep version numbers
-synced.
-Since v2.4.0 (released in 2025) the version numbering scheme is also aligned to match Dovecot's
-scheme.
+Pigeonhole does not follow a documented release policy for its own.
+It follows the same cycle as [Dovecot](/dovecot) does, even if that means to do a release without changes to keep version numbers synced.
+Since v2.4.0 (released in 2025) the version numbering scheme is also aligned to match Dovecot's scheme.

--- a/products/react.md
+++ b/products/react.md
@@ -8,7 +8,7 @@ permalink: /react
 releasePolicyLink: https://react.dev/community/versioning-policy
 changelogTemplate: https://github.com/facebook/react/releases/tag/v__LATEST__
 eoasColumn: true
-staleReleaseThresholdYears: 6
+staleReleaseThresholdDays: 2190 # https://react.dev/community/versioning-policy#stable-releases
 
 identifiers:
   - purl: pkg:github/facebook/react

--- a/products/robo.md
+++ b/products/robo.md
@@ -6,7 +6,7 @@ tags: php-runtime
 permalink: /robo
 versionCommand: robo --version
 eoasColumn: true
-staleReleaseThresholdYears: 8
+staleReleaseThresholdDays: 1090 # https://github.com/consolidation/robo#branches
 
 customFields:
   - name: supportedPHPVersions

--- a/products/samsung-galaxy-tab.md
+++ b/products/samsung-galaxy-tab.md
@@ -9,7 +9,7 @@ releasePolicyLink: https://security.samsungmobile.com/workScope.smsb
 latestColumn: false
 eoasColumn: Android Upgrades
 eolColumn: Security Updates
-staleReleaseThresholdYears: 5
+staleReleaseThresholdDays: 1825 # devices have longer support periods
 
 auto:
   cumulative: true

--- a/products/samsung-galaxy-watch.md
+++ b/products/samsung-galaxy-watch.md
@@ -9,7 +9,7 @@ releasePolicyLink: https://security.samsungmobile.com/workScope.smsb
 latestColumn: false
 eoasColumn: Wear OS Upgrades
 eolColumn: Security Updates
-staleReleaseThresholdYears: 5
+staleReleaseThresholdDays: 1825 # devices have longer support periods
 
 # eoas(x) = end of android upgrade
 # eol(x) = end of security support

--- a/products/samsung-mobile.md
+++ b/products/samsung-mobile.md
@@ -11,7 +11,7 @@ releasePolicyLink: https://security.samsungmobile.com/workScope.smsb
 latestColumn: false
 eoasColumn: Android Upgrades
 eolColumn: Security Updates
-staleReleaseThresholdYears: 5
+staleReleaseThresholdDays: 1825 # devices have longer support periods
 
 auto:
   cumulative: true

--- a/products/scala.md
+++ b/products/scala.md
@@ -12,7 +12,6 @@ releasePolicyLink: https://www.scala-lang.org/download/all.html
 changelogTemplate: "https://github.com/lampepfl/dotty/releases/tag/__LATEST__"
 eoasColumn: Current Releases
 eolColumn: Maintenance Releases
-staleReleaseThresholdYears: 3
 
 identifiers:
   - repology: scala

--- a/products/slackware.md
+++ b/products/slackware.md
@@ -12,7 +12,7 @@ versionCommand: cat /etc/os-release
 releasePolicyLink: http://www.slackware.com/faq/do_faq.php?faq=general#4
 changelogTemplate: http://www.slackware.com/announce/__RELEASE_CYCLE__.php
 latestColumn: false
-staleReleaseThresholdYears: 4
+staleReleaseThresholdDays: 1825 # oses have longer support periods
 
 identifiers:
   - cpe: cpe:/o:slackware:slackware_linux

--- a/products/sns-firmware.md
+++ b/products/sns-firmware.md
@@ -8,7 +8,7 @@ versionCommand: getversion
 latestColumn: false
 eoasColumn: End of Maintenance
 eolColumn: End of Life
-staleReleaseThresholdYears: 5
+staleReleaseThresholdDays: 1825 # devices have longer support periods
 
 auto:
   methods:

--- a/products/sns-hardware.md
+++ b/products/sns-hardware.md
@@ -7,7 +7,7 @@ permalink: /sns-hardware
 latestColumn: false
 eoasColumn: End of Sales
 eolColumn: End of Life
-staleReleaseThresholdYears: 10
+staleReleaseThresholdDays: 3650 # devices have longer support periods
 
 customFields:
   - name: lowestSNSVersion

--- a/products/steamos.md
+++ b/products/steamos.md
@@ -7,7 +7,7 @@ iconSlug: steam
 permalink: /steamos
 eolColumn: Support
 latestColumn: false
-staleReleaseThresholdYears: 4
+staleReleaseThresholdDays: 1825 # devices have longer support periods
 
 identifiers:
   - cpe: cpe:/o:valvesoftware:steamos

--- a/products/svelte.md
+++ b/products/svelte.md
@@ -23,8 +23,8 @@ releases:
     releaseDate: 2024-10-19
     eoas: false
     eol: false
-    latest: "5.43.4"
-    latestReleaseDate: 2025-11-06
+    latest: "5.43.5"
+    latestReleaseDate: 2025-11-08
 
   - releaseCycle: "4"
     releaseDate: 2023-06-22

--- a/products/tls.md
+++ b/products/tls.md
@@ -6,7 +6,7 @@ tags: ietf
 permalink: /tls
 releaseLabel: "TLS __RELEASE_CYCLE__"
 latestColumn: false
-staleReleaseThresholdYears: 20
+staleReleaseThresholdDays: 7300 # standards have longer support periods
 
 releases:
   - releaseCycle: "1.3"

--- a/products/vmware-photon.md
+++ b/products/vmware-photon.md
@@ -12,7 +12,7 @@ versionCommand: cat /etc/os-release
 releasePolicyLink: https://blogs.vmware.com/vsphere/2023/05/announcing-photon-os-5-0-general-availability.html
 latestColumn: false
 eolColumn: Security Support
-staleReleaseThresholdYears: 3
+staleReleaseThresholdDays: 1460 # oses have longer support periods
 
 customFields:
   - name: kernelVersion

--- a/products/windows-powershell.md
+++ b/products/windows-powershell.md
@@ -9,7 +9,7 @@ versionCommand: powershell -Command "$PSVersionTable.PSVersion"
 releasePolicyLink: https://learn.microsoft.com/powershell/scripting/install/powershell-support-lifecycle?view=powershell-5.1#windows-powershell-release-history
 eolColumn: Support Status
 latestColumn: false
-staleReleaseThresholdYears: 10
+staleReleaseThresholdDays: 3650 # oses have longer support periods
 
 releases:
   - releaseCycle: "5.1"

--- a/products/yarn.md
+++ b/products/yarn.md
@@ -7,7 +7,6 @@ iconSlug: yarn
 permalink: /yarn
 versionCommand: yarn --version
 changelogTemplate: https://github.com/yarnpkg/berry/releases/tag/%40yarnpkg%2Fcli%2F__LATEST__
-staleReleaseThresholdYears: 4
 
 identifiers:
   - purl: pkg:github/yarnpkg/berry
@@ -42,6 +41,7 @@ releases:
     latestReleaseDate: 2021-09-06
 
   - releaseCycle: "1"
+    staleReleaseThresholdDays: 1460 # https://github.com/yarnpkg/yarn/issues/8583
     releaseDate: 2017-09-05
     eol: false
     latest: "1.22.22"

--- a/products/zentyal.md
+++ b/products/zentyal.md
@@ -8,7 +8,7 @@ releasePolicyLink: https://zentyal.com/release-policy/
 latestColumn: false
 eolColumn: Development Edition Support
 eoesColumn: Commercial Support
-staleReleaseThresholdYears: 4
+staleReleaseThresholdDays: 1825 # devices have longer support periods
 
 customFields:
   - name: ubuntuVersion


### PR DESCRIPTION
- switch to days, following https://github.com/endoflife-date/release-data/pull/528,
- move some warnings to releases instead of applying them for all product releases,
- add comments.