### PR TITLE
[jenkins] Add 2.541 LTS

### DIFF
--- a/products/jenkins.md
+++ b/products/jenkins.md
@@ -37,10 +37,17 @@ releases:
     latest: "2.547"
     latestReleaseDate: 2026-01-20
 
+  - releaseCycle: "2.541"
+    releaseDate: 2025-12-10
+    lts: 2026-01-21
+    eol: false
+    latest: "2.541.1"
+    latestReleaseDate: 2026-01-21
+
   - releaseCycle: "2.528"
     releaseDate: 2025-09-17
     lts: 2025-10-15
-    eol: false
+    eol: 2026-01-21
     latest: "2.528.3"
     latestReleaseDate: 2025-12-08
 


### PR DESCRIPTION
See [Upgrading to Jenkins LTS 2.541.x](https://www.jenkins.io/doc/upgrade-guide/2.541/)