### PR TITLE
[AdonisJS] fix: change EOL status for AdonisJS release cycle 6

### DIFF
--- a/products/adonisjs.md
+++ b/products/adonisjs.md
@@ -28,7 +28,7 @@ releases:
 
   - releaseCycle: "6"
     releaseDate: 2023-02-20
-    eol: 2026-02-25
+    eol: false
     latest: "6.20.0"
     latestReleaseDate: 2026-02-05
 


### PR DESCRIPTION
This pull request makes a small change to the AdonisJS product release information, updating the end-of-life (EOL) value for release cycle 6 to indicate that it is not currently scheduled for EOL. Confirmation by AdonisJS creator in Discord.