### PR TITLE
Mastodon: Update EOL date for v4.3

### DIFF
--- a/products/mastodon.md
+++ b/products/mastodon.md
@@ -38,7 +38,7 @@ releases:
 
   - releaseCycle: "4.3"
     releaseDate: 2024-10-08
-    eol: false
+    eol: 2026-05-06
     latest: "4.3.17"
     latestReleaseDate: 2026-01-07
 


### PR DESCRIPTION
Mastodon announced the EOL date for the v4.3 branch: https://blog.joinmastodon.org/2026/01/trunk-tidbits-december-2025/
<img width="838" height="480" alt="grafik" src="https://github.com/user-attachments/assets/a727f131-430d-46fb-b36b-c735891cdeda" />

This pull request adds the EOL.