### PR TITLE
Add CPE identifiers to existing products

### DIFF
--- a/products/ansible.md
+++ b/products/ansible.md
@@ -39,6 +39,7 @@ identifiers:
   - purl: pkg:apk/alpine/ansible
   - purl: pkg:github/ansible/ansible
   - repology: ansible
+  - cpe: cpe:2.3:a:redhat:ansible
 
 auto:
   methods:

--- a/products/antix-linux.md
+++ b/products/antix-linux.md
@@ -12,6 +12,9 @@ releasePolicyLink: https://www.antixforum.com/forums/topic/when-is-end-of-suppor
 releaseLabel: "__RELEASE_CYCLE__ (__CODENAME__)"
 eoasColumn: true
 
+identifiers:
+  - cpe: cpe:2.3:o:antixlinux:antix_linux
+
 auto:
   methods:
     - distrowatch: antix

--- a/products/apache-airflow.md
+++ b/products/apache-airflow.md
@@ -19,6 +19,7 @@ identifiers:
   - purl: pkg:docker/bitnami/airflow
   - purl: pkg:oci/airflow?repository_url=cgr.dev/chainguard
   - purl: pkg:pypi/apache-airflow
+  - cpe: cpe:2.3:a:apache:airflow
 
 auto:
   methods:

--- a/products/apache-apisix.md
+++ b/products/apache-apisix.md
@@ -9,6 +9,9 @@ alternate_urls:
   - /apisix
 changelogTemplate: https://github.com/apache/apisix/releases/tag/__LATEST__
 
+identifiers:
+  - cpe: cpe:2.3:a:apache:apisix
+
 auto:
   methods:
     - github_releases: apache/apisix

--- a/products/apache-couchdb.md
+++ b/products/apache-couchdb.md
@@ -18,6 +18,7 @@ identifiers:
   - purl: pkg:docker/bitnami/couchdb
   - purl: pkg:docker/rapidfort/couchdb-official
   - repology: couchdb
+  - cpe: cpe:2.3:a:apache:couchdb
 
 auto:
   methods:

--- a/products/apache-lucene.md
+++ b/products/apache-lucene.md
@@ -10,6 +10,9 @@ alternate_urls:
 releasePolicyLink: https://lucene.apache.org/core/downloads.html
 changelogTemplate: "https://lucene.apache.org/core/{{'__LATEST__'|replace:'.','_'}}/changes/Changes.html"
 
+identifiers:
+  - cpe: cpe:2.3:a:apache:lucene
+
 auto:
   methods:
     - maven: org.apache.lucene/lucene-core

--- a/products/apache-nifi.md
+++ b/products/apache-nifi.md
@@ -12,6 +12,7 @@ eolColumn: Support
 
 identifiers:
   - repology: nifi
+  - cpe: cpe:2.3:a:apache:nifi
 
 auto:
   methods:

--- a/products/apache-pulsar.md
+++ b/products/apache-pulsar.md
@@ -12,6 +12,9 @@ changelogTemplate: https://pulsar.apache.org/release-notes/versioned/pulsar-__LA
 eolColumn: Active Support
 eoesColumn: Security Support
 
+identifiers:
+  - cpe: cpe:2.3:a:apache:pulsar
+
 auto:
   methods:
     - github_releases: apache/pulsar

--- a/products/backdrop.md
+++ b/products/backdrop.md
@@ -8,6 +8,9 @@ releasePolicyLink: https://backdropcms.org/releases
 releaseImage: https://backdropcms.org/files/images/release-cycles.png
 changelogTemplate: https://github.com/backdrop/backdrop/releases/tag/__LATEST__
 
+identifiers:
+  - cpe: cpe:2.3:a:backdropcms:backdrop_cms
+
 auto:
   methods:
     - github_releases: backdrop/backdrop

--- a/products/bigbluebutton.md
+++ b/products/bigbluebutton.md
@@ -9,6 +9,9 @@ alternate_urls:
 releasePolicyLink: https://github.com/bigbluebutton/bigbluebutton/security
 changelogTemplate: https://github.com/bigbluebutton/bigbluebutton/releases/tag/v__LATEST__
 
+identifiers:
+  - cpe: cpe:2.3:a:bigbluebutton:bigbluebutton
+
 auto:
   methods:
     - github_releases: bigbluebutton/bigbluebutton

--- a/products/boundary.md
+++ b/products/boundary.md
@@ -11,6 +11,7 @@ changelogTemplate: https://github.com/hashicorp/boundary/blob/release/__RELEASE_
 
 identifiers:
   - repology: boundary
+  - cpe: cpe:2.3:a:hashicorp:boundary
 
 auto:
   methods:

--- a/products/centreon.md
+++ b/products/centreon.md
@@ -10,6 +10,9 @@ changelogTemplate: "https://docs.centreon.com/docs/__RELEASE_CYCLE__/releases/ce
 eolColumn: OSS Support
 eoesColumn: Commercial Support
 
