### PR TITLE
Added purls from purl2cpe

### DIFF
--- a/_plugins/identifier-to-url.rb
+++ b/_plugins/identifier-to-url.rb
@@ -47,10 +47,6 @@ class IdentifierToUrl
       raise "Unsupported identifier type: #{type}"
     end
   end
-  
-  def _build_apache_url(purl)
-    return "https://#{purl.name.downcase}.apache.org/"
-  end
 
   def _build_repology_url(identifier)
     return "https://repology.org/project/#{identifier}"

--- a/_plugins/identifier-to-url.rb
+++ b/_plugins/identifier-to-url.rb
@@ -58,8 +58,8 @@ class IdentifierToUrl
 
   def _build_docker_url(purl)
     raise "Unsupported docker PURL #{purl}: no namespace specified" unless purl.namespace
-    name = purl.namespace == 'library' ? "_/#{purl.name}" : "#{purl.namespace}/#{purl.name}" # avoid redirects
-    return "https://hub.docker.com/r/#{name}"
+    name = purl.namespace == 'library' ? "_/#{purl.name}" : "r/#{purl.namespace}/#{purl.name}" # avoid redirects
+    return "https://hub.docker.com/#{name}"
   end
 
   def _build_github_url(purl)

--- a/_plugins/identifier-to-url.rb
+++ b/_plugins/identifier-to-url.rb
@@ -47,6 +47,10 @@ class IdentifierToUrl
       raise "Unsupported identifier type: #{type}"
     end
   end
+  
+  def _build_apache_url(purl)
+    return "https://#{purl.name.downcase}.apache.org/"
+  end
 
   def _build_repology_url(identifier)
     return "https://repology.org/project/#{identifier}"

--- a/products/akeneo-pim.md
+++ b/products/akeneo-pim.md
@@ -12,6 +12,7 @@ eolColumn: Support
 identifiers:
   - cpe: cpe:/a:akeneo:product_information_management
   - cpe: cpe:2.3:a:akeneo:product_information_management
+  - purl: pkg:github/akeneo/pim-community-dev
 
 auto:
   methods:

--- a/products/amazon-corretto.md
+++ b/products/amazon-corretto.md
@@ -14,6 +14,9 @@ changelogTemplate: https://github.com/corretto/corretto-__RELEASE_CYCLE__/releas
 identifiers:
   - cpe: cpe:/a:amazon:corretto
   - cpe: cpe:2.3:a:amazon:corretto
+  - purl: pkg:docker/amazoncorretto
+  - purl: pkg:github/corretto/corretto-11
+  - purl: pkg:github/corretto/corretto-8
 
 # There is one repository for each major release (except for 15 and 16).
 # Both tag and GitHub release dates are usually wrong, but GitHub release dates are closer to the correct date.

--- a/products/amazon-corretto.md
+++ b/products/amazon-corretto.md
@@ -14,7 +14,7 @@ changelogTemplate: https://github.com/corretto/corretto-__RELEASE_CYCLE__/releas
 identifiers:
   - cpe: cpe:/a:amazon:corretto
   - cpe: cpe:2.3:a:amazon:corretto
-  - purl: pkg:docker/amazoncorretto
+  - purl: pkg:docker/library/amazoncorretto
   - purl: pkg:github/corretto/corretto-11
   - purl: pkg:github/corretto/corretto-8
 

--- a/products/amazon-corretto.md
+++ b/products/amazon-corretto.md
@@ -15,6 +15,16 @@ identifiers:
   - cpe: cpe:/a:amazon:corretto
   - cpe: cpe:2.3:a:amazon:corretto
   - purl: pkg:docker/library/amazoncorretto
+  - purl: pkg:github/corretto/corretto-26
+  - purl: pkg:github/corretto/corretto-25
+  - purl: pkg:github/corretto/corretto-24
+  - purl: pkg:github/corretto/corretto-23
+  - purl: pkg:github/corretto/corretto-22
+  - purl: pkg:github/corretto/corretto-21
+  - purl: pkg:github/corretto/corretto-20
+  - purl: pkg:github/corretto/corretto-19
+  - purl: pkg:github/corretto/corretto-18
+  - purl: pkg:github/corretto/corretto-17
   - purl: pkg:github/corretto/corretto-11
   - purl: pkg:github/corretto/corretto-8
 

