### PR TITLE
[unity] Update 6.x release cycle format and auto configuration

### DIFF
--- a/products/unity.md
+++ b/products/unity.md
@@ -11,34 +11,37 @@ changelogTemplate: "https://unity.com/releases/editor/whats-new/{{'__LATEST__'|s
 eoesColumn: Extended Long Term Support
 
 auto:
-  disabled: true # there are anti-bot protection measures on https://unity.com/
   methods:
-    - unity: https://unity.com/releases/editor/qa/lts-releases
+    - unity: https://services.api.unity.com/unity/editor/release/v1/releases
 
 # For update release : eol(x) = releaseDate(x+1)
 # For LTS : eol(x) = releaseDate + 2 years
 releases:
-  - releaseCycle: "6.3"
+  - releaseCycle: "6000.3"
+    releaseLabel: "6.3"
     lts: true
     releaseDate: 2025-12-04
     eol: 2027-12-04
     eoes: 2028-12-04
     latest: "6000.3.8f1"
     latestReleaseDate: 2026-02-11
-    
-  - releaseCycle: "6.2"
+
+  - releaseCycle: "6000.2"
+    releaseLabel: "6.2"
     releaseDate: 2025-08-12
     eol: 2025-12-04
     latest: "6000.2.15f1"
     latestReleaseDate: 2025-12-03
 
-  - releaseCycle: "6.1"
+  - releaseCycle: "6000.1"
+    releaseLabel: "6.1"
     releaseDate: 2025-04-23
     eol: 2025-08-12
     latest: "6000.1.17f1"
     latestReleaseDate: 2025-10-03
 
-  - releaseCycle: "6.0"
+  - releaseCycle: "6000.0"
+    releaseLabel: "6.0"
     releaseDate: 2024-04-29
     lts: 2024-10-16
     eol: 2026-10-16


### PR DESCRIPTION
Move releaseCycle to releaseLabel and use first two components of latest field for releaseCycle. This change is required for auto-update to work properly, and is more aligned with what should be done usually on endoflife.date.

Update the auto configuration following https://github.com/endoflife-date/release-data/pull/558, and enable auto-update.