### PR TITLE
[confluence] Disable atlassian_eol auto method

### DIFF
--- a/products/confluence.md
+++ b/products/confluence.md
@@ -19,9 +19,10 @@ identifiers:
 auto:
   methods:
     - atlassian_versions: https://www.atlassian.com/software/confluence/download-archives
-    - atlassian_eol: https://confluence.atlassian.com/support/atlassian-support-end-of-life-policy-201851003.html
-      selector: AtlassianEndofSupportPolicy-Confluence
-      regex: '(?P<release>\d+(\.\d+)+) \(EO[SL] date: (?P<date>.+)\).*$'
+    # Cannot locate confluence releases because there is no more properly formatted title to locate them
+    #- atlassian_eol: https://confluence.atlassian.com/support/atlassian-support-end-of-life-policy-201851003.html
+    #  selector: AtlassianEndofSupportPolicy-Confluence
+    #  regex: '(?P<release>\d+(\.\d+)+) \(EO[SL] date: (?P<date>.+)\).*$'
 
 # Release dates from https://www.atlassian.com/software/confluence/download-archives.
 # LTS/EOL dates can be found on https://confluence.atlassian.com/support/atlassian-support-end-of-life-policy-201851003.html.


### PR DESCRIPTION
Releases can't be located because there is no more properly formatted title to locate them.

Closes #9689.