--- a/products/android.md
+++ b/products/android.md
@@ -23,7 +23,6 @@ customFields:
 identifiers:
   - cpe: cpe:/o:google:android
   - cpe: cpe:2.3:o:google:android
-  - purl: pkg:googlesource/android
 
 # EOL is the latest security patch date for "Old version" on https://en.wikipedia.org/wiki/Android_version_history.
 releases:

--- a/products/android.md
+++ b/products/android.md
@@ -23,7 +23,6 @@ customFields:
 identifiers:
   - cpe: cpe:/o:google:android
   - cpe: cpe:2.3:o:google:android
-  - purl: pkg:github/aosp-mirror
   - purl: pkg:googlesource/android
 
 # EOL is the latest security patch date for "Old version" on https://en.wikipedia.org/wiki/Android_version_history.

--- a/products/android.md
+++ b/products/android.md
@@ -23,6 +23,8 @@ customFields:
 identifiers:
   - cpe: cpe:/o:google:android
   - cpe: cpe:2.3:o:google:android
+  - purl: pkg:github/aosp-mirror
+  - purl: pkg:googlesource/android
 
 # EOL is the latest security patch date for "Old version" on https://en.wikipedia.org/wiki/Android_version_history.
 releases:

--- a/products/apache-activemq-artemis.md
+++ b/products/apache-activemq-artemis.md
@@ -13,6 +13,7 @@ versionCommand: artemis version
 
 identifiers:
   - repology: activemq-artemis
+  - purl: pkg:github/apache/activemq-artemis
 
 auto:
   methods:

--- a/products/apache-ant.md
+++ b/products/apache-ant.md
@@ -17,7 +17,6 @@ identifiers:
   - purl: pkg:deb/debian/ant
   - purl: pkg:deb/ubuntu/ant
   - purl: pkg:github/apache/ant
-  - purl: pkg:github/uriziel47/ant
   - purl: pkg:maven/org.apache.ant/ant
   - purl: pkg:rpm/fedora/ant
 

--- a/products/apache-ant.md
+++ b/products/apache-ant.md
@@ -14,6 +14,13 @@ identifiers:
   - cpe: cpe:/a:apache:ant
   - cpe: cpe:2.3:a:apache:ant
   - repology: ant
+  - purl: pkg:apache/ant
+  - purl: pkg:deb/debian/ant
+  - purl: pkg:deb/ubuntu/ant
+  - purl: pkg:github/apache/ant
+  - purl: pkg:github/uriziel47/ant
+  - purl: pkg:maven/org.apache.ant/ant
+  - purl: pkg:rpm/fedora/ant
 
 auto:
   methods:

--- a/products/apache-ant.md
+++ b/products/apache-ant.md
@@ -14,7 +14,6 @@ identifiers:
   - cpe: cpe:/a:apache:ant
   - cpe: cpe:2.3:a:apache:ant
   - repology: ant
-  - purl: pkg:apache/ant
   - purl: pkg:deb/debian/ant
   - purl: pkg:deb/ubuntu/ant
   - purl: pkg:github/apache/ant

--- a/products/apache-camel.md
+++ b/products/apache-camel.md
@@ -21,7 +21,6 @@ customFields:
 identifiers:
   - cpe: cpe:/a:apache:camel
   - cpe: cpe:2.3:a:apache:camel
-  - purl: pkg:apache/camel
   - purl: pkg:docker/apache/camel
   - purl: pkg:github/apache/camel
   - purl: pkg:maven/org.apache.camel/camel

--- a/products/apache-camel.md
+++ b/products/apache-camel.md
@@ -21,6 +21,10 @@ customFields:
 identifiers:
   - cpe: cpe:/a:apache:camel
   - cpe: cpe:2.3:a:apache:camel
+  - purl: pkg:apache/camel
+  - purl: pkg:docker/apache/camel
+  - purl: pkg:github/apache/camel
+  - purl: pkg:maven/org.apache.camel/camel
 
 auto:
   methods:

