### PR TITLE
[silverstripe] Fix eol/eoas dates

### DIFF
--- a/products/silverstripe.md
+++ b/products/silverstripe.md
@@ -62,8 +62,8 @@ releases:
 
   - releaseCycle: "6.0"
     releaseDate: 2025-06-10
-    eoas: 2025-10-31
-    eol: 2026-04-30
+    eoas: 2025-10-13
+    eol: 2026-04-14
     latest: "6.0.0"
     latestReleaseDate: 2025-06-10
 
@@ -76,15 +76,15 @@ releases:
 
   - releaseCycle: "5.3"
     releaseDate: 2024-11-04
-    eoas: 2025-04-30
-    eol: 2025-10-31
+    eoas: 2025-04-10
+    eol: 2025-10-11
     latest: "5.3.0"
     latestReleaseDate: 2024-11-04
 
   - releaseCycle: "5.2"
     releaseDate: 2024-04-15
-    eoas: 2024-11-30
-    eol: 2025-05-31
+    eoas: 2024-11-04
+    eol: 2025-05-05
     latest: "5.2.0"
     latestReleaseDate: 2024-04-15
 
@@ -104,8 +104,8 @@ releases:
 
   - releaseCycle: "4.13"
     releaseDate: 2023-04-26
-    eoas: 2024-04-30
-    eol: 2025-06-30
+    eoas: 2024-04-27
+    eol: 2025-06-10
     latest: "4.13.0"
     latestReleaseDate: 2023-04-26
 


### PR DESCRIPTION
Specific dates come from https://raw.githubusercontent.com/silverstripe/roadmap/refs/heads/main/data.json which is the data source for https://www.silverstripe.org/software/roadmap/

Note that specific EOL dates haven't been selected yet for version 5.4 and 6.1 - for 5.4 it will be sometime between April 2027 and June 2027, and for 6.1 it is scheduled for October 2026, with no specific day set. If your system allows for partial dates and date ranges, please let me know so I can resolve those as well.

I won't be keeping an eye on this going forward, this is a one-off to correct some dates - but I recommend the above-linked JSON source is referred to for future updates.