### PR TITLE
[openbao] Add v2.5 and brew purl

### DIFF
--- a/products/openbao.md
+++ b/products/openbao.md
@@ -22,6 +22,7 @@ identifiers:
   - purl: pkg:oci/openbao-ubi?repository_url=ghcr.io/openbao
   - purl: pkg:oci/openbao?repository_url=quay.io/openbao
   - purl: pkg:oci/openbao-ubi?repository_url=quay.io/openbao
+  - purl: pkg:brew/openbao
 
 auto:
   methods:
@@ -30,6 +31,12 @@ auto:
 # eol(x) = releaseDate(x+1)
 
 releases:
+  - releaseCycle: "2.5"
+    releaseDate: 2026-02-05
+    eol: false
+    latest: "2.5.0"
+    latestReleaseDate: 2026-02-05
+
   - releaseCycle: "2.4"
     releaseDate: 2025-08-28
     eol: false


### PR DESCRIPTION
# :grey_question: About

This PR add: 

- [Homebrew package URL](https://formulae.brew.sh/formula/openbao)
-  New release information for version [2.5](https://github.com/openbao/openbao/releases/tag/v2.5.0).