### PR TITLE
[Google-chrome] Added changelogtemplate and filled nulls for older ve…

### DIFF
--- a/products/chrome.md
+++ b/products/chrome.md
@@ -9,7 +9,7 @@ alternate_urls:
   - /google-chrome
 versionCommand: google-chrome --version
 releasePolicyLink: https://developer.chrome.com/docs/web-platform/chrome-release-channels
-changelogTemplate: https://developer.chrome.com/release-notes/__LATEST__
+changelogTemplate: https://developer.chrome.com/release-notes/__RELEASE_CYCLE__
 latestColumn: false
 
 identifiers:

--- a/products/chrome.md
+++ b/products/chrome.md
@@ -9,7 +9,7 @@ alternate_urls:
   - /google-chrome
 versionCommand: google-chrome --version
 releasePolicyLink: https://developer.chrome.com/docs/web-platform/chrome-release-channels
-# no changelogTemplate : changelog is only available for the latest 10-20 releases, it's simpler to manage the links manually
+changelogTemplate: https://developer.chrome.com/release-notes/__LATEST__
 latestColumn: false
 
 identifiers:
@@ -25,566 +25,662 @@ releases:
   - releaseCycle: "143"
     releaseDate: 2025-12-02
     eol: false
-    link: https://developer.chrome.com/release-notes/__RELEASE_CYCLE__
   
   - releaseCycle: "142"
     releaseDate: 2025-10-28
     eol: 2025-12-02
-    link: https://developer.chrome.com/release-notes/__RELEASE_CYCLE__
  
   - releaseCycle: "141"
     releaseDate: 2025-09-30
     eol: 2025-10-28
-    link: https://developer.chrome.com/release-notes/__RELEASE_CYCLE__
 
   - releaseCycle: "140"
     releaseDate: 2025-09-02
     eol: 2025-09-30
-    link: https://developer.chrome.com/release-notes/__RELEASE_CYCLE__
 
   - releaseCycle: "139"
     releaseDate: 2025-08-05
     eol: 2025-09-02
-    link: https://developer.chrome.com/release-notes/__RELEASE_CYCLE__
 
   - releaseCycle: "138"
     releaseDate: 2025-06-24
     eol: 2025-08-05
-    link: https://developer.chrome.com/release-notes/__RELEASE_CYCLE__
 
   - releaseCycle: "137"
     releaseDate: 2025-05-27
     eol: 2025-06-24
-    link: https://developer.chrome.com/release-notes/__RELEASE_CYCLE__
 
   - releaseCycle: "136"
     releaseDate: 2025-04-29
     eol: 2025-05-27
-    link: https://developer.chrome.com/release-notes/__RELEASE_CYCLE__
 
   - releaseCycle: "135"
     releaseDate: 2025-04-01
     eol: 2025-04-29
-    link: https://developer.chrome.com/release-notes/__RELEASE_CYCLE__
 
   - releaseCycle: "134"
     releaseDate: 2025-03-04
     eol: 2025-04-01
-    link: https://developer.chrome.com/release-notes/__RELEASE_CYCLE__
 
   - releaseCycle: "133"
     releaseDate: 2025-02-04
     eol: 2025-03-04
-    link: https://developer.chrome.com/release-notes/__RELEASE_CYCLE__
 
   - releaseCycle: "132"
     releaseDate: 2025-01-14
     eol: 2025-02-04
-    link: https://developer.chrome.com/release-notes/__RELEASE_CYCLE__
 
   - releaseCycle: "131"
     releaseDate: 2024-11-12
     eol: 2025-01-14
-    link: https://developer.chrome.com/release-notes/__RELEASE_CYCLE__
 
   - releaseCycle: "130"
     releaseDate: 2024-10-15
     eol: 2024-11-12
-    link: https://developer.chrome.com/release-notes/__RELEASE_CYCLE__
 
   - releaseCycle: "129"
     releaseDate: 2024-09-17
     eol: 2024-10-15