+identifiers:
+  - cpe: cpe:2.3:a:centreon:centreon
+
 auto:
   methods:
     - git: https://github.com/centreon/centreon.git

--- a/products/cilium.md
+++ b/products/cilium.md
@@ -14,6 +14,7 @@ identifiers:
   - purl: pkg:github/cilium/cilium
   - purl: pkg:docker/cilium/cilium
   - purl: pkg:docker/quay.io/cilium/cilium
+  - cpe: cpe:2.3:a:cilium:cilium
 
 auto:
   methods:

--- a/products/coder.md
+++ b/products/coder.md
@@ -13,6 +13,7 @@ identifiers:
   - repology: coder
   - purl: pkg:github/coder/coder
   - purl: pkg:generic/coder
+  - cpe: cpe:2.3:a:coder:code-server
 
 auto:
   methods:

--- a/products/commvault.md
+++ b/products/commvault.md
@@ -7,6 +7,9 @@ alternate_urls:
   - /commvault-backup
 releasePolicyLink: https://documentation.commvault.com/v11/software/commvault_software_releases_release_types_and_release_tracks.html
 
+identifiers:
+  - cpe: cpe:2.3:a:commvault:commvault
+
 auto:
   methods:
     - release_table: https://documentation.commvault.com/v11/software/commvault_software_releases_release_types_and_release_tracks.html

--- a/products/deno.md
+++ b/products/deno.md
@@ -13,6 +13,7 @@ identifiers:
   - purl: pkg:docker/denoland/deno
   - purl: pkg:github/denoland/deno
   - repology: deno
+  - cpe: cpe:2.3:a:deno:deno
 
 auto:
   methods:

--- a/products/dovecot.md
+++ b/products/dovecot.md
@@ -12,6 +12,7 @@ eoasColumn: Active Support
 
 identifiers:
   - repology: dovecot
+  - cpe: cpe:2.3:a:dovecot:dovecot
 
 auto:
   methods:

--- a/products/duckdb.md
+++ b/products/duckdb.md
@@ -11,6 +11,7 @@ eolColumn: Support Status
 
 identifiers:
   - repology: duckdb
+  - cpe: cpe:2.3:a:duckdb:duckdb
 
 auto:
   methods:

--- a/products/erlang.md
+++ b/products/erlang.md
@@ -12,6 +12,7 @@ eoasColumn: true
 
 identifiers:
   - repology: erlang
+  - cpe: cpe:2.3:a:erlang:erlang\/otp
 
 auto:
   methods:

--- a/products/erlang.md
+++ b/products/erlang.md
@@ -12,7 +12,6 @@ eoasColumn: true
 
 identifiers:
   - repology: erlang
-  - cpe: cpe:2.3:a:erlang:erlang\/otp
 
 auto:
   methods:

--- a/products/eslint.md
+++ b/products/eslint.md
@@ -19,6 +19,8 @@ customFields:
 
 identifiers:
   - repology: eslint
+  - cpe: cpe:2.3:a:openjsf:eslint
+  - cpe: cpe:2.3:a:microsoft:eslint
 
 auto:
   methods:

--- a/products/eslint.md
+++ b/products/eslint.md
@@ -19,8 +19,6 @@ customFields:
 
 identifiers:
   - repology: eslint
-  - cpe: cpe:2.3:a:openjsf:eslint
-  - cpe: cpe:2.3:a:microsoft:eslint
 
 auto:
   methods:

--- a/products/exim.md
+++ b/products/exim.md
@@ -8,6 +8,7 @@ changelogTemplate: https://github.com/Exim/exim/releases/tag/exim-__LATEST__
 
 identifiers:
   - repology: exim
+  - cpe: cpe:2.3:a:exim:exim
 
 auto:
   methods:

--- a/products/firefox.md
+++ b/products/firefox.md
@@ -15,6 +15,7 @@ identifiers:
   - purl: pkg:apk/alpine/firefox
   - purl: pkg:deb/debian/firefox-esr
   - purl: pkg:generic/firefox
+  - cpe: cpe:2.3:a:mozilla:firefox
 
 auto:
   # It takes too much time to fetch all versions.

--- a/products/flux.md
+++ b/products/flux.md
@@ -20,6 +20,7 @@ auto:
 
 identifiers:
   - repology: fluxcd
+  - cpe: cpe:2.3:a:fluxcd:flux2
 
 # eol(X) = releaseDate(X+3)
 releases:

--- a/products/font-awesome.md
+++ b/products/font-awesome.md
@@ -17,6 +17,7 @@ identifiers:
   - repology: fonts:fontawesome
   - purl: pkg:github/fortawesome/font-awesome
   - purl: pkg:npm/%40fortawesome/fontawesome-svg-core
+  - cpe: cpe:2.3:a:fontawesome:font_awesome
 
 releases:
   - releaseCycle: "7"

