### PR TITLE
[New Product] Open AI ChatGPT

### DIFF
--- a/products/openai-chatgpt.md
+++ b/products/openai-chatgpt.md
@@ -294,8 +294,9 @@ releases:
 - **Deprecated**: The model has an announced shutdown date. It remains accessible to all users
   until the retirement date, but is not recommended for new use cases.
 - **Retired**: The model is no longer accessible. API requests using retired models will fail.
+  May also be referred to in documentation as "sunset" and "shut down".
 
-Impacted developers are notified by email and in OpenAI's documentation. For publicly released
+Impacted developers are notified by email, in OpenAI's [documentation](https://developers.openai.com/api/docs/deprecations/) and [blog](https://openai.com/blog). For publicly released
 models, at least 60 days' notice is given before the retirement date.
 
 OpenAI recommends auditing API usage to identify which models are in use and testing replacement

--- a/products/openai-chatgpt.md
+++ b/products/openai-chatgpt.md
@@ -8,8 +8,8 @@ permalink: /chatgpt
 alternate_urls:
   - /openai-chatgpt
 releasePolicyLink: https://developers.openai.com/api/docs/deprecations/
-eoasColumn: Deprecated
-eolColumn: Retired
+eoasColumn: Active
+eolColumn: Available
 
 customFields:
   - name: recommendedReplacement
@@ -291,5 +291,5 @@ models, at least 60 days' notice is given before the retirement date.
 OpenAI recommends auditing API usage to identify which models are in use and testing replacement
 models before the retirement date.
 
-Retirement is treated as EOL and Deprecation as End-of-Active-support in the above table and
-endoflife.date API.
+The **Active** column shows when a model is recommended for new use; it ends at Deprecation.
+The **Available** column shows when the model remains accessible at all; it ends at Retirement.

--- a/products/openai-chatgpt.md
+++ b/products/openai-chatgpt.md
@@ -20,15 +20,255 @@ customFields:
     link: https://developers.openai.com/api/docs/deprecations/
 
 releases:
-  - releaseCycle: "OpenAI Model name in API"
-    releaseLabel: Proper model name
-    releaseDate: 2026-02-17
+  - releaseCycle: "gpt-5.4"
+    releaseLabel: GPT-5.4
+    releaseDate: 2025-03-05
     eoas: false
     eol: false
-    latest: "Latest version of OpenAI Model name in API"
+    latest: "gpt-5.4"
     recommendedReplacement: "N/A"
