### PR TITLE
`quarkus` > `Quarkus` 3.30 released (and `3.29` EOL)

### DIFF
--- a/products/quarkus-framework.md
+++ b/products/quarkus-framework.md
@@ -33,9 +33,15 @@ auto:
 # - eol(x) = releaseDate(x)+1y for LTS
 # - For EOES see https://access.redhat.com/support/policy/updates/red_hat_build_of_quarkus_notes
 releases:
+  - releaseCycle: "3.30"
+    releaseDate: 2025-11-27
+    eol: false
+    latest: "3.30.1"
+    latestReleaseDate: 2025-11-27
+    
   - releaseCycle: "3.29"
     releaseDate: 2025-10-29
-    eol: false
+    eol: 2025-11-27
     latest: "3.29.4"
     latestReleaseDate: 2025-11-19
 


### PR DESCRIPTION
# :grey_question: About

[As announced yesterday](https://x.com/QuarkusIO/status/1994003094061936917), [Quarkus 3.30](https://quarkus.io/blog/quarkus-3-30-released/) is now released  : 

<img width="601" height="599" alt="image" src="https://github.com/user-attachments/assets/5e5cbb15-c6a1-498b-8368-3e6f5b30425d" />
