### PR TITLE
[quarkus-framework] Added 3.31 cycle,  Updated eol date of 3.30 cycle

### DIFF
--- a/products/quarkus-framework.md
+++ b/products/quarkus-framework.md
@@ -33,9 +33,16 @@ auto:
 # - eol(x) = releaseDate(x)+1y for LTS
 # - For EOES see https://access.redhat.com/support/policy/updates/red_hat_build_of_quarkus_notes
 releases:
+  - releaseCycle: "3.31"
+    releaseDate: 2026-01-28
+    eol: false
+    latest: "3.31.1"
+    latestReleaseDate: 2026-01-28
+    link: https://quarkus.io/blog/quarkus-3-31-released/
+    
   - releaseCycle: "3.30"
     releaseDate: 2025-11-26
-    eol: false
+    eol: 2026-01-28
     latest: "3.30.8"
     latestReleaseDate: 2026-01-23
 


### PR DESCRIPTION
# :information_source: About auto documentation

- I'm aware that Quarkus is automated, but it seems like for this release it takes longer than usual, so I made this PR
- I've added the link as for Quarkus, they are really nicely crafted : what do you think ?

# :grey_question: About

[Quarkus 3.31 is out](https://x.com/QuarkusIO/status/2016580877946417239) since 2026-01-28 : : 

<img width="604" height="611" alt="image" src="https://github.com/user-attachments/assets/42a867b1-bce8-4896-be87-0517ff4e8291" />

# :telescope: About future `LTS`

cf [tweet](https://x.com/gsmet_/status/2016863994510791123) and official [Release Planning](https://github.com/quarkusio/quarkus/wiki/Release-Planning)

> 3.33 will be the next LTS. But the feature freeze is coming soon as it comes with 3.32.0.CR1.

# :bookmark_tabs: Related Quarkus PR

- https://github.com/endoflife-date/endoflife.date/pull/9368