### PR TITLE
Remove duplicate identifiers prometheus, harbor

### DIFF
--- a/products/harbor.md
+++ b/products/harbor.md
@@ -25,7 +25,6 @@ identifiers:
   - purl: pkg:docker/bitnami/harbor-jobservice
   - purl: pkg:docker/bitnami/harbor-portal
   - purl: pkg:docker/bitnami/harbor-registryctl
-  - purl: pkg:docker/bitnami/harbor-registry
   # Chainguard Images (Wolfi-based)
   - purl: pkg:oci/harbor-core?repository_url=cgr.dev/chainguard
   - purl: pkg:oci/harbor-jobservice?repository_url=cgr.dev/chainguard

--- a/products/prometheus.md
+++ b/products/prometheus.md
@@ -13,7 +13,6 @@ identifiers:
   - purl: pkg:docker/prom/prometheus
   - purl: pkg:docker/bitnami/prometheus
   - purl: pkg:docker/rapidfort/prometheus-official
-  - purl: pkg:docker/bitnami/prometheus
   - purl: pkg:oci/prometheus?repository_url=quay.io/repository/prometheus
   - purl: pkg:oci/prometheus?repository_url=cgr.dev/chainguard
   - purl: pkg:github/prometheus/prometheus


### PR DESCRIPTION
Prometheus and harbor products have a duplicate purl product identifier, this pr fixes this

Fix https://github.com/endoflife-date/endoflife.date/issues/9350