### PR TITLE
[apache-maven] Switch to github_releases auto method

### DIFF
--- a/products/apache-maven.md
+++ b/products/apache-maven.md
@@ -28,7 +28,9 @@ identifiers:
 
 auto:
   methods:
-    - maven: org.apache.maven/maven-core
+    - github_releases: apache/maven
+      regex: '^maven-(?P<version>[\d\.]+)$'
+      template: "{{version}}"
 
 # See https://maven.apache.org/docs/history.html
 releases:


### PR DESCRIPTION
Versions take too much time to show up in https://search.maven.org, and GitHub releases dates are a little bit more accurate.