### PR TITLE
[Stormshield Management Center] Rename eoasColumn and eolColumn Labels

### DIFF
--- a/products/sns-smc.md
+++ b/products/sns-smc.md
@@ -5,8 +5,8 @@ category: os
 tags: stormshield
 permalink: /sns-smc
 latestColumn: false
-eoasColumn: End of Maintenance
-eolColumn: End of Life
+eoasColumn: Maintenance Support
+eolColumn: Lifecycle Support
 
 customFields:
   - name: lowestSNSVersion


### PR DESCRIPTION
Changed column names to give correct semantics. 

Now the page shows: End of Maintenance => yes 
even if the specified version is still maintained, same goes for End of life.