### PR TITLE
Update latest releases for Mastodon versions

### DIFF
--- a/products/mastodon.md
+++ b/products/mastodon.md
@@ -27,26 +27,26 @@ releases:
   - releaseCycle: "4.5"
     releaseDate: 2025-11-06
     eol: false
-    latest: "4.5.3"
-    latestReleaseDate: 2025-12-08
+    latest: "4.5.4"
+    latestReleaseDate: 2026-01-07
 
   - releaseCycle: "4.4"
     releaseDate: 2025-07-08
     eol: false
-    latest: "4.4.10"
-    latestReleaseDate: 2025-12-08
+    latest: "4.4.11"
+    latestReleaseDate: 2026-01-07
 
   - releaseCycle: "4.3"
     releaseDate: 2024-10-08
     eol: false
-    latest: "4.3.16"
-    latestReleaseDate: 2025-12-08
+    latest: "4.3.17"
+    latestReleaseDate: 2026-01-07
 
   - releaseCycle: "4.2"
     releaseDate: 2023-09-21
     eol: 2026-01-08
-    latest: "4.2.28"
-    latestReleaseDate: 2025-12-08
+    latest: "4.2.29"
+    latestReleaseDate: 2026-01-07
 
   - releaseCycle: "4.1"
     releaseDate: 2023-02-10


### PR DESCRIPTION
Updated current versions of v4.2 - v4.5 as new version have been released today.