### PR TITLE
[openbao] Update end-of-life date for release cycle 2.4

### DIFF
--- a/products/openbao.md
+++ b/products/openbao.md
@@ -39,7 +39,7 @@ releases:
 
   - releaseCycle: "2.4"
     releaseDate: 2025-08-28
-    eol: false
+    eol: 2026-02-05
     latest: "2.4.4"
     latestReleaseDate: 2025-11-24
 


### PR DESCRIPTION
# :grey_question: About

> Only the latest release cycle is maintained at any given time.

So the `2.4` should be EOL since 2.5 release date cf

- https://github.com/endoflife-date/endoflife.date/pull/9424

<img width="935" height="636" alt="image" src="https://github.com/user-attachments/assets/313d0440-f7b4-4979-98ee-e31e757deab9" />
