### PR TITLE
[New Product] Amazon OpenSearch

### DIFF
--- a/.playwright-mcp/console-2026-02-23T12-29-18-841Z.log
+++ b/.playwright-mcp/console-2026-02-23T12-29-18-841Z.log
@@ -1,0 +1,25 @@
+[    1232ms] [ERROR] [TangerineBox] Telemetry configuration is missing. Error: Error: Session data meta tag not found @ https://a.b.cdn.console.awsstatic.com/a/v1/YRING43GISMZ55PQVLRQ7GEJWK2K42P5ER7ZESQSTPFHH6OQM4ZA/eade49c098ff40c0abc641e3c8eeb22b82cf6d6688e04b789af571b487c8aeae.js:1
+[    1232ms] [ERROR] [TangerineBox] Telemetry configuration is missing. Error: Error: Session data meta tag not found @ https://a.b.cdn.console.awsstatic.com/a/v1/YRING43GISMZ55PQVLRQ7GEJWK2K42P5ER7ZESQSTPFHH6OQM4ZA/eade49c098ff40c0abc641e3c8eeb22b82cf6d6688e04b789af571b487c8aeae.js:1
+[    1242ms] [WARNING] Unable to parse the data using legacy methods @ https://a.b.cdn.console.awsstatic.com/a/v1/YRING43GISMZ55PQVLRQ7GEJWK2K42P5ER7ZESQSTPFHH6OQM4ZA/eade49c098ff40c0abc641e3c8eeb22b82cf6d6688e04b789af571b487c8aeae.js:1
+[    1242ms] [ERROR] Couldn't determine console domain and dual-stack values. @ https://a.b.cdn.console.awsstatic.com/a/v1/YRING43GISMZ55PQVLRQ7GEJWK2K42P5ER7ZESQSTPFHH6OQM4ZA/eade49c098ff40c0abc641e3c8eeb22b82cf6d6688e04b789af571b487c8aeae.js:1
+[    1553ms] [WARNING] Unable to parse the data using legacy methods @ https://docs.aws.amazon.com/assets/r/5787.112557dbc7c886289685.js:1
+[    1553ms] [ERROR] Couldn't determine console domain and dual-stack values. @ https://docs.aws.amazon.com/assets/r/5787.112557dbc7c886289685.js:1
+[    2613ms] [WARNING] Unable to parse the data using legacy methods @ https://a.b.cdn.console.awsstatic.com/a/v1/BDTCI64IMYTNXYTQG733YAYQCQDJKBZCHFARTMYTXRCBDV7DKNFQ/module2.js:80
+[    2613ms] [ERROR] Couldn't determine console domain and dual-stack values. @ https://a.b.cdn.console.awsstatic.com/a/v1/BDTCI64IMYTNXYTQG733YAYQCQDJKBZCHFARTMYTXRCBDV7DKNFQ/module2.js:80
+[    2829ms] [ERROR] Framing 'https://conversational-experience-worker.widget.console.aws.amazon.com/' violates the following Content Security Policy directive: "frame-ancestors 'none'". The request has been blocked.
+ @ :0
+[    2885ms] [ERROR] Failed to load resource: the server responded with a status of 403 () @ chrome-error://chromewebdata/:0
+[    2902ms] [WARNING] Failed to execute 'postMessage' on 'DOMWindow': The target origin provided ('https://conversational-experience-worker.widget.console.aws.amazon.com') does not match the recipient window's origin ('null'). @ https://a.b.cdn.console.awsstatic.com/a/v1/BDTCI64IMYTNXYTQG733YAYQCQDJKBZCHFARTMYTXRCBDV7DKNFQ/module2.js:170
+[    4164ms] [ERROR] It does not seem your site has onboarded to Shortbread. Onboarding to Shortbread is required for using Visitor ID Service. @ https://d2c.aws.amazon.com/client/lib/v1/module/index-7ae49672.js:1
+[  302625ms] SecurityError: Failed to read a named property 'frameElement' from 'Window': Blocked a frame with origin "https://docs.aws.amazon.com" from accessing a cross-origin frame.
+    at https://docs.aws.amazon.com/assets/r/5787.112557dbc7c886289685.js:2:117200
+[  602626ms] TimeoutError: Timeout occurred while waiting for a reply
+    at https://docs.aws.amazon.com/assets/r/5787.112557dbc7c886289685.js:2:89969
+[  602626ms] TimeoutError: Timeout occurred while waiting for a reply
+    at https://docs.aws.amazon.com/assets/r/5787.112557dbc7c886289685.js:2:89969
+[  602626ms] TimeoutError: Timeout occurred while waiting for a reply
+    at https://docs.aws.amazon.com/assets/r/5787.112557dbc7c886289685.js:2:89969
+[  602627ms] TimeoutError: Timeout occurred while waiting for a reply
+    at https://docs.aws.amazon.com/assets/r/5787.112557dbc7c886289685.js:2:89969
+[  602627ms] TimeoutError: Timeout occurred while waiting for a reply
+    at https://docs.aws.amazon.com/assets/r/5787.112557dbc7c886289685.js:2:89969

