### PR TITLE
[Update] Netapp Ontap - add missing release 9.17.1 & 9.18.1

### DIFF
--- a/products/netapp-ontap.md
+++ b/products/netapp-ontap.md
@@ -16,6 +16,14 @@ latestColumn: false # no public access to the latest patches
 
 # Releases are documented on https://mysupport.netapp.com/site/info/version-support.
 releases:
+  - releaseCycle: "9.18.1"
+    releaseDate: 2026-04-02 # estimated date from https://docs.netapp.com/us-en/ontap/release-notes/release-support-reference.html
+    eol: 2028-09-30
+
+  - releaseCycle: "9.17.1"
+    releaseDate: 2026-01-15 # estimated date from https://docs.netapp.com/us-en/ontap/release-notes/release-support-reference.html
+    eol: 2028-09-30
+
   - releaseCycle: "9.16.1"
     releaseDate: 2025-01-01 # estimated date from https://docs.netapp.com/us-en/ontap/release-notes/release-support-reference.html
     eol: 2028-01-31

--- a/products/netapp-ontap.md
+++ b/products/netapp-ontap.md
@@ -17,7 +17,7 @@ latestColumn: false # no public access to the latest patches
 # Releases are documented on https://mysupport.netapp.com/site/info/version-support.
 releases:
   - releaseCycle: "9.18.1"
-    releaseDate: 2026-04-02 # estimated date from https://docs.netapp.com/us-en/ontap/release-notes/release-support-reference.html
+    releaseDate: 2026-02-04 # estimated date from https://docs.netapp.com/us-en/ontap/release-notes/release-support-reference.html
     eol: 2028-09-30
 
   - releaseCycle: "9.17.1"


### PR DESCRIPTION
The current page missed two versions.
EOL for 9.18.1 is missing on netapp support https://mysupport.netapp.com/site/info/version-support so I put the same as 9.17.1 for now.

