### PR TITLE
Fix XML escaping in Atom feeds

### DIFF
--- a/_layouts/product-feed.atom
+++ b/_layouts/product-feed.atom
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <feed xmlns="http://www.w3.org/2005/Atom">
   <id>{{ page.product_link }}</id>
-  <title>endoflife.date: {{ page.product_label }} events</title>
-  <subtitle>{{ page.product_label }} release and end-of-life events</subtitle>
+  <title>endoflife.date: {{ page.product_label | xml_escape }} events</title>
+  <subtitle>{{ page.product_label | xml_escape }} release and end-of-life events</subtitle>
   <link href="{{ page.url | absolute_url }}" rel="self" />
   <link href="{{ page.product_link }}"/>
   <updated>{{ page.last_updated | date_to_xmlschema }}</updated>
@@ -14,20 +14,20 @@
     <link href="{{ page.product_link }}"/>
     <updated>{{ event.occurred_at | date_to_xmlschema }}</updated>
 {%- if event.type == "release" %}
-    <title>{{ page.product_label }} {{ event.release_label }} released</title>
-    <summary>{{ page.product_label }} {{ event.release_label }} has been released.</summary>
+    <title>{{ page.product_label | xml_escape }} {{ event.release_label | xml_escape }} released</title>
+    <summary>{{ page.product_label | xml_escape }} {{ event.release_label | xml_escape }} has been released.</summary>
 {% elsif event.type == "eoas" %}
-    <title>{{ page.product_label }} {{ event.release_label }} end of active support</title>
-    <summary>{{ page.product_label }} {{ event.release_label }} active support ended.</summary>
+    <title>{{ page.product_label | xml_escape }} {{ event.release_label | xml_escape }} end of active support</title>
+    <summary>{{ page.product_label | xml_escape }} {{ event.release_label | xml_escape }} active support ended.</summary>
 {% elsif event.type == "eol-7d" %}
-    <title>{{ page.product_label }} {{ event.release_label }} upcoming end of life</title>
-    <summary>{{ page.product_label }} {{ event.release_label }} will be end-of-life in 7 days.</summary>
+    <title>{{ page.product_label | xml_escape }} {{ event.release_label | xml_escape }} upcoming end of life</title>
+    <summary>{{ page.product_label | xml_escape }} {{ event.release_label | xml_escape }} will be end-of-life in 7 days.</summary>
 {% elsif event.type == "eol" %}
-    <title>{{ page.product_label }} {{ event.release_label }} end of life</title>
-    <summary>{{ page.product_label }} {{ event.release_label }} is end-of-life.</summary>
+    <title>{{ page.product_label | xml_escape }} {{ event.release_label | xml_escape }} end of life</title>
+    <summary>{{ page.product_label | xml_escape }} {{ event.release_label | xml_escape }} is end-of-life.</summary>
 {% elsif event.type == "eoes" %}
-    <title>{{ page.product_label }} {{ event.release_label }} end of extended support</title>
-    <summary>{{ page.product_label }} {{ event.release_label }} extended support ended.</summary>
+    <title>{{ page.product_label | xml_escape }} {{ event.release_label | xml_escape }} end of extended support</title>
+    <summary>{{ page.product_label | xml_escape }} {{ event.release_label | xml_escape }} extended support ended.</summary>
 {% endif -%}
   </entry>
 {% endfor -%}


### PR DESCRIPTION
Add `xml_escape` filter to product labels and release labels in Atom feed template to properly escape special characters like ampersands. This fixes invalid XML in feeds for products with special characters in their names, such as 'Veeam Backup & Replication'.

Fixes #9419