### PR TITLE
[pan-gp] Update 6.2: 6.2.8-c471 → 6.2.8-c814

### DIFF
--- a/products/pan-gp.md
+++ b/products/pan-gp.md
@@ -41,8 +41,8 @@ releases:
     releaseDate: 2023-05-23
     eol: 2027-06-30
     eoas: 2027-06-30
-    latest: "6.2.8-c471"
-    latestReleaseDate: 2026-02-03
+    latest: "6.2.8-c814"
+    latestReleaseDate: 2026-03-03
     link: https://docs.paloaltonetworks.com/globalprotect/6-2/globalprotect-app-release-notes/globalprotect-addressed-issues
 
   - releaseCycle: "6.1"


### PR DESCRIPTION
## Summary
Automated update of GlobalProtect App versions.

### Changes
6.2: 6.2.8-c471 -> 6.2.8-c814

---
Data sourced from [GlobalProtectVersions.json](https://github.com/mrjcap/globalprotect-versions/blob/main/GlobalProtectVersions.json)