### PR TITLE
[oracle-jdk] Update link for 7u351

### DIFF
--- a/products/oracle-jdk.md
+++ b/products/oracle-jdk.md
@@ -180,7 +180,7 @@ releases:
     releaseDate: 2011-07-11
     eol: 2019-07-31
     eoes: 2022-07-19
-    link: https://www.oracle.com/java/technologies/javase/7-support-relnotes.html#R170_361
+    link: https://www.oracle.com/java/technologies/javase/7-support-relnotes.html#R170_351
     latest: "7u351"
     latestReleaseDate: 2022-07-19
 


### PR DESCRIPTION
The section is incorrectly marked - the link is currently pointing to 7u361, while it should be 7u351.