-    link: https://developer.chrome.com/release-notes/__RELEASE_CYCLE__
 
   - releaseCycle: "128"
     releaseDate: 2024-08-20
     eol: 2024-09-17
-    link: https://developer.chrome.com/release-notes/__RELEASE_CYCLE__
 
   - releaseCycle: "127"
     releaseDate: 2024-07-23
     eol: 2024-08-20
-    link: https://developer.chrome.com/release-notes/__RELEASE_CYCLE__
 
   - releaseCycle: "126"
     releaseDate: 2024-06-11
     eol: 2024-07-23
-    link: https://developer.chrome.com/release-notes/__RELEASE_CYCLE__
 
   - releaseCycle: "125"
     releaseDate: 2024-05-14
     eol: 2024-06-11
-    link: https://developer.chrome.com/release-notes/__RELEASE_CYCLE__
 
   - releaseCycle: "124"
     releaseDate: 2024-04-16
     eol: 2024-05-14
-    link: https://developer.chrome.com/release-notes/__RELEASE_CYCLE__
 
   - releaseCycle: "123"
     releaseDate: 2024-03-19
     eol: 2024-04-16
+    link: null
 
   - releaseCycle: "122"
     releaseDate: 2024-02-20
     eol: 2024-03-19
+    link: null
 
   - releaseCycle: "121"
     releaseDate: 2024-01-23
     eol: 2024-02-20
+    link: null
 
   - releaseCycle: "120"
     releaseDate: 2023-12-05
     eol: 2024-01-23
+    link: null
 
   - releaseCycle: "119"
     releaseDate: 2023-10-31
     eol: 2023-12-05
+    link: null
 
   - releaseCycle: "118"
     releaseDate: 2023-10-10
     eol: 2023-10-31
+    link: null
 
   - releaseCycle: "117"
     releaseDate: 2023-09-12
     eol: 2023-10-10
+    link: null
 
   - releaseCycle: "116"
     releaseDate: 2023-08-15
     eol: 2023-09-12
+    link: null
 
   - releaseCycle: "115"
     releaseDate: 2023-07-18
     eol: 2023-08-15
+    link: null
 
   - releaseCycle: "114"
     releaseDate: 2023-05-30
     eol: 2023-07-18
+    link: null
 
   - releaseCycle: "113"
     releaseDate: 2023-05-02
     eol: 2023-05-30
+    link: null
 
   - releaseCycle: "112"
     releaseDate: 2023-04-04
     eol: 2023-05-02
+    link: null
 
   - releaseCycle: "111"
     releaseDate: 2023-03-07
     eol: 2023-04-04
+    link: null
 
   - releaseCycle: "110"
     releaseDate: 2023-02-07
     eol: 2023-03-07
+    link: null
 
   - releaseCycle: "109"
     releaseDate: 2023-01-10
     eol: 2023-02-07
+    link: null
 
   - releaseCycle: "108"
     releaseDate: 2022-11-29
     eol: 2023-01-10
+    link: null
 
   - releaseCycle: "107"
     releaseDate: 2022-10-25
     eol: 2022-11-29
+    link: null
 
   - releaseCycle: "106"
     releaseDate: 2022-09-27
     eol: 2022-10-25
+    link: null
 
   - releaseCycle: "105"
     releaseDate: 2022-08-30
     eol: 2022-09-27
+    link: null
 
   - releaseCycle: "104"
     releaseDate: 2022-08-02
     eol: 2022-08-30
+    link: null
 
   - releaseCycle: "103"
     releaseDate: 2022-06-21
     eol: 2022-08-02
+    link: null
 
   - releaseCycle: "102"
     releaseDate: 2022-05-24
     eol: 2022-06-21
+    link: null
 
   - releaseCycle: "101"
     releaseDate: 2022-04-26
     eol: 2022-05-24
