### PR TITLE
[mattermost] Note down v11 free changes

### DIFF
--- a/products/mattermost.md
+++ b/products/mattermost.md
@@ -326,7 +326,7 @@ releases:
 
 ---
 
-> [Mattermost](https://mattermost.com/) is an open-source, self-hostable online chat service with
+> [Mattermost](https://mattermost.com/) is an [open-core](https://isitreallyfoss.com/projects/mattermost/), self-hostable online chat service with
 > file sharing, search, and integrations. It is designed as an internal chat for organizations and
 > companies.
 
@@ -336,10 +336,21 @@ A new ESR release is made when a significant number of new features and improvem
 to the product and have had enough time to stabilize. A new ESR is released twice a year in
 February and August. ESR releases are supported for nine months.
 
+Mattermost's self-hosted offering is distributed in the following [editions](https://docs.mattermost.com/product-overview/editions-and-offerings.html):
+
+1. **Enterprise** is the primary commercial offering. It comes with 24x7 support.
+1. **Enterprise Advanced** is same as the Enterprise Edition, but with a few extra compliance features.
+1. **Entry** is the limited free but commercial offering. It is Community supported.
+1. **Professional** is similar to Enterprise, but with a lower tier of support. It doesn't have features targeted at large(>250 user) organizations,
+   such as high-scalability, air-gapped deployments, Kanban, and Microsoft Teams integration.
+1. **Team** is the limited open-source offering: The AGPL source code is built and distributed as MIT licensed binaries.
+   This is also offered via GitLab in the GitLab Omnibus package.
+
+This page tracks only the self-hosted offerings as listed above. Mattermost Cloud has different [security guarantees](https://docs.mattermost.com/product-overview/cloud-subscriptions.html#who-is-responsible-for-server-maintenance-and-upgrades) and is not tracked here.
+
 {: .warning }
 > Mattermost announced [Major Changes in Free Offerings](https://forum.mattermost.com/t/mattermost-v11-changes-in-free-offerings/25126) from v11
 > 
-> - The Free Edition is renamed to **Entry Edition**.
 > - Entry edition (earlier Free) now supports a maximum of 50 users, and a 10000 message history.
 > - Team Edition is now limited to a maximum of 250 users.
 > - GitLab SSO is removed from the Team edition.

--- a/products/mattermost.md
+++ b/products/mattermost.md
@@ -335,3 +335,11 @@ releases and to supported [extended support releases (ESR)](https://docs.matterm
 A new ESR release is made when a significant number of new features and improvements have been added
 to the product and have had enough time to stabilize. A new ESR is released twice a year in
 February and August. ESR releases are supported for nine months.
+
+{: .warning }
+> [Major Changes in Free Offerings](https://forum.mattermost.com/t/mattermost-v11-changes-in-free-offerings/25126) from v11
+> 
+> Starting with Mattermost 11, the Free Edition was renamed to Entry Edition alongside reductions in the user and message limits.
+> The new limits are 250 users, and 10,000 messages for the Entry edition. Additionally, GitLab Mattermost is getting deprecated
+> from the v11 release and is no longer supported. Mattermost v10.11 ESR will continue to receive security and maintenance updates
+> in the [Gitlab Omnibus from Mattermost through August 2026](https://forum.mattermost.com/t/how-long-will-mattermost-be-bundled-in-omnibus-gitlab/25298/2).

--- a/products/mattermost.md
+++ b/products/mattermost.md
@@ -337,9 +337,11 @@ to the product and have had enough time to stabilize. A new ESR is released twic
 February and August. ESR releases are supported for nine months.
 
 {: .warning }
-> [Major Changes in Free Offerings](https://forum.mattermost.com/t/mattermost-v11-changes-in-free-offerings/25126) from v11
+> Mattermost announced [Major Changes in Free Offerings](https://forum.mattermost.com/t/mattermost-v11-changes-in-free-offerings/25126) from v11
 > 
-> Starting with Mattermost 11, the Free Edition was renamed to Entry Edition alongside reductions in the user and message limits.
-> The new limits are 250 users, and 10,000 messages for the Entry edition. Additionally, GitLab Mattermost is getting deprecated
-> from the v11 release and is no longer supported. Mattermost v10.11 ESR will continue to receive security and maintenance updates
+> - The Free Edition is renamed to **Entry Edition**.
+> - Entry edition (earlier Free) now supports a maximum of 50 users, and a 10000 message history.
+> - Team Edition is now limited to a maximum of 250 users.
+> - GitLab SSO is removed from the Team edition.
+> - GitLab Mattermost, which relied on GitLab SSO+Team edition is getting deprecated. Mattermost v10.11 ESR will continue to receive security and maintenance updates
 > in the [Gitlab Omnibus from Mattermost through August 2026](https://forum.mattermost.com/t/how-long-will-mattermost-be-bundled-in-omnibus-gitlab/25298/2).


### PR DESCRIPTION
https://github.com/mattermost/mattermost/issues/34271

No note at https://docs.gitlab.com/integration/mattermost/ so far. GitLab has promised a 3 month deprecation notice.

Main ref: https://forum.mattermost.com/t/mattermost-v11-changes-in-free-offerings/25126