--- a/products/foreman.md
+++ b/products/foreman.md
@@ -10,6 +10,7 @@ changelogTemplate: https://theforeman.org/manuals/__RELEASE_CYCLE__/index.html#R
 
 identifiers:
   - repology: foreman
+  - cpe: cpe:2.3:a:theforeman:foreman
 
 auto:
   methods:

--- a/products/forgejo.md
+++ b/products/forgejo.md
@@ -24,6 +24,7 @@ auto:
 
 identifiers:
   - repology: forgejo
+  - cpe: cpe:2.3:a:forgejo:forgejo
 
 # eol dates: https://forgejo.org/releases/ or https://forgejo.org/docs/latest/admin/release-schedule/
 releases:

--- a/products/fortios.md
+++ b/products/fortios.md
@@ -11,6 +11,9 @@ latestColumn: false
 eolColumn: End of Support
 eoasColumn: End of Engineering Support
 
+identifiers:
+  - cpe: cpe:2.3:o:fortinet:fortios
+
 releases:
   - releaseCycle: "7.6"
     releaseDate: 2024-07-25

--- a/products/gatekeeper.md
+++ b/products/gatekeeper.md
@@ -17,6 +17,7 @@ identifiers:
   - purl: pkg:github/open-policy-agent/gatekeeper
   - purl: pkg:docker/openpolicyagent/gatekeeper
   - purl: pkg:oci/gatekeeper?repository_url=cgr.dev/chainguard
+  - cpe: cpe:2.3:a:openpolicyagent:gatekeeper
 
 # eol(x) = releaseDate(x+2)
 releases:

--- a/products/gerrit.md
+++ b/products/gerrit.md
@@ -12,6 +12,7 @@ eolColumn: "Support"
 identifiers:
   - purl: pkg:docker/gerritcodereview/gerrit
   - repology: gerrit
+  - cpe: cpe:2.3:a:google:gerrit
 
 auto:
   methods:

--- a/products/go.md
+++ b/products/go.md
@@ -21,6 +21,7 @@ identifiers:
   - purl: pkg:docker/bitnami/golang
   - purl: pkg:brew/go
   # - purl: pkg:snap/go
+  - cpe: cpe:2.3:a:golang:go
 
 auto:
   methods:

--- a/products/graalvm-ce.md
+++ b/products/graalvm-ce.md
@@ -11,6 +11,7 @@ changelogTemplate: "https://www.graalvm.org/release-notes/JDK___RELEASE_CYCLE__/
 
 identifiers:
   - repology: graalvm
+  - cpe: cpe:2.3:a:oracle:graalvm
 
 auto:
   methods:

--- a/products/grafana-loki.md
+++ b/products/grafana-loki.md
@@ -19,6 +19,7 @@ identifiers:
   - purl: pkg:docker/ubuntu/loki
   - purl: pkg:docker/bitnami/grafana-loki
   - purl: pkg:oci/loki?repository_url=cgr.dev/chainguard
+  - cpe: cpe:2.3:a:grafana:loki
 
 # eol(x) = releaseDate(x+2), except for the last minor of a major.
 releases:

--- a/products/grafana.md
+++ b/products/grafana.md
@@ -12,6 +12,7 @@ identifiers:
   - repology: grafana
   - purl: pkg:github/grafana/grafana
   - purl: pkg:golang/github.com/grafana/grafana
+  - cpe: cpe:2.3:a:grafana:grafana
 
 # See https://grafana.com/blog/2024/11/08/grafana-release-cycle-end-of-year-update/#grafana-security-releases-improved-version-naming-convention
 # https://regex101.com/r/2GkIJ5/1

--- a/products/greenlight.md
+++ b/products/greenlight.md
@@ -6,6 +6,9 @@ iconSlug: bigbluebutton
 permalink: /greenlight
 changelogTemplate: https://github.com/bigbluebutton/greenlight/releases/tag/release-__LATEST__
 
+identifiers:
+  - cpe: cpe:2.3:a:bigbluebutton:greenlight
+
 auto:
   methods:
     - git: https://github.com/bigbluebutton/greenlight.git

--- a/products/haproxy.md
+++ b/products/haproxy.md
@@ -21,6 +21,7 @@ identifiers:
   - purl: pkg:rpm/redhat/haproxy
   - purl: pkg:rpm/centos/haproxy
   - purl: pkg:apk/alpine/haproxy
+  - cpe: cpe:2.3:a:haproxy:haproxy
 
 # releaseCycle, releaseDate, lts, eol and latest are listed on https://www.haproxy.org/
 # eol dates noted as Q1-4 set to: Q1 -> YYYY-01-01, Q2 -> YYYY-04-01, Q3 -> YYYY-07-01, Q4 -> YYYY-10-01