--- a/products/apache-cassandra.md
+++ b/products/apache-cassandra.md
@@ -14,7 +14,6 @@ identifiers:
   - repology: cassandra
   - cpe: cpe:/a:apache:cassandra
   - cpe: cpe:2.3:a:apache:cassandra
-  - purl: pkg:apache/cassandra
   - purl: pkg:github/apache/cassandra
   - purl: pkg:maven/org.apache.cassandra/apache-cassandra
   - purl: pkg:maven/org.apache.cassandra/cassandra

--- a/products/apache-cassandra.md
+++ b/products/apache-cassandra.md
@@ -14,7 +14,12 @@ identifiers:
   - repology: cassandra
   - cpe: cpe:/a:apache:cassandra
   - cpe: cpe:2.3:a:apache:cassandra
-
+  - purl: pkg:apache/cassandra
+  - purl: pkg:github/apache/cassandra
+  - purl: pkg:maven/org.apache.cassandra/apache-cassandra
+  - purl: pkg:maven/org.apache.cassandra/cassandra
+  - purl: pkg:maven/org.apache.cassandra/cassandra-parent
+  
 auto:
   methods:
     - git: https://github.com/apache/cassandra.git

--- a/products/apache-cassandra.md
+++ b/products/apache-cassandra.md
@@ -17,7 +17,6 @@ identifiers:
   - purl: pkg:github/apache/cassandra
   - purl: pkg:maven/org.apache.cassandra/apache-cassandra
   - purl: pkg:maven/org.apache.cassandra/cassandra
-  - purl: pkg:maven/org.apache.cassandra/cassandra-parent
 auto:
   methods:
     - git: https://github.com/apache/cassandra.git

--- a/products/apache-cassandra.md
+++ b/products/apache-cassandra.md
@@ -16,6 +16,7 @@ identifiers:
   - cpe: cpe:2.3:a:apache:cassandra
   - purl: pkg:github/apache/cassandra
   - purl: pkg:maven/org.apache.cassandra/apache-cassandra
+
 auto:
   methods:
     - git: https://github.com/apache/cassandra.git

--- a/products/apache-cassandra.md
+++ b/products/apache-cassandra.md
@@ -16,7 +16,6 @@ identifiers:
   - cpe: cpe:2.3:a:apache:cassandra
   - purl: pkg:github/apache/cassandra
   - purl: pkg:maven/org.apache.cassandra/apache-cassandra
-  - purl: pkg:maven/org.apache.cassandra/cassandra
 auto:
   methods:
     - git: https://github.com/apache/cassandra.git

--- a/products/apache-cassandra.md
+++ b/products/apache-cassandra.md
@@ -18,7 +18,6 @@ identifiers:
   - purl: pkg:maven/org.apache.cassandra/apache-cassandra
   - purl: pkg:maven/org.apache.cassandra/cassandra
   - purl: pkg:maven/org.apache.cassandra/cassandra-parent
-  
 auto:
   methods:
     - git: https://github.com/apache/cassandra.git

--- a/products/apache-hadoop.md
+++ b/products/apache-hadoop.md
@@ -21,8 +21,6 @@ identifiers:
   - purl: pkg:docker/apache/hadoop
   - purl: pkg:github/apache/hadoop
   - purl: pkg:maven/org.apache.hadoop/hadoop-core
-  - purl: pkg:rpm/fedora/hadoop
-  - purl: pkg:rpm/opensuse/hadoop
   
 auto:
   methods:

--- a/products/apache-hadoop.md
+++ b/products/apache-hadoop.md
@@ -18,7 +18,13 @@ identifiers:
   - cpe: cpe:2.3:a:apache:hadoop
   - cpe: cpe:/a:cloudera:hadoop
   - cpe: cpe:2.3:a:cloudera:hadoop
-
+  - purl: pkg:apache/hadoop
+  - purl: pkg:dokcer/apache/hadoop
+  - purl: pkg:github/apache/hadoop
+  - purl: pkg:maven/org.apache.hadoop/hadoop-core
+  - purl: pkg:rpm/fedora/hadoop
+  - purl: pkg:rpm/opensuse/hadoop
+  
 auto:
   methods:
     - git: https://github.com/apache/hadoop.git

