### PR TITLE
Add `purl` identifier for Ubuntu

### DIFF
--- a/products/ubuntu.md
+++ b/products/ubuntu.md
@@ -29,7 +29,8 @@ auto:
 identifiers:
   - cpe: cpe:2.3:o:canonical:ubuntu_linux
   - cpe: cpe:/o:canonical:ubuntu_linux
-  - purl: pkg:os/ubuntu
+  - purl: pkg:deb/ubuntu/
+
 
 
 # Support and EOL dates available on https://wiki.ubuntu.com/Releases.

--- a/products/ubuntu.md
+++ b/products/ubuntu.md
@@ -29,6 +29,8 @@ auto:
 identifiers:
   - cpe: cpe:2.3:o:canonical:ubuntu_linux
   - cpe: cpe:/o:canonical:ubuntu_linux
+  - purl: pkg:os/ubuntu
+
 
 # Support and EOL dates available on https://wiki.ubuntu.com/Releases.
 # Exact day for some dates is not available, in this case use the same day as the release date.


### PR DESCRIPTION
# :grey_question: About

I wanted to generate a SBOM thanks to `endoflife.date` data and `geol`, then I discovered that I needed the `purl` for ubuntu and that it was lacking for example i nmy case : `pkg:os/ubuntu@24.04`

:point_right: Adding this data could help generate SBOM around Ubuntu.