--- a/products/harbor.md
+++ b/products/harbor.md
@@ -41,6 +41,7 @@ identifiers:
   - purl: pkg:oci/harbor-core?repository_url=quay.io/goharbor
   - purl: pkg:oci/harbor-portal?repository_url=quay.io/goharbor
   - purl: pkg:oci/harbor-jobservice?repository_url=quay.io/goharbor
+  - cpe: cpe:2.3:a:linuxfoundation:harbor
 
 auto:
   methods:

--- a/products/hashicorp-packer.md
+++ b/products/hashicorp-packer.md
@@ -14,6 +14,7 @@ versionCommand: packer --version
 
 identifiers:
   - repology: packer
+  - cpe: cpe:2.3:a:hashicorp:packer
 
 auto:
   methods:

--- a/products/icinga-web.md
+++ b/products/icinga-web.md
@@ -17,6 +17,7 @@ identifiers:
   - purl: pkg:docker/icinga/icingaweb2
   - purl: pkg:github/Icinga/icingaweb2
   - purl: pkg:github/Icinga/icinga-web
+  - cpe: cpe:2.3:a:icinga:icinga_web_2
 
 auto:
   methods:

--- a/products/icinga.md
+++ b/products/icinga.md
@@ -15,6 +15,7 @@ identifiers:
   - purl: pkg:docker/icinga/icinga2
   - purl: pkg:github/Icinga/icinga2
   - purl: pkg:github/Icinga/icinga-core
+  - cpe: cpe:2.3:a:icinga:icinga
 
 auto:
   methods:

--- a/products/influxdb.md
+++ b/products/influxdb.md
@@ -14,6 +14,7 @@ eoasColumn: false
 
 identifiers:
   - repology: influxdb
+  - cpe: cpe:2.3:a:influxdata:influxdb
 
 auto:
   methods:

--- a/products/istio.md
+++ b/products/istio.md
@@ -29,6 +29,7 @@ identifiers:
   - purl: pkg:docker/istio/proxyv2
   - purl: pkg:docker/istio/operator
   - purl: pkg:github/istio/istio
+  - cpe: cpe:2.3:a:istio:istio
 
 auto:
   methods:

--- a/products/jaeger.md
+++ b/products/jaeger.md
@@ -10,6 +10,7 @@ eolColumn: Security Support
 
 identifiers:
   - repology: jaeger
+  - cpe: cpe:2.3:a:linuxfoundation:jaeger
 
 auto:
   methods:

--- a/products/joomla.md
+++ b/products/joomla.md
@@ -11,6 +11,7 @@ eoasColumn: true
 
 identifiers:
   - repology: joomla
+  - cpe: cpe:2.3:a:joomla:joomla\!
 
 auto:
   methods:

--- a/products/joomla.md
+++ b/products/joomla.md
@@ -11,7 +11,6 @@ eoasColumn: true
 
 identifiers:
   - repology: joomla
-  - cpe: cpe:2.3:a:joomla:joomla\!
 
 auto:
   methods:

--- a/products/jquery.md
+++ b/products/jquery.md
@@ -15,6 +15,7 @@ identifiers:
   - purl: pkg:nuget/jQuery
   - repology: jquery
   - repology: js-jquery
+  - cpe: cpe:2.3:a:jquery:jquery
 
 # NPM is also possible, but versions up to 1.10.2 and between 2.0.0 to 2.0.3 are not on
 # https://www.npmjs.com/package/jquery, so better it's better to keep git.

--- a/products/julia.md
+++ b/products/julia.md
@@ -15,6 +15,7 @@ auto:
     - git: https://github.com/JuliaLang/julia.git
 identifiers:
   - repology: julia
+  - cpe: cpe:2.3:a:julialang:julia
 
 releases:
   - releaseCycle: "1.12"

--- a/products/keycloak.md
+++ b/products/keycloak.md
@@ -12,6 +12,7 @@ eolColumn: Supported
 identifiers:
   - purl: pkg:github/keycloak/keycloak
   - repology: keycloak
+  - cpe: cpe:2.3:a:redhat:keycloak
 
 auto:
   methods:

--- a/products/kong-gateway.md
+++ b/products/kong-gateway.md
@@ -18,6 +18,7 @@ auto:
 
 identifiers:
   - purl: pkg:github/Kong/kong
+  - cpe: cpe:2.3:a:konghq:kong_gateway
 
 # Policy is not clear, maybe a more precise answer will be available someday on
 # https://discuss.konghq.com/t/question-about-the-support-policy-on-kong-community/11891.

--- a/products/kubernetes.md
+++ b/products/kubernetes.md
@@ -16,6 +16,7 @@ eolColumn: Maintenance Support
 identifiers:
   - purl: pkg:github/kubernetes/kubernetes
   - repology: kubernetes
+  - cpe: cpe:2.3:a:kubernetes:kubernetes
 
 auto:
   methods:

