### PR TITLE
[Karpenter] remove duplicate purl identifier

### DIFF
--- a/products/karpenter.md
+++ b/products/karpenter.md
@@ -14,7 +14,6 @@ identifiers:
   - purl: pkg:oci/karpenter?repository_url=public.ecr.aws/karpenter
   - purl: pkg:oci/karpenter?repository_url=dhi.io
   - purl: pkg:oci/karpenter?repository_url=cgr.dev/chainguard
-  - purl: pkg:github/kubernetes-sigs/karpenter
 
 auto:
   methods:


### PR DESCRIPTION
Karpenter product has a duplicate purl product identifier, this pr fixes this