### PR TITLE
[drupal] Switch to major release cycles

### DIFF
--- a/products/drupal.md
+++ b/products/drupal.md
@@ -29,129 +29,38 @@ auto:
 # eol(x) documented on https://www.drupal.org/about/core/policies/core-release-cycles/schedule.
 # Minor releases usually happen on the third Wednesday every six months.
 releases:
-  - releaseCycle: "11.2"
-    releaseDate: 2025-06-18
-    eoas: 2025-12-10 # guessed, releaseDate(11.3) as planned on https://www.drupal.org/about/core/policies/core-release-cycles/schedule
-    eol: false # not documented on https://www.drupal.org/about/core/policies/core-release-cycles/schedule
+  - releaseCycle: "11"
+    releaseDate: 2024-08-02 # https://www.drupal.org/project/drupal/releases/11.0.0
+    eoas: 2026-08-02 # guessed, as planned on https://www.drupal.org/about/core/policies/core-release-cycles/schedule
+    eol: 2028-08-02 # same as above
     latest: "11.2.9"
     latestReleaseDate: 2025-12-04
 
-  - releaseCycle: "10.5"
-    releaseDate: 2025-06-18
-    eoas: 2025-12-10 # guessed, releaseDate(10.6) as planned on https://www.drupal.org/about/core/policies/core-release-cycles/schedule
-    eol: false # not documented on https://www.drupal.org/about/core/policies/core-release-cycles/schedule
+  - releaseCycle: "10"
+    releaseDate: 2022-12-15 # https://www.drupal.org/project/drupal/releases/10.0.0
+    eoas: 2024-12-15
+    eol: 2026-12-09 # https://www.drupal.org/about/core/policies/core-release-cycles/schedule#d10-eol
     latest: "10.5.7"
     latestReleaseDate: 2025-12-04
 
-  - releaseCycle: "10.4"
-    releaseDate: 2024-12-17
-    eoas: 2025-06-18 # releaseDate(10.5)
-    eol: 2025-12-10 # guessed, as planned on https://www.drupal.org/about/core/policies/core-release-cycles/schedule
-    latest: "10.4.9"
-    latestReleaseDate: 2025-11-12
-
-  - releaseCycle: "11.1"
-    releaseDate: 2024-12-16
-    eoas: 2025-06-18 # releaseDate(11.2)
-    eol: 2025-12-10 # guessed, as planned on https://www.drupal.org/about/core/policies/core-release-cycles/schedule
-    latest: "11.1.9"
-    latestReleaseDate: 2025-11-12
-
-  - releaseCycle: "11.0"
-    releaseDate: 2024-08-02
-    eoas: 2024-12-16 # releaseDate(11.1)
-    eol: 2025-06-16
-    latest: "11.0.13"
-    latestReleaseDate: 2025-03-19
-
-  - releaseCycle: "10.3"
-    releaseDate: 2024-06-20
-    eoas: 2024-08-02
-    eol: 2025-06-16
-    latest: "10.3.14"
-    latestReleaseDate: 2025-03-19
-
-  - releaseCycle: "10.2"
-    releaseDate: 2023-12-15
-    eoas: 2024-06-20
-    eol: 2024-12-17
-    latest: "10.2.12"
-    latestReleaseDate: 2024-11-22
-
-  - releaseCycle: "10.1"
-    releaseDate: 2023-06-22
-    eoas: 2023-12-15
-    eol: 2024-06-20
-    latest: "10.1.8"
-    latestReleaseDate: 2024-01-16
-
-  - releaseCycle: "10.0"
-    releaseDate: 2022-12-15
-    eoas: 2023-06-21
-    eol: 2023-12-15
-    latest: "10.0.11"
-    latestReleaseDate: 2023-09-19
-
-  - releaseCycle: "9.5"
-    releaseDate: 2022-12-15
-    eoas: 2023-06-21
+  - releaseCycle: "9"
+    releaseDate: 2020-06-03
+    eoas: 2023-11-01
     eol: 2023-11-01
     latest: "9.5.11"
-    latestReleaseDate: 2023-09-19
+    latestReleaseDate: 2023-09-20
 
