### PR TITLE
[Apache ActiveMQ Artemis] Add 2.51.0

### DIFF
--- a/products/apache-activemq-artemis.md
+++ b/products/apache-activemq-artemis.md
@@ -20,9 +20,15 @@ auto:
 
 # eol(x) = releaseDate(x+1)
 releases:
+  - releaseCycle: "2.51"
+    releaseDate: 2026-02-06
+    eol: false
+    latest: "2.51.0"
+    latestReleaseDate: 2026-02-06
+
   - releaseCycle: "2.50"
     releaseDate: 2026-01-23
-    eol: false
+    eol: 2026-02-06
     latest: "2.50.0"
     latestReleaseDate: 2026-01-15
 

--- a/products/apache-activemq-artemis.md
+++ b/products/apache-activemq-artemis.md
@@ -21,14 +21,14 @@ auto:
 # eol(x) = releaseDate(x+1)
 releases:
   - releaseCycle: "2.51"
-    releaseDate: 2026-02-06
+    releaseDate: 2026-02-11
     eol: false
     latest: "2.51.0"
-    latestReleaseDate: 2026-02-06
+    latestReleaseDate: 2026-02-11
 
   - releaseCycle: "2.50"
     releaseDate: 2026-01-23
-    eol: 2026-02-06
+    eol: 2026-02-11
     latest: "2.50.0"
     latestReleaseDate: 2026-01-15
 


### PR DESCRIPTION
Not yet listed on
https://artemis.apache.org/components/artemis/documentation/latest/versions.html

so draft first