### PR TITLE
[routeros] Remove duplicated os tag

### DIFF
--- a/products/routeros.md
+++ b/products/routeros.md
@@ -2,7 +2,7 @@
 title: RouterOS
 addedAt: 2026-02-22
 category: os
-tags: mikrotik os
+tags: mikrotik
 iconSlug: mikrotik
 permalink: /routeros
 changelogTemplate: https://mikrotik.com/download/changelogs?versionFilter=__LATEST__&channelFilter=


### PR DESCRIPTION
Currently, the `routeros` product has a duplicate `os` tag.

<img width="418" height="183" alt="image" src="https://github.com/user-attachments/assets/45c7b2aa-7f35-4b7b-8151-c50100a70316" />

This duplicate is because of the `os` present in the `tags` line in the markdown. According to [the contributing guide](https://endoflife.date/contribute), we should not use an existing category as a tag (automatically used). So this pr fixes this 

<img width="725" height="40" alt="image" src="https://github.com/user-attachments/assets/42da4134-e617-4d89-9784-fe98efd58b6f" />