-    latestReleaseDate: 2026-02-17
-    link: https://developers.openai.com/api/docs/deprecations/#IncludeAnchorIfAvailable
+    latestReleaseDate: 2025-11-12
+    link: https://developers.openai.com/api/docs/models
+
+  - releaseCycle: "gpt-5.2"
+    releaseLabel: GPT-5.2
+    releaseDate: 2025-12-11
+    eoas: false
+    eol: false
+    latest: "gpt-5.2"
+    recommendedReplacement: "N/A"
+    latestReleaseDate: 2025-11-12
+    link: https://developers.openai.com/api/docs/models
+
+  - releaseCycle: "gpt-5.1"
+    releaseLabel: GPT-5.1
+    releaseDate: 2025-08-07
+    eoas: false
+    eol: false
+    latest: "gpt-5.1"
+    recommendedReplacement: "N/A"
+    latestReleaseDate: 2025-11-12
+    link: https://developers.openai.com/api/docs/models
+
+  - releaseCycle: "gpt-5"
+    releaseLabel: GPT-5
+    releaseDate: 2025-08-07
+    eoas: false
+    eol: false
+    latest: "gpt-5"
+    recommendedReplacement: "N/A"
+    latestReleaseDate: 2025-08-07
+    link: https://developers.openai.com/api/docs/models
+
+  - releaseCycle: "o4-mini"
+    releaseLabel: OpenAI o4-mini
+    releaseDate: 2025-04-16
+    eoas: false
+    eol: false
+    latest: "o4-mini-2025-04-16"
+    recommendedReplacement: "N/A"
+    latestReleaseDate: 2025-04-16
+    link: https://developers.openai.com/api/docs/models
+
+  - releaseCycle: "o3"
+    releaseLabel: OpenAI o3
+    releaseDate: 2025-04-16
+    eoas: false
+    eol: false
+    latest: "o3-2025-04-16"
+    recommendedReplacement: "N/A"
+    latestReleaseDate: 2025-04-16
+    link: https://developers.openai.com/api/docs/models
+
+  - releaseCycle: "gpt-4.1"
+    releaseLabel: GPT-4.1
+    releaseDate: 2025-04-14
+    eoas: false
+    eol: false
+    latest: "gpt-4.1-2025-04-14"
+    recommendedReplacement: "N/A"
+    latestReleaseDate: 2025-04-14
+    link: https://developers.openai.com/api/docs/models
+
+  - releaseCycle: "gpt-4.1-mini"
+    releaseLabel: GPT-4.1 mini
+    releaseDate: 2025-04-14
+    eoas: false
+    eol: false
+    latest: "gpt-4.1-mini-2025-04-14"
+    recommendedReplacement: "N/A"
+    latestReleaseDate: 2025-04-14
+    link: https://developers.openai.com/api/docs/models
+
+  - releaseCycle: "gpt-4.5-preview"
+    releaseLabel: GPT-4.5 Preview
+    releaseDate: 2025-02-27
+    eoas: 2025-04-14
+    eol: 2025-07-14
+    latest: "gpt-4.5-preview"
+    recommendedReplacement: "gpt-4.1"
+    latestReleaseDate: 2025-02-27
+    link: https://developers.openai.com/api/docs/deprecations/#2025-04-14-gpt-4-5-preview
+
+  - releaseCycle: "o3-mini"
+    releaseLabel: OpenAI o3-mini
+    releaseDate: 2025-01-31
+    eoas: false
+    eol: false
+    latest: "o3-mini-2025-01-31"
+    recommendedReplacement: "N/A"
+    latestReleaseDate: 2025-01-31
+    link: https://developers.openai.com/api/docs/models
+
+  - releaseCycle: "o1"
+    releaseLabel: OpenAI o1
+    releaseDate: 2024-12-05
+    eoas: false
+    eol: false
+    latest: "o1-2024-12-17"
+    recommendedReplacement: "N/A"
+    latestReleaseDate: 2024-12-17
+    link: https://developers.openai.com/api/docs/models
+
+  - releaseCycle: "o1-preview"
+    releaseLabel: OpenAI o1 Preview
+    releaseDate: 2024-09-12
+    eoas: 2025-04-28
+    eol: 2025-07-28
+    latest: "o1-preview"
+    recommendedReplacement: "o3"
+    latestReleaseDate: 2024-09-12
+    link: https://developers.openai.com/api/docs/deprecations/#2025-04-28-o1-preview-and-o1-mini
+
+  - releaseCycle: "o1-mini"
+    releaseLabel: OpenAI o1 mini
+    releaseDate: 2024-09-12
+    eoas: 2025-04-28
+    eol: 2025-10-27
+    latest: "o1-mini"
+    recommendedReplacement: "o4-mini"
+    latestReleaseDate: 2024-09-12
+    link: https://developers.openai.com/api/docs/deprecations/#2025-04-28-o1-preview-and-o1-mini
+
+  - releaseCycle: "gpt-4o-mini"
+    releaseLabel: GPT-4o mini
+    releaseDate: 2024-07-18
+    eoas: false
+    eol: false
+    latest: "gpt-4o-mini-2024-07-18"
+    recommendedReplacement: "N/A"
+    latestReleaseDate: 2024-07-18
+    link: https://developers.openai.com/api/docs/models
+
+  - releaseCycle: "gpt-4o"
+    releaseLabel: GPT-4o
+    releaseDate: 2024-05-13
+    eoas: false
+    eol: false
+    latest: "gpt-4o-2024-11-20"
+    recommendedReplacement: "N/A"
+    latestReleaseDate: 2024-11-20
+    link: https://developers.openai.com/api/docs/models
+
+  - releaseCycle: "chatgpt-4o-latest"
+    releaseLabel: ChatGPT-4o Latest
+    releaseDate: 2024-05-13
+    eoas: 2025-11-18
+    eol: 2026-02-17
+    latest: "chatgpt-4o-latest"
+    recommendedReplacement: "gpt-5.1-chat-latest"
+    latestReleaseDate: 2024-05-13
+    link: https://developers.openai.com/api/docs/deprecations/#2025-11-18-chatgpt-4o-latest-snapshot
+
+  - releaseCycle: "gpt-4-0125-preview"
+    releaseLabel: GPT-4 Turbo Preview (0125)
+    releaseDate: 2024-01-25
+    eoas: 2025-09-26
+    eol: 2026-03-26
+    latest: "gpt-4-0125-preview"
+    recommendedReplacement: "gpt-5 or gpt-4.1"
+    latestReleaseDate: 2024-01-25
+    link: https://developers.openai.com/api/docs/deprecations/#2025-09-26-legacy-gpt-model-snapshots
+
+  - releaseCycle: "gpt-4-1106-preview"
+    releaseLabel: GPT-4 Turbo Preview (1106)
+    releaseDate: 2023-11-06
+    eoas: 2025-09-26
+    eol: 2026-03-26
+    latest: "gpt-4-1106-preview"
+    recommendedReplacement: "gpt-5 or gpt-4.1"
+    latestReleaseDate: 2023-11-06
+    link: https://developers.openai.com/api/docs/deprecations/#2025-09-26-legacy-gpt-model-snapshots
+
+  - releaseCycle: "gpt-4-vision-preview"
+    releaseLabel: GPT-4 Vision Preview
+    releaseDate: 2023-11-06
+    eoas: 2024-06-06
+    eol: 2024-12-06
+    latest: "gpt-4-vision-preview"
+    recommendedReplacement: "gpt-4o"
+    latestReleaseDate: 2023-11-06
+    link: https://developers.openai.com/api/docs/deprecations/#2024-06-06-gpt-4-32k-and-vision-preview-models
+
+  - releaseCycle: "gpt-3.5-turbo-1106"
+    releaseLabel: GPT-3.5 Turbo 1106
+    releaseDate: 2023-11-06
+    eoas: 2025-09-26
+    eol: 2026-09-28
+    latest: "gpt-3.5-turbo-1106"
+    recommendedReplacement: "gpt-5-mini or gpt-4.1-mini"
+    latestReleaseDate: 2023-11-06
+    link: https://developers.openai.com/api/docs/deprecations/#2025-09-26-legacy-gpt-model-snapshots
+
+  - releaseCycle: "gpt-3.5-turbo-instruct"
+    releaseLabel: GPT-3.5 Turbo Instruct
+    releaseDate: 2023-09-22
+    eoas: 2025-09-26
+    eol: 2026-09-28
+    latest: "gpt-3.5-turbo-instruct"
+    recommendedReplacement: "gpt-5-mini or gpt-4.1-mini"
+    latestReleaseDate: 2023-09-22
+    link: https://developers.openai.com/api/docs/deprecations/#2025-09-26-legacy-gpt-model-snapshots
+
+  - releaseCycle: "gpt-3.5-turbo-0613"
+    releaseLabel: GPT-3.5 Turbo (June 2023)
+    releaseDate: 2023-06-13
+    eoas: 2023-11-06
+    eol: 2024-09-13
+    latest: "gpt-3.5-turbo-0613"
+    recommendedReplacement: "gpt-3.5-turbo"
+    latestReleaseDate: 2023-06-13
+    link: https://developers.openai.com/api/docs/deprecations/#2023-11-06-chat-model-updates
+
+  - releaseCycle: "gpt-4-32k"
+    releaseLabel: GPT-4 32K
+    releaseDate: 2023-03-14
+    eoas: 2024-06-06
+    eol: 2025-06-06
+    latest: "gpt-4-32k"
+    recommendedReplacement: "gpt-4o"
+    latestReleaseDate: 2023-03-14
+    link: https://developers.openai.com/api/docs/deprecations/#2024-06-06-gpt-4-32k-and-vision-preview-models
+
+  - releaseCycle: "gpt-4-0314"
+    releaseLabel: GPT-4 (March 2023)
+    releaseDate: 2023-03-14
+    eoas: 2023-06-13
+    eol: 2026-03-26
+    latest: "gpt-4-0314"
+    recommendedReplacement: "gpt-5 or gpt-4.1"
+    latestReleaseDate: 2023-03-14
+    link: https://developers.openai.com/api/docs/deprecations/#2023-06-13-updated-chat-models
+
+  - releaseCycle: "gpt-3.5-turbo-0301"
+    releaseLabel: GPT-3.5 Turbo (March 2023)
+    releaseDate: 2023-03-01
+    eoas: 2023-06-13
+    eol: 2024-09-13
+    latest: "gpt-3.5-turbo-0301"
+    recommendedReplacement: "gpt-3.5-turbo"
+    latestReleaseDate: 2023-03-01
+    link: https://developers.openai.com/api/docs/deprecations/#2023-06-13-updated-chat-models
 ---
 
 > [OpenAI ChatGPT](https://openai.com/) is a family of large language models provided by OpenAI.
@@ -39,18 +279,18 @@ releases:
 
 ## Lifecycle states
 
-- **Active**: The model is fully supported and recommended for use.
-- **Legacy**: The model will no longer receive updates and may be deprecated in the future.
-- **Deprecated**: The model is no longer available for new customers but continues to be available
-  for existing users until retirement. OpenAI assigns a retirement date at this point.
-- **Retired**: The model is no longer available for use. Requests to retired models will fail.
+- **Active**: The model is fully supported and recommended for new use cases.
+- **Legacy**: The model no longer receives updates. OpenAI tags models as legacy to signal that
+  developers should migrate to newer models. Legacy models will be deprecated at some point.
+- **Deprecated**: The model has an announced shutdown date. It remains accessible to all users
+  until the retirement date, but is not recommended for new use cases.
+- **Retired**: The model is no longer accessible. API requests using retired models will fail.
 
-**Note** Deprecated models are likely to be less reliable than active models.
-OpenAI recommends moving workloads to active models to maintain the highest level of support and reliability.
+Impacted developers are notified by email and in OpenAI's documentation. For publicly released
+models, at least 60 days' notice is given before the retirement date.
 
-Customers with active deployments receive at least 60 days' notice before retirement for publicly released models.
-OpenAI recommends auditing API usage to discover model usage and testing replacement models before retirement.
+OpenAI recommends auditing API usage to identify which models are in use and testing replacement
+models before the retirement date.
 
-OpenAI has committed to preserve the weights of publicly released models and may make past models available again in the future.
-
-Retirement is treated as EOL and Deprecation as End-of-Active-support in the above table and endoflife.date API.
+Retirement is treated as EOL and Deprecation as End-of-Active-support in the above table and
+endoflife.date API.

--- a/products/openai-chatgpt.md
+++ b/products/openai-chatgpt.md
@@ -49,6 +49,16 @@ releases:
     latestReleaseDate: 2025-11-12
     link: https://developers.openai.com/api/docs/models
 
+  - releaseCycle: "gpt-5-mini"
+    releaseLabel: GPT-5
+    releaseDate: 2025-08-07
+    eoas: false
+    eol: false
+    latest: "gpt-5-mini"
+    recommendedReplacement: "N/A"
+    latestReleaseDate: 2025-08-07
+    link: https://developers.openai.com/api/docs/models
+
   - releaseCycle: "gpt-5"
     releaseLabel: GPT-5
     releaseDate: 2025-08-07

--- a/products/openai-chatgpt.md
+++ b/products/openai-chatgpt.md
@@ -8,8 +8,8 @@ permalink: /chatgpt
 alternate_urls:
   - /openai-chatgpt
 releasePolicyLink: https://developers.openai.com/api/docs/deprecations/
-eoasColumn: Deprecated
-eolColumn: Retired
+eoasColumn: Active Support
+eolColumn: Supported
 
 customFields:
   - name: recommendedReplacement

--- a/products/openai-chatgpt.md
+++ b/products/openai-chatgpt.md
@@ -1,4 +1,3 @@
-
 ---
 title: OpenAI ChatGPT
 addedAt: 2026-03-10
@@ -22,7 +21,7 @@ customFields:
 releases:
   - releaseCycle: "gpt-5.4"
     releaseLabel: GPT-5.4
-    releaseDate: 2025-03-05
+    releaseDate: 2026-03-05
     eoas: false
     eol: false
     latest: "gpt-5.4"

--- a/products/openai-chatgpt.md
+++ b/products/openai-chatgpt.md
@@ -8,8 +8,8 @@ permalink: /chatgpt
 alternate_urls:
   - /openai-chatgpt
 releasePolicyLink: https://developers.openai.com/api/docs/deprecations/
-eoasColumn: Active
-eolColumn: Available
+eoasColumn: Deprecated
+eolColumn: Retired
 
 customFields:
   - name: recommendedReplacement
@@ -301,6 +301,3 @@ models, at least 60 days' notice is given before the retirement date.
 
 OpenAI recommends auditing API usage to identify which models are in use and testing replacement
 models before the retirement date.
-
-The **Active** column shows when a model is recommended for new use; it ends at Deprecation.
-The **Available** column shows when the model remains accessible at all; it ends at Retirement.

--- a/products/openai-chatgpt.md
+++ b/products/openai-chatgpt.md
@@ -1,0 +1,56 @@
+
+---
+title: OpenAI ChatGPT
+addedAt: 2026-03-10
+category: service
+tags: llm
+iconSlug: openai
+permalink: /chatgpt
+alternate_urls:
+  - /openai-chatgpt
+releasePolicyLink: https://developers.openai.com/api/docs/deprecations/
+eoasColumn: Deprecated
+eolColumn: Retired
+
+customFields:
+  - name: recommendedReplacement
+    display: after-latest-column
+    label: Recommended replacement
+    description: Replacement model from OpenAI deprecation history
+    link: https://developers.openai.com/api/docs/deprecations/
+
+releases:
+  - releaseCycle: "OpenAI Model name in API"
+    releaseLabel: Proper model name
+    releaseDate: 2026-02-17
+    eoas: false
+    eol: false
+    latest: "Latest version of OpenAI Model name in API"
+    recommendedReplacement: "N/A"
+    latestReleaseDate: 2026-02-17
+    link: https://developers.openai.com/api/docs/deprecations/#IncludeAnchorIfAvailable
+---
+
+> [OpenAI ChatGPT](https://openai.com/) is a family of large language models provided by OpenAI.
+
+{: .warning }
+> This page tracks ChatGPT model availability on the OpenAI API. This does not include the ChatGPT app,
+> OpenAI Codex, or third-party integrations such as Amazon Bedrock and Google Cloud Vertex AI.
+
+## Lifecycle states
+
+- **Active**: The model is fully supported and recommended for use.
+- **Legacy**: The model will no longer receive updates and may be deprecated in the future.
+- **Deprecated**: The model is no longer available for new customers but continues to be available
+  for existing users until retirement. OpenAI assigns a retirement date at this point.
+- **Retired**: The model is no longer available for use. Requests to retired models will fail.
+
+**Note** Deprecated models are likely to be less reliable than active models.
+OpenAI recommends moving workloads to active models to maintain the highest level of support and reliability.
+
+Customers with active deployments receive at least 60 days' notice before retirement for publicly released models.
+OpenAI recommends auditing API usage to discover model usage and testing replacement models before retirement.
+
+OpenAI has committed to preserve the weights of publicly released models and may make past models available again in the future.
+
+Retirement is treated as EOL and Deprecation as End-of-Active-support in the above table and endoflife.date API.


### PR DESCRIPTION
As part of https://github.com/endoflife-date/endoflife.date/issues/9544, I am submitting this PR to add an initial EOL page for OpenAI ChatGPT through their API. 

One thing I noticed that I am unsure about is when EOL is marked as `false`, the column gets colored green and marked with a yes which I'm not sure make sense grammatically. It's correct in the API, with `{"eol": false}`.  I have kept it consistent with the other pages for now with the column Deprecated, colored green with a yes. 

<img width="1102" height="896" alt="image" src="https://github.com/user-attachments/assets/2b9a5215-34e9-4c4a-b379-500ef883fed3" />

