### PR TITLE
[OpenSearch] Update  link to new blog post

### DIFF
--- a/products/opensearch.md
+++ b/products/opensearch.md
@@ -40,7 +40,7 @@ releases:
     eol: false
     latest: "3.5.0"
     latestReleaseDate: 2026-02-12
-    link: https://github.com/opensearch-project/opensearch-build/blob/main/release-notes/opensearch-release-notes-3.5.0.md
+    link: https://opensearch.org/blog/opensearch-3-5-is-live/
 
   - releaseCycle: "2"
     releaseDate: 2022-05-26


### PR DESCRIPTION
# :grey_question: ABout

Update the link of the 3.5 as [the dedicated  blog post ](https://opensearch.org/blog/opensearch-3-5-is-live/)is much richer than the releaseNote, witch charts, eetc...

<img width="1364" height="956" alt="image" src="https://github.com/user-attachments/assets/3072dbc6-590e-4013-b328-2c19973de3e6" />
