### PR TITLE
[CFEngine] Add 3.27 cycle and update changelogtemplate

### DIFF
--- a/products/cfengine.md
+++ b/products/cfengine.md
@@ -5,7 +5,7 @@ category: app
 permalink: /cfengine
 versionCommand: cf-agent --version
 releasePolicyLink: https://cfengine.com
-changelogTemplate: https://docs.cfengine.com/docs/__RELEASE_CYCLE__/release-notes-whatsnew-changelog-core.html
+changelogTemplate: https://docs.cfengine.com/docs/__RELEASE_CYCLE__/release-notes/whatsnew/changelog-core/
 eolColumn: Supported
 
 identifiers:
@@ -22,17 +22,26 @@ auto:
 # non-lts eol(x) = releaseDate(x+1)
 # lts eol(x) = releaseDate(x) + 3 years
 releases:
+  - releaseCycle: "3.27"
+    releaseDate: 2026-01-09
+    lts: true
+    eol: false
+    latest: "3.27.0"
+    latestReleaseDate: 2026-01-09
+
   - releaseCycle: "3.26"
     releaseDate: 2025-05-20
-    eol: false
+    eol: 2026-01-09
     latest: "3.26.0"
     latestReleaseDate: 2025-05-20
+    link: https://docs.cfengine.com/docs/__RELEASE_CYCLE__/release-notes-whatsnew-changelog-core.html
 
   - releaseCycle: "3.25"
     releaseDate: 2025-01-06
     eol: 2025-05-20
     latest: "3.25.0"
     latestReleaseDate: 2025-01-06
+    link: https://docs.cfengine.com/docs/__RELEASE_CYCLE__/release-notes-whatsnew-changelog-core.html
 
   - releaseCycle: "3.24"
     releaseDate: 2024-07-22
@@ -40,18 +49,21 @@ releases:
     eol: 2027-07-31
     latest: "3.24.3"
     latestReleaseDate: 2025-12-15
+    link: https://docs.cfengine.com/docs/__RELEASE_CYCLE__/release-notes-whatsnew-changelog-core.html
 
   - releaseCycle: "3.23"
     releaseDate: 2023-12-05
     eol: 2024-07-22
     latest: "3.23.0"
     latestReleaseDate: 2023-12-05
+    link: https://docs.cfengine.com/docs/__RELEASE_CYCLE__/release-notes-whatsnew-changelog-core.html
 
   - releaseCycle: "3.22"
     releaseDate: 2023-06-16
     eol: 2023-12-05
     latest: "3.22.0"
     latestReleaseDate: 2023-06-16
+    link: https://docs.cfengine.com/docs/__RELEASE_CYCLE__/release-notes-whatsnew-changelog-core.html
 
   - releaseCycle: "3.21"
     releaseDate: 2022-12-21
@@ -59,6 +71,7 @@ releases:
     eol: 2025-12-31
     latest: "3.21.8"
     latestReleaseDate: 2025-12-15
+    link: https://docs.cfengine.com/docs/__RELEASE_CYCLE__/release-notes-whatsnew-changelog-core.html
 
   - releaseCycle: "3.20"
     releaseDate: 2022-07-01


### PR DESCRIPTION
https://cfengine.com/blog/2026/cfengine-3-27-lts-released-exploration/

Note: reference link structure changed with 3.27.0.