### PR TITLE
[elasticsearch] fix EOL date for 8.18

### DIFF
--- a/products/beats.md
+++ b/products/beats.md
@@ -58,7 +58,7 @@ releases:
 
   - releaseCycle: "8.18"
     releaseDate: 2025-04-09
-    eol: false # Until 9.2 is released
+    eol: 2025-10-20
     latest: "8.18.8"
     latestReleaseDate: 2025-10-02
 

--- a/products/elasticsearch.md
+++ b/products/elasticsearch.md
@@ -59,7 +59,7 @@ releases:
 
   - releaseCycle: "8.18"
     releaseDate: 2025-04-10
-    eol: false # Until 9.2 is released
+    eol: 2025-10-21
     latest: "8.18.8"
     latestReleaseDate: 2025-10-02
 

--- a/products/kibana.md
+++ b/products/kibana.md
@@ -56,7 +56,7 @@ releases:
 
   - releaseCycle: "8.18"
     releaseDate: 2025-04-10
-    eol: false # Until 9.2 is released
+    eol: 2025-10-21
     latest: "8.18.8"
     latestReleaseDate: 2025-10-02
 

--- a/products/logstash.md
+++ b/products/logstash.md
@@ -49,7 +49,7 @@ releases:
 
   - releaseCycle: "8.18"
     releaseDate: 2025-04-09
-    eol: false # Until 9.2 is released
+    eol: 2025-10-21
     latest: "8.18.8"
     latestReleaseDate: 2025-09-30
 


### PR DESCRIPTION
https://www.elastic.co/support/eol says in the 2nd footnote:

Elastic Stack version 8.18 will be maintained until the release date of version 9.2.