### PR TITLE
[apache-maven] Revise EOL dates and enhance documentation

### DIFF
--- a/products/apache-maven.md
+++ b/products/apache-maven.md
@@ -27,12 +27,6 @@ auto:
 
 # See https://maven.apache.org/docs/history.html
 releases:
-  - releaseCycle: "4.0"
-    releaseDate: 2022-10-24
-    eol: false
-    latest: "4.0.0-rc-5"
-    latestReleaseDate: 2025-11-13
-    
   - releaseCycle: "3.9"
     releaseDate: 2023-01-31
     eol: false

--- a/products/apache-maven.md
+++ b/products/apache-maven.md
@@ -25,9 +25,14 @@ auto:
   methods:
     - maven: org.apache.maven/maven-core
 
-# Before 3.8: eol(x) = releaseDate(x+1) (introduced in https://web.archive.org/web/20230615224740/https://maven.apache.org/docs/history.html)
-# Since 3.8: eol(x) = releaseDate(x+2)
+# See https://maven.apache.org/docs/history.html
 releases:
+  - releaseCycle: "4.0"
+    releaseDate: 2022-10-24
+    eol: false
+    latest: "4.0.0-rc-5"
+    latestReleaseDate: 2025-11-13
+    
   - releaseCycle: "3.9"
     releaseDate: 2023-01-31
     eol: false
@@ -36,7 +41,7 @@ releases:
 
   - releaseCycle: "3.8"
     releaseDate: 2021-03-30
-    eol: false
+    eol: 2025-06-14
     latest: "3.8.9"
     latestReleaseDate: 2025-06-14
 
@@ -94,6 +99,5 @@ releases:
 > Based on the concept of a project object model (POM), Maven can manage a project's build,
 > reporting and documentation from a central piece of information.
 
-Apache Maven follows [semantic versioning](https://semver.org).
-[Since mid-2023](https://web.archive.org/web/20230615224740/https://maven.apache.org/docs/history.html),
-the Apache Maven team maintains the two last minor versions.
+Apache Maven follows [semantic versioning](https://semver.org). The Apache Maven team maintains 
+the [two last minor versions](https://maven.apache.org/docs/history.html).


### PR DESCRIPTION
Updated end-of-life dates for Maven versions and improved documentation clarity.

* EOL/EOS for 3.8.x is reached already.
* 4.0.0 is not yet GA but supported and available.

Refer to the Maven website for details at https://maven.apache.org/docs/history.html#maven-3-8-x-and-before

Also note that I am an Apache Maven committer with Manfred Moser <mmoser@apache.org>