### PR TITLE
[linuxmint] Add 22.3 cycle

### DIFF
--- a/products/linuxmint.md
+++ b/products/linuxmint.md
@@ -28,14 +28,14 @@ releases:
     releaseDate: 2026-01-11
     eol: 2029-04-30
     link: https://www.linuxmint.com/rel_zena.php
-    
+
   - releaseCycle: "lmde7"
     releaseLabel: "LMDE 7 '__CODENAME__'"
     codename: Gigi
     releaseDate: 2025-10-14
     eol: false
     link: https://blog.linuxmint.com/?p=4924
-  
+
   - releaseCycle: "22.2"
     codename: Zara
     lts: true

--- a/products/linuxmint.md
+++ b/products/linuxmint.md
@@ -22,19 +22,19 @@ auto:
           regex: '^.*supported until (?P<value>\w+ \d+).*$'
 
 releases:
-  - releaseCycle: "lmde7"
-    releaseLabel: "LMDE 7 '__CODENAME__'"
-    codename: Gigi
-    releaseDate: 2025-10-14
-    eol: false
-    link: https://blog.linuxmint.com/?p=4924
-
   - releaseCycle: "22.3"
     codename: Zena
     lts: true
     releaseDate: 2026-01-11
     eol: 2029-04-30
     link: https://www.linuxmint.com/rel_zena.php
+    
+  - releaseCycle: "lmde7"
+    releaseLabel: "LMDE 7 '__CODENAME__'"
+    codename: Gigi
+    releaseDate: 2025-10-14
+    eol: false
+    link: https://blog.linuxmint.com/?p=4924
   
   - releaseCycle: "22.2"
     codename: Zara

--- a/products/linuxmint.md
+++ b/products/linuxmint.md
@@ -29,6 +29,13 @@ releases:
     eol: false
     link: https://blog.linuxmint.com/?p=4924
 
+  - releaseCycle: "22.3"
+    codename: Zena
+    lts: true
+    releaseDate: 2026-01-11
+    eol: 2029-04-30
+    link: https://www.linuxmint.com/rel_zena.php
+  
   - releaseCycle: "22.2"
     codename: Zara
     lts: true


### PR DESCRIPTION
# :grey_question: About

cf [official Release Note](https://www.linuxmint.com/rel_zena.php), `Linux Mint 22.3, codename Zena.` is out : 


[<img width="585" height="618" alt="image" src="https://github.com/user-attachments/assets/907d9661-9326-4e53-ba28-c60335bbcaba" />
](https://x.com/9to5linux/status/2010442066879516986)