### PR TITLE
[kuma] Update changelogTemplate and add links prior than 2.10

### DIFF
--- a/products/kuma.md
+++ b/products/kuma.md
@@ -21,7 +21,6 @@ releases:
     eol: 2026-12-22
     latest: "2.13.0"
     latestReleaseDate: 2025-12-22
-    link: https://github.com/kumahq/kuma/releases/tag/v__LATEST__
 
   - releaseCycle: "2.12"
     releaseDate: 2025-09-09

--- a/products/kuma.md
+++ b/products/kuma.md
@@ -21,18 +21,21 @@ releases:
     eol: 2026-09-09
     latest: "2.12.5"
     latestReleaseDate: 2025-11-25
+    link: https://github.com/kumahq/kuma/releases/tag/v__LATEST__  # since 2.10 the tag url will include v prefix
 
   - releaseCycle: "2.11"
     releaseDate: 2025-06-10
     eol: 2026-06-10
     latest: "2.11.8"
     latestReleaseDate: 2025-11-14
+    link: https://github.com/kumahq/kuma/releases/tag/v__LATEST__ # since 2.10 the tag url will include v prefix
 
   - releaseCycle: "2.10"
     releaseDate: 2025-03-20
     eol: 2026-03-20
     latest: "2.10.9"
     latestReleaseDate: 2025-11-18
+    link: https://github.com/kumahq/kuma/releases/tag/v__LATEST__  # since 2.10 the tag url will include v prefix
 
   - releaseCycle: "2.9"
     releaseDate: 2024-10-22

--- a/products/kuma.md
+++ b/products/kuma.md
@@ -5,7 +5,7 @@ category: server-app
 tags: cncf linux-foundation
 iconSlug: kuma
 permalink: /kuma
-changelogTemplate: https://github.com/kumahq/kuma/releases/tag/__LATEST__
+changelogTemplate: https://github.com/kumahq/kuma/releases/tag/v__LATEST__
 eolColumn: Support
 
 auto:
@@ -21,33 +21,32 @@ releases:
     eol: 2026-09-09
     latest: "2.12.5"
     latestReleaseDate: 2025-11-25
-    link: https://github.com/kumahq/kuma/releases/tag/v__LATEST__  # since 2.10 the tag url will include v prefix
 
   - releaseCycle: "2.11"
     releaseDate: 2025-06-10
     eol: 2026-06-10
     latest: "2.11.8"
     latestReleaseDate: 2025-11-14
-    link: https://github.com/kumahq/kuma/releases/tag/v__LATEST__ # since 2.10 the tag url will include v prefix
 
   - releaseCycle: "2.10"
     releaseDate: 2025-03-20
     eol: 2026-03-20
     latest: "2.10.9"
     latestReleaseDate: 2025-11-18
-    link: https://github.com/kumahq/kuma/releases/tag/v__LATEST__  # since 2.10 the tag url will include v prefix
 
   - releaseCycle: "2.9"
     releaseDate: 2024-10-22
     eol: 2025-10-22
     latest: "2.9.10"
     latestReleaseDate: 2025-10-17
+    link: https://github.com/kumahq/kuma/releases/tag/__LATEST__
 
   - releaseCycle: "2.8"
     releaseDate: 2024-06-24
     eol: 2025-06-24
     latest: "2.8.8"
     latestReleaseDate: 2025-03-31
+    link: https://github.com/kumahq/kuma/releases/tag/__LATEST__
 
   - releaseCycle: "2.7"
     releaseDate: 2024-04-19
@@ -55,90 +54,105 @@ releases:
     latest: "2.7.20"
     latestReleaseDate: 2025-11-18
     lts: true
+    link: https://github.com/kumahq/kuma/releases/tag/__LATEST__
 
   - releaseCycle: "2.6"
     releaseDate: 2024-02-01
     eol: 2025-02-01
     latest: "2.6.15"
     latestReleaseDate: 2025-01-21
+    link: https://github.com/kumahq/kuma/releases/tag/__LATEST__
 
   - releaseCycle: "2.5"
     releaseDate: 2023-11-15
     eol: 2024-11-15
     latest: "2.5.11"
     latestReleaseDate: 2024-10-08
+    link: https://github.com/kumahq/kuma/releases/tag/__LATEST__
 
   - releaseCycle: "2.4"
     releaseDate: 2023-08-29
     eol: 2024-08-29
     latest: "2.4.10"
     latestReleaseDate: 2024-07-24
+    link: https://github.com/kumahq/kuma/releases/tag/__LATEST__
 
   - releaseCycle: "2.3"
     releaseDate: 2023-06-23
     eol: 2024-06-23
     latest: "2.3.7"
     latestReleaseDate: 2024-04-09
+    link: https://github.com/kumahq/kuma/releases/tag/__LATEST__
 
   - releaseCycle: "2.2"
     releaseDate: 2023-04-14
     eol: 2024-04-14
     latest: "2.2.9"
     latestReleaseDate: 2024-04-09
+    link: https://github.com/kumahq/kuma/releases/tag/__LATEST__
 
   - releaseCycle: "2.1"
     releaseDate: 2023-01-30
     eol: 2024-02-01
     latest: "2.1.7"
     latestReleaseDate: 2023-10-12
+    link: https://github.com/kumahq/kuma/releases/tag/__LATEST__
 
   - releaseCycle: "2.0"
     releaseDate: 2022-11-04
     eol: 2023-11-04
     latest: "2.0.8"
     latestReleaseDate: 2023-10-12
+    link: https://github.com/kumahq/kuma/releases/tag/__LATEST__
 
   - releaseCycle: "1.8"
     releaseDate: 2022-08-22
     eol: 2023-08-24
     latest: "1.8.8"
     latestReleaseDate: 2023-07-28
+    link: https://github.com/kumahq/kuma/releases/tag/__LATEST__
 
   - releaseCycle: "1.7"
     releaseDate: 2022-06-13
     eol: 2023-06-16
     latest: "1.7.6"
     latestReleaseDate: 2023-04-07
+    link: https://github.com/kumahq/kuma/releases/tag/__LATEST__
 
   - releaseCycle: "1.6"
     releaseDate: 2022-04-11
     eol: 2023-04-12
     latest: "1.6.5"
     latestReleaseDate: 2023-02-16
+    link: https://github.com/kumahq/kuma/releases/tag/__LATEST__
 
   - releaseCycle: "1.5"
     releaseDate: 2022-02-24
     eol: 2023-02-24
     latest: "1.5.5"
     latestReleaseDate: 2023-02-13
+    link: https://github.com/kumahq/kuma/releases/tag/__LATEST__
 
   - releaseCycle: "1.4"
     releaseDate: 2021-11-19
     eol: 2022-11-22
     latest: "1.4.1"
     latestReleaseDate: 2022-01-20
+    link: https://github.com/kumahq/kuma/releases/tag/__LATEST__
 
   - releaseCycle: "1.3"
     releaseDate: 2021-08-24
     eol: 2022-08-26
     latest: "1.3.1"
     latestReleaseDate: 2021-10-06
+    link: https://github.com/kumahq/kuma/releases/tag/__LATEST__
 
   - releaseCycle: "1.2"
     releaseDate: 2021-06-17
     eol: 2022-06-17
     latest: "1.2.3"
     latestReleaseDate: 2021-08-26
+    link: https://github.com/kumahq/kuma/releases/tag/__LATEST__
 
 ---
 


### PR DESCRIPTION
Add v prefix into changelogtemplate
Add link tags for versions which are older than 2.10

source : https://github.com/kumahq/kuma/releases/tag/v2.10.9