### PR TITLE
[solr] version 9 still get fixes

### DIFF
--- a/products/solr.md
+++ b/products/solr.md
@@ -36,7 +36,7 @@ releases:
 
   - releaseCycle: "9"
     releaseDate: 2022-05-11
-    eol: 2026-03-03
+    eol: false
     latest: "9.10.1"
     latestReleaseDate: 2026-01-20
 


### PR DESCRIPTION
As stated in documentation 

> The previous major version will see occasional critical security- or bug fixes releases

https://solr.apache.org/downloads.html#about-versions-and-support

So version 9 should not be considered as ended