--- a/products/apache-hadoop.md
+++ b/products/apache-hadoop.md
@@ -19,7 +19,7 @@ identifiers:
   - cpe: cpe:/a:cloudera:hadoop
   - cpe: cpe:2.3:a:cloudera:hadoop
   - purl: pkg:apache/hadoop
-  - purl: pkg:dokcer/apache/hadoop
+  - purl: pkg:docker/apache/hadoop
   - purl: pkg:github/apache/hadoop
   - purl: pkg:maven/org.apache.hadoop/hadoop-core
   - purl: pkg:rpm/fedora/hadoop

--- a/products/apache-hadoop.md
+++ b/products/apache-hadoop.md
@@ -18,7 +18,6 @@ identifiers:
   - cpe: cpe:2.3:a:apache:hadoop
   - cpe: cpe:/a:cloudera:hadoop
   - cpe: cpe:2.3:a:cloudera:hadoop
-  - purl: pkg:apache/hadoop
   - purl: pkg:docker/apache/hadoop
   - purl: pkg:github/apache/hadoop
   - purl: pkg:maven/org.apache.hadoop/hadoop-core

--- a/products/apache-hadoop.md
+++ b/products/apache-hadoop.md
@@ -21,6 +21,7 @@ identifiers:
   - purl: pkg:docker/apache/hadoop
   - purl: pkg:github/apache/hadoop
   - purl: pkg:maven/org.apache.hadoop/hadoop-core
+
 auto:
   methods:
     - git: https://github.com/apache/hadoop.git

--- a/products/apache-hadoop.md
+++ b/products/apache-hadoop.md
@@ -21,7 +21,6 @@ identifiers:
   - purl: pkg:docker/apache/hadoop
   - purl: pkg:github/apache/hadoop
   - purl: pkg:maven/org.apache.hadoop/hadoop-core
-  
 auto:
   methods:
     - git: https://github.com/apache/hadoop.git

--- a/products/apache-http-server.md
+++ b/products/apache-http-server.md
@@ -19,7 +19,6 @@ identifiers:
   - repology: apache
   - cpe: cpe:/a:apache:http_server
   - cpe: cpe:2.3:a:apache:http_server
-  - purl: pkg:docker/apache/httpd
   - purl: pkg:github/apache/httpd
   - purl: pkg:rpm/fedora/httpd
 

--- a/products/apache-http-server.md
+++ b/products/apache-http-server.md
@@ -19,7 +19,6 @@ identifiers:
   - repology: apache
   - cpe: cpe:/a:apache:http_server
   - cpe: cpe:2.3:a:apache:http_server
-  - purl: pkg:apache/httpd
   - purl: pkg:docker/apache/httpd
   - purl: pkg:github/apache/httpd
   - purl: pkg:rpm/fedora/httpd

--- a/products/apache-http-server.md
+++ b/products/apache-http-server.md
@@ -19,6 +19,10 @@ identifiers:
   - repology: apache
   - cpe: cpe:/a:apache:http_server
   - cpe: cpe:2.3:a:apache:http_server
+  - purl: pkg:apache/httpd
+  - purl: pkg:docker/apache/httpd
+  - purl: pkg:github/apache/httpd
+  - purl: pkg:rpm/fedora/httpd
 
 auto:
   methods:

--- a/products/apache-kafka.md
+++ b/products/apache-kafka.md
@@ -17,7 +17,6 @@ identifiers:
   - repology: kafka
   - cpe: cpe:/a:apache:kafka
   - cpe: cpe:2.3:a:apache:kafka
-  - purl: pkg:apache/kafka
   - purl: pkg:github/apache/kafka
 
 auto:

--- a/products/apache-kafka.md
+++ b/products/apache-kafka.md
@@ -17,6 +17,8 @@ identifiers:
   - repology: kafka
   - cpe: cpe:/a:apache:kafka
   - cpe: cpe:2.3:a:apache:kafka
+  - purl: pkg:apache/kafka
+  - purl: pkg:github/apache/kafka
 
 auto:
   methods:

--- a/products/apache-maven.md
+++ b/products/apache-maven.md
@@ -20,7 +20,6 @@ identifiers:
   - repology: maven-shared-utils
   - cpe: cpe:/a:apache:maven_shared_utils
   - cpe: cpe:2.3:a:apache:maven_shared_utils