--- a/products/laravel.md
+++ b/products/laravel.md
@@ -21,6 +21,7 @@ identifiers:
   - purl: pkg:docker/bitnami/laravel
   - purl: pkg:github/laravel/framework
   - repology: php:laravel-framework
+  - cpe: cpe:2.3:a:laravel:laravel
 
 # Note that laravel/laravel is just a starter application.
 auto:

--- a/products/ldap-account-manager.md
+++ b/products/ldap-account-manager.md
@@ -10,6 +10,7 @@ changelogTemplate: https://github.com/LDAPAccountManager/lam/releases/tag/__LATE
 
 identifiers:
   - repology: ldap-account-manager
+  - cpe: cpe:2.3:a:ldap-account-manager:ldap_account_manager
 
 auto:
   methods:

--- a/products/linuxmint.md
+++ b/products/linuxmint.md
@@ -12,6 +12,9 @@ latestColumn: false
 releasePolicyLink: https://linuxmint.com/download_all.php
 releaseLabel: "__RELEASE_CYCLE__ '__CODENAME__'"
 
+identifiers:
+  - cpe: cpe:2.3:o:linuxmint:linuxmint
+
 auto:
   methods:
     - release_table: https://linuxmint.com/download_all.php

--- a/products/liquibase.md
+++ b/products/liquibase.md
@@ -10,6 +10,7 @@ changelogTemplate: https://github.com/liquibase/liquibase/releases/tag/v__LATEST
 
 identifiers:
   - repology: liquibase
+  - cpe: cpe:2.3:a:liquibase:liquibase
 
 auto:
   methods:

--- a/products/looker.md
+++ b/products/looker.md
@@ -10,6 +10,9 @@ LTSLabel: "<abbr title='Extended Support Release'>ESR</abbr>"
 eolColumn: Support Status
 latestColumn: false
 
+identifiers:
+  - cpe: cpe:2.3:a:google:looker
+
 # Used only for detecting new minor releases.
 auto:
   methods:

--- a/products/mariadb.md
+++ b/products/mariadb.md
@@ -24,6 +24,7 @@ identifiers:
   - purl: pkg:rpm/redhat/mariadb-server
   - purl: pkg:rpm/centos/mariadb-server
   - purl: pkg:rpm/opensuse/mariadb
+  - cpe: cpe:2.3:a:mariadb:mariadb
 
 auto:
   methods:

--- a/products/matomo.md
+++ b/products/matomo.md
@@ -22,6 +22,7 @@ identifiers:
   - purl: pkg:docker/library/matomo
   - purl: pkg:docker/bitnami/matomo
   - purl: pkg:github/matomo-org/matomo
+  - cpe: cpe:2.3:a:matomo:matomo
 
 # eoas(x) = releaseDate(x+1)
 # eol(x) documented on https://matomo.org/blog/2016/01/announcing-long-term-support-in-matomo-the-analytics-platform-for-your-mission-critical-projects/

--- a/products/mattermost.md
+++ b/products/mattermost.md
@@ -26,6 +26,7 @@ auto:
 
 identifiers:
   - repology: mattermost
+  - cpe: cpe:2.3:a:mattermost:mattermost_server
 
 # releaseDate and eol see: https://docs.mattermost.com/about/mattermost-server-releases.html
 releases:

--- a/products/memcached.md
+++ b/products/memcached.md
@@ -15,6 +15,7 @@ identifiers:
   - purl: pkg:rpm/centos/memcached
   - purl: pkg:docker/library/memcached
   - repology: memcached
+  - cpe: cpe:2.3:a:memcached:memcached
 
 auto:
   methods:

--- a/products/mongodb.md
+++ b/products/mongodb.md
@@ -24,6 +24,7 @@ identifiers:
   - purl: pkg:rpm/redhat/mongodb-enterprise-server
   - purl: pkg:rpm/centos/mongodb-enterprise-server
   - repology: mongodb
+  - cpe: cpe:2.3:a:mongodb:mongodb
 
 auto:
   methods:

--- a/products/mysql.md
+++ b/products/mysql.md
@@ -32,6 +32,7 @@ identifiers:
   - purl: pkg:docker/library/mysql
   - purl: pkg:deb/ubuntu/mysql-server
   - purl: pkg:deb/debian/mysql
+  - cpe: cpe:2.3:a:oracle:mysql
 
 # For LTS: see https://www.oracle.com/us/support/library/lifetime-support-technology-069183.pdf
 # For Non-LTS (Innovation): eoas(x)/eol(x) = releaseDate(x+1)

--- a/products/neo4j.md
+++ b/products/neo4j.md
@@ -12,6 +12,7 @@ eolColumn: Support Status
 
 identifiers:
   - purl: pkg:github/neo4j/neo4j
+  - cpe: cpe:2.3:a:neo4j:neo4j
 
 auto:
   methods:

