### PR TITLE
[pan-os] Update 11.2: 11.2.10-h3 → 11.2.10-h4

### DIFF
--- a/products/pan-os.md
+++ b/products/pan-os.md
@@ -39,9 +39,9 @@ releases:
   - releaseCycle: "11.2"
     releaseDate: 2024-05-02
     eol: 2027-05-02
-    latest: "11.2.10-h3"
-    latestReleaseDate: 2026-02-05
-    link: https://docs.paloaltonetworks.com/pan-os/11-2/pan-os-release-notes/pan-os-11-2-10-known-and-addressed-issues/pan-os-11-2-10-h3-addressed-issues
+    latest: "11.2.10-h4"
+    latestReleaseDate: 2026-03-06
+    link: https://docs.paloaltonetworks.com/pan-os/11-2/pan-os-release-notes/pan-os-11-2-10-known-and-addressed-issues/pan-os-11-2-10-h4-addressed-issues
 
   - releaseCycle: "11.1"
     releaseDate: 2023-11-03


### PR DESCRIPTION
## Summary
Automated update of PAN-OS versions.

### Changes
11.2: 11.2.10-h3 -> 11.2.10-h4

---
Data sourced from [PaloAltoVersions.json](https://github.com/mrjcap/panos-versions/blob/master/PaloAltoVersions.json)