### PR TITLE
[apache-airflow] Update release cycles and dates

### DIFF
--- a/products/apache-airflow.md
+++ b/products/apache-airflow.md
@@ -116,7 +116,7 @@ releases:
     latestReleaseDate: 2021-10-12
 
   - releaseCycle: "2.1"
-    releaseDate: 2021-04-20
+    releaseDate: 2021-05-18
     eoas: 2025-10-22
     eol: 2026-04-22
     latest: "2.1.4"
@@ -162,7 +162,7 @@ releases:
     eoas: 2017-03-19
     eol: 2017-03-19
     latest: "1.6.2"
-    latestReleaseDate: 2026-01-05
+    latestReleaseDate: 2016-01-05
 
   - releaseCycle: "1.5"
     releaseDate: 2015-09-04

--- a/products/apache-airflow.md
+++ b/products/apache-airflow.md
@@ -38,19 +38,19 @@ releases:
     latest: "3.1.3"
     latestReleaseDate: 2025-11-14
 
-  - releaseCycle: "3.0"
-    releaseDate: 2025-04-23
-    eoas: false
-    eol: false
-    latest: "3.0.6"
-    latestReleaseDate: 2025-08-30
-
   - releaseCycle: "2.11"
     releaseDate: 2025-05-20
     eoas: 2025-10-22
     eol: 2026-04-22
     latest: "2.11.0"
     latestReleaseDate: 2025-05-20
+
+  - releaseCycle: "3.0"
+    releaseDate: 2025-04-23
+    eoas: false
+    eol: false
+    latest: "3.0.6"
+    latestReleaseDate: 2025-08-30
 
   - releaseCycle: "2.10"
     releaseDate: 2024-08-16

--- a/products/apache-airflow.md
+++ b/products/apache-airflow.md
@@ -116,7 +116,7 @@ releases:
     latestReleaseDate: 2021-10-12
 
   - releaseCycle: "2.1"
-    releaseDate: 
+    releaseDate: 2021-04-20
     eoas: 2025-10-22
     eol: 2026-04-22
     latest: "2.1.4"

--- a/products/apache-airflow.md
+++ b/products/apache-airflow.md
@@ -31,26 +31,110 @@ auto:
         eol: "EOL/Terminated"
 
 releases:
-  - releaseCycle: "3"
-    releaseDate: 2025-04-22
+  - releaseCycle: "3.1"
+    releaseDate: 2025-09-26
     eoas: false
     eol: false
     latest: "3.1.3"
     latestReleaseDate: 2025-11-14
 
-  - releaseCycle: "2"
-    releaseDate: 2020-12-17
+  - releaseCycle: "3.0"
+    releaseDate: 2025-04-23
+    eoas: false
+    eol: false
+    latest: "3.0.6"
+    latestReleaseDate: 2025-08-30
+
+  - releaseCycle: "2.11"
+    releaseDate: 2025-05-20
     eoas: 2025-10-22
     eol: 2026-04-22
     latest: "2.11.0"
     latestReleaseDate: 2025-05-20
 
+  - releaseCycle: "2.10"
+    releaseDate: 2024-08-16
+    eoas: 2025-10-22
+    eol: 2026-04-22
+    latest: "2.10.5"
+    latestReleaseDate: 2025-02-11
+
+  - releaseCycle: "2.9"
+    releaseDate: 2024-04-08
+    eoas: 2025-10-22
+    eol: 2026-04-22
+    latest: "2.9.3"
+    latestReleaseDate: 2024-07-16
+
+  - releaseCycle: "2.8"
+    releaseDate: 2023-12-19
+    eoas: 2025-10-22
+    eol: 2026-04-22
+    latest: "2.8.4"
+    latestReleaseDate: 2024-04-26
+
+  - releaseCycle: "2.7"
+    releaseDate: 2023-08-19
+    eoas: 2025-10-22
+    eol: 2026-04-22
+    latest: "2.7.3"
+    latestReleaseDate: 2023-11-06
+    
+  - releaseCycle: "2.6"
+    releaseDate: 2023-05-01
+    eoas: 2025-10-22
+    eol: 2026-04-22
+    latest: "2.6.3"
+    latestReleaseDate: 2023-07-11
+
+  - releaseCycle: "2.5"
+    releaseDate: 2022-12-03
+    eoas: 2025-10-22
+    eol: 2026-04-22
+    latest: "2.5.3"
+    latestReleaseDate: 2023-04-01
+
+  - releaseCycle: "2.4"
+    releaseDate: 2022-09-19
+    eoas: 2025-10-22
+    eol: 2026-04-22
+    latest: "2.4.3"
+    latestReleaseDate: 2022-11-15
+
+  - releaseCycle: "2.3"
+    releaseDate: 2022-05-01
+    eoas: 2025-10-22
+    eol: 2026-04-22
+    latest: "2.3.4"
+    latestReleaseDate: 2022-08-24
+
+  - releaseCycle: "2.2"
+    releaseDate: 2021-10-12
+    eoas: 2025-10-22
+    eol: 2026-04-22
+    latest: "2.2.5"
+    latestReleaseDate: 2021-10-12
+
+  - releaseCycle: "2.1"
+    releaseDate: 
+    eoas: 2025-10-22
+    eol: 2026-04-22
+    latest: "2.1.4"
+    latestReleaseDate: 2021-07-03
+
+  - releaseCycle: "2.0"
+    releaseDate: 2020-12-19
+    eoas: 2025-10-22
+    eol: 2026-04-22
+    latest: "2.0.2"
+    latestReleaseDate: 2021-04-20
+
   - releaseCycle: "1.10"
-    releaseDate: 2018-08-27
+    releaseDate: 2019-07-18
     eoas: 2020-12-17
     eol: 2021-06-17
     latest: "1.10.15"
-    latestReleaseDate: 2021-03-17
+    latestReleaseDate: 2021-03-18
 
   - releaseCycle: "1.9"
     releaseDate: 2018-01-02
@@ -67,11 +151,32 @@ releases:
     latestReleaseDate: 2017-09-04
 
   - releaseCycle: "1.7"
-    releaseDate: 2016-03-28
+    releaseDate: 2016-03-29
     eoas: 2017-03-19
     eol: 2017-03-19
     latest: "1.7.1.2"
     latestReleaseDate: 2017-05-20
+
+  - releaseCycle: "1.6"
+    releaseDate: 2015-11-13
+    eoas: 2017-03-19
+    eol: 2017-03-19
+    latest: "1.6.2"
+    latestReleaseDate: 2026-01-05
+
+  - releaseCycle: "1.5"
+    releaseDate: 2015-09-04
+    eoas: 2017-03-19
+    eol: 2017-03-19
+    latest: "1.5.2"
+    latestReleaseDate: 2015-10-23
+
+  - releaseCycle: "1.4"
+    releaseDate: 2015-08-19
+    eoas: 2017-03-19
+    eol: 2017-03-19
+    latest: "1.4.0"
+    latestReleaseDate: 2015-08-19
 
 ---
 


### PR DESCRIPTION
# :grey_question: About

Currently, [`airflow`](https://endoflife.date/apache-airflow) version are at a very high level : 

<img width="787" height="279" alt="image" src="https://github.com/user-attachments/assets/b00eb899-0e25-40de-a3e5-9da4f20774c5" />


... this makes it difficult to automate stack watching, for example when we are running a given `3.1` cycle or any `3.x` or `2.x` cycle... for maintenance purpose.

This PR is an attempt to enhance this, please let me know what you think about it.


# :moneybag: Benefits

- It makes it possible to monitor `3.x` and `2.x` cycles like we can on `1.x` ones