### PR TITLE
fix(drupal): update release cycle image

### DIFF
--- a/products/drupal.md
+++ b/products/drupal.md
@@ -7,7 +7,7 @@ iconSlug: drupal
 permalink: /drupal
 versionCommand: drush status
 releasePolicyLink: https://www.drupal.org/about/core/policies/core-release-cycles/schedule
-releaseImage: https://www.drupal.org/files/Drupal2024-2027.png
+releaseImage: https://www.drupal.org/files/Drupal11and12ScheduleDec2025.png
 changelogTemplate: https://www.drupal.org/project/drupal/releases/__LATEST__
 eoesColumn: Commercial Support
 eoasColumn: true


### PR DESCRIPTION
The current image is out of date, in particular not having the v10.6 release