### PR TITLE
[pan-os]Update PAN-OS version(s)

### DIFF
--- a/products/pan-os.md
+++ b/products/pan-os.md
@@ -39,16 +39,16 @@ releases:
   - releaseCycle: "11.2"
     releaseDate: 2024-05-02
     eol: 2027-05-02
-    latest: "11.2.10"
-    latestReleaseDate: 2025-11-05
-    link: https://docs.paloaltonetworks.com/pan-os/11-2/pan-os-release-notes/pan-os-11-2-10-known-and-addressed-issues/pan-os-11-2-10-addressed-issues
+    latest: "11.2.10-h1"
+    latestReleaseDate: 2025-12-02
+    link: https://docs.paloaltonetworks.com/pan-os/11-2/pan-os-release-notes/pan-os-11-2-10-known-and-addressed-issues/pan-os-11-2-10-h1-addressed-issues
 
   - releaseCycle: "11.1"
     releaseDate: 2023-11-03
     eol: 2027-05-03
-    latest: "11.1.12"
-    latestReleaseDate: 2025-10-09
-    link: https://docs.paloaltonetworks.com/pan-os/11-1/pan-os-release-notes/pan-os-11-1-12-known-and-addressed-issues/pan-os-11-1-12-addressed-issues
+    latest: "11.1.13"
+    latestReleaseDate: 2025-12-01
+    link: https://docs.paloaltonetworks.com/pan-os/11-1/pan-os-release-notes/pan-os-11-1-13-known-and-addressed-issues/pan-os-11-1-13-addressed-issues
 
   - releaseCycle: "11.0"
     releaseDate: 2022-11-17


### PR DESCRIPTION
[panos] This PR updates the PAN-OS versions, Release dates and the Release Notes url.

Updated Pan-OS Version:  11.2.10-h1 

Released:                2025-12-02 

Release Notes:           https://docs.paloaltonetworks.com/pan-os/11-2/pan-os-release-notes/pan-os-11-2-10-known-and-addressed-issues/pan-os-11-2-10-h1-addressed-issues


Updated Pan-OS Version:  11.1.13 

Released:                2025-12-01 

Release Notes:           https://docs.paloaltonetworks.com/pan-os/11-1/pan-os-release-notes/pan-os-11-1-13-known-and-addressed-issues/pan-os-11-1-13-addressed-issues
