### PR TITLE
[ffmpeg] Add 8.1 "Hoare" Cycle and Add brew purl

### DIFF
--- a/products/ffmpeg.md
+++ b/products/ffmpeg.md
@@ -14,6 +14,7 @@ identifiers:
   - repology: ffmpeg
   - cpe: cpe:/a:ffmpeg:ffmpeg
   - cpe: cpe:2.3:a:ffmpeg:ffmpeg
+  - purl: pkg:brew/ffmpeg
 
 auto:
   methods:
@@ -24,6 +25,13 @@ auto:
 # EOL date can be found on https://ffmpeg.org/olddownload.html
 # LTS: every ODD.1 release is LTS from https://news.ycombinator.com/item?id=41695542
 releases:
+  - releaseCycle: "8.1"
+    codename: Hoare
+    releaseDate: 2026-03-16
+    eol: false
+    latest: "8.1.0"
+    latestReleaseDate: 2026-03-16
+    
   - releaseCycle: "8.0"
     codename: Huffman
     releaseDate: 2025-08-22


### PR DESCRIPTION
# :grey_question: About

Cf [announce](https://www.ffmpeg.org/index.html#news) : 

> March 16th, 2026, FFmpeg 8.1 "Hoare"
> A new minor release, [FFmpeg 8.1 "Hoare"](https://www.ffmpeg.org/download.html#release_8.1), is now available for download. Here are some of the highlights:
> 
> Decoders: xHE-AAC Mps212 (experimental) MPEG-H decoding via libmpeghdec
> EXIF Metadata Parsing
> LCEVC: support for parsing and forwarding metadata
> Vulkan compute-based codecs: ProRes encoding and decoding, DPX decoding
> D3D12: D3D12 H.264/AV1 encoding, scale_d3d12, mestimate_d3d12, deinterlace_d3d12 filters
> Rockchip H.264/HEVC hardware encoding
> IAMF: Projection mode Ambisonic Audio Elements muxing and demuxing
> Formats: hxvs demuxer
> Filters: drawvg, vpp_amf
> This release features a lot of internal changes and bugfixes. The groundwork for the upcoming swscale rewrite is progressing. The Vulkan compute-based codecs, and a few filters, no longer depend on runtime GLSL compilation, which speeds up their initialization.
> 
> A companion post about the Vulkan Compute-based codec implementations has been published on the [Khronos blog](https://www.khronos.org/blog/video-encoding-and-decoding-with-vulkan-compute-shaders-in-ffmpeg), featuring technical details on the implementations and future plans.