### PR TITLE
[Stormshield Firmware] Rename eoasColumn and eolColumn Labels

### DIFF
--- a/products/sns-firmware.md
+++ b/products/sns-firmware.md
@@ -6,8 +6,8 @@ tags: stormshield
 permalink: /sns-firmware
 versionCommand: getversion
 latestColumn: false
-eoasColumn: End of Maintenance
-eolColumn: End of Life
+eoasColumn: Maintenance Support
+eolColumn: Lifecycle Support
 staleReleaseThresholdDays: 1825 # devices have longer support periods
 
 auto:


### PR DESCRIPTION
Change of columns for creating the right meaning.
Now the page shows: End of Maintenance => yes
even if the specified version is still maintained, same goes for End of life.

Similar to  #9284