### PR TITLE
[docker-engine] Add 29.0 and EOL 28.5

### DIFF
--- a/products/docker-engine.md
+++ b/products/docker-engine.md
@@ -24,9 +24,15 @@ auto:
 # Inside a given major release, eol(x) = releaseDate(x+1)
 # For major release EOL, see https://github.com/moby/moby/blob/master/project/BRANCHES-AND-TAGS.md
 releases:
+  - releaseCycle: "29.0"
+    releaseDate: 2025-11-10
+    eol: false # not announced on https://github.com/moby/moby/blob/master/project/BRANCHES-AND-TAGS.md
+    latest: "29.0.0"
+    latestReleaseDate: 2025-11-10
+
   - releaseCycle: "28.5"
     releaseDate: 2025-10-02
-    eol: false # not announced on https://github.com/moby/moby/blob/master/project/BRANCHES-AND-TAGS.md
+    eol: 2025-11-10
     latest: "28.5.2"
     latestReleaseDate: 2025-11-05
 


### PR DESCRIPTION
See: https://github.com/moby/moby/releases/tag/docker-v29.0.0