### PR TITLE
[apache-activemq-artemis] add 2.53

### DIFF
--- a/products/apache-activemq-artemis.md
+++ b/products/apache-activemq-artemis.md
@@ -21,9 +21,15 @@ auto:
 
 # eol(x) = releaseDate(x+1)
 releases:
+  - releaseCycle: "2.53"
+    releaseDate: 2026-03-17
+    eol: false
+    latest: "2.53.0"
+    latestReleaseDate: 2026-03-17
+
   - releaseCycle: "2.52"
     releaseDate: 2026-03-02
-    eol: false
+    eol: 2026-03-17
     latest: "2.52.0"
     latestReleaseDate: 2026-03-02
 


### PR DESCRIPTION
was tagged yesterday

https://github.com/apache/artemis/releases/tag/2.53.0