--- a/products/amazon-opensearch.md
+++ b/products/amazon-opensearch.md
@@ -1,0 +1,231 @@
+---
+title: Amazon OpenSearch Service
+addedAt: 2026-02-23
+category: service
+tags: amazon
+iconSlug: amazonopensearch
+permalink: /amazon-opensearch
+alternate_urls:
+  - /amazon-opensearch-service
+  - /amazon-elasticsearch-service
+releasePolicyLink: https://docs.aws.amazon.com/opensearch-service/latest/developerguide/what-is.html
+latestColumn: false
+eolColumn: End of Standard Support
+eoesColumn: Extended Support
+staleReleaseThresholdDays: 2000
+
+releases:
+  - releaseCycle: "os-3.1"
+    releaseLabel: "OpenSearch 3.1"
+    releaseDate: 2025-06-01
+    eol: false
+    eoes: false
+
+  - releaseCycle: "os-2.19"
+    releaseLabel: "OpenSearch 2.19"
+    releaseDate: 2024-11-01
+    eol: false
+    eoes: false
+
+  - releaseCycle: "os-2.17"
+    releaseLabel: "OpenSearch 2.17"
+    releaseDate: 2024-09-01
+    eol: false
+    eoes: false
+
+  - releaseCycle: "os-2.15"
+    releaseLabel: "OpenSearch 2.15"
+    releaseDate: 2024-07-01
+    eol: false
+    eoes: false
+
+  - releaseCycle: "os-2.13"
+    releaseLabel: "OpenSearch 2.13"
+    releaseDate: 2024-03-01
+    eol: false
+    eoes: false
+
+  - releaseCycle: "os-2.11"
+    releaseLabel: "OpenSearch 2.11"
+    releaseDate: 2023-11-01
+    eol: false
+    eoes: false
+
+  - releaseCycle: "os-2.9"
+    releaseLabel: "OpenSearch 2.9"
+    releaseDate: 2023-07-01
+    eol: 2025-11-07
+    eoes: 2026-11-07
+
+  - releaseCycle: "os-2.7"
+    releaseLabel: "OpenSearch 2.7"
+    releaseDate: 2023-04-01
+    eol: 2025-11-07
+    eoes: 2026-11-07
+
+  - releaseCycle: "os-2.5"
+    releaseLabel: "OpenSearch 2.5"
+    releaseDate: 2023-02-01
+    eol: 2025-11-07
+    eoes: 2026-11-07
+
+  - releaseCycle: "os-2.3"
+    releaseLabel: "OpenSearch 2.3"
+    releaseDate: 2022-08-01
+    eol: 2025-11-07
+    eoes: 2026-11-07
+
+  - releaseCycle: "os-1.3"
+    releaseLabel: "OpenSearch 1.3"
+    releaseDate: 2022-03-01
+    eol: false
+    eoes: false
+
+  - releaseCycle: "os-1.2"
+    releaseLabel: "OpenSearch 1.2"
+    releaseDate: 2021-12-01
+    eol: 2025-11-07
+    eoes: 2026-11-07
+
+  - releaseCycle: "os-1.1"
+    releaseLabel: "OpenSearch 1.1"
+    releaseDate: 2021-11-01
+    eol: 2025-11-07
+    eoes: 2026-11-07
+
+  - releaseCycle: "os-1.0"
+    releaseLabel: "OpenSearch 1.0"
+    releaseDate: 2021-09-08
+    eol: 2025-11-07
+    eoes: 2026-11-07
+
+  - releaseCycle: "es-7.10"
+    releaseLabel: "Elasticsearch 7.10"
+    releaseDate: 2020-11-01
+    eol: false
+    eoes: false
+
+  - releaseCycle: "es-7.9"
+    releaseLabel: "Elasticsearch 7.9"
+    releaseDate: 2020-08-01
+    eol: false
+    eoes: false
+
+  - releaseCycle: "es-7.8"
+    releaseLabel: "Elasticsearch 7.8"
+    releaseDate: 2020-06-01
+    eol: 2025-11-07
+    eoes: 2026-11-07
+
+  - releaseCycle: "es-7.7"
+    releaseLabel: "Elasticsearch 7.7"
+    releaseDate: 2020-04-01
+    eol: 2025-11-07
+    eoes: 2026-11-07
+
+  - releaseCycle: "es-7.4"
+    releaseLabel: "Elasticsearch 7.4"
+    releaseDate: 2019-09-01
+    eol: 2025-11-07
+    eoes: 2026-11-07
+
+  - releaseCycle: "es-6.8"
+    releaseLabel: "Elasticsearch 6.8"
+    releaseDate: 2019-06-01
+    eol: false
+    eoes: false
+
+  - releaseCycle: "es-7.1"
+    releaseLabel: "Elasticsearch 7.1"
+    releaseDate: 2019-04-01
+    eol: 2025-11-07
+    eoes: 2026-11-07
+
+  - releaseCycle: "es-6.7"
+    releaseLabel: "Elasticsearch 6.7"
+    releaseDate: 2019-03-01
+    eol: 2025-11-07
+    eoes: 2026-11-07
+
+  - releaseCycle: "es-6.5"
+    releaseLabel: "Elasticsearch 6.5"
+    releaseDate: 2018-11-01
+    eol: 2025-11-07
+    eoes: 2026-11-07
+
+  - releaseCycle: "es-6.4"
+    releaseLabel: "Elasticsearch 6.4"
+    releaseDate: 2018-08-01
+    eol: 2025-11-07
+    eoes: 2026-11-07
+
+  - releaseCycle: "es-6.3"
+    releaseLabel: "Elasticsearch 6.3"
+    releaseDate: 2018-06-01
+    eol: 2025-11-07
+    eoes: 2026-11-07
+
+  - releaseCycle: "es-6.2"
+    releaseLabel: "Elasticsearch 6.2"
+    releaseDate: 2018-03-01
+    eol: 2025-11-07
+    eoes: 2026-11-07
+
+  - releaseCycle: "es-6.0"
+    releaseLabel: "Elasticsearch 6.0"
+    releaseDate: 2017-11-01
+    eol: 2025-11-07
+    eoes: 2026-11-07
+
+  - releaseCycle: "es-5.6"
+    releaseLabel: "Elasticsearch 5.6"
+    releaseDate: 2017-09-01
+    eol: 2025-11-07
+    eoes: 2028-11-07
+
+  - releaseCycle: "es-5.5"
+    releaseLabel: "Elasticsearch 5.5"
+    releaseDate: 2017-07-01
+    eol: 2025-11-07
+    eoes: 2026-11-07
+
+  - releaseCycle: "es-5.3"
+    releaseLabel: "Elasticsearch 5.3"
+    releaseDate: 2017-03-01
+    eol: 2025-11-07
+    eoes: 2026-11-07
+
+  - releaseCycle: "es-5.1"
+    releaseLabel: "Elasticsearch 5.1"
+    releaseDate: 2016-11-01
+    eol: 2025-11-07
+    eoes: 2026-11-07
+
+  - releaseCycle: "es-2.3"
+    releaseLabel: "Elasticsearch 2.3"
+    releaseDate: 2016-03-01
+    eol: 2025-11-07
+    eoes: 2026-11-07
+
+  - releaseCycle: "es-1.5"
+    releaseLabel: "Elasticsearch 1.5"
+    releaseDate: 2015-10-01
+    eol: 2025-11-07
+    eoes: 2026-11-07
+---
+
+> [Amazon OpenSearch Service](https://aws.amazon.com/opensearch-service/) (formerly Amazon
+> Elasticsearch Service) is a managed service that makes it easy to deploy, operate, and scale
+> OpenSearch clusters in the AWS Cloud.
+
+Amazon OpenSearch Service supports two search engine families: **OpenSearch** (versions 1.x–3.x)
+and legacy **Elasticsearch OSS** (versions 1.5–7.10, the final open-source Elasticsearch release).
+Release cycles in this page are prefixed with `os-` for OpenSearch and `es-` for Elasticsearch.
+
+Extended Support charges apply automatically when a domain runs a version for which standard
+support has ended. To avoid charges, upgrade to a version still under standard support. See
+[Standard and extended support](https://docs.aws.amazon.com/opensearch-service/latest/developerguide/what-is.html#choosing-version)
+for details.
+
+Note: Elasticsearch 5.6 has an extended support window until November 7, 2028 (vs. November 7,
+2026 for most other versions).


### PR DESCRIPTION
Add tracking for Amazon OpenSearch Service Extended Support lifecycle.

Covers both OpenSearch (1.x–3.x) and legacy Elasticsearch OSS (1.5–7.10) engine versions with their standard support end dates and Extended Support surcharge windows.

Permalink uses `/amazon-opensearch` for consistency with repo naming conventions; `/amazon-opensearch-service` and `/amazon-elasticsearch-service` are alternate URLs.