### PR TITLE
[pan-os] Update PAN-OS 12.1 to 12.1.4-h2

### DIFF
--- a/products/pan-os.md
+++ b/products/pan-os.md
@@ -32,9 +32,9 @@ releases:
   - releaseCycle: "12.1"
     releaseDate: 2025-08-28
     eol: 2028-08-28
-    latest: "12.1.4"
-    latestReleaseDate: 2025-12-15
-    link: https://docs.paloaltonetworks.com/ngfw/release-notes/12-1/pan-os-12-1-4-known-and-addressed-issues/pan-os-12-1-4-addressed-issues
+    latest: "12.1.4-h2"
+    latestReleaseDate: 2026-02-04
+    link: https://docs.paloaltonetworks.com/ngfw/release-notes/12-1/pan-os-12-1-4-known-and-addressed-issues/pan-os-12-1-4-h2-addressed-issues
 
   - releaseCycle: "11.2"
     releaseDate: 2024-05-02


### PR DESCRIPTION
## Summary
- Update PAN-OS 12.1 latest version from 12.1.4 to 12.1.4-h2
- Update release date to 2026-02-04
- Update release notes link to 12.1.4-h2 addressed issues