+    link: null
 
   - releaseCycle: "100"
     releaseDate: 2022-03-29
     eol: 2022-04-26
+    link: null
 
   - releaseCycle: "99"
     releaseDate: 2022-03-01
     eol: 2022-03-29
+    link: null
 
   - releaseCycle: "98"
     releaseDate: 2022-02-01
     eol: 2022-03-01
+    link: null
 
   - releaseCycle: "97"
     releaseDate: 2022-01-04
     eol: 2022-02-01
+    link: null
 
   - releaseCycle: "96"
     releaseDate: 2021-11-16
     eol: 2022-01-04
+    link: null
 
   - releaseCycle: "95"
     releaseDate: 2021-10-19
     eol: 2021-11-16
+    link: null
 
   - releaseCycle: "94"
     releaseDate: 2021-09-21
     eol: 2021-10-19
+    link: null
 
   - releaseCycle: "93"
     releaseDate: 2021-08-31
     eol: 2021-09-21
+    link: null
 
   - releaseCycle: "92"
     releaseDate: 2021-07-20
     eol: 2021-08-31
+    link: null
 
   - releaseCycle: "91"
     releaseDate: 2021-05-25
     eol: 2021-07-20
+    link: null
 
   - releaseCycle: "90"
     releaseDate: 2021-04-13
     eol: 2021-05-25
+    link: null
 
   - releaseCycle: "89"
     releaseDate: 2021-03-02
     eol: 2021-04-13
+    link: null
 
   - releaseCycle: "88"
     releaseDate: 2021-01-19
     eol: 2021-03-02
+    link: null
 
   - releaseCycle: "87"
     releaseDate: 2020-11-17
     eol: 2021-01-19
+    link: null
 
   - releaseCycle: "86"
     releaseDate: 2020-10-06
     eol: 2020-11-17
+    link: null
 
   - releaseCycle: "85"
     releaseDate: 2020-08-25
     eol: 2020-10-06
+    link: null
 
   - releaseCycle: "84"
     releaseDate: 2020-07-14
     eol: 2020-08-25
+    link: null
 
   - releaseCycle: "83"
     releaseDate: 2020-05-19
     eol: 2020-07-14
+    link: null
 
   - releaseCycle: "81"
     releaseDate: 2020-04-07
     eol: 2020-05-19
+    link: null
 
   - releaseCycle: "80"
     releaseDate: 2020-02-04
     eol: 2020-04-07
+    link: null
 
   - releaseCycle: "79"
     releaseDate: 2019-12-10
     eol: 2020-02-04
+    link: null
 
   - releaseCycle: "78"
     releaseDate: 2019-10-22
     eol: 2019-12-10
+    link: null
 
   - releaseCycle: "77"
     releaseDate: 2019-09-10
     eol: 2019-10-22
+    link: null
 
   - releaseCycle: "76"
     releaseDate: 2019-07-30
     eol: 2019-09-10
+    link: null
 
   - releaseCycle: "75"
     releaseDate: 2019-06-04
     eol: 2019-07-30
+    link: null
 
   - releaseCycle: "74"
     releaseDate: 2019-04-23
     eol: 2019-06-04
+    link: null
 
   - releaseCycle: "73"
     releaseDate: 2019-03-12
     eol: 2019-04-23
+    link: null
 
   - releaseCycle: "72"
     releaseDate: 2019-01-29
     eol: 2019-03-12
+    link: null
 
   - releaseCycle: "71"
     releaseDate: 2018-12-04
     eol: 2019-01-29
+    link: null
 
   - releaseCycle: "70"
     releaseDate: 2018-10-16
     eol: 2018-12-04
+    link: null
 
   - releaseCycle: "69"
     releaseDate: 2018-09-04
     eol: 2018-10-16
+    link: null
 
   - releaseCycle: "68"
     releaseDate: 2018-07-24
     eol: 2018-09-04
