### PR TITLE
[duckdb] Add1.5 cycle

### DIFF
--- a/products/duckdb.md
+++ b/products/duckdb.md
@@ -20,12 +20,10 @@ auto:
 releases:
   - releaseCycle: "1.5"
     codename: "Variegata"
-    lts: false
     releaseDate: 2026-03-09
     eol: false
     latest: "1.5.0"
     latestReleaseDate: 2026-03-09
-    link: https://duckdb.org/2026/03/09/announcing-duckdb-150
     
   - releaseCycle: "1.4"
     codename: "Andium"

--- a/products/duckdb.md
+++ b/products/duckdb.md
@@ -18,7 +18,16 @@ auto:
     - github_releases: duckdb/duckdb
 
 releases:
-  - releaseCycle: "1.4"
+  - releaseCycle: "1.5"
+    codename: "Variegata"
+    lts: false
+    releaseDate: 2026-03-09
+    eol: false
+    latest: "1.5.0"
+    latestReleaseDate: 2026-03-09
+    link: https://duckdb.org/2026/03/09/announcing-duckdb-150
+    
+- releaseCycle: "1.4"
     codename: "Andium"
     lts: true
     releaseDate: 2025-09-16

--- a/products/duckdb.md
+++ b/products/duckdb.md
@@ -27,7 +27,7 @@ releases:
     latestReleaseDate: 2026-03-09
     link: https://duckdb.org/2026/03/09/announcing-duckdb-150
     
-- releaseCycle: "1.4"
+  - releaseCycle: "1.4"
     codename: "Andium"
     lts: true
     releaseDate: 2025-09-16


### PR DESCRIPTION
# :grey_question: About

cf [tweet](https://x.com/duckdb/status/2030998835632234784) and [detailed Release Note](https://duckdb.org/2026/03/09/announcing-duckdb-150)

<img width="610" height="727" alt="image" src="https://github.com/user-attachments/assets/9f8f598d-3585-41bd-bf84-e8f344faaca0" />


> We released DuckDB v1.5!
> This new release comes with a “friendly CLI” client, a new (opt-in) PEG parser, support for the VARIANT type and a built-in GEOMETRY type. It also ships a new network stack and a few lakehouse features. Finally, it can write to Azure and connect to databases through ODBC.