### PR TITLE
[pop-os] Add 24.04 LTS

### DIFF
--- a/products/pop-os.md
+++ b/products/pop-os.md
@@ -13,6 +13,12 @@ latestColumn: false
 eolColumn: General Support
 
 releases:
+  - releaseCycle: "24.04"
+    releaseDate: 2025-12-11
+    lts: true
+    eol: 2029-05-31
+    link: https://blog.system76.com/post/pop-os-letter-from-our-founder
+
   - releaseCycle: "22.04"
     releaseDate: 2022-04-25
     lts: true


### PR DESCRIPTION
Added Pop!_OS 24.04 LTS release

EOL date is based on [this announcement](https://discourse.ubuntu.com/t/ubuntu-24-04-lts-noble-numbat-release-notes/39890) for Ubuntu 24.04 LTS.