### PR TITLE
Add 'new products' Atom feed

### DIFF
--- a/_includes/head_custom.html
+++ b/_includes/head_custom.html
@@ -3,6 +3,7 @@ Favicons were generated from the SVG icons with https://realfavicongenerator.net
 
 The SVG favicon supports dark mode (https://blog.tomayac.com/2019/09/21/prefers-color-scheme-in-svg-favicons-for-dark-mode-icons/).
 {% endcomment %}
+<link rel="alternate" type="application/atom+xml" title="New products feed" href="/new-products.atom" />
 {% if page.layout == "product" %}
 <link rel="alternate" type="text/calendar" title="{{ page.title }} events calendar" href="webcal://{{site.url | split: '://' | last}}/calendar{{page.permalink}}.ics" />
 <link rel="alternate" type="application/atom+xml" title="{{ page.title }} events feed" href="{{ page.permalink | relative_url }}.atom" />

--- a/_layouts/new-products-feed.atom
+++ b/_layouts/new-products-feed.atom
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom">
+  <id>{{ site.url }}/new-products.atom</id>
+  <title>endoflife.date: new products</title>
+  <subtitle>Products recently added to endoflife.date</subtitle>
+  <link href="{{ '/new-products.atom' | absolute_url }}" rel="self" />
+  <link href="{{ site.url }}"/>
+  <updated>{{ page.products.first.added_at | date_to_xmlschema }}</updated>
+  <author><name>endoflife.date</name></author>
+{%- for product in page.products %}
+  <entry>
+    <id>{{ product.link }}</id>
+    <link href="{{ product.link }}"/>
+    <updated>{{ product.added_at | date_to_xmlschema }}</updated>
+    <title>{{ product.title | xml_escape }} added</title>
+    <summary>{{ product.title | xml_escape }} has been added to endoflife.date.</summary>
+  </entry>
+{% endfor -%}
+</feed>

--- a/_layouts/product.html
+++ b/_layouts/product.html
@@ -193,15 +193,14 @@ layout: default
 <p>
   You can submit an improvement to this page
   <a href="{{page.permalink}}/_edit" title="Click the Pencil, the link takes you directly to the correct page">
-    on GitHub
-    <img class="emoji" title=":octocat:" alt=":octocat:" src="https://github.githubassets.com/images/icons/emoji/octocat.png" width="20" height="20">
+    on GitHub&nbsp;<img class="emoji" title=":octocat:" alt=":octocat:" src="https://github.githubassets.com/images/icons/emoji/octocat.png" width="20" height="20">
   </a>.
-  This page has a corresponding <a title="Talk Page for {{page.title}}" href="https://github.com/endoflife-date/talk/wiki{{page.permalink}}">Talk Page</a>.
+  This page has also a corresponding <a title="Talk Page for {{page.title}}" href="https://github.com/endoflife-date/talk/wiki{{page.permalink}}">Talk Page 💬</a>.
 </p>
 
 <p>
-  A JSON version of this page is available at <a href="/api/v1/products{{page.permalink}}/">/api/v1/products{{page.permalink}}/</a>.
-  See the <a href="/docs/api/v1/">API Documentation</a> for more information.
-  You can subscribe to the RSS feed at <a href="{{page.permalink}}.atom" aria-label="Product events feed">{{page.permalink}}.atom</a>
-  or to the iCalendar feed at <a href="webcal://{{site.url | split: '://' | last}}/calendar{{page.permalink}}.ics" aria-label="Product events calendar">/calendar{{page.permalink}}.ics</a>.
+  A JSON version of this page is available <a href="/api/v1/products{{page.permalink}}/">at /api/v1/products{{page.permalink}}/&nbsp;📡</a>.
+  See <a href="/docs/api/v1/">the API Documentation&nbsp;📖</a> for more information.
+  You can subscribe to the RSS feed <a href="{{page.permalink}}.atom" aria-label="Product events feed">at {{page.permalink}}.atom&nbsp;⚛️</a>
+  or to the iCalendar feed <a href="webcal://{{site.url | split: '://' | last}}/calendar{{page.permalink}}.ics" aria-label="Product events calendar">at /calendar{{page.permalink}}.ics&nbsp;📅</a>.
 </p>

--- a/_plugins/generate-product-feeds.rb
+++ b/_plugins/generate-product-feeds.rb
@@ -23,6 +23,8 @@ module EndOfLife
         site.pages << ProductFeed.new(site, product)
       end
 
+      site.pages << NewProductsFeed.new(site)
+
       Jekyll.logger.info TOPIC, "Done in #{(Time.now - start).round(3)} seconds."
     end
   end
@@ -94,6 +96,35 @@ module EndOfLife
         "last_updated" => product.data['last_modified_at'],
         "events" => events.select { |event| event["occurred_at"] <= Time.now },
         "nav_exclude" => true
+      }
+
+      self.process(@name)
+    end
+  end
+
+  class NewProductsFeed < Jekyll::Page
+    def initialize(site)
+      @site = site
+      @base = site.source
+      @dir = ""
+      @name = "new-products.atom"
+
+      products = site.pages
+        .select { |p| p.data['layout'] == 'product' && p.data['addedAt'] }
+        .map { |p|
+          {
+            "title"    => p.data['title'],
+            "link"     => EndOfLife.site_url(site, p.data['permalink']),
+            "added_at" => p.data['addedAt'].to_datetime.beginning_of_day,
+          }
+        }
+        .sort_by { |p| p["added_at"] }
+        .reverse
+
+      @data = {
+        "layout"      => "new-products-feed",
+        "products"    => products,
+        "nav_exclude" => true,
       }
 
       self.process(@name)

--- a/index.md
+++ b/index.md
@@ -27,7 +27,7 @@ Here are some of our most popular pages:
 | Cloud Services | [Amazon Elastic Kubernetes Service](/amazon-eks) | [Google Kubernetes Engine](/google-kubernetes-engine) | [Azure Kubernetes Service](/azure-kubernetes-service) | [Alibaba ACK](/alibaba-ack) |
 | Standards | [PCI-DSS](/pci-dss) | [TLS](/tls) |
 
-## Last added products
+## Last added products <a href="/new-products.atom" aria-label="New products feed">⚛️</a>
 
 <ul>
 {% assign products = site.pages | where: "layout", "product" | sort: "addedAt" | reverse %}


### PR DESCRIPTION
Update `generate-product-feeds.rb` to generate also a 'new products' Atom feed which lists products based on their `addedAt` date (newest first).

Also update the footer of products page to include icons and make the links more visible.

Closes #6138.