--- a/products/neos.md
+++ b/products/neos.md
@@ -13,6 +13,7 @@ eoasColumn: true
 
 identifiers:
   - purl: pkg:composer/neos/neos
+  - cpe: cpe:2.3:a:neos:neos_cms
 
 auto:
   methods:

--- a/products/nextcloud.md
+++ b/products/nextcloud.md
@@ -9,6 +9,9 @@ versionCommand: su -m www -c 'php $WEBROOT/occ config:system:get version'
 releasePolicyLink: https://github.com/nextcloud/server/wiki/Maintenance-and-Release-Schedule
 changelogTemplate: "https://nextcloud.com/changelog/#latest__RELEASE_CYCLE__"
 
+identifiers:
+  - cpe: cpe:2.3:a:nextcloud:nextcloud_server
+
 auto:
   methods:
     - git: https://github.com/nextcloud/server.git

--- a/products/nexus.md
+++ b/products/nexus.md
@@ -16,6 +16,7 @@ eolColumn: Extended Maintenance
 
 identifiers:
   - purl: pkg:github/sonatype/nexus-public
+  - cpe: cpe:2.3:a:sonatype:nexus_repository_manager
 
 auto:
   methods:

--- a/products/numpy.md
+++ b/products/numpy.md
@@ -12,6 +12,7 @@ changelogTemplate: https://github.com/numpy/numpy/releases/tag/v__LATEST__
 identifiers:
   - purl: pkg:pypi/numpy
   - purl: pkg:github/numpy/numpy
+  - cpe: cpe:2.3:a:numpy:numpy
 
 auto:
   methods:

--- a/products/openbsd.md
+++ b/products/openbsd.md
@@ -9,6 +9,9 @@ versionCommand: uname -r
 changelogTemplate: "https://www.openbsd.org/{{'__RELEASE_CYCLE__'|replace:'.',''}}.html"
 latestColumn: false
 
+identifiers:
+  - cpe: cpe:2.3:o:openbsd:openbsd
+
 # eol(x) = releaseDate(x+2), Estimation releaseDate(x) + 1 year -> round to the first of next month
 releases:
   - releaseCycle: "7.8"

--- a/products/opensearch.md
+++ b/products/opensearch.md
@@ -31,6 +31,7 @@ auto:
 identifiers:
   - repology: opensearch
   - purl: pkg:docker/opensearchproject/opensearch
+  - cpe: cpe:2.3:a:amazon:opensearch
     
 releases:
   - releaseCycle: "3"

--- a/products/phpmyadmin.md
+++ b/products/phpmyadmin.md
@@ -24,6 +24,7 @@ identifiers:
   - purl: pkg:rpm/redhat/phpmyadmin
   - purl: pkg:rpm/centos/phpmyadmin
   - purl: pkg:docker/library/phpmyadmin
+  - cpe: cpe:2.3:a:phpmyadmin:phpmyadmin
 
 releases:
   - releaseCycle: "5.2"

--- a/products/pigeonhole.md
+++ b/products/pigeonhole.md
@@ -10,6 +10,7 @@ changelogTemplate: https://github.com/dovecot/pigeonhole/releases/tag/__LATEST__
 
 identifiers:
   - repology: dovecot-pigeonhole
+  - cpe: cpe:2.3:a:dovecot:pigeonhole
 
 auto:
   methods:

--- a/products/plone.md
+++ b/products/plone.md
@@ -18,6 +18,7 @@ customFields:
 
 identifiers:
   - repology: plone
+  - cpe: cpe:2.3:a:plone:plone
 
 auto:
   methods:

--- a/products/pnpm.md
+++ b/products/pnpm.md
@@ -13,6 +13,7 @@ eolColumn: Support
 identifiers:
   - purl: pkg:npm/pnpm
   - repology: pnpm
+  - cpe: cpe:2.3:a:pnpm:pnpm
 
 auto:
   methods:

--- a/products/podman.md
+++ b/products/podman.md
@@ -10,6 +10,7 @@ changelogTemplate: "https://github.com/containers/podman/releases/tag/v__LATEST_
 
 identifiers:
   - repology: podman
+  - cpe: cpe:2.3:a:podman_project:podman
 
 auto:
   methods:

--- a/products/powershell.md
+++ b/products/powershell.md
@@ -17,6 +17,7 @@ eolColumn: Support Status
 identifiers:
   - purl: pkg:github/powershell/powershell
   - repology: powershell
+  - cpe: cpe:2.3:a:microsoft:powershell
 
 customFields:
   - name: dotnetVersion

--- a/products/privatebin.md
+++ b/products/privatebin.md
@@ -12,6 +12,7 @@ auto:
 
 identifiers:
   - repology: privatebin
+  - cpe: cpe:2.3:a:privatebin:privatebin
 
 # eol(x) = releaseDate(x+1)
 releases:

--- a/products/proftpd.md
+++ b/products/proftpd.md
@@ -11,6 +11,7 @@ eoasColumn: Stable Support
 
 identifiers:
   - repology: proftpd
