### PR TITLE
Add auto-generated release timeline SVG images

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -95,7 +95,7 @@ npx @pb33f/wiretap@latest -s http://localhost:4000/docs/api/v1/openapi.yml -u ht
 1. **Naming**: Filename is `productname.md` (lowercase, dashes for spaces)
 2. **Frontmatter only**: Product files are YAML frontmatter with markdown content below
 3. **Frontmatter order** (blank line between sections):
-   - Product info: `title`, `category`, `tags`, `iconSlug`, `permalink`, `alternate_urls`, `versionCommand`, `releasePolicyLink`, `releaseImage`, `changelogTemplate`
+   - Product info: `title`, `category`, `tags`, `iconSlug`, `permalink`, `alternate_urls`, `versionCommand`, `releasePolicyLink`, `changelogTemplate`
    - Formatting: `releaseLabel`, `LTSLabel`, `eolColumn`, `eoasColumn`, `releaseDateColumn`, `discontinuedColumn`, `eoesColumn`, etc.
    - Identifiers: `identifiers`
    - Auto-update: `auto`

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -107,11 +107,6 @@ versionCommand: swish and flick
 # Do not use a localized URL (such as one containing en-us) if possible.
 releasePolicyLink: https://nodejs.org/about/releases/
 
-# An image that shows a graphical representation of the releases (optional).
-# If provided, this image will be displayed at the top of the product's page.
-# This is not the product logo. Remove if you don't find a relevant image.
-releaseImage: https://raw.githubusercontent.com/nodejs/Release/main/schedule.svg?sanitize=true
-
 # Template to be used to generate a link for the releases (optional).
 # Available variables inside the template are:
 # - __RELEASE_CYCLE__: will be replaced by the value of `releaseCycle`,
@@ -392,9 +387,6 @@ releases:
 ---
 
 # All the product information text should be under triple-dashes.
