### PR TITLE
[pan-gp] Update latest version from 6.3.3-c828 to 6.3.3-c842

### DIFF
--- a/products/pan-gp.md
+++ b/products/pan-gp.md
@@ -33,8 +33,8 @@ releases:
     releaseDate: 2024-06-13
     eol: 2027-06-30
     eoas: 2027-06-30
-    latest: "6.3.3-c828"
-    latestReleaseDate: 2025-11-20
+    latest: "6.3.3-c842"
+    latestReleaseDate: 2025-12-17
     link: https://docs.paloaltonetworks.com/globalprotect/6-3/globalprotect-app-release-notes/globalprotect-addressed-issues
 
   - releaseCycle: "6.2"


### PR DESCRIPTION
Updates GlobalProtect latest release information.

## Changes
- Update `latest` version from `6.3.3-c828` to `6.3.3-c842`
- Update `latestReleaseDate` from `2025-11-20` to `2025-12-17`

Release notes: https://docs.paloaltonetworks.com/globalprotect/6-3/globalprotect-app-release-notes/globalprotect-addressed-issues