### PR TITLE
[fortios] Remove fortinet alternate_urls

### DIFF
--- a/products/fortios.md
+++ b/products/fortios.md
@@ -5,8 +5,6 @@ category: os
 tags: fortinet
 iconSlug: fortinet
 permalink: /fortios
-alternate_urls:
-  - /fortinet
 versionCommand: get system status
 changelogTemplate: https://docs.fortinet.com/product/fortigate/__RELEASE_CYCLE__
 latestColumn: false


### PR DESCRIPTION
`fortinet` is the brand name, not an alternate name for the product.