+  - cpe: cpe:2.3:a:proftpd:proftpd
 
 auto:
   methods:

--- a/products/prometheus.md
+++ b/products/prometheus.md
@@ -17,6 +17,7 @@ identifiers:
   - purl: pkg:oci/prometheus?repository_url=cgr.dev/chainguard
   - purl: pkg:github/prometheus/prometheus
   - purl: pkg:golang/github.com/prometheus/prometheus
+  - cpe: cpe:2.3:a:prometheus:prometheus
 
 auto:
   methods:

--- a/products/rancher.md
+++ b/products/rancher.md
@@ -16,6 +16,7 @@ eolColumn: Limited Support
 identifiers:
   - purl: pkg:docker/rancher/rancher
   - repology: rancher
+  - cpe: cpe:2.3:a:suse:rancher
 
 auto:
   methods:

--- a/products/react-native.md
+++ b/products/react-native.md
@@ -12,6 +12,7 @@ eoasColumn: true
 identifiers:
   - purl: pkg:github/facebook/react-native
   - purl: pkg:npm/react-native
+  - cpe: cpe:2.3:a:facebook:react-native
 
 # NPM dates are more accurate than git tag dates.
 auto:

--- a/products/react.md
+++ b/products/react.md
@@ -13,6 +13,7 @@ staleReleaseThresholdDays: 2190 # https://react.dev/community/versioning-policy#
 identifiers:
   - purl: pkg:github/facebook/react
   - purl: pkg:npm/react
+  - cpe: cpe:2.3:a:facebook:react
 
 # NPM dates are more accurate than git tag dates.
 auto:

--- a/products/redis.md
+++ b/products/redis.md
@@ -24,6 +24,7 @@ identifiers:
   - purl: pkg:docker/ubuntu/redis
   - purl: pkg:brew/redis/redis
   - repology: redis
+  - cpe: cpe:2.3:a:redis:redis
 
 auto:
   methods:

--- a/products/roundcube.md
+++ b/products/roundcube.md
@@ -12,6 +12,7 @@ eolColumn: Security Support
 
 identifiers:
   - repology: roundcube
+  - cpe: cpe:2.3:a:roundcube:webmail
 
 auto:
   methods:

--- a/products/ruby-on-rails.md
+++ b/products/ruby-on-rails.md
@@ -19,6 +19,7 @@ identifiers:
   - repology: ruby:rails
   - purl: pkg:gem/rails
   - purl: pkg:github/rails/rails
+  - cpe: cpe:2.3:a:rubyonrails:rails
 
 auto:
   methods:

--- a/products/ruby.md
+++ b/products/ruby.md
@@ -24,6 +24,7 @@ identifiers:
   - repology: ruby
   - purl: pkg:docker/library/ruby
   - purl: pkg:generic/ruby
+  - cpe: cpe:2.3:a:ruby-lang:ruby
 
 releases:
   - releaseCycle: "4.0"

--- a/products/rust.md
+++ b/products/rust.md
@@ -19,6 +19,7 @@ auto:
 
 identifiers:
   - repology: rust
+  - cpe: cpe:2.3:a:rust-lang:rust
 
 # eol(x) = releaseDate(x+1)
 releases:

--- a/products/salt.md
+++ b/products/salt.md
@@ -35,6 +35,7 @@ identifiers:
   - repology: salt
   - purl: pkg:oci/docker-salt-master?repository_url=ghcr.io/cdalvaro
   - purl: pkg:docker/saltstack/salt
+  - cpe: cpe:2.3:a:saltstack:salt
 
 # link(x) =
 # - latest version: https://docs.saltproject.io/en/latest/topics/releases/__LATEST__.html

--- a/products/sonarqube-community.md
+++ b/products/sonarqube-community.md
@@ -14,6 +14,7 @@ eolColumn: Support
 
 identifiers:
   - repology: sonarqube
+  - cpe: cpe:2.3:a:sonarsource:sonarqube
 
 auto:
   methods:

--- a/products/sourcegraph.md
+++ b/products/sourcegraph.md
@@ -11,6 +11,7 @@ eolColumn: Support
 
 identifiers:
   - purl: pkg:docker/sourcegraph/sg
+  - cpe: cpe:2.3:a:sourcegraph:sourcegraph
 
 auto:
   methods:

--- a/products/splunk.md
+++ b/products/splunk.md
@@ -11,6 +11,7 @@ changelogTemplate: https://help.splunk.com/en/splunk-enterprise/release-notes-an
 
 identifiers:
   - repology: splunk
+  - cpe: cpe:2.3:a:splunk:splunk
 
 auto:
   disabled: true # there are anti-bot protection measures on https://docs.splunk.com

