### PR TITLE
[jira-software] add 11.3 (LTS release)

### DIFF
--- a/products/jira-software.md
+++ b/products/jira-software.md
@@ -27,6 +27,13 @@ auto:
 # Release dates from https://www.atlassian.com/software/jira/download-archives.
 # LTS/EOL dates can be found on https://confluence.atlassian.com/support/atlassian-support-end-of-life-policy-201851003.html.
 releases:
+  - releaseCycle: "11.3"
+    lts: true
+    releaseDate: 2025-12-03
+    eol: 2027-12-03
+    latest: "11.3.0"
+    latestReleaseDate: 2025-12-03
+
   - releaseCycle: "11.2"
     releaseDate: 2025-11-06
     eol: 2027-11-06


### PR DESCRIPTION
https://confluence.atlassian.com/jirasoftware/jira-software-11-3-x-release-notes-1689288832.html

did not see much difference with the EOL schedule for 11.3 (LTS) vs 11.2 (non-LTS) though. 