### PR TITLE
[prometheus] Add 3.9 release cycle

### DIFF
--- a/products/prometheus.md
+++ b/products/prometheus.md
@@ -34,6 +34,12 @@ auto:
 # eol(x) = releaseDate(x) + 6w (non-LTS)
 # For LTS, as per https://prometheus.io/docs/introduction/release-cycle/#long-term-support
 releases:
+  - releaseCycle: "3.9"
+    releaseDate: 2026-01-06
+    eol: 2026-02-17
+    latest: "3.9.1"
+    latestReleaseDate: 2026-01-07
+
   - releaseCycle: "3.8"
     releaseDate: 2025-11-28
     eol: 2026-01-09


### PR DESCRIPTION
Here I add the 3.9 release cycle.

See https://github.com/prometheus/prometheus/releases/tag/v3.9.1
