### PR TITLE
replace misleading Wikipedia links with explicit references

### DIFF
--- a/products/apple-tvos.md
+++ b/products/apple-tvos.md
@@ -7,7 +7,6 @@ iconSlug: apple
 permalink: /tvos
 alternate_urls:
   - /apple-tvos
-releasePolicyLink: https://en.wikipedia.org/wiki/TvOS#Version_history
 changelogTemplate: https://developer.apple.com/documentation/tvos-release-notes/tvos-__RELEASE_CYCLE__-release-notes
 eolColumn: Service Status
 
@@ -102,3 +101,5 @@ releases:
 Major versions of tvOS are released annually, with the previous major version losing support.
 
 A [Compatibility Table](https://en.wikipedia.org/wiki/TvOS#Supported_OS_releases) for supported combinations of tvOS and Apple TV generations is available.
+
+A detailed version history can be found on [Wikipedia](https://en.wikipedia.org/wiki/TvOS#Version_history).

--- a/products/apple-tvos.md
+++ b/products/apple-tvos.md
@@ -102,4 +102,4 @@ Major versions of tvOS are released annually, with the previous major version lo
 
 A [Compatibility Table](https://en.wikipedia.org/wiki/TvOS#Supported_OS_releases) for supported combinations of tvOS and Apple TV generations is available.
 
-A detailed version history can be found on [Wikipedia](https://en.wikipedia.org/wiki/TvOS#Version_history).
+A detailed version history can be found on [Wikipedia](https://wikipedia.org/wiki/TvOS#Version_history).

--- a/products/ios.md
+++ b/products/ios.md
@@ -149,4 +149,4 @@ As of now, only iOS 18 appears to be receiving security fixes, as iOS 17 is miss
 
 Support information for iPhone devices is available at [/iphone](/iphone).
 
-A detailed overview of iOS versions can be found on [Wikipedia](https://en.wikipedia.org/wiki/IOS_version_history#Overview).
+A detailed overview of iOS versions can be found on [Wikipedia](https://wikipedia.org/wiki/IOS_version_history#Overview).

--- a/products/ios.md
+++ b/products/ios.md
@@ -5,7 +5,6 @@ category: os
 tags: apple
 iconSlug: ios
 permalink: /ios
-releasePolicyLink: https://en.wikipedia.org/wiki/IOS_version_history#Overview
 changelogTemplate: https://developer.apple.com/documentation/ios-ipados-release-notes/ios-ipados-__RELEASE_CYCLE__-release-notes
 eoasColumn: true
 
@@ -149,3 +148,5 @@ Apple has occasionally backported critical security fixes to [much older iOS ver
 As of now, only iOS 18 appears to be receiving security fixes, as iOS 17 is missing fixes published in iOS 18.2.
 
 Support information for iPhone devices is available at [/iphone](/iphone).
+
+A detailed overview of iOS versions can be found on [Wikipedia](https://en.wikipedia.org/wiki/IOS_version_history#Overview).

--- a/products/ipad.md
+++ b/products/ipad.md
@@ -5,7 +5,6 @@ category: device
 tags: apple tablet
 iconSlug: apple
 permalink: /ipad
-releasePolicyLink: https://en.wikipedia.org/wiki/List_of_iPad_models#iPad
 discontinuedColumn: true
 eolColumn: Supported
 latestColumn: false
@@ -352,10 +351,11 @@ releases:
     supportedIpadOsVersions: "3 - 5"
 ---
 
-> The iPad is a line of tablet-based computers designed and marketed by Apple Inc. that use Apple's
+> The [iPad](https://www.apple.com/ipad/)is a line of tablet-based computers designed and marketed by Apple Inc. that use Apple's
 > iOS and iPadOS mobile operating system.
 
-Apple maintains a list of Supported iPad models
-[on its website](https://support.apple.com/en-in/guide/ipad/ipad213a25b2/ipados).
+Apple maintains a list of supported iPad models [on its website](https://support.apple.com/en-in/guide/ipad/ipad213a25b2/ipados).
 
-Support information for iPadOS versions is also available [on endoflife.date](/ipados).
+Support information for iPadOS versions is also available [/ipados](/ipados).
+
+A detailed list of all iPad models can also be found on [Wikipedia](https://en.wikipedia.org/wiki/List_of_iPad_models#iPad).

--- a/products/ipad.md
+++ b/products/ipad.md
@@ -356,6 +356,6 @@ releases:
 
 Apple maintains a list of supported iPad models [on its website](https://support.apple.com/en-in/guide/ipad/ipad213a25b2/ipados).
 
-Support information for iPadOS versions is also available [/ipados](/ipados).
+Support information for iPadOS versions is also available at [/ipados](/ipados).
 
-A detailed list of all iPad models can also be found on [Wikipedia](https://en.wikipedia.org/wiki/List_of_iPad_models#iPad).
+A detailed list of all iPad models can also be found on [Wikipedia](https://wikipedia.org/wiki/List_of_iPad_models#iPad).

--- a/products/ipados.md
+++ b/products/ipados.md
@@ -5,7 +5,6 @@ category: os
 tags: apple
 iconSlug: apple
 permalink: /ipados
-releasePolicyLink: https://en.wikipedia.org/wiki/IPadOS_version_history
 changelogTemplate: https://developer.apple.com/documentation/ios-ipados-release-notes/ios-ipados-__RELEASE_CYCLE__-release-notes
 eoasColumn: true
 
@@ -78,3 +77,5 @@ releases:
 Major versions of iPadOS are released annually.
 
 Support information for iPad devices is available at [/ipad](/ipad).
+
+A detailed overview of iPadOS versions can be found on [Wikipedia](https://en.wikipedia.org/wiki/IPadOS_version_history).

--- a/products/ipados.md
+++ b/products/ipados.md
@@ -78,4 +78,4 @@ Major versions of iPadOS are released annually.
 
 Support information for iPad devices is available at [/ipad](/ipad).
 
-A detailed overview of iPadOS versions can be found on [Wikipedia](https://en.wikipedia.org/wiki/IPadOS_version_history).
+A detailed overview of iPadOS versions can be found on [Wikipedia](https://wikipedia.org/wiki/IPadOS_version_history).

--- a/products/iphone.md
+++ b/products/iphone.md
@@ -5,7 +5,6 @@ category: device
 tags: apple mobile-phone
 iconSlug: apple
 permalink: /iphone
-releasePolicyLink: https://en.wikipedia.org/wiki/List_of_iPhone_models#Release_dates
 discontinuedColumn: true
 eolColumn: Supported
 latestColumn: false
@@ -447,3 +446,5 @@ as a stop-gap to allow users time to update.
 Apple maintains a list of Supported iPhone models at <https://support.apple.com/guide/iphone/iphe3fa5df43>.
 
 Support information for iOS versions is available at [/ios](/ios).
+
+A detailed list of all iPhone models can also be found on [Wikipedia](https://en.wikipedia.org/wiki/List_of_iPhone_models).

--- a/products/iphone.md
+++ b/products/iphone.md
@@ -447,4 +447,4 @@ Apple maintains a list of Supported iPhone models at <https://support.apple.com/
 
 Support information for iOS versions is available at [/ios](/ios).
 
-A detailed list of all iPhone models can also be found on [Wikipedia](https://en.wikipedia.org/wiki/List_of_iPhone_models).
+A detailed list of all iPhone models can also be found on [Wikipedia](https://wikipedia.org/wiki/List_of_iPhone_models).

--- a/products/raspberry-pi.md
+++ b/products/raspberry-pi.md
@@ -8,7 +8,6 @@ alternate_urls:
   - /raspberrypi
   - /raspi
   - /rpi
-releasePolicyLink: https://en.wikipedia.org/wiki/Raspberry_Pi#Model_comparison
 eolColumn: Discontinued
 latestColumn: false
 
@@ -192,3 +191,5 @@ releases:
 Some of the Raspberry Pi hardware comes with an Obsolescence statement guaranteeing production until a
 specific date. [Raspberry Pi OS](https://www.raspberrypi.com/software/operating-systems/) supports
 all Raspberry Pi models (excluding Pico).
+
+A detailed model comparison can be found on [Wikipedia](https://en.wikipedia.org/wiki/Raspberry_Pi#Model_comparison).

--- a/products/raspberry-pi.md
+++ b/products/raspberry-pi.md
@@ -192,4 +192,4 @@ Some of the Raspberry Pi hardware comes with an Obsolescence statement guarantee
 specific date. [Raspberry Pi OS](https://www.raspberrypi.com/software/operating-systems/) supports
 all Raspberry Pi models (excluding Pico).
 
-A detailed model comparison can be found on [Wikipedia](https://en.wikipedia.org/wiki/Raspberry_Pi#Model_comparison).
+A detailed model comparison can be found on [Wikipedia](https://wikipedia.org/wiki/Raspberry_Pi#Model_comparison).

--- a/products/visionos.md
+++ b/products/visionos.md
@@ -5,7 +5,6 @@ category: os
 tags: apple
 iconSlug: apple
 permalink: /visionos
-releasePolicyLink: https://en.wikipedia.org/wiki/VisionOS#Version_history
 changelogTemplate: https://developer.apple.com/documentation/visionos-release-notes/visionos-__RELEASE_CYCLE__-release-notes
 
 auto:
@@ -41,4 +40,6 @@ releases:
 > It integrates elements from iOS, iPadOS, and macOS, enabling users to interact with digital content in a mixed reality environment.
 > VisionOS supports new interaction paradigms such as eye-tracking, gesture control, and voice input.
 
-Major versions of tvOS are released annually, with the previous major version losing support.
+Major versions of visionOS are released annually, with the previous major version losing support.
+
+A detailed version history can be found on [Wikipedia](https://en.wikipedia.org/wiki/VisionOS#Version_history).

--- a/products/visionos.md
+++ b/products/visionos.md
@@ -42,4 +42,4 @@ releases:
 
 Major versions of visionOS are released annually, with the previous major version losing support.
 
-A detailed version history can be found on [Wikipedia](https://en.wikipedia.org/wiki/VisionOS#Version_history).
+A detailed version history can be found on [Wikipedia](https://wikipedia.org/wiki/VisionOS#Version_history).

--- a/products/watchos.md
+++ b/products/watchos.md
@@ -5,7 +5,6 @@ category: os
 tags: apple smartwatch
 iconSlug: apple
 permalink: /watchos
-releasePolicyLink: https://en.wikipedia.org/wiki/WatchOS#Version_history
 changelogTemplate: https://developer.apple.com/documentation/watchos-release-notes/watchos-__RELEASE_CYCLE__-release-notes
 
 identifiers:
@@ -93,3 +92,5 @@ releases:
 Major versions of watchOS are released annually, with the previous major version losing support.
 
 Apple publishes a [Compatibility Table](https://support.apple.com/118490) for supported combinations of iPhone, iOS, watchOS.
+
+A detailed version history can be found on [Wikipedia](https://en.wikipedia.org/wiki/WatchOS#Version_history).

--- a/products/watchos.md
+++ b/products/watchos.md
@@ -93,4 +93,4 @@ Major versions of watchOS are released annually, with the previous major version
 
 Apple publishes a [Compatibility Table](https://support.apple.com/118490) for supported combinations of iPhone, iOS, watchOS.
 
-A detailed version history can be found on [Wikipedia](https://en.wikipedia.org/wiki/WatchOS#Version_history).
+A detailed version history can be found on [Wikipedia](https://wikipedia.org/wiki/WatchOS#Version_history).


### PR DESCRIPTION
## Summary
Fix misleading "More information is available on the {Product} website" text 
when the link points to Wikipedia instead of the official product website.

## Changes
- Removed `releasePolicyLink` for products linking to Wikipedia
- Added explicit Wikipedia references at the end of description text

### Additional fixes
- **visionos.md**: Fixed typo ("tvOS" → "visionOS")
- **ipad.md**: Added link to official Apple iPad website in intro quote
- **ipad.md**: Changed "Supported" to "supported" (lowercase)
- **ipad.md**: Changed link text from "on endoflife.date" to "/ipados" for consistency

## Affected products
- ios, ipados, ipad
- iphone  
- watchos, visionos, tvos
- raspberry-pi

## Why
The auto-generated text implied linking to official vendor websites, 
which was misleading when the actual link pointed to Wikipedia.