### PR TITLE
[Unity] add 6.3, fix 6.0 wrong EOL

### DIFF
--- a/products/unity.md
+++ b/products/unity.md
@@ -18,11 +18,18 @@ auto:
 # For update release : eol(x) = releaseDate(x+1)
 # For LTS : eol(x) = releaseDate + 2 years
 releases:
+  - releaseCycle: "6.3"
+    releaseDate: 2025-12-04
+    eol: 2027-12-04
+    eoes: 2028-12-04
+    latest: "6000.3.0f1"
+    latestReleaseDate: 2025-12-04
+    
   - releaseCycle: "6.2"
     releaseDate: 2025-08-12
-    eol: false
-    latest: "6000.2.14f1"
-    latestReleaseDate: 2025-11-26
+    eol: 2025-12-04
+    latest: "6000.2.15f1"
+    latestReleaseDate: 2025-12-03
 
   - releaseCycle: "6.1"
     releaseDate: 2025-04-23
@@ -31,10 +38,10 @@ releases:
     latestReleaseDate: 2025-10-03
 
   - releaseCycle: "6.0"
-    lts: 2024-10-16
     releaseDate: 2024-04-29
-    eol: 2026-04-29
-    eoes: 2027-04-29
+    lts: 2024-10-16
+    eol: 2026-10-16
+    eoes: 2027-10-16
     latest: "6000.0.63f1"
     latestReleaseDate: 2025-11-28
 


### PR DESCRIPTION
- Update Unity with 6.3 new cycle.
- Fix issue with wrong 6.0 EOL date. The EOL is 2 years after the release date of 6000.0.23f1 (2024-10-16), not from 6000.0.0f1 (2024-04-29) that wasn't labeled as an LTS.

https://unity.com/blog/unity-6-3-lts-is-now-available