### PR TITLE
[New Product] Amazon ElastiCache for Redis OSS

### DIFF
--- a/products/amazon-elasticache-redis.md
+++ b/products/amazon-elasticache-redis.md
@@ -52,8 +52,9 @@ releases:
 > Redis OSS to Valkey 7.2 is [supported](https://docs.aws.amazon.com/AmazonElastiCache/latest/dg/VersionManagement.HowTo.html#VersionManagement.HowTo.cross-engine-upgrade).
 > A downgrade from Valkey 7.2 to Redis OSS 7.1 is also supported.
 
-Amazon ElastiCache for Redis OSS does not follow the same support lifecycle as open-source Redis.
+Amazon ElastiCache for Redis OSS does not follow the same support lifecycle as open-source Redis. 
+ElastiCache v7.1 is compatible with Redis OSS v7.0.
 
 After the end of standard support date, ElastiCache automatically enrolls clusters in 
 [Extended Support](https://docs.aws.amazon.com/AmazonElastiCache/latest/dg/extended-support.html)
-— a paid offering providing critical security fixes for up to 3 years, see.
+— a paid offering providing critical security fixes for up to 3 years.

--- a/products/amazon-elasticache-redis.md
+++ b/products/amazon-elasticache-redis.md
@@ -1,6 +1,6 @@
 ---
 title: Amazon ElastiCache for Redis OSS
-addedAt: 2026-02-23
+addedAt: 2026-03-01
 category: service
 tags: amazon database
 iconSlug: amazonelasticache

--- a/products/amazon-elasticache-redis.md
+++ b/products/amazon-elasticache-redis.md
@@ -26,21 +26,29 @@ releases:
     releaseDate: 2022-04-12
     eol: false
     eoes: false
+    latest: "7.1"
+    latestReleaseDate: 2023-11-14
 
   - releaseCycle: "6"
     releaseDate: 2020-10-13
     eol: 2027-01-31
     eoes: 2030-01-31
+    latest: "6.2"
+    latestReleaseDate: 2021-11-23
 
   - releaseCycle: "5"
     releaseDate: 2018-10-17
     eol: 2026-01-31
     eoes: 2029-01-31
+    latest: "5.0.6"
+    latestReleaseDate: 2019-12-18
 
   - releaseCycle: "4"
     releaseDate: 2017-11-17
     eol: 2026-01-31
     eoes: 2029-01-31
+    latest: "4.0.10"
+    latestReleaseDate: 2018-06-14
 ---
 
 > [Amazon ElastiCache for Redis OSS](https://aws.amazon.com/elasticache/redis/) is a fully managed,

--- a/products/amazon-elasticache-redis.md
+++ b/products/amazon-elasticache-redis.md
@@ -7,7 +7,7 @@ iconSlug: amazonelasticache
 permalink: /amazon-elasticache-redis
 releasePolicyLink: https://docs.aws.amazon.com/AmazonElastiCache/latest/dg/engine-versions.html
 latestColumn: false
-eolColumn: End of Standard Support
+eolColumn: Standard Support
 eoesColumn: Extended Support
 staleReleaseThresholdDays: 2000
 
@@ -46,10 +46,14 @@ releases:
 > [Amazon ElastiCache for Redis OSS](https://aws.amazon.com/elasticache/redis/) is a fully managed,
 > Redis OSS-compatible in-memory data store from Amazon Web Services.
 
-Amazon ElastiCache for Redis OSS does not follow the same support lifecycle as open-source Redis.
-Supported engine versions and their end-of-life schedule are documented in the
-[ElastiCache documentation](https://docs.aws.amazon.com/AmazonElastiCache/latest/dg/engine-versions.html).
+{: .note }
+> This page only tracks the Elasticache Redis OSS offering, and not the Valkey variant. The highest
+> upgrade possible for Redis OSS is 7.1. 7.2 and higher versions are Valkey only. An upgrade from
+> Redis OSS to Valkey 7.2 is [supported](https://docs.aws.amazon.com/AmazonElastiCache/latest/dg/VersionManagement.HowTo.html#VersionManagement.HowTo.cross-engine-upgrade).
+> A downgrade from Valkey 7.2 to Redis OSS 7.1 is also supported.
 
-After the end of standard support date, ElastiCache automatically enrolls clusters in Extended
-Support — a paid offering providing critical security fixes for up to 3 years, see
-[ElastiCache Extended Support](https://docs.aws.amazon.com/AmazonElastiCache/latest/dg/extended-support.html).
+Amazon ElastiCache for Redis OSS does not follow the same support lifecycle as open-source Redis.
+
+After the end of standard support date, ElastiCache automatically enrolls clusters in 
+[Extended Support](https://docs.aws.amazon.com/AmazonElastiCache/latest/dg/extended-support.html)
+— a paid offering providing critical security fixes for up to 3 years, see.

--- a/products/amazon-elasticache-redis.md
+++ b/products/amazon-elasticache-redis.md
@@ -1,0 +1,55 @@
+---
+title: Amazon ElastiCache for Redis OSS
+addedAt: 2026-02-23
+category: service
+tags: amazon database
+iconSlug: amazonelasticache
+permalink: /amazon-elasticache-redis
+releasePolicyLink: https://docs.aws.amazon.com/AmazonElastiCache/latest/dg/engine-versions.html
+latestColumn: false
+eolColumn: End of Standard Support
+eoesColumn: Extended Support
+staleReleaseThresholdDays: 2000
+
+auto:
+  methods:
+    - release_table: https://docs.aws.amazon.com/AmazonElastiCache/latest/dg/engine-versions.html
+      fields:
+        releaseCycle:
+          column: "Major Engine Version"
+          regex: '^Redis OSS v(?P<value>\d+(\.\d+)?)$'
+        eol: "End of Standard Support"
+        eoes: "End of Extended Support and version EOL"
+
+releases:
+  - releaseCycle: "7"
+    releaseDate: 2022-04-12
+    eol: false
+    eoes: false
+
+  - releaseCycle: "6"
+    releaseDate: 2020-10-13
+    eol: 2027-01-31
+    eoes: 2030-01-31
+
+  - releaseCycle: "5"
+    releaseDate: 2018-10-17
+    eol: 2026-01-31
+    eoes: 2029-01-31
+
+  - releaseCycle: "4"
+    releaseDate: 2017-11-17
+    eol: 2026-01-31
+    eoes: 2029-01-31
+---
+
+> [Amazon ElastiCache for Redis OSS](https://aws.amazon.com/elasticache/redis/) is a fully managed,
+> Redis OSS-compatible in-memory data store from Amazon Web Services.
+
+Amazon ElastiCache for Redis OSS does not follow the same support lifecycle as open-source Redis.
+Supported engine versions and their end-of-life schedule are documented in the
+[ElastiCache documentation](https://docs.aws.amazon.com/AmazonElastiCache/latest/dg/engine-versions.html).
+
+After the end of standard support date, ElastiCache automatically enrolls clusters in Extended
+Support — a paid offering providing critical security fixes for up to 3 years, see
+[ElastiCache Extended Support](https://docs.aws.amazon.com/AmazonElastiCache/latest/dg/extended-support.html).


### PR DESCRIPTION
Add tracking for Amazon ElastiCache for Redis OSS Extended Support lifecycle.

Covers Redis OSS engine versions 6.0, 6.2, 7.0, and 7.1 with their standard support end dates and Extended Support surcharge windows.

~Valkey and Memcached are excluded as they have no Extended Support program.~