### PR TITLE
[IBM Semeru] update Java 8 end of support date

### DIFF
--- a/products/ibm-semeru.md
+++ b/products/ibm-semeru.md
@@ -96,7 +96,7 @@ releases:
   - releaseCycle: "8"
     lts: true
     releaseDate: 2021-09-16
-    eol: 2026-11-30
+    eol: 2030-12-31
     latest: "8u472-b08"
     latestReleaseDate: 2025-10-28
 


### PR DESCRIPTION
IBM has extended Semeru Runtimes End of Support date for Java 8 to Dec 31, 2030 (See Java 8 row on https://www.ibm.com/support/pages/semeru-runtimes-support).