### PR TITLE
[couchbase-server] Disable release_table automation

### DIFF
--- a/products/couchbase-server.md
+++ b/products/couchbase-server.md
@@ -23,7 +23,9 @@ auto:
     - couchbase-server: https://docs.couchbase.com/server
       regex: '^Release (?P<version>\d+\.\d+(\.\d+)?) \((?P<date>.+)\)$'
     - release_table: https://www.couchbase.com/support-policy/EOL/
-      user_agent: "Mozilla/5.0 (X11; Linux x86_64; rv:140.0) Gecko/20100101 Firefox/140.0"
+      disabled: true  # script does not work in headless mode, must be run manually
+      render_javascript: true
+      render_javascript_headless: false
       fields:
         releaseCycle:
           column: "Release"


### PR DESCRIPTION
This automation does not work anymore in headless mode, it must now be run manually by running update-release-data.py with the `-f` option.