### PR TITLE
[pan-gp] Updated GlobalProtect 6.3.3 and 6.2.8

### DIFF
--- a/products/pan-gp.md
+++ b/products/pan-gp.md
@@ -33,16 +33,16 @@ releases:
     releaseDate: 2024-06-13
     eol: 2027-06-30
     eoas: 2027-06-30
-    latest: "6.3.3-c711"
-    latestReleaseDate: 2025-09-22
+    latest: "6.3.3-c828"
+    latestReleaseDate: 2025-11-20
     link: https://docs.paloaltonetworks.com/globalprotect/6-3/globalprotect-app-release-notes/globalprotect-addressed-issues
 
   - releaseCycle: "6.2"
     releaseDate: 2023-05-23
     eol: 2027-06-30
     eoas: 2027-06-30
-    latest: "6.2.8-c317"
-    latestReleaseDate: 2025-09-09
+    latest: "6.2.8-c416"
+    latestReleaseDate: 2025-11-18
     link: https://docs.paloaltonetworks.com/globalprotect/6-2/globalprotect-app-release-notes/globalprotect-addressed-issues
 
   - releaseCycle: "6.1"


### PR DESCRIPTION
This pull request updates the GlobalProtect product metadata in products/pan-gp.md to reflect the latest available builds from Palo Alto Networks documentation.

Changes:

Updated latest for 6.3.3 from c711 → c828

Updated latestReleaseDate for 6.3.3 from 2025-09-22 → 2025-11-20

Updated latest for 6.2.8 from c317 → c416

Updated latestReleaseDate for 6.2.8 from 2025-09-09 → 2025-11-18

Release notes:

https://docs.paloaltonetworks.com/globalprotect/6-3/globalprotect-app-release-notes/globalprotect-addressed-issues

https://docs.paloaltonetworks.com/globalprotect/6-2/globalprotect-app-release-notes/globalprotect-addressed-issues