--- a/products/sqlite.md
+++ b/products/sqlite.md
@@ -16,6 +16,7 @@ identifiers:
   - purl: pkg:generic/sqlite
   - purl: pkg:apk/alpine/sqlite
   - purl: pkg:github/sqlite/sqlite
+  - cpe: cpe:2.3:a:sqlite:sqlite
 
 # This git mirror only contains versions from 3.6.10.
 auto:

--- a/products/squid.md
+++ b/products/squid.md
@@ -17,6 +17,7 @@ identifiers:
   - purl: pkg:rpm/redhat/squid
   - purl: pkg:rpm/centos/squid
   - purl: pkg:apk/alpine/squid
+  - cpe: cpe:2.3:a:squid-cache:squid
 
 # v4+ has stable releases as major.minor
 # v2,3 had stable releases as major.minor.patch, where patch=0 was for RC releases.

--- a/products/statamic.md
+++ b/products/statamic.md
@@ -25,6 +25,7 @@ customFields:
 identifiers:
   - purl: pkg:composer/statamic/cms
   - purl: pkg:github/statamic/cms
+  - cpe: cpe:2.3:a:statamic:statamic
 
 auto:
   methods:

--- a/products/svelte.md
+++ b/products/svelte.md
@@ -17,6 +17,7 @@ auto:
 identifiers:
   - purl: pkg:npm/svelte
   - purl: pkg:github/sveltejs/svelte
+  - cpe: cpe:2.3:a:svelte:svelte
 
 releases:
   - releaseCycle: "5"

--- a/products/tails.md
+++ b/products/tails.md
@@ -8,6 +8,9 @@ permalink: /tails
 versionCommand: cat /etc/amnesia/version
 changelogTemplate: https://tails.net/news/version___LATEST__/
 
+identifiers:
+  - cpe: cpe:2.3:o:tails_project:tails
+
 # We fetch dates from Git and then override a few
 # older releases with more accurate dates from distrowatch
 # pre-1.3 releases were tagged later, so git data isn't accurate for those.

--- a/products/teleport.md
+++ b/products/teleport.md
@@ -11,6 +11,7 @@ eoasColumn: true
 identifiers:
   - purl: pkg:github/gravitational/teleport
   - repology: teleport
+  - cpe: cpe:2.3:a:goteleport:teleport
 
 auto:
   methods:

--- a/products/terraform.md
+++ b/products/terraform.md
@@ -13,6 +13,7 @@ identifiers:
   - repology: terraform
   - purl: pkg:github/hashicorp/terraform
   - purl: pkg:generic/terraform
+  - cpe: cpe:2.3:a:hashicorp:terraform
 
 auto:
   methods:

--- a/products/tomcat.md
+++ b/products/tomcat.md
@@ -20,6 +20,7 @@ identifiers:
   - repology: tomcat
   - purl: pkg:maven/org.apache.tomcat/tomcat
   - purl: pkg:github/apache/tomcat
+  - cpe: cpe:2.3:a:apache:tomcat
 
 auto:
   methods:

--- a/products/typo3.md
+++ b/products/typo3.md
@@ -13,6 +13,7 @@ eoesColumn: Extended Long Term Support
 identifiers:
   - repology: typo3
   - purl: pkg:composer/typo3/cms
+  - cpe: cpe:2.3:a:typo3:typo3
 
 auto:
   methods:

--- a/products/valkey.md
+++ b/products/valkey.md
@@ -14,6 +14,7 @@ identifiers:
   - repology: valkey
   - purl: pkg:github/valkey-io/valkey
   - purl: pkg:docker/valkey/valkey
+  - cpe: cpe:2.3:a:lfprojects:valkey
 
 auto:
   methods:

--- a/products/vitess.md
+++ b/products/vitess.md
@@ -18,6 +18,7 @@ identifiers:
   - purl: pkg:github/vitessio/vitess
   - purl: pkg:docker/vitess/lite
   - repology: vitess
+  - cpe: cpe:2.3:a:linuxfoundation:vitess
 
 # eol(x) = releaseDate(x) + 1 year
 releases:

--- a/products/wagtail.md
+++ b/products/wagtail.md
@@ -13,6 +13,7 @@ eoasColumn: true
 identifiers:
   - repology: python:wagtail
   - purl: pkg:pypi/wagtail
+  - cpe: cpe:2.3:a:torchbox:wagtail
 
 auto:
   methods:


### PR DESCRIPTION
I used [NIST's NVD CPE Dictionary](https://nvd.nist.gov/products/cpe) (via their [Product API](https://nvd.nist.gov/developers/products)) to find CPEs for products that had none.

I ensured that the CPE references (JSON `refs` field) was consistent with the various URLs found in the product.md file.

I added the CPE identifier only I was 100% it was the right one ; no CPE was forged or guessed (no AI was used).

I only added the CPE identifiers in their FS/formatted-string bound form (`cpe:2.3:...`) because that's the only one provided by the NIST API (no URI form `cpe:/...`).
