### PR TITLE
[Guzzle] Support for PHP 8.5

### DIFF
--- a/products/guzzle.md
+++ b/products/guzzle.md
@@ -27,32 +27,32 @@ identifiers:
 releases:
   - releaseCycle: "7"
     eol: false
-    supportedPHPVersions: ">=7.2.5, <8.5"
+    supportedPHPVersions: ">=7.2.5, <8.6"
     latest: "7.10.0"
     releaseDate: 2020-06-27
-
     latestReleaseDate: 2025-08-23
+
   - releaseCycle: "6"
     eol: 2023-10-31
     supportedPHPVersions: ">=5.5, <8.0"
     latest: "6.5.8"
     releaseDate: 2015-05-26
-
     latestReleaseDate: 2022-06-20
+
   - releaseCycle: "5"
     eol: 2019-10-31
     supportedPHPVersions: ">=5.4, <7.4"
     latest: "5.3.4"
     releaseDate: 2014-10-12
-
     latestReleaseDate: 2019-10-30
+
   - releaseCycle: "4"
     eol: 2016-10-31
     supportedPHPVersions: ">=5.4, <7.0"
     latest: "4.2.4"
     releaseDate: 2014-03-29
-
     latestReleaseDate: 2016-07-15
+
   - releaseCycle: "3"
     eol: 2016-10-31
     supportedPHPVersions: ">=5.3.3, <7.0"


### PR DESCRIPTION
7.10 added support for PHP 8.5 https://github.com/guzzle/guzzle/releases/tag/7.10.0

readme not updated, PR opened 
https://github.com/guzzle/guzzle/pull/3320