-# If you are adding any images in the text, they might get blocked due to our CSP,
-# so prefer using releaseImage in such cases.
-# Note that images on the same website as releaseImage will not be blocked.
 
 > [Time Turner](https://jkrowling.com/time-turner) is a device that powers short-term time travel.
 

--- a/_layouts/release-image.svg
+++ b/_layouts/release-image.svg
@@ -12,8 +12,9 @@
     .grid { stroke: #e8e8e8; stroke-width: 1; }
     .today { stroke: #cc4444; stroke-width: 1.5; stroke-dasharray: 4,3; }
     .bar { rx: 2; ry: 2; }
-    .active { fill: #73ba9b; }
-    {% if page.has_eoas_column %}.security { fill: #f7a456; }{% else %}.security { fill: #73ba9b; }{% endif %}
+    .eoas { fill: #0A2472; }
+    .eol { fill: #1E96FC; }
+    .eoes { fill: #CDEBFF; }
     .legend-icon { width: 14px; height: 14px; rx: 2; ry: 2; }
   </style>
 
@@ -35,10 +36,10 @@
     <g transform="translate(0, {{ y }})">
       <text class="label" x="{{ page.label_x }}" y="{{ page.text_y_offset }}" text-anchor="end">{{ row.label | xml_escape }}</text>
       {% if row.active_width > 0 %}
-      <rect class="bar active" x="{{ row.active_x }}" y="0" width="{{ row.active_width }}" height="{{ page.row_height }}"/>
+      <rect class="bar eoas" x="{{ row.active_x }}" y="0" width="{{ row.active_width }}" height="{{ page.row_height }}"/>
       {% endif %}
       {% if row.security_width > 0 %}
-      <rect class="bar security" x="{{ row.security_x }}" y="0" width="{{ row.security_width }}" height="{{ page.row_height }}"/>
+      <rect class="bar eol" x="{{ row.security_x }}" y="0" width="{{ row.security_width }}" height="{{ page.row_height }}"/>
       {% endif %}
     </g>
     {% endfor %}
@@ -49,15 +50,14 @@
     <!-- Legend -->
     <g transform="translate({{ page.legend_dx }}, {{ page.legend_y }})">
       {% if page.has_eoas_column %}
-      <rect class="legend-icon active" x="0" y="0"/>
+      <rect class="legend-icon eoas" x="0" y="0"/>
       <text class="label" x="18" y="11">{{ page.eoas_label | xml_escape }}</text>
-      <rect class="legend-icon security" x="240" y="0"/>
+      <rect class="legend-icon eol" x="240" y="0"/>
       <text class="label" x="258" y="11">{{ page.eol_label | xml_escape }}</text>
       {% else %}
-      <rect class="legend-icon security" x="0" y="0"/>
+      <rect class="legend-icon eol" x="0" y="0"/>
       <text class="label" x="18" y="11">{{ page.eol_label | xml_escape }}</text>
       {% endif %}
     </g>
-
   </g>
 </svg>

--- a/_layouts/release-image.svg
+++ b/_layouts/release-image.svg
@@ -1,0 +1,63 @@
+---
+---
+<?xml version="1.0" encoding="utf-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 {{ page.svg_width }} {{ page.svg_height }}" role="img"
+     aria-label="{{ page.title | xml_escape }} Release Schedule">
+  <title>{{ page.title | xml_escape }} Release Schedule</title>
+
+  <style>
+    text { font-family: sans-serif; fill: #333; }
+    .label { font-size: 12px; }
+    .tick { font-size: 11px; fill: #888; }
+    .grid { stroke: #e8e8e8; stroke-width: 1; }
+    .today { stroke: #cc4444; stroke-width: 1.5; stroke-dasharray: 4,3; }
+    .bar { rx: 2; ry: 2; }
+    .active { fill: #73ba9b; }
+    {% if page.has_eoas_column %}.security { fill: #f7a456; }{% else %}.security { fill: #73ba9b; }{% endif %}
+    .legend-icon { width: 14px; height: 14px; rx: 2; ry: 2; }
+  </style>
+
+  <!-- Background -->
+  <rect width="{{ page.svg_width }}" height="{{ page.svg_height }}" fill="white"/>
+
+  <!-- Chart area -->
+  <g transform="translate(0, {{ page.top_padding }})">
+
+    <!-- Year grid lines and labels -->
+    {% for tick in page.year_ticks %}
+    <line class="grid" x1="{{ tick.x }}" y1="0" x2="{{ tick.x }}" y2="{{ page.chart_height }}"/>
+    <text class="tick" x="{{ tick.x }}" y="{{ page.year_label_y }}" text-anchor="middle">{{ tick.year }}</text>
+    {% endfor %}
+
+    <!-- Release rows -->
+    {% for row in page.rows %}
+    {% assign y = forloop.index0 | times: page.row_stride %}
+    <g transform="translate(0, {{ y }})">
+      <text class="label" x="{{ page.label_x }}" y="{{ page.text_y_offset }}" text-anchor="end">{{ row.label | xml_escape }}</text>
+      {% if row.active_width > 0 %}
+      <rect class="bar active" x="{{ row.active_x }}" y="0" width="{{ row.active_width }}" height="{{ page.row_height }}"/>
+      {% endif %}
+      {% if row.security_width > 0 %}
+      <rect class="bar security" x="{{ row.security_x }}" y="0" width="{{ row.security_width }}" height="{{ page.row_height }}"/>
+      {% endif %}
+    </g>
+    {% endfor %}
+
+    <!-- Today marker -->
+    <line class="today" x1="{{ page.today_x }}" y1="0" x2="{{ page.today_x }}" y2="{{ page.chart_height }}"/>
+
+    <!-- Legend -->
+    <g transform="translate({{ page.legend_dx }}, {{ page.legend_y }})">
+      {% if page.has_eoas_column %}
+      <rect class="legend-icon active" x="0" y="0"/>
+      <text class="label" x="18" y="11">{{ page.eoas_label | xml_escape }}</text>
+      <rect class="legend-icon security" x="240" y="0"/>
+      <text class="label" x="258" y="11">{{ page.eol_label | xml_escape }}</text>
+      {% else %}
+      <rect class="legend-icon security" x="0" y="0"/>
+      <text class="label" x="18" y="11">{{ page.eol_label | xml_escape }}</text>
+      {% endif %}
+    </g>
+
+  </g>
+</svg>

--- a/_plugins/generate-release-images.rb
+++ b/_plugins/generate-release-images.rb
@@ -1,0 +1,188 @@
+require 'jekyll'
+require 'date'
+
+module EndOfLife
+  class ReleaseImagesGenerator < Jekyll::Generator
+    safe true
+    priority :lowest
+
+    TOPIC = "Release Images:"
+
+    # SVG canvas & layout
+    SVG_WIDTH      = 900  # total image width in pixels
+    TOP_PADDING    = 10   # space above the first row
+    BOTTOM_PADDING = 60   # space below rows for x-axis labels and legend
+
+    # Row dimensions & labels
+    ROW_HEIGHT              = 25                 # height of each release bar in pixels
+    ROW_GAP                 = 4                  # vertical gap between rows in pixels
+    LABEL_GAP               = 8                  # gap between label text and the chart area
+    CHAR_WIDTH              = 7                  # estimated pixel width per character at 12px sans-serif
+    MAX_RELEASE_LABEL_WIDTH = 200                # maximum space reserved on the left for release labels
+    TEXT_Y_OFFSET           = ROW_HEIGHT / 2 + 4 # vertical offset to center label text in a row
+
+    # Axis & legend
+    YEAR_LABEL_GAP     = 16  # vertical distance from chart bottom to year label baseline
+    LEGEND_GAP         = 28  # vertical distance from chart bottom to legend icons
+    LEGEND_EOAS_OFFSET = 195 # distance from center to legend left edge (two-item: EOAS + EOL)
+    LEGEND_EOL_OFFSET  = 70  # distance from center to legend left edge (one-item: EOL only)
+
+    # Release filtering & date range
+    MAX_NON_EOL       = 10  # refuse to generate image if non-EOL releases exceed this
+    MAX_TRAILING_EOL  = 3   # maximum EOL releases kept at the bottom for context
+    SOFT_MAX_ROWS     = 10  # EOL releases beyond this total row count are dropped
+    DATE_PADDING_DAYS = 60  # padding added to the right end of the visible date range
+    MIN_FUTURE_DAYS   = 182 # chart always extends at least this many days past today
+
+    def generate(site)
+      start = Time.now
+      Jekyll.logger.info TOPIC, "Generating..."
+
+      site.pages.select { |page| page.data['layout'] == 'product' }.each do |product|
+        next unless product.data['eolColumn']
+        next if product.data['releaseImage']  # skip products that already have an image
+
+        svg_data = build_svg_data(product)
+        next if svg_data.nil?
+
+        site.pages << ProductReleaseImagePage.new(site, product, svg_data)
+        product.data['releaseImage'] = "/#{product.data['id']}.svg"
+      end
+
+      Jekyll.logger.info TOPIC, "Done in #{(Time.now - start).round(3)} seconds."
+    end
+
+    private
+
+    def build_svg_data(product)
+      today = Date.today
+      has_eoas_column = product.data['eoasColumn']
+
+      releases = select_releases(product)
+      return nil if releases.nil? || releases.empty?
+
+      longest_label_length = releases.map { |r| strip_html(r['label']).length }.max
+      release_label_width = [longest_label_length * CHAR_WIDTH + LABEL_GAP, MAX_RELEASE_LABEL_WIDTH].min
+      release_label_length = (release_label_width - LABEL_GAP) / CHAR_WIDTH
+
+      min_date, max_date, date_to_x_fn = build_timeline_scale(releases, today, release_label_width)
+      rows = build_rows(releases, has_eoas_column, date_to_x_fn, max_date, release_label_length)
+      return nil if rows.empty?
+
+      # One vertical tick per year within the date range.
+      year_ticks = ((min_date.year + 1)..max_date.year).map do |year|
+        { "year" => year, "x" => date_to_x_fn.call(Date.new(year, 1, 1)) }
+      end
+
+      chart_height = rows.length * (ROW_HEIGHT + ROW_GAP) - ROW_GAP
+      legend_x = SVG_WIDTH / 2 - (has_eoas_column ? LEGEND_EOAS_OFFSET : LEGEND_EOL_OFFSET)
+
+      {
+        "svg_width"          => SVG_WIDTH,
+        "svg_height"         => TOP_PADDING + chart_height + BOTTOM_PADDING,
+        "top_padding"        => TOP_PADDING,
+        "label_x"            => release_label_width - LABEL_GAP,
+        "row_height"         => ROW_HEIGHT,
+        "row_stride"         => ROW_HEIGHT + ROW_GAP,
+        "text_y_offset"      => TEXT_Y_OFFSET,
+        "chart_height"       => chart_height,
+        "year_label_y"       => chart_height + YEAR_LABEL_GAP,
+        "legend_dx"          => legend_x,
+        "legend_y"           => chart_height + LEGEND_GAP,
+        "today_x"            => date_to_x_fn.call(today),
+        "year_ticks"         => year_ticks,
+        "rows"               => rows,
+        "has_eoas_column"    => !!has_eoas_column,
+        "eoas_label"         => product.data['eoasColumnLabel'],
+        "eol_label"          => product.data['eolColumnLabel'],
+        "title"              => product.data['title'],
+      }
+    end
+
+    def select_releases(product)
+      releases = product.data['releases'].reject { |r| r['eol'] == true }
+
+      non_eol_count = releases.count { |r| !r['is_eol'] }
+      return nil if non_eol_count.zero? || non_eol_count > MAX_NON_EOL
+
+      # Keep up to MAX_TRAILING_EOL releases after the last non-EOL one,
+      # but cap the total so it stays within SOFT_MAX_ROWS.
+      last_non_eol  = releases.rindex { |r| !r['is_eol'] } || -1
+      trailing_eol  = (SOFT_MAX_ROWS - (last_non_eol + 1)).clamp(0, MAX_TRAILING_EOL)
+      releases.first(last_non_eol + 1 + trailing_eol)
+    end
+
+    def build_timeline_scale(releases, today, release_label_width)
+      all_dates = [today]
+      releases.each do |release|
+        all_dates << release['releaseDate'] if release['releaseDate'].is_a?(Date)
+        all_dates << release['eol']         if release['eol'].is_a?(Date)
+      end
+
+      min_date = all_dates.min
+      max_date = [all_dates.max + DATE_PADDING_DAYS, today + MIN_FUTURE_DAYS].max
+      total_days    = (max_date - min_date).to_f
+      drawable_width = SVG_WIDTH - release_label_width
+      date_to_x_fn = ->(date) { (release_label_width + (date - min_date) / total_days * drawable_width).round(1) }
+
+      [min_date, max_date, date_to_x_fn]
+    end
+
+    def build_rows(releases, has_eoas_column, date_to_x_fn, max_date, release_label_length)
+      max_x = date_to_x_fn.call(max_date)
+
+      # Build one row per release (newest first = top of chart).
+      releases.map do |release|
+        row = {
+          "label"      => truncate_label(strip_html(release['label']), release_label_length),
+          "active_x"   => 0, "active_width"   => 0,
+          "security_x" => 0, "security_width" => 0,
+        }
+
+        start_x = date_to_x_fn.call(release['releaseDate'])
+        eol_x  = resolve_value_to_x(release['eol'], date_to_x_fn, max_x)
+        eoas_x = has_eoas_column ? resolve_value_to_x(release['eoas'], date_to_x_fn, eol_x || max_x) : nil
+        if eoas_x
+          row["active_x"] = start_x
+          row["active_width"] = [eoas_x - start_x, 0].max
+
+          if release['eoas'].is_a?(Date) && eol_x
+            row["security_x"] = eoas_x
+            row["security_width"] = [eol_x - eoas_x, 0].max
+          end
+        elsif eol_x
+          row["security_x"] = start_x
+          row["security_width"] = [eol_x - start_x, 0].max
+        end
+
+        row
+      end
+    end
+
+    # Resolves a date field (Date, false, or true/nil) to an x-coordinate.
+    def resolve_value_to_x(value, date_to_x_fn, false_x)
+      value.is_a?(Date) ? date_to_x_fn.call(value) : (value == false ? false_x : nil)
+    end
+
+    def strip_html(str)
+      str.to_s.gsub(/<[^>]+>/, '')
+    end
+
+    def truncate_label(str, max_chars)
+      str.length > max_chars ? "#{str[0, max_chars - 1]}…" : str
+    end
+  end
+
+  class ProductReleaseImagePage < Jekyll::Page
+    def initialize(site, product, svg_data)
+      @site = site
+      @base = site.source
+      @dir  = ""
+      @name = "#{product.data['id']}.svg"
+
+      @data = { "layout" => "release-image", "nav_exclude" => true }.merge(svg_data)
+
+      self.process(@name)
+    end
+  end
+end

--- a/products/azure-kubernetes-service.md
+++ b/products/azure-kubernetes-service.md
@@ -8,7 +8,6 @@ alternate_urls:
   - /aks
 versionCommand: az aks show --resource-group myResourceGroup --name myAKSCluster
 releasePolicyLink: https://learn.microsoft.com/azure/aks/supported-kubernetes-versions
-releaseImage: https://learn.microsoft.com/en-us/azure/aks/media/supported-kubernetes-versions/kubernetes-versions-gantt.png
 latestColumn: false
 eolColumn: Support
 eoesColumn: LTS Support

--- a/products/backdrop.md
+++ b/products/backdrop.md
@@ -5,7 +5,6 @@ category: server-app
 tags: php-runtime
 permalink: /backdrop
 releasePolicyLink: https://backdropcms.org/releases
-releaseImage: https://backdropcms.org/files/images/release-cycles.png
 changelogTemplate: https://github.com/backdrop/backdrop/releases/tag/__LATEST__
 
 identifiers:

--- a/products/bazel.md
+++ b/products/bazel.md
@@ -7,7 +7,6 @@ iconSlug: bazel
 permalink: /bazel
 versionCommand: bazel --version
 releasePolicyLink: https://bazel.build/release
-releaseImage: https://blog.bazel.build/assets/lts_timeline.png
 changelogTemplate: "https://github.com/bazelbuild/bazel/releases/tag/__LATEST__"
 eoasColumn: true
 

--- a/products/centreon.md
+++ b/products/centreon.md
@@ -5,7 +5,6 @@ category: server-app
 tags: php-runtime
 permalink: /centreon
 releasePolicyLink: https://docs.centreon.com/docs/releases/lifecycle/
-releaseImage: https://docs.centreon.com/assets/images/lifecycle-from-24.10-de6e3693d62648fbe4760ab65fa21015.png
 changelogTemplate: "https://docs.centreon.com/docs/__RELEASE_CYCLE__/releases/centreon-os/#{{'__LATEST__'|replace:'.',''}}"
 eolColumn: OSS Support
 eoesColumn: Commercial Support

--- a/products/django.md
+++ b/products/django.md
@@ -7,7 +7,6 @@ iconSlug: django
 permalink: /django
 versionCommand: python -c "import django; print(django.get_version())"
 releasePolicyLink: https://www.djangoproject.com/download/#supported-versions
-releaseImage: https://static.djangoproject.com/img/release-roadmap.f1c2fefeeb00.svg
 changelogTemplate: https://docs.djangoproject.com/en/__RELEASE_CYCLE__/releases/__LATEST__/
 eoasColumn: true
 

--- a/products/dotnet.md
+++ b/products/dotnet.md
@@ -9,7 +9,6 @@ alternate_urls:
   - /dotnetcore
 versionCommand: dotnet --version
 releasePolicyLink: https://dotnet.microsoft.com/platform/support/policy/dotnet-core
-releaseImage: https://dotnet.microsoft.com/blob-assets/images/illustrations/release-schedule.svg
 changelogTemplate: https://github.com/dotnet/core/blob/main/release-notes/{{"__LATEST__"|split:'.'|slice:0,2|join:'.'}}/__LATEST__/__LATEST__.md
 eolColumn: Support Status
 

--- a/products/drupal.md
+++ b/products/drupal.md
@@ -7,7 +7,6 @@ iconSlug: drupal
 permalink: /drupal
 versionCommand: drush status
 releasePolicyLink: https://www.drupal.org/about/core/policies/core-release-cycles/schedule
-releaseImage: https://www.drupal.org/files/Drupal11and12ScheduleDec2025.png
 changelogTemplate: https://www.drupal.org/project/drupal/releases/__LATEST__
 eoesColumn: Commercial Support
 eoasColumn: true

--- a/products/linux-kernel.md
+++ b/products/linux-kernel.md
@@ -10,7 +10,6 @@ alternate_urls:
   - /linux-kernel
 versionCommand: uname -r
 # Found on https://en.wikipedia.org/wiki/Linux_kernel_version_history
-releaseImage: https://upload.wikimedia.org/wikipedia/en/timeline/4jw1oq6xzs412om0p07w1rnepswq6lo.png
 releasePolicyLink: https://www.kernel.org/
 changelogTemplate: https://kernelnewbies.org/Linux___RELEASE_CYCLE__
 

--- a/products/lua.md
+++ b/products/lua.md
@@ -5,7 +5,6 @@ category: lang
 iconSlug: lua
 permalink: /lua
 versionCommand: lua -v
-releaseImage: https://www.lua.org/images/timeline.png
 releasePolicyLink: https://www.lua.org/versions.html
 changelogTemplate: "https://www.lua.org/versions.html#{{'__RELEASE_CYCLE__'|split:' '|first}}/"
 eolColumn: Support

--- a/products/mariadb.md
+++ b/products/mariadb.md
@@ -6,7 +6,6 @@ iconSlug: mariadb
 permalink: /mariadb
 versionCommand: mariadbd --version
 releasePolicyLink: https://mariadb.org/about/#maintenance-policy
-releaseImage: https://lh7-rt.googleusercontent.com/docsz/AD_4nXcwwM8QxUnz_2MHM7-y8bZDqyh5_C8QMyRqTaJLs02iL3qSn9hY6gEvtkn5YAzaHoip9EU6UXgAUjwOkf6FBca-LVSjU6Vu9LtiHmIAxfSPmi9oz-3-pxjc5T0ovaw2VfNv9oH1dA?key=hghz9RPI1zQ7R7CURRAsxEVO
 changelogTemplate: "https://mariadb.com/docs/release-notes/community-server/changelogs/__RELEASE_CYCLE__/__LATEST__"
 eolColumn: Community support
 eoesColumn: Enterprise support
@@ -66,7 +65,7 @@ auto:
 releases:
   - releaseCycle: "12.2"
     releaseDate: 2026-02-13
-    eol: 2026-05-13 #estimated 
+    eol: 2026-05-13 #estimated
     latest: "12.2.2"
     latestReleaseDate: 2026-02-13
 

--- a/products/mediawiki.md
+++ b/products/mediawiki.md
@@ -6,7 +6,6 @@ tags: php-runtime
 permalink: /mediawiki
 versionCommand: https://your-server-url/mediawiki/Special:Version
 releasePolicyLink: https://www.mediawiki.org/wiki/Version_lifecycle
-releaseImage: https://upload.wikimedia.org/wikipedia/mediawiki/timeline/hs5faq2k9b3pw5dm4fabgjwtjf2l8jw.png
 changelogTemplate: https://www.mediawiki.org/wiki/Release_notes/__RELEASE_CYCLE__
 eolColumn: End-of-Life
 

--- a/products/mysql.md
+++ b/products/mysql.md
@@ -7,7 +7,6 @@ iconSlug: mysql
 permalink: /mysql
 versionCommand: mysqld --version
 releasePolicyLink: https://www.oracle.com/us/support/library/lifetime-support-technology-069183.pdf
-releaseImage: https://blogs.oracle.com/content/published/api/v1.1/assets/CONT32EABEA4FBCC4464BD35F58CEEA2EAFD/Medium?format=jpg&channelToken=32954b2a813146c9b9a4fa99364eba8e
 changelogTemplate: "https://dev.mysql.com/doc/relnotes/mysql/__RELEASE_CYCLE__/en/news-{{'__LATEST__'|replace:'.','-'}}.html"
 eoasColumn: Premier Support
 eolColumn: Extended Support

--- a/products/nodejs.md
+++ b/products/nodejs.md
@@ -9,7 +9,6 @@ alternate_urls:
   - /node
 versionCommand: node --version
 releasePolicyLink: https://nodejs.org/en/about/previous-releases
-releaseImage: https://raw.githubusercontent.com/nodejs/Release/main/schedule.svg?sanitize=true
 changelogTemplate: https://github.com/nodejs/node/blob/main/doc/changelogs/CHANGELOG_V__RELEASE_CYCLE__.md#__LATEST__
 eoasColumn: true
 eoesColumn: "Commercial Support"

--- a/products/opensuse.md
+++ b/products/opensuse.md
@@ -9,7 +9,6 @@ alternate_urls:
   - /opensuseleap
 versionCommand: cat /usr/lib/os-release
 releasePolicyLink: https://en.opensuse.org/Lifetime
-releaseImage: https://upload.wikimedia.org/wikipedia/en/timeline/slucio84mdla0deffiv2vrszinbrlek.png
 changelogTemplate: https://doc.opensuse.org/release-notes/x86_64/openSUSE/Leap/__RELEASE_CYCLE__/
 releaseLabel: "Leap __RELEASE_CYCLE__"
 latestColumn: false

--- a/products/perl.md
+++ b/products/perl.md
@@ -5,7 +5,6 @@ category: lang
 iconSlug: perl
 permalink: /perl
 versionCommand: perl -v
-releaseImage: https://www.versio.io/img/product-release-version-end-of-life/Perl_Foundation-Perl.jpg
 releasePolicyLink: https://perldoc.perl.org/perlpolicy#MAINTENANCE-AND-SUPPORT
 changelogTemplate: "https://perldoc.perl.org/__LATEST__/perldelta"
 eoasColumn: true

--- a/products/plone.md
+++ b/products/plone.md
@@ -5,7 +5,6 @@ category: server-app
 tags: python-runtime
 permalink: /plone
 releasePolicyLink: https://plone.org/download/release-schedule
-releaseImage: https://plone.org/download/release-schedule/plone-release-schedule-2025-01-23.png/@@images/image
 changelogTemplate: "https://plone.org/download/releases/__LATEST__"
 eoasColumn: Maintenance Support
 eolColumn: Security Support

--- a/products/qt.md
+++ b/products/qt.md
@@ -5,7 +5,6 @@ category: framework
 iconSlug: qt
 permalink: /qt
 versionCommand: qmake --version
-releaseImage: https://www.qt.io/hs-fs/hubfs/subscription%20timeline.png
 releasePolicyLink: https://cdn2.hubspot.net/hubfs/149513/_Website_Blog/Qt%20offering%20change%20FAQ-2020-01-27.pdf
 changelogTemplate: "https://www.qt.io/blog/qt-{{'__LATEST__' | drop_zero_patch}}-released"
 eolColumn: OSS support

--- a/products/red-hat-ansible-automation-platform.md
+++ b/products/red-hat-ansible-automation-platform.md
@@ -9,7 +9,6 @@ alternate_urls:
   - /ansible-automation-platform
   - /aap
 releasePolicyLink: https://access.redhat.com/support/policy/updates/ansible-automation-platform
-releaseImage: https://access.redhat.com/sites/hub/files/2025-10/AAP%20Lifecycle%20Doodle.jpg
 eoasColumn: Full Support
 eolColumn: Maintenance Support 1
 eoesColumn: Maintenance Support 2

--- a/products/red-hat-openshift.md
+++ b/products/red-hat-openshift.md
@@ -10,7 +10,6 @@ alternate_urls:
   - /rh-openshift
 versionCommand: oc version
 releasePolicyLink: https://access.redhat.com/support/policy/updates/openshift
-releaseImage: https://access.redhat.com/sites/default/files/styles/XL%20-%20Extra%20Large/public/images/ocp_lifecycle_eus_v4_0.png
 changelogTemplate: https://docs.redhat.com/en/documentation/openshift_container_platform/__RELEASE_CYCLE__/html/release_notes/ocp-{{"__RELEASE_CYCLE__"| replace:'.','-'}}-release-notes
 eoasColumn: Full Support
 eolColumn: Maintenance Support

--- a/products/red-hat-satellite.md
+++ b/products/red-hat-satellite.md
@@ -13,7 +13,6 @@ versionCommand: |-
 
   # or, on older versions
   yum info satellite
-releaseImage: https://access.redhat.com/sites/default/files/styles/XL%20-%20Extra%20Large/public/images/satellite_n-2_lifecycle_latest_v2.png
 releasePolicyLink: https://access.redhat.com/support/policy/updates/satellite
 changelogTemplate: "https://access.redhat.com/documentation/en-us/red_hat_satellite/__RELEASE_CYCLE__/html/release_notes/index"
 releaseDateColumn: General availability

--- a/products/silverstripe.md
+++ b/products/silverstripe.md
@@ -8,7 +8,6 @@ alternate_urls:
   - /silverstripe-cms
   - /silverstripe-framework
 versionCommand: composer info silverstripe/cms
-releaseImage: https://www.silverstripe.org/assets/Uploads/_resampled/ResizedImageWzYwMCw0ODdd/CMS-5.1-Support-Timeline-with-provisional-release-date.png
 releasePolicyLink: https://www.silverstripe.org/software/roadmap/
 changelogTemplate: "https://docs.silverstripe.org/en/{{'__RELEASE_CYCLE__'|split:'.'|first}}/changelogs/__RELEASE_CYCLE__.0/"
 eoasColumn: Active Development

--- a/products/tarantool.md
+++ b/products/tarantool.md
@@ -4,7 +4,6 @@ addedAt: 2022-03-21
 category: database
 permalink: /tarantool
 versionCommand: $ tarantool --version
-releaseImage: https://hb.bizmrg.com/tarantool-io/doc-builds/tarantool/latest/images_en/releases_calendar.svg
 releasePolicyLink: https://www.tarantool.io/en/doc/latest/release/policy/
 changelogTemplate: https://github.com/tarantool/tarantool/releases/tag/__LATEST__
 eolColumn: Support Status

--- a/products/ubuntu.md
+++ b/products/ubuntu.md
@@ -9,8 +9,6 @@ alternate_urls:
   - /ubuntu-linux
 versionCommand: cat /etc/os-release
 releasePolicyLink: https://wiki.ubuntu.com/Releases
-releaseImage: https://github.com/endoflife-date/endoflife.date/assets/1423115/c1d812cd-9179-4ff6-9607-520dbf37fa3e
-
 releaseLabel: "__RELEASE_CYCLE__ '__CODENAME__'"
 changelogTemplate: https://wiki.ubuntu.com/{{"__CODENAME__"|replace:' ',''}}/ReleaseNotes/
 eoasColumn: Hardware & Maintenance


### PR DESCRIPTION
Adds a Jekyll generator plugin to generate release timeline SVG images, similar to the one for [Node.js](https://endoflife.date/nodejs).

SVG generation rules:
- Only runs for products that have eolColumn set and no existing releaseImage
- Skips products with zero or more than 10 non-EOL release cycles
- Includes up to 3 trailing EOL cycles for context, capped at 10 rows total
- Releases with eol: true (date unknown) are excluded entirely
- Two bar colours: active/green (releaseDate→eoas) and security/orange (eoas→eol)
- If no eoasColumn the single bar covers releaseDate→eol/green
- X-axis spans from the earliest releaseDate to max(latest known date + 60 d, today + 182 d)
- Yearly grid lines, a red dashed today-marker, and a centred legend are rendered
- Labels longer than the reserved left column are truncated with an ellipsis

Also removes the now-redundant manual releaseImage field from the products where it was previously set, and drops it from the documentation.

Closes #285 and #166.