### PR TITLE
Update chef products auto methods

### DIFF
--- a/products/chef-infra-client.md
+++ b/products/chef-infra-client.md
@@ -19,7 +19,9 @@ identifiers:
 
 auto:
   methods:
-    - chef-infra: https://docs.chef.io/release_notes_client/
+    - chef-versions: https://docs.chef.io/release_notes/client/
+      regex: '^Chef Infra Client (?P<value>.+)$'
+      template: "{{value}}"
       repository: https://github.com/chef/chef.git
 
 # eol(x) = releaseDate(x+2) > confirm EOL date here https://docs.chef.io/versions/

--- a/products/chef-infra-server.md
+++ b/products/chef-infra-server.md
@@ -18,7 +18,9 @@ identifiers:
 
 auto:
   methods:
-    - chef-infra: https://docs.chef.io/release_notes_server/
+    - chef-versions: https://docs.chef.io/release_notes/server/
+      regex: '^Chef Infra Server (?P<value>.+)$'
+      template: "{{value}}"
       repository: https://github.com/chef/chef-server.git
 
 # eoas(x) = releaseDate(x+1)

--- a/products/chef-inspec.md
+++ b/products/chef-inspec.md
@@ -16,7 +16,10 @@ identifiers:
 
 auto:
   methods:
-    - chef-inspec: https://docs.chef.io/release_notes_inspec/
+    - chef-versions: https://docs.chef.io/release_notes/inspec/
+      regex: '^Chef InSpec (?P<value>.+)$'
+      template: "{{value}}"
+      repository: https://github.com/inspec/inspec.git
 
 # eoas(x) = releaseDate(x+1)
 # eol(x) = releaseDate(x+2) or the date documented on https://docs.chef.io/versions/

--- a/products/chef-supermarket.md
+++ b/products/chef-supermarket.md
@@ -11,7 +11,9 @@ changelogTemplate: "https://docs.chef.io/release_notes_supermarket/#__LATEST__"
 
 auto:
   methods:
-    - chef-infra: https://docs.chef.io/release_notes_supermarket/
+    - chef-versions: https://docs.chef.io/release_notes/supermarket/
+      regex: '^Chef Supermarket (?P<value>.+)$'
+      template: "{{value}}"
       repository: https://github.com/chef/supermarket.git
 
 # eol(x) = releaseDate(x+1)

--- a/products/chef-workstation.md
+++ b/products/chef-workstation.md
@@ -14,7 +14,9 @@ identifiers:
 
 auto:
   methods:
-    - chef-infra: https://docs.chef.io/release_notes_workstation/
+    - chef-versions: https://docs.chef.io/release_notes_workstation/
+      regex: '^Chef Workstation (?P<value>.+)$'
+      template: "{{value}}"
       repository: https://github.com/chef/chef-workstation.git
 
 releases:


### PR DESCRIPTION
Release note pages changed on https://docs.chef.io, and this broke automation.
Switch to the new `chef-versions` auto-method instead.