### PR TITLE
[Firefox] Change EOL date for Firefox 115 to February 28, 2026

### DIFF
--- a/products/firefox.md
+++ b/products/firefox.md
@@ -224,7 +224,7 @@ releases:
   - releaseCycle: "115"
     lts: true
     releaseDate: 2023-07-04
-    eol: 2026-03-15 # extended becuase of support of Windows 7-8.1 and macOS 10.12-10.14 up to March 2026
+    eol: 2026-02-28 # https://support.mozilla.org/en-US/kb/firefox-users-windows-7-8-and-81-moving-extended-support
     latest: "115.32.1"
     latestReleaseDate: 2026-02-16
 


### PR DESCRIPTION
Updated the end of life (EOL) date for Firefox 115 due to changes in support policy.

https://support.mozilla.org/en-US/kb/firefox-users-windows-7-8-and-81-moving-extended-support