### PR TITLE
[golang] Add brew purl identifiers

### DIFF
--- a/products/go.md
+++ b/products/go.md
@@ -20,7 +20,7 @@ identifiers:
   - purl: pkg:docker/cimg/go
   - purl: pkg:docker/bitnami/golang
   - purl: pkg:brew/go
-  - purl: pkg:snap/go
+  # - purl: pkg:snap/go
 
 auto:
   methods:

--- a/products/go.md
+++ b/products/go.md
@@ -19,6 +19,8 @@ identifiers:
   - purl: pkg:docker/circleci/golang
   - purl: pkg:docker/cimg/go
   - purl: pkg:docker/bitnami/golang
+  - purl: pkg:brew/go
+  - purl: pkg:snap/go
 
 auto:
   methods:


### PR DESCRIPTION
# :grey_question: About

I saw the announce of [🎊 Go 1.25.6 and 1.24.12 are released!](https://x.com/golang/status/2011876643539698018),

<img width="604" height="728" alt="image" src="https://github.com/user-attachments/assets/05e154f4-f60d-470f-bf47-a2facb337a02" />

 and I've installed Go with brew, so I wonder if adding these identifiers would make sense.