### PR TITLE
[deno] correct Deno versioning and support details

### DIFF
--- a/products/deno.md
+++ b/products/deno.md
@@ -72,15 +72,14 @@ releases:
 > [Deno](https://deno.com) is a JavaScript, TypeScript, and WebAssembly runtime with
 > secure defaults and a great developer experience. It's built on V8, Rust, and Tokio.
 
-Deno follows [SemVer](https://semver.org/). 
-Deno releases a new stable, minor version (eg. v2.1.0, v2.0.0) on a 12 week schedule.
+Deno follows [SemVer](https://semver.org/) and releases a new stable, minor version (eg. v2.1.0, v2.0.0) on a 12 week schedule.
 
 Patch releases including bug fixes for the latest minor version are released as needed - 
 you can expect several patch releases before a new minor version is released.
 
 Deno [offeres multiple release channels](https://docs.deno.com/runtime/fundamentals/stability_and_releases/#release-channels) which can be used as version aliases.
 
-> [!WARNING]
-> [LTS support will be discontinued](https://docs.deno.com/runtime/fundamentals/stability_and_releases/#long-term-support-(lts)) after April 30, 2026; there will be no LTS releases or maintenance beyond that date.
+> {: .warning }
+> [LTS support will be discontinued](https://docs.deno.com/runtime/fundamentals/stability_and_releases/#long-term-support-(lts)) after April 30, 2026 (EOL for v2.5); there will be no LTS releases or maintenance beyond that date.
 
 As of Deno 1.0.0, the `Deno` namespace APIs are stable. The Deno maintainers we will strive to make code working under 1.0.0 continue to work in future versions.

--- a/products/deno.md
+++ b/products/deno.md
@@ -72,10 +72,15 @@ releases:
 > [Deno](https://deno.com) is a JavaScript, TypeScript, and WebAssembly runtime with
 > secure defaults and a great developer experience. It's built on V8, Rust, and Tokio.
 
-Deno follows [SemVer](https://semver.org/). New minor releases are made monthly and
-are supported with bug and security fixes until the next minor release.
-Every six months a minor version is promoted to LTS and is supported with critical
-bug and security fixes for an additional 5 months.
+Deno follows [SemVer](https://semver.org/). 
+Deno releases a new stable, minor version (eg. v2.1.0, v2.0.0) on a 12 week schedule.
 
-Deno maintainers are committed to maintaining a stable standard library API (`Deno`
-namespace) from version `1.0.0` onward.
+Patch releases including bug fixes for the latest minor version are released as needed - 
+you can expect several patch releases before a new minor version is released.
+
+Deno [offeres multiple release channels](https://docs.deno.com/runtime/fundamentals/stability_and_releases/#release-channels) which can be used as version aliases.
+
+> [!WARNING]
+> [LTS support will be discontinued](https://docs.deno.com/runtime/fundamentals/stability_and_releases/#long-term-support-(lts)) after April 30, 2026; there will be no LTS releases or maintenance beyond that date.
+
+As of Deno 1.0.0, the `Deno` namespace APIs are stable. The Deno maintainers we will strive to make code working under 1.0.0 continue to work in future versions.

--- a/products/deno.md
+++ b/products/deno.md
@@ -72,14 +72,13 @@ releases:
 > [Deno](https://deno.com) is a JavaScript, TypeScript, and WebAssembly runtime with
 > secure defaults and a great developer experience. It's built on V8, Rust, and Tokio.
 
-Deno follows [SemVer](https://semver.org/) and releases a new stable, minor version (eg. v2.1.0, v2.0.0) on a 12 week schedule.
-
-Patch releases including bug fixes for the latest minor version are released as needed - 
-you can expect several patch releases before a new minor version is released.
-
-Deno [offeres multiple release channels](https://docs.deno.com/runtime/fundamentals/stability_and_releases/#release-channels) which can be used as version aliases.
-
 > {: .warning }
-> [LTS support will be discontinued](https://docs.deno.com/runtime/fundamentals/stability_and_releases/#long-term-support-(lts)) after April 30, 2026 (EOL for v2.5); there will be no LTS releases or maintenance beyond that date.
+> [LTS support will be discontinued](https://docs.deno.com/runtime/fundamentals/stability_and_releases/#long-term-support-(lts)) after April 30, 2026 (EOL for v2.5);
+> there will be no LTS releases or maintenance beyond that date.
+
+Deno follows [SemVer](https://semver.org/).
+New minor releases are made every 12 weeks and are supported with bug and security fixes until the next minor release.
+
+Deno [has release channels](https://docs.deno.com/runtime/fundamentals/stability_and_releases/#release-channels), such as `stable`, which can be used as version aliases.
 
 As of Deno 1.0.0, the `Deno` namespace APIs are stable. The Deno maintainers we will strive to make code working under 1.0.0 continue to work in future versions.


### PR DESCRIPTION
Updates Deno release schedule and support information unsing the information from  https://docs.deno.com/runtime/fundamentals/stability_and_releases/

Decided to not list the different channels, since that information is going to change soonish (April next year), so I just added a link to the page listing them.

Added the warning about the deprecation of the `lts` channel, verified that it works as expected on the preview deployment?

I also noticed that the front-matter doesn't list the EOL for version 2.5, even though it is already listed on the linked page. also it lists EOL dates for wrong versions.

But I didn't touch it since it seems to be something automated which I have now knowledge of.