### PR TITLE
[mongodb] Fix broken Links via using archived links

### DIFF
--- a/products/mongodb.md
+++ b/products/mongodb.md
@@ -55,6 +55,7 @@ releases:
     eol: 2025-09-30
     latest: "8.1.3"
     latestReleaseDate: 2025-08-08
+    link: null
 
   - releaseCycle: "8.0"
     releaseDate: 2024-10-31
@@ -95,6 +96,7 @@ releases:
     eol: 2023-08-31
     latest: "6.3.2"
     latestReleaseDate: 2023-06-28
+    link: https://web.archive.org/web/20240117080159/http://www.mongodb.com/docs/manual/release-notes/6.3/
 
   - releaseCycle: "6.2"
     releaseLabel: "6.2 (Rapid Release)"
@@ -102,6 +104,7 @@ releases:
     eol: 2023-04-24
     latest: "6.2.1"
     latestReleaseDate: 2023-02-28
+    link: https://web.archive.org/web/20231205173501/http://www.mongodb.com/docs/manual/release-notes/6.2/
 
   - releaseCycle: "6.1"
     releaseLabel: "6.1 (Rapid Release)"
@@ -109,6 +112,7 @@ releases:
     eol: 2023-02-09
     latest: "6.1.1"
     latestReleaseDate: 2023-01-03
+    link: https://web.archive.org/web/20240119192418/http://www.mongodb.com/docs/manual/release-notes/6.1/
 
   - releaseCycle: "6.0"
     releaseDate: 2022-07-31
@@ -122,6 +126,7 @@ releases:
     eol: 2022-07-31
     latest: "5.3.2"
     latestReleaseDate: 2022-06-15
+    link: https://web.archive.org/web/20240117081126/http://www.mongodb.com/docs/manual/release-notes/5.3/
 
   - releaseCycle: "5.2"
     releaseLabel: "5.2 (Rapid Release)"
@@ -129,6 +134,7 @@ releases:
     eol: 2022-03-23
     latest: "5.2.1"
     latestReleaseDate: 2022-02-17
+    link: https://web.archive.org/web/20240119192416/http://www.mongodb.com/docs/manual/release-notes/5.2/
 
   - releaseCycle: "5.1"
     releaseLabel: "5.1 (Rapid Release)"
@@ -136,6 +142,7 @@ releases:
     eol: 2022-01-18
     latest: "5.1.1"
     latestReleaseDate: 2021-12-01
+    link: https://web.archive.org/web/20240222034545/http://www.mongodb.com/docs/manual/release-notes/5.1/
 
   - releaseCycle: "5.0"
     releaseDate: 2021-07-31


### PR DESCRIPTION
Added links to archived release notes for MongoDB versions 6.3, 6.2, 6.1, 5.3, 5.2, and 5.1. Removed link for 8.1