### PR TITLE
[sapmachine] Add 10

### DIFF
--- a/products/sapmachine.md
+++ b/products/sapmachine.md
@@ -111,6 +111,12 @@ releases:
     latest: "11.0.30"
     latestReleaseDate: 2026-01-20
 
+  - releaseCycle: "10"
+    releaseDate: 2018-03-21
+    eol: 2018-09-25 # releaseDate of OpenJDK 11
+    latest: "10.0.2"
+    latestReleaseDate: 2018-08-02
+
 ---
 
 > [SapMachine](https://sap.github.io/SapMachine/) is a [GPLv2 with CPE](https://openjdk.org/legal/gplv2+ce.html)


### PR DESCRIPTION
See https://github.com/SAP/SapMachine/releases/tag/sapmachine-10 and https://github.com/SAP/SapMachine/releases/tag/sapmachine-10.0.2.

For the EOL date the official release date of OpenJDK 11 was used, instead of the release date of SAP Machine 11. It makes more sense considering there was no release after August 2018 and anyway all OpenJDK distribution builds are aligned on [OpenJDK code](https://github.com/openjdk/jdk).