-  - releaseCycle: "9.4"
-    releaseDate: 2022-06-15
-    eoas: 2022-12-14
-    eol: 2023-06-21
-    latest: "9.4.15"
-    latestReleaseDate: 2023-05-03
-
-  - releaseCycle: "9.3"
-    releaseDate: 2021-12-08
-    eoas: 2022-06-15
-    eol: 2022-12-14
-    latest: "9.3.22"
-    latestReleaseDate: 2022-09-28
-
-  - releaseCycle: "9.2"
-    releaseDate: 2021-06-16
-    eoas: 2021-12-08
-    eol: 2022-06-15
-    latest: "9.2.21"
-    latestReleaseDate: 2022-06-10
-
-  - releaseCycle: "9.1"
-    releaseDate: 2020-12-02
-    eoas: 2021-06-16
-    eol: 2021-12-08
-    latest: "9.1.15"
-    latestReleaseDate: 2021-11-24
-
-  - releaseCycle: "9.0"
-    releaseDate: 2020-06-03
-    eoas: 2020-12-02
-    eol: 2021-06-16
-    latest: "9.0.14"
-    latestReleaseDate: 2021-05-25
-
-  - releaseCycle: "8.9"
-    releaseDate: 2020-06-03
+  - releaseCycle: "8"
+    releaseDate: 2016-06-03
     eoas: 2020-12-01
     eol: 2021-11-02
     latest: "8.9.20"
     latestReleaseDate: 2021-11-17
 
-  - releaseCycle: "8.8"
-    releaseDate: 2019-12-04
-    eoas: 2020-06-03
-    eol: 2020-12-01
-    latest: "8.8.12"
-    latestReleaseDate: 2020-11-25
-
   - releaseCycle: "7"
     lts: true
     releaseDate: 2011-01-05
-    eoas: 2015-11-19
+    eoas: 2025-01-05
     eol: 2025-01-05
     eoes: false
     latest: "7.103"


### PR DESCRIPTION
**Link to product page on endoflife.date**

https://endoflife.date/drupal

**Details of incorrect and correct details you have found**

Would it make the page more useful, if Drupal releases were listed the same way as TYPO3 and Joomla, with a Major version for each row?

- https://endoflife.date/typo3
- https://endoflife.date/joomla

**What is the source website for the product and for its version information?**

- https://www.drupal.org/about/core/policies/core-release-cycles/release-process-overview#s-major-versions
- https://www.drupal.org/about/core/policies/core-release-cycles/schedule#s-past-milestones


**Additional context**

Preview: https://deploy-preview-9113--endoflife-date.netlify.app/drupal



| Release | Released | Active Support | Security Support | Commercial Support | Latest |
| --- | --- | --- | --- | --- | --- |
| 11  | 1 year and 4 months ago<br>(02 Aug 2024) | Ends in 7 months<br>(02 Aug 2026) | Ends in 2 years and 8 months<br>(02 Aug 2028) | Unavailable | [11.2.9](https://www.drupal.org/project/drupal/releases/11.2.9 "Release Notes / Changelog")<br>(04 Dec 2025) |
| 10  | 3 years ago<br>(15 Dec 2022) | Ended 1 year ago<br>(15 Dec 2024) | Ends in 1 year<br>(09 Dec 2026) | Unavailable | [10.5.7](https://www.drupal.org/project/drupal/releases/10.5.7 "Release Notes / Changelog")<br>(04 Dec 2025) |
| 9   | 5 years ago<br>(03 Jun 2020) | Ended 2 years ago<br>(01 Nov 2023) | Ended 2 years ago<br>(01 Nov 2023) | Unavailable | [9.5.11](https://www.drupal.org/project/drupal/releases/9.5.11 "Release Notes / Changelog")<br>(19 Sep 2023) |
| 8   | 9 years ago<br>(03 Jun 2016) | Ended 5 years ago<br>(01 Dec 2020) | Ended 4 years ago<br>(02 Nov 2021) | Unavailable | [8.9.20](https://www.drupal.org/project/drupal/releases/8.9.20 "Release Notes / Changelog")<br>(17 Nov 2021) |
| 7 (LTS) | 14 years ago<br>(05 Jan 2011) | Ended 11 months ago<br>(05 Jan 2025) | Ended 11 months ago<br>(05 Jan 2025) | Yes | [7.103](https://www.drupal.org/project/drupal/releases/7.103 "Release Notes / Changelog")<br>(04 Dec 2024) |