### PR TITLE
[dovecot] Update stale release threshold for 2.3

### DIFF
--- a/products/dovecot.md
+++ b/products/dovecot.md
@@ -28,7 +28,7 @@ releases:
     latestReleaseDate: 2025-10-28
 
   - releaseCycle: "2.3"
-    staleReleaseThresholdDays: 500 # mentioned recently on https://dovecot.org/mailman3/archives/list/dovecot-news@dovecot.org/thread/3P45L76DOC3NKUNSSPIXQNKINGOCYH5K/
+    staleReleaseThresholdDays: 730 # mentioned recently on https://dovecot.org/mailman3/archives/list/dovecot-news@dovecot.org/thread/3P45L76DOC3NKUNSSPIXQNKINGOCYH5K/
     releaseDate: 2017-12-22
     eoas: 2025-01-24
     eol: false


### PR DESCRIPTION
The previous threshold became too low, see https://github.com/endoflife-date/endoflife.date/pull/9244.