### PR TITLE
[bun] Add brew and npm package identifier , Update official website url

### DIFF
--- a/products/bun.md
+++ b/products/bun.md
@@ -13,6 +13,7 @@ identifiers:
   - repology: bun
   - purl: pkg:docker/oven/bun
   - purl: pkg:github/oven-sh/bun
+  - pkg: brew/oven-sh/bun
 
 auto:
   methods:

--- a/products/bun.md
+++ b/products/bun.md
@@ -13,7 +13,7 @@ identifiers:
   - repology: bun
   - purl: pkg:docker/oven/bun
   - purl: pkg:github/oven-sh/bun
-  - purl: pkg:brew/oven-sh/bun
+  - purl: pkg:brew/oven-sh/bun/bun
 
 auto:
   methods:

--- a/products/bun.md
+++ b/products/bun.md
@@ -30,7 +30,7 @@ releases:
 
 ---
 
-> [Bun](https://bun.sh/) is an open-source JavaScript runtime that focuses on speed
+> [Bun](https://bun.com/) is an open-source JavaScript runtime that focuses on speed
 > and comes with a bundler, test runner, and a Node.js-compatible package manager.
 
 Bun does not have a clearly defined support policy.

--- a/products/bun.md
+++ b/products/bun.md
@@ -13,7 +13,7 @@ identifiers:
   - repology: bun
   - purl: pkg:docker/oven/bun
   - purl: pkg:github/oven-sh/bun
-  - purl: brew/oven-sh/bun
+  - purl: pkg:brew/oven-sh/bun
 
 auto:
   methods:

--- a/products/bun.md
+++ b/products/bun.md
@@ -14,6 +14,7 @@ identifiers:
   - purl: pkg:docker/oven/bun
   - purl: pkg:github/oven-sh/bun
   - purl: pkg:brew/oven-sh/bun/bun
+  - purl: pkg:npm/bun
 
 auto:
   methods:

--- a/products/bun.md
+++ b/products/bun.md
@@ -13,7 +13,7 @@ identifiers:
   - repology: bun
   - purl: pkg:docker/oven/bun
   - purl: pkg:github/oven-sh/bun
-  - pkg: brew/oven-sh/bun
+  - purl: brew/oven-sh/bun
 
 auto:
   methods:


### PR DESCRIPTION
# :grey_question: About

This PR : 

- Adds the package url for `brew`
- Adds the package url for `npm`
- Updates the website url since [Anhtropic bought bun](https://www.anthropic.com/news/anthropic-acquires-bun-as-claude-code-reaches-usd1b-milestone), the official url now is a `.com` (even if .sh is still working)
<img width="436" height="285" alt="image" src="https://github.com/user-attachments/assets/a6beeb90-6b04-4a69-b31c-22a1cba673ff" />

# :bulb:  About maintenance lifecycle

I've [also asked if there are plans for LTS ](https://x.com/bunjavascript/status/2017527899423699411)and lifecycle management, see below

<img width="633" height="950" alt="image" src="https://github.com/user-attachments/assets/68a7afcc-5c50-49da-a6b4-0c542cd1d558" />
