### PR TITLE
[pan-gp] Updated GlobalProtect 6.2 latest to 6.2.8-c431 (2025-12-11)

### DIFF
--- a/products/pan-gp.md
+++ b/products/pan-gp.md
@@ -41,8 +41,8 @@ releases:
     releaseDate: 2023-05-23
     eol: 2027-06-30
     eoas: 2027-06-30
-    latest: "6.2.8-c416"
-    latestReleaseDate: 2025-11-18
+    latest: "6.2.8-c431"
+    latestReleaseDate: 2025-12-11
     link: https://docs.paloaltonetworks.com/globalprotect/6-2/globalprotect-app-release-notes/globalprotect-addressed-issues
 
   - releaseCycle: "6.1"


### PR DESCRIPTION
- Updated GlobalProtect release cycle 6.2 `latest` from `6.2.8-c416` to `6.2.8-c431`
- Updated `latestReleaseDate` from `2025-11-18` to `2025-12-11`
