### PR TITLE
[sqlite] SQLite Release 3.52.0

### DIFF
--- a/products/sqlite.md
+++ b/products/sqlite.md
@@ -29,8 +29,9 @@ releases:
     # 3.0.7 release date, because it is the first stable release in the 3.x line
     releaseDate: 2004-09-18
     eol: false
-    latest: "3.51.2"
-    latestReleaseDate: 2026-01-09
+    latest: "3.52.0"
+    latestReleaseDate: 2026-03-06
+    link: https://sqlite.org/releaselog/3_52_0.html
 
   - releaseCycle: "2"
     releaseDate: 2001-09-28


### PR DESCRIPTION
# :grey_question: About

Since today ,cf

- [tweet](https://x.com/linuxiac/status/2029966860628709717) 
- [Announce](https://linuxiac.com/sqlite-3-52-released-with-wal-corruption-fix-and-cli-improvements/)
- [Official release note SQLite Release 3.52.0 On 2026-03-06](https://sqlite.org/releaselog/3_52_0.html)

> SQLite 3.52 fixes a WAL-reset database corruption bug and introduces CLI improvements, new SQL functions, and query planner optimizations.
, 
<img width="640" height="621" alt="image" src="https://github.com/user-attachments/assets/a9e77467-1bfb-48c3-b219-5f81dab2c0b0" />
