### PR TITLE
[amazon-documentdb] add 8.0

### DIFF
--- a/products/amazon-documentdb.md
+++ b/products/amazon-documentdb.md
@@ -22,6 +22,11 @@ auto:
         eoes: "End of Extended Support"
 
 releases:
+  - releaseCycle: "8.0"
+    releaseDate: 2026-11-30
+    eol: false
+    eoes: false
+
   - releaseCycle: "5.0"
     releaseDate: 2023-03-01
     eol: false

--- a/products/amazon-documentdb.md
+++ b/products/amazon-documentdb.md
@@ -31,7 +31,7 @@ releases:
     releaseDate: 2023-03-01
     eol: false
     eoes: false
-    lts:true
+    lts: true
 
   - releaseCycle: "4.0"
     releaseDate: 2020-11-09

--- a/products/amazon-documentdb.md
+++ b/products/amazon-documentdb.md
@@ -23,7 +23,7 @@ auto:
 
 releases:
   - releaseCycle: "8.0"
-    releaseDate: 2026-11-30
+    releaseDate: 2025-11-30
     eol: false
     eoes: false
 

--- a/products/amazon-documentdb.md
+++ b/products/amazon-documentdb.md
@@ -31,6 +31,7 @@ releases:
     releaseDate: 2023-03-01
     eol: false
     eoes: false
+    lts:true
 
   - releaseCycle: "4.0"
     releaseDate: 2020-11-09


### PR DESCRIPTION
https://docs.aws.amazon.com/documentdb/latest/developerguide/docdb-version-support-dates.html

doesn't list exact date, therefore chosen 2025-11-30