### PR TITLE
[vmware-photon] Update EOL dates for 3.0 and 4.0

### DIFF
--- a/products/vmware-photon.md
+++ b/products/vmware-photon.md
@@ -59,4 +59,7 @@ releases:
 > VMWare [Photon OS](https://vmware.github.io/photon/) is an open source Linux container host
 > optimized for cloud-native applications, cloud platforms, and VMware infrastructure.
 
-End-of-Life dates are tentative.
+The EOL dates for the 3.0 and 4.0 release cyles are aligned with vSphere 
+[7.x/8.x support timelines](https://endoflife.date/vcenter) on this page
+[as per VMWare employees](https://github.com/endoflife-date/endoflife.date/pull/9025), but is not yet documented
+on the Photon OS website.

--- a/products/vmware-photon.md
+++ b/products/vmware-photon.md
@@ -24,8 +24,6 @@ identifiers:
   - cpe: cpe:2.3:o:vmware:photon_os
   - cpe: cpe:/o:vmware:photon_os
 
-# EOL Dates for 3.0 and 4.0 are tentative, as they are documented as:
-# March 2024, and March 2026.
 releases:
   - releaseCycle: "5.0"
     releaseDate: 2023-05-02
@@ -35,13 +33,13 @@ releases:
 
   - releaseCycle: "4.0"
     releaseDate: 2021-02-25
-    eol: 2026-03-31
+    eol: 2027-10-11
     link: https://blogs.vmware.com/vsphere/2021/02/photon-os-4-0-release-announcement.html
     kernelVersion: "5.10"
 
   - releaseCycle: "3.0"
     releaseDate: 2019-02-08
-    eol: 2024-03-31
+    eol: 2025-10-02
     link: https://vmware.github.io/photon/assets/files/html/3.0/What-is-New-in-Photon-OS-3.0.html
     kernelVersion: "4.19"
 


### PR DESCRIPTION
These are actual Photon OS 3.0/4.0 EOL dates aligned with vSphere 7.x/8.x general support timelines.