### PR TITLE
[quarkus-framework] Add purl for maven

### DIFF
--- a/products/quarkus-framework.md
+++ b/products/quarkus-framework.md
@@ -17,7 +17,7 @@ identifiers:
   - repology: quarkus
   - cpe: cpe:/a:quarkus:quarkus
   - cpe: cpe:2.3:a:quarkus:quarkus
-  - purl: pkg:maven/io.quarkus.platform/quarkus-bom?type=pom
+  - purl: pkg:maven/io.quarkus.platform/quarkus-bom
 
 # The Quarkus team forgot to declare a GitHub release for 2.11.0.
 # Tag and Maven release of new minor versions are usually created

--- a/products/quarkus-framework.md
+++ b/products/quarkus-framework.md
@@ -17,7 +17,7 @@ identifiers:
   - repology: quarkus
   - cpe: cpe:/a:quarkus:quarkus
   - cpe: cpe:2.3:a:quarkus:quarkus
-  - purl: pkg:maven/io.quarkus.platform/quarkus-bomtype=pom
+  - purl: pkg:maven/io.quarkus.platform/quarkus-bom?type=pom
 
 # The Quarkus team forgot to declare a GitHub release for 2.11.0.
 # Tag and Maven release of new minor versions are usually created

--- a/products/quarkus-framework.md
+++ b/products/quarkus-framework.md
@@ -17,6 +17,7 @@ identifiers:
   - repology: quarkus
   - cpe: cpe:/a:quarkus:quarkus
   - cpe: cpe:2.3:a:quarkus:quarkus
+  - purl: pkg:maven/io.quarkus.platform/quarkus-bomtype=pom
 
 # The Quarkus team forgot to declare a GitHub release for 2.11.0.
 # Tag and Maven release of new minor versions are usually created


### PR DESCRIPTION
# :grey_question: About

Quarkus is primarly used from `maven`, but the product was lacking the corresponding `purl`.

:point_right: This PR fixes that.

# :bookmark_tabs: Related resources

- https://mvnrepository.com/artifact/io.quarkus/quarkus-bom
- https://github.com/endoflife-date/endoflife.date/pull/9368
