### PR TITLE
[Gitlab] Add 18.6

### DIFF
--- a/products/gitlab.md
+++ b/products/gitlab.md
@@ -23,8 +23,15 @@ auto:
 
 # eoas(x) = releaseDate(x+1)
 # eol(x) = releaseDate(x+3)
-# Upcoming release dates are available on https://about.gitlab.com/releases/
+# Upcoming release dates are available on https://handbook.gitlab.com/handbook/marketing/blog/release-posts/managers/
 releases:
+  - releaseCycle: "18.6"
+    releaseDate: 2025-11-20
+    eoas: 2025-12-18 # releaseDate(18.7)
+    eol: 2026-02-19 # releaseDate(18.9)
+    latest: "18.6.0"
+    latestReleaseDate: 2025-11-20
+
   - releaseCycle: "18.5"
     releaseDate: 2025-10-16
     eoas: 2025-11-20 # releaseDate(18.6)
@@ -442,7 +449,7 @@ Critical bug fixes can rarely be backported based on [a set of criteria](https:/
 | Version Type | Description                                                                                                                                                     | Cadence                                                                                                                           |
 | :----------- | :-------------------------------------------------------------------------------------------------------------------------------------------------------------- | :-------------------------------------------------------------------------------------------------------------------------------- |
 | Major        | For significant changes, or when any backward-incompatible changes are introduced to the public API.                                                            | Yearly. Subsequent major releases will be scheduled for [third Thursday][release-day] of May each year, by default.               |
-| Minor        | For when new backward-compatible functionality is introduced to the public API, a minor feature is introduced, or when a set of smaller features is rolled out. | Monthly on [third Thursday][release-day]. Upcoming release dates can be seen [on this page](https://about.gitlab.com/releases/)). |
+| Minor        | For when new backward-compatible functionality is introduced to the public API, a minor feature is introduced, or when a set of smaller features is rolled out. | Monthly on [third Thursday][release-day]. Upcoming release dates can be seen [on this page](https://handbook.gitlab.com/handbook/marketing/blog/release-posts/managers/)). |
 | Patch        | For backward-compatible bug fixes that fix incorrect behavior.                                                                                                  | As needed.                                                                                                                        |
 
 [release-day]: https://about.gitlab.com/blog/2023/09/18/gitlab-release-date-change/ "Release Date Change"


### PR DESCRIPTION
also update upcoming release page, as the old url now redirects to blog category realeases