### PR TITLE
[quarkus-framework] Fixes RHBQ eoes dates

### DIFF
--- a/products/quarkus-framework.md
+++ b/products/quarkus-framework.md
@@ -55,6 +55,7 @@ releases:
     lts: true
     releaseDate: 2025-09-24
     eol: 2026-09-24
+    eoes: false
     latest: "3.27.2"
     latestReleaseDate: 2026-01-21
 
@@ -98,7 +99,7 @@ releases:
     lts: true
     releaseDate: 2025-03-26
     eol: 2026-03-28
-    eoes: false
+    eoes: 2026-03-24
     latest: "3.20.5"
     latestReleaseDate: 2026-01-21
 
@@ -130,7 +131,7 @@ releases:
     lts: true
     releaseDate: 2024-09-25
     eol: 2025-09-25
-    eoes: false
+    eoes: 2025-09-26
     latest: "3.15.7"
     latestReleaseDate: 2025-09-24
 
@@ -174,7 +175,7 @@ releases:
     lts: true
     releaseDate: 2024-02-28
     eol: 2025-02-28
-    eoes: false
+    eoes: 2025-03-25
     latest: "3.8.6.1"
     latestReleaseDate: 2025-02-27
 
@@ -212,7 +213,7 @@ releases:
     lts: true
     releaseDate: 2023-07-05
     eol: 2024-07-05
-    eoes: false
+    eoes: 2024-08-28
     latest: "3.2.12"
     latestReleaseDate: 2024-04-16
     link: https://github.com/quarkusio/quarkus/releases/tag/__LATEST__.Final

--- a/products/quarkus-framework.md
+++ b/products/quarkus-framework.md
@@ -106,7 +106,7 @@ releases:
     lts: true
     releaseDate: 2025-03-26
     eol: 2026-03-28
-    eoes: 2026-03-24
+    eoes: 2026-03-29
     latest: "3.20.5"
     latestReleaseDate: 2026-01-21
 


### PR DESCRIPTION
Hey, I noticed that the endoflife.date isn't correctly setting support for RHBQ (Red Hat Build of Quarkus) on Quarkus page.

RHBQ support is always 6 months after the new LTS/RHBQ version is released. - https://access.redhat.com/support/policy/updates/red_hat_build_of_quarkus_notes

```
The latest minor version is fully supported, and the previous version is considered in maintenance for six months, starting when a new minor version is released.
```

If you point me to where you do the computations, I can help you fix this.

I also noticed that some of the eol dates don't correlate with this. Basically, upstream Quarkus LTS is supported a slightly differently. For LTSes, we do maintainance release for one year after the release. Will be happy to work with you to fix these dates setting on your site.