### PR TITLE
[bitbucket] add 10.2

### DIFF
--- a/products/bitbucket.md
+++ b/products/bitbucket.md
@@ -29,7 +29,7 @@ releases:
     releaseDate: 2026-03-03
     lts: true
     eol: false
-    latest: "10.2.5"
+    latest: "10.2.0"
     latestReleaseDate: 2026-03-03
 
   - releaseCycle: "10.1"

--- a/products/bitbucket.md
+++ b/products/bitbucket.md
@@ -25,6 +25,13 @@ auto:
 # Release dates from https://www.atlassian.com/software/bitbucket/download-archives.
 # LTS/EOL dates can be found on https://confluence.atlassian.com/support/atlassian-support-end-of-life-policy-201851003.html
 releases:
+  - releaseCycle: "10.2"
+    releaseDate: 2026-03-03
+    lts: true
+    eol: false
+    latest: "10.2.5"
+    latestReleaseDate: 2026-03-03
+
   - releaseCycle: "10.1"
     releaseDate: 2025-11-20
     eol: 2027-11-20


### PR DESCRIPTION
LTS release
https://confluence.atlassian.com/bitbucketserver/bitbucket-data-center-10-2-release-notes-1738146526.html

doesn't list EOL yet
https://confluence.atlassian.com/support/atlassian-support-end-of-life-policy-201851003.html
