### PR TITLE
[quarkus] Add 3.32 cycle and Update eol dates for 3.31

### DIFF
--- a/products/quarkus-framework.md
+++ b/products/quarkus-framework.md
@@ -34,9 +34,16 @@ auto:
 # - eol(x) = releaseDate(x)+1y for LTS
 # - For EOES see https://access.redhat.com/support/policy/updates/red_hat_build_of_quarkus_notes
 releases:
-  - releaseCycle: "3.31"
-    releaseDate: 2026-01-28
+  - releaseCycle: "3.32"
+    releaseDate: 2026-02-26
     eol: false
+    latest: "3.32.1"
+    latestReleaseDate: 2026-02-26
+    link: https://quarkus.io/blog/quarkus-3-32-released/
+
+- releaseCycle: "3.31"
+    releaseDate: 2026-01-28
+    eol: 2026-02-26
     latest: "3.31.4"
     latestReleaseDate: 2026-02-18
     link: https://quarkus.io/blog/quarkus-3-31-released/

--- a/products/quarkus-framework.md
+++ b/products/quarkus-framework.md
@@ -41,7 +41,7 @@ releases:
     latestReleaseDate: 2026-02-26
     link: https://quarkus.io/blog/quarkus-3-32-released/
 
-- releaseCycle: "3.31"
+  - releaseCycle: "3.31"
     releaseDate: 2026-01-28
     eol: 2026-02-26
     latest: "3.31.4"


### PR DESCRIPTION
# :grey_question: About

cf [tweet](https://x.com/QuarkusIO/status/2027036792080179292) (and [releaseNote](https://quarkus.io/blog/quarkus-3-32-released/))

<img width="604" height="326" alt="image" src="https://github.com/user-attachments/assets/a6d9e3df-0df8-4025-ac71-a354bd1dd6cd" />

# :information_source: More about this release (and next LTS to come  considerations)

> We strongly recommend upgrading to 3.32 soon so we can gather feedback and ensure the upcoming 3.33 LTS is as solid as possible.
> 
> If you are currently running 3.27 LTS, now is the right time to validate your upgrade path to 3.33 LTS, and let us know if you encounter any issues. Your feedback at this stage is especially valuable.

<img width="1126" height="486" alt="Screenshot_20260227_064620" src="https://github.com/user-attachments/assets/8d8be18f-1d54-4f77-8e5a-f5267c9951c6" />


