### PR TITLE
[angular] Modify changelogTemplate links for newer than 18.x

### DIFF
--- a/products/angular.md
+++ b/products/angular.md
@@ -7,7 +7,7 @@ iconSlug: angular
 permalink: /angular
 versionCommand: ng version
 releasePolicyLink: https://angular.dev/reference/releases
-changelogTemplate: https://github.com/angular/angular/releases/tag/__LATEST__
+changelogTemplate: https://github.com/angular/angular/releases/tag/v__LATEST__
 eoasColumn: true
 eoesColumn: Commercial Support
 
@@ -61,6 +61,7 @@ releases:
     eoes: false
     latest: "18.2.14"
     latestReleaseDate: 2025-09-10
+    link: https://github.com/angular/angular/releases/tag/__LATEST__
 
   - releaseCycle: "17"
     releaseDate: 2023-11-08
@@ -69,6 +70,7 @@ releases:
     eoes: false
     latest: "17.3.12"
     latestReleaseDate: 2024-07-17
+    link: https://github.com/angular/angular/releases/tag/__LATEST__
 
   - releaseCycle: "16"
     releaseDate: 2023-05-03
@@ -77,6 +79,7 @@ releases:
     eoes: false
     latest: "16.2.12"
     latestReleaseDate: 2023-11-02
+    link: https://github.com/angular/angular/releases/tag/__LATEST__
 
   - releaseCycle: "15"
     releaseDate: 2022-11-16
@@ -85,6 +88,7 @@ releases:
     eoes: false
     latest: "15.2.10"
     latestReleaseDate: 2023-10-04
+    link: https://github.com/angular/angular/releases/tag/__LATEST__
 
   - releaseCycle: "14"
     releaseDate: 2022-06-02
@@ -93,6 +97,7 @@ releases:
     eoes: false
     latest: "14.3.0"
     latestReleaseDate: 2023-03-13
+    link: https://github.com/angular/angular/releases/tag/__LATEST__
 
   - releaseCycle: "13"
     releaseDate: 2021-11-03
@@ -101,6 +106,7 @@ releases:
     eoes: false
     latest: "13.4.0"
     latestReleaseDate: 2023-04-06
+    link: https://github.com/angular/angular/releases/tag/__LATEST__
 
   - releaseCycle: "12"
     releaseDate: 2021-05-13
@@ -109,6 +115,7 @@ releases:
     eoes: false
     latest: "12.2.17"
     latestReleaseDate: 2022-11-22
+    link: https://github.com/angular/angular/releases/tag/__LATEST__
 
   - releaseCycle: "11"
     releaseDate: 2020-11-11
@@ -117,6 +124,7 @@ releases:
     eoes: false
     latest: "11.2.14"
     latestReleaseDate: 2021-05-12
+    link: https://github.com/angular/angular/releases/tag/__LATEST__
 
   - releaseCycle: "10"
     releaseDate: 2020-06-24
@@ -125,6 +133,7 @@ releases:
     eoes: false
     latest: "10.2.5"
     latestReleaseDate: 2021-04-21
+    link: https://github.com/angular/angular/releases/tag/__LATEST__
 
   - releaseCycle: "9"
     releaseDate: 2020-02-06
@@ -133,6 +142,7 @@ releases:
     eoes: false
     latest: "9.1.13"
     latestReleaseDate: 2020-12-16
+    link: https://github.com/angular/angular/releases/tag/__LATEST__
 
 ---
 


### PR DESCRIPTION
* Add link tag for version prior then v19
* Modify changelogtemplate for upcomming angular versions