### PR TITLE
[docs]: rollback fix for identifiers link

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -481,7 +481,7 @@ bin/lint-product.sh products/<product>.md
 ## 🆔 Adding Identifiers
 
 We need help with adding more identifiers.
-Please see [this page](/pages/help/identifiers-needed/) for a list of pages missing identifiers.
+Please see [this page](/help/identifiers-needed/) for a list of pages missing identifiers.
 
 ## 📑 Suggested Reading
 


### PR DESCRIPTION
Hi, it's a revert for commit fee3c8c00a0a0a161e6cabf665d21fc5d8cdf245, currently breaking the link in contribution.md for identifiers needed page.