### PR TITLE
[Stormshield Firewall] Rename eoasColumn and eolColumn Labels

### DIFF
--- a/products/sns-hardware.md
+++ b/products/sns-hardware.md
@@ -5,8 +5,8 @@ category: device
 tags: stormshield
 permalink: /sns-hardware
 latestColumn: false
-eoasColumn: End of Sales
-eolColumn: End of Life
+eoasColumn: Commercial Availability
+eolColumn: Software Support
 staleReleaseThresholdDays: 3650 # devices have longer support periods
 
 customFields:


### PR DESCRIPTION
Change of columns for creating the right meaning. 
Now it states: _End of Sales_ when the product is still sold. 

Similar to PR #9284. 