### PR TITLE
[Laravel] add php 8.5

### DIFF
--- a/products/laravel.md
+++ b/products/laravel.md
@@ -6,7 +6,7 @@ tags: php-runtime
 iconSlug: laravel
 permalink: /laravel
 versionCommand: composer show laravel/framework|grep versions
-releasePolicyLink: https://laravel.com/docs/master/releases#support-policy
+releasePolicyLink: https://laravel.com/docs/releases#support-policy
 changelogTemplate: https://laravel.com/docs/__RELEASE_CYCLE__.x/releases
 eoasColumn: true
 
@@ -47,7 +47,7 @@ releases:
     releaseDate: 2025-02-24
     eoas: 2026-08-16
     eol: 2027-02-24
-    supportedPhpVersions: "8.2 - 8.4"
+    supportedPhpVersions: "8.2 - 8.5"
     latest: "12.48.1"
     latestReleaseDate: 2026-01-20
 


### PR DESCRIPTION
Support policy in v12 docs list for version 12 supported PHP Version 8.2-8.5

https://laravel.com/docs/12.x/releases#support-policy

<img width="689" height="529" alt="image" src="https://github.com/user-attachments/assets/1be7d743-ef2f-477e-86a5-d50174fb2e66" />


also change the link to non master or version as it link without redirects to the latest docs

https://laravel.com/docs/releases#support-policy