+    link: null
 
   - releaseCycle: "67"
     releaseDate: 2018-05-29
     eol: 2018-07-24
+    link: null
 
   - releaseCycle: "66"
     releaseDate: 2018-04-17
     eol: 2018-05-29
+    link: null
 
   - releaseCycle: "65"
     releaseDate: 2018-03-06
     eol: 2018-04-17
+    link: null
 
   - releaseCycle: "64"
     releaseDate: 2018-01-23
     eol: 2018-03-06
+    link: null
 
   - releaseCycle: "63"
     releaseDate: 2017-12-05
     eol: 2018-01-23
+    link: null
 
   - releaseCycle: "62"
     releaseDate: 2017-10-17
     eol: 2017-12-05
+    link: null
 
   - releaseCycle: "61"
     releaseDate: 2017-09-05
     eol: 2017-10-17
+    link: null
 
   - releaseCycle: "60"
     releaseDate: 2017-07-25
     eol: 2017-09-05
+    link: null
 
   - releaseCycle: "59"
     releaseDate: 2017-05-30
     eol: 2017-07-25
+    link: null
 
   - releaseCycle: "58"
     releaseDate: 2017-04-18
     eol: 2017-05-30
+    link: null
 
   - releaseCycle: "57"
     releaseDate: 2017-03-07
     eol: 2017-04-18
+    link: null
 
   - releaseCycle: "56"
     releaseDate: 2017-01-24
     eol: 2017-03-07
+    link: null
 
   - releaseCycle: "55"
     releaseDate: 2016-11-29
     eol: 2017-01-24
+    link: null
 
   - releaseCycle: "54"
     releaseDate: 2016-10-11
     eol: 2016-11-29
+    link: null
 
   - releaseCycle: "53"
     releaseDate: 2016-08-30
     eol: 2016-10-11
+    link: null
 
   - releaseCycle: "52"
     releaseDate: 2016-07-19
     eol: 2016-08-30
+    link: null
 
   - releaseCycle: "51"
     releaseDate: 2016-05-24
     eol: 2016-07-19
+    link: null
 
   - releaseCycle: "50"
     releaseDate: 2016-04-12
     eol: 2016-05-24
+    link: null
 
   - releaseCycle: "49"
     releaseDate: 2016-03-01
     eol: 2016-04-12
+    link: null
 
   - releaseCycle: "48"
     releaseDate: 2016-01-19
     eol: 2016-03-01
+    link: null
 
   - releaseCycle: "47"
     releaseDate: 2015-11-17
     eol: 2016-01-19
+    link: null
 
   - releaseCycle: "46"
     releaseDate: 2015-10-06
     eol: 2015-11-17
+    link: null
 
   - releaseCycle: "45"
     releaseDate: 2015-08-25
     eol: 2015-10-06
+    link: null
 
   - releaseCycle: "44"
     releaseDate: 2015-07-14
     eol: 2015-08-25
+    link: null
 
   - releaseCycle: "43"
     releaseDate: 2015-05-19
     eol: 2015-07-14
+    link: null
 
   - releaseCycle: "42"
     releaseDate: 2015-04-07
     eol: 2015-05-19
+    link: null
 
   - releaseCycle: "41"
     releaseDate: 2015-02-24
     eol: 2015-04-07
+    link: null
 
   - releaseCycle: "40"
     releaseDate: 2015-01-13
     eol: 2015-02-24
+    link: null
 
   - releaseCycle: "39"
     releaseDate: 2014-11-11
     eol: 2015-01-13
+    link: null
 
   - releaseCycle: "38"
     releaseDate: 2014-09-30
     eol: 2014-11-11
+    link: null
 
   - releaseCycle: "37"
     releaseDate: 2014-08-19
     eol: 2014-09-30
+    link: null
 
   - releaseCycle: "36"
     releaseDate: 2014-06-24
     eol: 2014-08-19
