### PR TITLE
[ubuntu] Fix 24.04 LTS dates

### DIFF
--- a/products/ubuntu.md
+++ b/products/ubuntu.md
@@ -61,9 +61,9 @@ releases:
     codename: "Noble Numbat"
     lts: true
     releaseDate: 2024-04-25
-    eoas: 2029-04-25
-    eol: 2029-04-25
-    eoes: 2036-04-25
+    eoas: 2029-05-31
+    eol: 2029-05-31
+    eoes: 2036-05-31
     latest: "24.04.3"
     latestReleaseDate: 2025-08-07
 


### PR DESCRIPTION
Added accurate EOL dates for Ubuntu 24.04 LTS.

Based on [this announcement](https://discourse.ubuntu.com/t/ubuntu-24-04-lts-noble-numbat-release-notes/39890) and the [release cycle page](https://ubuntu.com/about/release-cycle) listing May instead of April.

This change is also reflected in #9211 for Pop!_OS