### PR TITLE
[macos] Update 10.15 cycle for 10.15.8

### DIFF
--- a/products/macos.md
+++ b/products/macos.md
@@ -64,16 +64,16 @@ releases:
   - releaseCycle: "11"
     codename: "Big Sur"
     releaseDate: 2020-11-12
-    eol: 2023-09-26
-    latest: "11.7.11"
+    eol: 2026-02-02
+    latest: "11.7.11 - This update only extends the certification required by features such as iMessage, FaceTime, and device activation to continue working after January 2027. Security fixes haven't been released since 2023."
     latestReleaseDate: 2026-02-02
     link: https://developer.apple.com/documentation/macos-release-notes/macos-big-sur-11_0_1-release-notes
 
   - releaseCycle: "10.15"
     codename: "Catalina"
     releaseDate: 2019-10-07
-    eol: 2022-09-12
-    latest: "10.15.8"
+    eol: 2026-02-02
+    latest: "10.15.8 - This update only extends the certification required by features such as iMessage, FaceTime, and device activation to continue working after January 2027. Security fixes haven't been released since 2022."
     latestReleaseDate: 2026-02-02
     link: https://developer.apple.com/documentation/macos-release-notes/macos-catalina-10_15-release-notes
 

--- a/products/macos.md
+++ b/products/macos.md
@@ -73,8 +73,8 @@ releases:
     codename: "Catalina"
     releaseDate: 2019-10-07
     eol: 2022-09-12
-    latest: "10.15.7"
-    latestReleaseDate: 2020-09-24
+    latest: "10.15.8"
+    latestReleaseDate: 2026-02-02
     link: https://developer.apple.com/documentation/macos-release-notes/macos-catalina-10_15-release-notes
 
   - releaseCycle: "10.14"

--- a/products/macos.md
+++ b/products/macos.md
@@ -65,7 +65,7 @@ releases:
     codename: "Big Sur"
     releaseDate: 2020-11-12
     eol: 2026-02-02
-    latest: "11.7.11 - This update only extends the certification required by features such as iMessage, FaceTime, and device activation to continue working after January 2027. Security fixes haven't been released since 2023."
+    latest: "11.7.11"
     latestReleaseDate: 2026-02-02
     link: https://developer.apple.com/documentation/macos-release-notes/macos-big-sur-11_0_1-release-notes
 
@@ -73,7 +73,7 @@ releases:
     codename: "Catalina"
     releaseDate: 2019-10-07
     eol: 2026-02-02
-    latest: "10.15.8 - This update only extends the certification required by features such as iMessage, FaceTime, and device activation to continue working after January 2027. Security fixes haven't been released since 2022."
+    latest: "10.15.8"
     latestReleaseDate: 2026-02-02
     link: https://developer.apple.com/documentation/macos-release-notes/macos-catalina-10_15-release-notes
 


### PR DESCRIPTION
Despite being EOL for over 3 years Apple released a small certificate Update for macOS Catalina last month. Apple named it "Security Update 2026-001 Catalina" and bumped up the OS version number to 10.15.8.

See:
https://support.apple.com/en-ca/100100
https://9to5mac.com/2026/02/02/apple-just-released-new-updates-for-old-versions-of-ios-macos-watchos-more/