### PR TITLE
[mysql] Update latest release date 8.4

### DIFF
--- a/products/mysql.md
+++ b/products/mysql.md
@@ -84,7 +84,7 @@ releases:
     eoas: 2029-04-30
     eol: 2032-04-30
     latest: "8.4.8"
-    latestReleaseDate: 2025-12-24
+    latestReleaseDate: 2026-01-20
 
   - releaseCycle: "8.3"
     releaseDate: 2023-12-14


### PR DESCRIPTION
# :grey_question: About

I saw [this tweet](https://x.com/MySQL/status/2013650232601395660) today : 

<img width="589" height="848" alt="image" src="https://github.com/user-attachments/assets/487b1460-a55c-4bf4-ba35-5cd12255698b" />


and, according to [Changes in MySQL 8.4.8 (2026-01-20, LTS Release)](https://dev.mysql.com/doc/relnotes/mysql/8.4/en/news-8-4-8.html), it looks like the `8.4.8` release date is `2026-01-20,` : 

<img width="1104" height="734" alt="image" src="https://github.com/user-attachments/assets/9dc37d5a-059e-4c2a-8670-5b993fec759e" />