+    link: null
 
   - releaseCycle: "35"
     releaseDate: 2014-05-13
     eol: 2014-06-24
+    link: null
 
   - releaseCycle: "34"
     releaseDate: 2014-04-01
     eol: 2014-05-13
+    link: null
 
   - releaseCycle: "33"
     releaseDate: 2014-02-18
     eol: 2014-04-01
+    link: null
 
   - releaseCycle: "32"
     releaseDate: 2014-01-07
     eol: 2014-02-18
+    link: null
 
   - releaseCycle: "31"
     releaseDate: 2013-11-05
     eol: 2014-01-07
+    link: null
 
   - releaseCycle: "30"
     releaseDate: 2013-09-24
     eol: 2013-11-05
+    link: null
 
   - releaseCycle: "29"
     releaseDate: 2013-08-13
     eol: 2013-09-24
+    link: null
 
   - releaseCycle: "28"
     releaseDate: 2013-06-25
     eol: 2013-08-13
+    link: null
 
   - releaseCycle: "27"
     releaseDate: 2013-05-07
     eol: 2013-06-25
+    link: null
 
   - releaseCycle: "26"
     releaseDate: 2013-03-26
     eol: 2013-05-07
+    link: null
 
   - releaseCycle: "25"
     releaseDate: 2013-02-12
     eol: 2013-03-26
+    link: null
 
   - releaseCycle: "24"
     releaseDate: 2012-12-18
     eol: 2013-02-12
+    link: null
 
   - releaseCycle: "23"
     releaseDate: 2012-10-30
     eol: 2012-12-18
+    link: null
 
   - releaseCycle: "22"
     releaseDate: 2012-09-18
     eol: 2012-10-30
+    link: null
 
   - releaseCycle: "21"
     releaseDate: 2012-08-07
     eol: 2012-09-18
+    link: null
 
   - releaseCycle: "20"
     releaseDate: 2012-06-19
     eol: 2012-08-07
+    link: null
 
   - releaseCycle: "19"
     releaseDate: 2012-04-24
     eol: 2012-06-19
+    link: null
 
   - releaseCycle: "18"
     releaseDate: 2012-03-13
     eol: 2012-04-24
+    link: null
 
   - releaseCycle: "17"
     releaseDate: 2012-01-31
     eol: 2012-03-13
+    link: null
 
   - releaseCycle: "16"
     releaseDate: 2011-12-06
     eol: 2012-01-31
+    link: null
 
   - releaseCycle: "15"
     releaseDate: 2011-10-18
     eol: 2011-12-06
+    link: null
 
   - releaseCycle: "14"
     releaseDate: 2011-09-06
     eol: 2011-10-18
+    link: null
 
   - releaseCycle: "13"
     releaseDate: 2011-07-26
     eol: 2011-09-06
+    link: null
 
   - releaseCycle: "12"
     releaseDate: 2011-05-31
     eol: 2011-07-26
+    link: null
 
   - releaseCycle: "11"
     releaseDate: 2011-04-19
     eol: 2011-05-31
+    link: null
 
   - releaseCycle: "10"
     releaseDate: 2011-03-08
     eol: 2011-04-19
+    link: null
 
   - releaseCycle: "9"
     releaseDate: 2011-01-25
     eol: 2011-03-08
+    link: null
 
   - releaseCycle: "8"
     releaseDate: 2010-11-30
     eol: 2011-01-25
+    link: null
 
   - releaseCycle: "7"
     releaseDate: 2010-10-12
     eol: 2010-11-30
+    link: null
 ---
 
 > [Google Chrome](https://www.google.com/chrome/) is a web browser developed by Google.


### PR DESCRIPTION
Looks like the https://developer.chrome.com/release-notes/ became standard after version 123 so we have 2 options 

A-  Fill the same url for each newcoming versions.

B- Fill null for older ( <124 ) versions. and add changelogtemplate

this PR is for choosing option B