### PR TITLE
[solr] Update 9 eol

### DIFF
--- a/products/solr.md
+++ b/products/solr.md
@@ -27,22 +27,23 @@ auto:
       regex: '^releases\/solr\/(?P<version>\d+\.\d+(.\d+)?)$'
       template: "{{version}}"
 
+# eol(x) = releaseDate(x+2) or announcement on https://solr.apache.org/news.html
 releases:
   - releaseCycle: "10"
     releaseDate: 2026-03-03
-    eol: false
+    eol: false # releaseDate(12)
     latest: "10.0.0"
     latestReleaseDate: 2026-03-03
 
   - releaseCycle: "9"
     releaseDate: 2022-05-11
-    eol: 2026-03-03
+    eol: false # releaseDate(11)
     latest: "9.10.1"
     latestReleaseDate: 2026-01-20
 
   - releaseCycle: "8"
     releaseDate: 2019-03-13
-    eol: 2024-10-25
+    eol: 2024-10-25 # https://solr.apache.org/news.html#solr-8-reaches-end-of-life
     latest: "8.11.4"
     latestReleaseDate: 2024-09-24
 


### PR DESCRIPTION
_Originally posted by @worming004 in https://github.com/endoflife-date/endoflife.date/issues/9603#issuecomment-4031975823_

> Does v9 really reached eol ? As I read in documentation

>> Apache Solr is under active development with frequent feature releases on the current major version. **The previous major version will see occasional critical security- or bug fixes releases**. Older versions are considered EOL (End Of Life) and will not be further updated. For this reason it may also be difficult to obtain community support for EOL versions.

> https://solr.apache.org/downloads.html#about-versions-and-support