### PR TITLE
Add 18.7 and update Patch definition

### DIFF
--- a/products/gitlab.md
+++ b/products/gitlab.md
@@ -25,6 +25,13 @@ auto:
 # eol(x) = releaseDate(x+3)
 # Upcoming release dates are available on https://handbook.gitlab.com/handbook/marketing/blog/release-posts/managers/
 releases:
+  - releaseCycle: "18.7"
+    releaseDate: 2025-12-18
+    eoas: 2026-01-15 # releaseDate(18.8)
+    eol: 2026-03-19 # releaseDate(18.10)
+    latest: "18.7.0"
+    latestReleaseDate: 2025-12-18
+
   - releaseCycle: "18.6"
     releaseDate: 2025-11-20
     eoas: 2025-12-18 # releaseDate(18.7)
@@ -446,10 +453,10 @@ public Docker images on [DockerHub](https://hub.docker.com/u/gitlab) :
 The previous two minor (monthly) releases get security fixes.
 Critical bug fixes can rarely be backported based on [a set of criteria](https://docs.gitlab.com/ee/policy/maintenance.html#backporting-to-older-releases).
 
-| Version Type | Description                                                                                                                                                     | Cadence                                                                                                                           |
-| :----------- | :-------------------------------------------------------------------------------------------------------------------------------------------------------------- | :-------------------------------------------------------------------------------------------------------------------------------- |
-| Major        | For significant changes, or when any backward-incompatible changes are introduced to the public API.                                                            | Yearly. Subsequent major releases will be scheduled for [third Thursday][release-day] of May each year, by default.               |
-| Minor        | For when new backward-compatible functionality is introduced to the public API, a minor feature is introduced, or when a set of smaller features is rolled out. | Monthly on [third Thursday][release-day]. Upcoming release dates can be seen [on this page](https://handbook.gitlab.com/handbook/marketing/blog/release-posts/managers/)). |
-| Patch        | For backward-compatible bug fixes that fix incorrect behavior.                                                                                                  | As needed.                                                                                                                        |
+| Version Type | Description                                                                                                                                                         | Cadence                                                                                                                           |
+| :----------- | :------------------------------------------------------------------------------------------------------------------------------------------------------------------ | :-------------------------------------------------------------------------------------------------------------------------------- |
+| Major        | For significant changes, or when any backward-incompatible changes are introduced to the public API.                                                                | Yearly. Subsequent major releases will be scheduled for [third Thursday][release-day] of May each year, by default.               |
+| Minor        | For when new backward-compatible functionality is introduced to the public API, a minor feature is introduced, or when a set of smaller features is rolled out.     | Monthly on [third Thursday][release-day]. Upcoming release dates can be seen [on this page](https://handbook.gitlab.com/handbook/marketing/blog/release-posts/managers/)). |
+| Patch        | For backward-compatible bug fixes that fix incorrect behavior. See GitLab's [Patch release](https://docs.gitlab.com/policy/maintenance/#patch-releases) definition. | Twice monthly, scheduled for the Wednesday the week before and the Wednesday the week after the monthly minor release.            |
 
 [release-day]: https://about.gitlab.com/blog/2023/09/18/gitlab-release-date-change/ "Release Date Change"


### PR DESCRIPTION
GitLab has now a patch release cycle which is now written on the page. See https://docs.gitlab.com/policy/maintenance/#versioning