### PR TITLE
[tomcat] Rename 9 to 9.0

### DIFF
--- a/products/tomcat.md
+++ b/products/tomcat.md
@@ -50,7 +50,7 @@ releases:
 
   - releaseCycle: "9.0"
     releaseDate: 2017-09-27
-    eol: false # https://tomcat.apache.org/tomcat-9.0.x-eos.html
+    eol: 2027-03-31 # https://tomcat.apache.org/tomcat-9.0.x-eos.html
     minJavaVersion: "8"
     latest: "9.0.115"
     latestReleaseDate: 2026-01-21

--- a/products/tomcat.md
+++ b/products/tomcat.md
@@ -48,7 +48,7 @@ releases:
     latest: "10.0.27"
     latestReleaseDate: 2022-10-03
 
-  - releaseCycle: "9.0" # will be replaced by 9.1
+  - releaseCycle: "9.0"
     releaseDate: 2017-09-27
     eol: false # https://tomcat.apache.org/tomcat-9.0.x-eos.html
     minJavaVersion: "8"

--- a/products/tomcat.md
+++ b/products/tomcat.md
@@ -48,9 +48,9 @@ releases:
     latest: "10.0.27"
     latestReleaseDate: 2022-10-03
 
-  - releaseCycle: "9"
+  - releaseCycle: "9.0" # will be replaced by 9.1
     releaseDate: 2017-09-27
-    eol: false
+    eol: false # https://tomcat.apache.org/tomcat-9.0.x-eos.html
     minJavaVersion: "8"
     latest: "9.0.115"
     latestReleaseDate: 2026-01-21


### PR DESCRIPTION
This is to prepare for upcoming Tomcat 9.1 release. An EOL date for Tomcat 9.0 has been announced as well as plans for Tomcat 9.1 to replace it until TLS runs out for Java 8 (which is the baseline version of Java for all Tomcat 9.x versions).