### PR TITLE
[linux] Add release information for Linux kernel 6.18

### DIFF
--- a/products/linux-kernel.md
+++ b/products/linux-kernel.md
@@ -10,7 +10,7 @@ alternate_urls:
   - /linux-kernel
 versionCommand: uname -r
 # Found on https://en.wikipedia.org/wiki/Linux_kernel_version_history
-releaseImage: https://upload.wikimedia.org/wikipedia/en/timeline/ip63q0eabh7onfwkhspcmhpccgg6b5u.png
+releaseImage: https://upload.wikimedia.org/wikipedia/en/timeline/dqzx6dkhq3j9s9i1y84hvttb8x53qnk.png
 releasePolicyLink: https://www.kernel.org/
 changelogTemplate: https://kernelnewbies.org/Linux___RELEASE_CYCLE__
 

--- a/products/linux-kernel.md
+++ b/products/linux-kernel.md
@@ -31,7 +31,6 @@ identifiers:
 # non-LTS: releaseDate(x)+4 months
 releases:
   - releaseCycle: "6.18"
-    lts: true
     releaseDate: 2025-11-30
     eol: false # not yet announced
     latest: "6.18"

--- a/products/linux-kernel.md
+++ b/products/linux-kernel.md
@@ -34,7 +34,7 @@ releases:
     lts: true
     releaseDate: 2025-11-30
     eol: false # not yet announced
-    latest: "6.189"
+    latest: "6.18"
     latestReleaseDate: 2025-11-30
 
   - releaseCycle: "6.17"

--- a/products/linux-kernel.md
+++ b/products/linux-kernel.md
@@ -30,6 +30,13 @@ identifiers:
 # LTS 2-year projected EOL see https://www.kernel.org/category/releases.html
 # non-LTS: releaseDate(x)+4 months
 releases:
+  - releaseCycle: "6.18"
+    lts: true
+    releaseDate: 2025-11-30
+    eol: false # not yet announced
+    latest: "6.189"
+    latestReleaseDate: 2025-11-30
+
   - releaseCycle: "6.17"
     releaseDate: 2025-09-28
     eol: false # not yet announced


### PR DESCRIPTION
This release will probably be an LTS version if it goes with current pattern. Thus i marked it as LTS

https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=7d0a66e4bb9081d75c82ec4957c50034cb0ea449