### PR TITLE
[go] Add Go 1.26 release and mark 1.24 eol

### DIFF
--- a/products/go.md
+++ b/products/go.md
@@ -29,6 +29,13 @@ auto:
 
 # eol(x) = releaseDate(x+2)
 releases:
+  - releaseCycle: "1.26"
+    releaseDate: 2026-02-11
+    eol: false
+    latest: "1.26.0"
+    latestReleaseDate: 2026-02-11
+    link: https://go.dev/doc/go1.26
+    
   - releaseCycle: "1.25"
     releaseDate: 2025-08-12
     eol: false
@@ -37,7 +44,7 @@ releases:
 
   - releaseCycle: "1.24"
     releaseDate: 2025-02-11
-    eol: false
+    eol: 2026-02-11
     latest: "1.24.13"
     latestReleaseDate: 2026-02-04
 


### PR DESCRIPTION
# :grey_question: About

[As announced today](https://x.com/golang/status/2021311438384398737) Go 1.26 is out : : 

<img width="613" height="708" alt="image" src="https://github.com/user-attachments/assets/ce44e1c2-cf2c-4b2e-9baa-bb46ff221a49" />


# :bookmark_tabs: Resources

- [Tweet](https://x.com/golang/status/2021311438384398737)
- Download links : https://go.dev/dl/#go1.26.0
- Release notes : https://go.dev/doc/go1.26
- [Dedicated blog post](https://go.dev/blog/go1.26)