### PR TITLE
[apache-couchdb] Add github repo url ,  fix versionCommand

### DIFF
--- a/products/apache-couchdb.md
+++ b/products/apache-couchdb.md
@@ -2,7 +2,7 @@
 title: Apache CouchDB
 addedAt: 2024-08-10
 category: database
-tags: apache erlang-runtime
+tags: apache erlang-runtime nosql
 iconSlug: apachecouchdb
 permalink: /apache-couchdb
 alternate_urls:

--- a/products/apache-couchdb.md
+++ b/products/apache-couchdb.md
@@ -2,7 +2,7 @@
 title: Apache CouchDB
 addedAt: 2024-08-10
 category: database
-tags: apache erlang-runtime nosql
+tags: apache erlang-runtime
 iconSlug: apachecouchdb
 permalink: /apache-couchdb
 alternate_urls:

--- a/products/apache-couchdb.md
+++ b/products/apache-couchdb.md
@@ -9,7 +9,7 @@ alternate_urls:
   - /couchdb
 releasePolicyLink: https://docs.couchdb.org/en/stable/cve/index.html
 changelogTemplate: https://docs.couchdb.org/en/stable/whatsnew/__RELEASE_CYCLE__.html
-versionCommand: curl -s http://localhost:5984/ | jq -r '.version'
+versionCommand: curl -s http://localhost:5984/ | grep -oP '"version"\s*:\s*"\K[^"]+'
 
 identifiers:
   - purl: pkg:github/apache/couchdb

--- a/products/apache-couchdb.md
+++ b/products/apache-couchdb.md
@@ -9,7 +9,7 @@ alternate_urls:
   - /couchdb
 releasePolicyLink: https://docs.couchdb.org/en/stable/cve/index.html
 changelogTemplate: https://docs.couchdb.org/en/stable/whatsnew/__RELEASE_CYCLE__.html
-versionCommand: curl -s http://localhost:5984/ | grep -oP '"version"\s*:\s*"\K[^"]+'
+versionCommand: curl -s http://localhost:5984/ | jq -r '.version'
 
 identifiers:
   - purl: pkg:github/apache/couchdb

--- a/products/apache-couchdb.md
+++ b/products/apache-couchdb.md
@@ -9,7 +9,7 @@ alternate_urls:
   - /couchdb
 releasePolicyLink: https://docs.couchdb.org/en/stable/cve/index.html
 changelogTemplate: https://docs.couchdb.org/en/stable/whatsnew/__RELEASE_CYCLE__.html
-versionCommand: curl http://localhost:5984/_config/vendor/version
+versionCommand: curl -s http://localhost:5984/ | jq -r '.version'
 
 identifiers:
   - purl: pkg:github/apache/couchdb

--- a/products/apache-couchdb.md
+++ b/products/apache-couchdb.md
@@ -51,8 +51,10 @@ releases:
 
 ---
 
-> [Apache CouchDB](https://couchdb.apache.org/) is an open-source, document-oriented NoSQL database implemented
-> in Erlang. CouchDB uses various formats and protocols to store, transfer, and
+> [Apache CouchDB](https://couchdb.apache.org/) is an (Apache Licensed) open-source
+> (see [`apache/couchdb`](https://github.com/apache/couchdb)), document-oriented
+> NoSQL database implemented in Erlang.
+> CouchDB uses various formats and protocols to store, transfer, and
 > process data, with JSON as its primary data storage format.
 
 CouchDB maintains the two most recent releases for CVEs. Older versions are


### PR DESCRIPTION
While discovering this [tweet](https://x.com/TheASF/status/1989751534964375569)

<img width="590" height="611" alt="image" src="https://github.com/user-attachments/assets/bb0b1db2-d781-4aa3-bff5-a5e8bea8add6" />

I discovered that this product was missing the gtihub repo.

I didn't really know how it should be added, let me know what you thing