### PR TITLE
[ckeditor] Increase stale release threshold to 40 days

### DIFF
--- a/products/ckeditor.md
+++ b/products/ckeditor.md
@@ -7,7 +7,7 @@ permalink: /ckeditor
 releasePolicyLink: https://ckeditor.com/docs/ckeditor5/latest/updating/versioning-policy.html
 eolColumn: Support
 eoesColumn: true
-staleReleaseThresholdDays: 30 # so that maintainers are reminded to manually update the latest version frequently
+staleReleaseThresholdDays: 40 # so that maintainers are reminded to manually update the latest version frequently
 
 identifiers:
   - repology: ckeditor


### PR DESCRIPTION
The previous value, 30, was too small. See https://github.com/endoflife-date/endoflife.date/pull/9244.