### PR TITLE
[notepad-plusplus] Fix latest version info

### DIFF
--- a/products/notepad-plus-plus.md
+++ b/products/notepad-plus-plus.md
@@ -18,7 +18,7 @@ releases:
   - releaseCycle: "8.9"
     releaseDate: 2025-12-27
     eol: false
-    latest: "8.9.0"
+    latest: "8.9"
     latestReleaseDate: 2025-12-27
 
   - releaseCycle: "8.8"


### PR DESCRIPTION
They have named it as 8.9 instead of 8.9.0 which was also braking our changelog template. With this patch it also fixes broken link