### PR TITLE
[nixos] Add 25.11 ( Xantusia )

### DIFF
--- a/products/nixos.md
+++ b/products/nixos.md
@@ -21,7 +21,7 @@ releases:
   - releaseCycle: "25.11"
     codename: "Xantusia"
     releaseDate: 2025-11-30
-    eol: false
+    eol: 2026-06-30
     
   - releaseCycle: "25.05"
     codename: "Warbler"

--- a/products/nixos.md
+++ b/products/nixos.md
@@ -18,6 +18,11 @@ identifiers:
   - cpe: cpe:2.3:o:nixos:nixos
 
 releases:
+  - releaseCycle: "25.11"
+    codename: "Xantusia"
+    releaseDate: 2025-11-30
+    eol: false
+    
   - releaseCycle: "25.05"
     codename: "Warbler"
     releaseDate: 2025-05-23


### PR DESCRIPTION
# :grey_question: About

Cf following [tweet](https://x.com/linuxiac/status/1995233588745482350) : 

<img width="601" height="654" alt="image" src="https://github.com/user-attachments/assets/1afcd5bd-2a6d-4be2-87cb-9ddabc98a421" />


[NixOS 25.11 “Xantusia” Ships with GNOME 49, Linux kernel 6.17 is out](https://linuxiac.com/nixos-25-11-ships-with-gnome-49-linux-kernel-6-17/)

# :question: About `eol`

- I was not able to find the `eol`