-  - purl: pkg:apache/maven
   - purl: pkg:deb/debian/maven
   - purl: pkg:deb/ubuntu/maven
   - purl: pkg:github/apache/maven

--- a/products/apache-maven.md
+++ b/products/apache-maven.md
@@ -20,6 +20,12 @@ identifiers:
   - repology: maven-shared-utils
   - cpe: cpe:/a:apache:maven_shared_utils
   - cpe: cpe:2.3:a:apache:maven_shared_utils
+  - purl: pkg:apache/maven
+  - purl: pkg:deb/debian/maven
+  - purl: pkg:deb/ubuntu/maven
+  - purl: pkg:github/apache/maven
+  - purl: pkg:maven/org.apache.maven/maven
+  - purl: pkg:rpm/opensuse/maven
 
 auto:
   methods:

--- a/products/apache-nifi.md
+++ b/products/apache-nifi.md
@@ -13,7 +13,6 @@ eolColumn: Support
 identifiers:
   - repology: nifi
   - cpe: cpe:2.3:a:apache:nifi
-  - purl: pkg:apache/nifi
   - purl: pkg:docker/apache/nifi
   - purl: pkg:github/apache/nifi
   - purl: pkg:maven/org.apache.nifi/nifi

--- a/products/apache-nifi.md
+++ b/products/apache-nifi.md
@@ -13,7 +13,11 @@ eolColumn: Support
 identifiers:
   - repology: nifi
   - cpe: cpe:2.3:a:apache:nifi
-
+  - purl: pkg:apache/nifi
+  - purl: pkg:docker/apache/nifi
+  - purl: pkg:github/apache/nifi
+  - purl: pkg:maven/org.apache.nifi/nifi
+  
 auto:
   methods:
     - git: https://github.com/apache/nifi.git

--- a/products/apache-nifi.md
+++ b/products/apache-nifi.md
@@ -16,7 +16,6 @@ identifiers:
   - purl: pkg:docker/apache/nifi
   - purl: pkg:github/apache/nifi
   - purl: pkg:maven/org.apache.nifi/nifi
-  
 auto:
   methods:
     - git: https://github.com/apache/nifi.git

--- a/products/apache-nifi.md
+++ b/products/apache-nifi.md
@@ -16,6 +16,7 @@ identifiers:
   - purl: pkg:docker/apache/nifi
   - purl: pkg:github/apache/nifi
   - purl: pkg:maven/org.apache.nifi/nifi
+
 auto:
   methods:
     - git: https://github.com/apache/nifi.git

--- a/products/apache-spark.md
+++ b/products/apache-spark.md
@@ -17,6 +17,9 @@ identifiers:
   - repology: apache-spark
   - cpe: cpe:/a:apache:spark
   - cpe: cpe:2.3:a:apache:spark
+  - purl: pkg:apache/spark
+  - purl: pkg:github/apache/spark
+  - purl: pkg:maven/org.apache.spark/spark-core
 
 auto:
   methods:

--- a/products/apache-spark.md
+++ b/products/apache-spark.md
@@ -17,7 +17,6 @@ identifiers:
   - repology: apache-spark
   - cpe: cpe:/a:apache:spark
   - cpe: cpe:2.3:a:apache:spark
-  - purl: pkg:apache/spark
   - purl: pkg:github/apache/spark
   - purl: pkg:maven/org.apache.spark/spark-core
 

--- a/products/apache-spark.md
+++ b/products/apache-spark.md
@@ -18,7 +18,6 @@ identifiers:
   - cpe: cpe:/a:apache:spark
   - cpe: cpe:2.3:a:apache:spark
   - purl: pkg:github/apache/spark
-  - purl: pkg:maven/org.apache.spark/spark-core
 
 auto:
   methods:


### PR DESCRIPTION
Added purls for the first 13 endoflife.date components that missed purls. Could add the rest and also the CPEs, if this PR gets accepted.

Verified all purls. Some were wrong at purl2cpe.

Adjusted _build_docker_url for libraries. Docker doesn't use "r/" for libraries