### PR TITLE
[rust] Add 1.94 and Update Eol date for 1.93

### DIFF
--- a/products/rust.md
+++ b/products/rust.md
@@ -23,9 +23,15 @@ identifiers:
 
 # eol(x) = releaseDate(x+1)
 releases:
+  - releaseCycle: "1.94"
+    releaseDate: 2026-03-06
+    eol: false
+    latest: "1.94.0"
+    latestReleaseDate: 2026-03-06
+
   - releaseCycle: "1.93"
     releaseDate: 2026-01-22
-    eol: false
+    eol: 2026-03-06
     latest: "1.93.1"
     latestReleaseDate: 2026-02-12
 


### PR DESCRIPTION
Added release information for Rust version 1.94.
https://github.com/rust-lang/rust/releases/tag/1.94.0