### PR TITLE
[ipados] update eoas and eol dates for releaseCycle 17

### DIFF
--- a/products/ipados.md
+++ b/products/ipados.md
@@ -24,6 +24,7 @@ releases:
     eol: false
     latest: "26.3.1"
     latestReleaseDate: 2026-03-04
+    link: https://developer.apple.com/documentation/ios-ipados-release-notes/ios-ipados-26-release-notes
 
   - releaseCycle: "18"
     releaseDate: 2024-09-16
@@ -31,13 +32,15 @@ releases:
     eol: false
     latest: "18.7.5"
     latestReleaseDate: 2026-02-11
+    link: https://developer.apple.com/documentation/ios-ipados-release-notes/ios-ipados-18-release-notes
 
   - releaseCycle: "17"
     releaseDate: 2023-09-18
-    eoas: false
-    eol: false
+    eoas: 2025-09-15
+    eol: 2025-09-15
     latest: "17.7.10"
     latestReleaseDate: 2025-08-20
+    link: https://developer.apple.com/documentation/ios-ipados-release-notes/ios-ipados-17-release-notes
 
   - releaseCycle: "16"
     releaseDate: 2022-10-24
@@ -53,6 +56,7 @@ releases:
     eol: 2025-03-31
     latest: "15.8.6"
     latestReleaseDate: 2026-01-26
+    link: https://developer.apple.com/documentation/ios-ipados-release-notes/ios-ipados-15-release-notes
 
   - releaseCycle: "14"
     releaseDate: 2020-09-16
@@ -60,6 +64,7 @@ releases:
     eol: 2021-10-01
     latest: "14.8.1"
     latestReleaseDate: 2021-10-26
+    link: https://developer.apple.com/documentation/ios-ipados-release-notes/ios-ipados-14-release-notes
 
   - releaseCycle: "13"
     releaseDate: 2019-09-24
@@ -67,7 +72,7 @@ releases:
     eol: 2020-09-16 # releaseDate(14)
     latest: "13.6"
     latestReleaseDate: 2020-07-15
-    link: https://developer.apple.com/documentation/ios-ipados-release-notes/ios-ipados-13_1-release-notes
+    link: https://developer.apple.com/documentation/ios-ipados-release-notes/ios-13-release-notes
 
   - releaseCycle: "12"
     releaseDate: 2018-09-17

--- a/products/ipados.md
+++ b/products/ipados.md
@@ -24,7 +24,6 @@ releases:
     eol: false
     latest: "26.3.1"
     latestReleaseDate: 2026-03-04
-    link: https://developer.apple.com/documentation/ios-ipados-release-notes/ios-ipados-26-release-notes
 
   - releaseCycle: "18"
     releaseDate: 2024-09-16
@@ -32,7 +31,6 @@ releases:
     eol: false
     latest: "18.7.5"
     latestReleaseDate: 2026-02-11
-    link: https://developer.apple.com/documentation/ios-ipados-release-notes/ios-ipados-18-release-notes
 
   - releaseCycle: "17"
     releaseDate: 2023-09-18
@@ -40,7 +38,6 @@ releases:
     eol: 2025-09-15
     latest: "17.7.10"
     latestReleaseDate: 2025-08-20
-    link: https://developer.apple.com/documentation/ios-ipados-release-notes/ios-ipados-17-release-notes
 
   - releaseCycle: "16"
     releaseDate: 2022-10-24
@@ -48,7 +45,6 @@ releases:
     eol: 2025-03-31
     latest: "16.7.14"
     latestReleaseDate: 2026-02-02
-    link: https://developer.apple.com/documentation/ios-ipados-release-notes/ipados-16-release-notes
 
   - releaseCycle: "15"
     releaseDate: 2021-09-20
@@ -56,7 +52,6 @@ releases:
     eol: 2025-03-31
     latest: "15.8.6"
     latestReleaseDate: 2026-01-26
-    link: https://developer.apple.com/documentation/ios-ipados-release-notes/ios-ipados-15-release-notes
 
   - releaseCycle: "14"
     releaseDate: 2020-09-16
@@ -64,7 +59,6 @@ releases:
     eol: 2021-10-01
     latest: "14.8.1"
     latestReleaseDate: 2021-10-26
-    link: https://developer.apple.com/documentation/ios-ipados-release-notes/ios-ipados-14-release-notes
 
   - releaseCycle: "13"
     releaseDate: 2019-09-24
@@ -72,7 +66,7 @@ releases:
     eol: 2020-09-16 # releaseDate(14)
     latest: "13.6"
     latestReleaseDate: 2020-07-15
-    link: https://developer.apple.com/documentation/ios-ipados-release-notes/ios-13-release-notes
+    link: https://developer.apple.com/documentation/ios-ipados-release-notes/ios-ipados-13_1-release-notes
 
   - releaseCycle: "12"
     releaseDate: 2018-09-17

--- a/products/ipados.md
+++ b/products/ipados.md
@@ -34,7 +34,7 @@ releases:
 
   - releaseCycle: "17"
     releaseDate: 2023-09-18
-    eoas: 2025-09-15
+    eoas: 2024-08-19
     eol: 2025-09-15
     latest: "17.7.10"
     latestReleaseDate: 2025-08-20

--- a/products/ipados.md
+++ b/products/ipados.md
@@ -45,6 +45,7 @@ releases:
     eol: 2025-03-31
     latest: "16.7.14"
     latestReleaseDate: 2026-02-02
+    link: https://developer.apple.com/documentation/ios-ipados-release-notes/ipados-16-release-notes
 
   - releaseCycle: "15"
     releaseDate: 2021-09-20


### PR DESCRIPTION
Updated iPadOS 17 eoas, eol. Added missing links for multiple versions. Apple is no longer providing security updates or support for iPadOS 17. While not officially documented, Apple generally only provides security updates for two generations of iPadOS (similar to iOS).  There has not been a security update released for iPadOS since 2025-08-20. iPadOS 18 has received five security patches since then.