### PR TITLE
[keda] Add 2.19 release cycle

### DIFF
--- a/products/keda.md
+++ b/products/keda.md
@@ -44,7 +44,7 @@ releases:
 
   - releaseCycle: "2.17"
     releaseDate: 2025-04-07
-    eol: false
+    eol: 2026-02-02
     supportedKubernetesVersions: 1.30 - 1.32
     latest: "2.17.3"
     latestReleaseDate: 2025-12-22

--- a/products/keda.md
+++ b/products/keda.md
@@ -28,6 +28,13 @@ identifiers:
 # eol(x) = releaseDate(x+2)
 # For supportedKubernetesVersions: https://keda.sh/docs/latest/operate/cluster/#kubernetes-compatibility
 releases:
+  - releaseCycle: "2.19"
+    releaseDate: 2026-02-02
+    eol: false
+    supportedKubernetesVersions: 1.32 - 1.34
+    latest: "2.19.0"
+    latestReleaseDate: 2026-02-02
+
   - releaseCycle: "2.18"
     releaseDate: 2025-10-08
     eol: false


### PR DESCRIPTION
Keda have released [2.19.0](https://github.com/kedacore/keda/releases/tag/v2.19.0)