### PR TITLE
[podman] Podman is part of `cncf`

### DIFF
--- a/products/podman.md
+++ b/products/podman.md
@@ -2,7 +2,7 @@
 title: Podman
 addedAt: 2024-09-23
 category: app
-tags: linux-foundation
+tags: cncf linux-foundation
 iconSlug: podman
 permalink: /podman
 versionCommand: podman --remote version --format '{{.Server.Version}}'


### PR DESCRIPTION
# :grey_question: About

cf, https://www.cncf.io/projects/podman-container-tools/

> A set of tools providing full management of container lifecycle, including Podman, Buildah, and Skopeo, which manage containers and images without requiring a daemon or root privileges.

<img width="1349" height="853" alt="image" src="https://github.com/user-attachments/assets/3f741deb-a6c2-41f5-a625-a62bc44d679d" />
