### PR TITLE
[New Product] ClickHouse

### DIFF
--- a/products/clickhouse.md
+++ b/products/clickhouse.md
@@ -17,7 +17,7 @@ identifiers:
 auto:
   methods:
     - git: https://github.com/ClickHouse/ClickHouse.git
-      regex: ^v(?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)\.(?P<build>\d+)-(stable|lts)$
+      regex: ^v(?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)\.(?P<tiny>\d+)-(stable|lts)$
 
 releases:
   - releaseCycle: "25.9"

--- a/products/clickhouse.md
+++ b/products/clickhouse.md
@@ -7,7 +7,7 @@ permalink: /clickhouse
 versionCommand: clickhouse-client --version
 releasePolicyLink: https://clickhouse.com/docs/faq/operations/production#how-to-choose-between-clickhouse-releases
 changelogTemplate: https://github.com/ClickHouse/ClickHouse/blob/master/CHANGELOG.md
-eolColumn: Support Status
+eolColumn: Support
 
 identifiers:
   - purl: pkg:github/ClickHouse/ClickHouse

--- a/products/clickhouse.md
+++ b/products/clickhouse.md
@@ -19,6 +19,8 @@ auto:
     - git: https://github.com/ClickHouse/ClickHouse.git
       regex: ^v(?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)\.(?P<tiny>\d+)-(stable|lts)$
 
+# Non-LTS : eol(x) = releaseDate(x+3)
+# LTS : eol(x) = releaseDate(x) + 1 year
 releases:
   - releaseCycle: "25.9"
     releaseDate: 2025-09-27

--- a/products/clickhouse.md
+++ b/products/clickhouse.md
@@ -1,6 +1,6 @@
 ---
 title: ClickHouse
-addedAt: 2025-09-29
+addedAt: 2025-10-26
 category: database
 iconSlug: clickhouse
 permalink: /clickhouse
@@ -54,9 +54,8 @@ releases:
 
 ---
 
-> [ClickHouse](https://clickhouse.com/) is a high-performance, column-oriented SQL database
-> management system (DBMS) for online analytical processing (OLAP). It enables real-time
-> analytics on large datasets using standard SQL queries.
+> [ClickHouse](https://clickhouse.com/) is a high-performance, column-oriented SQL database management system (DBMS) for online analytical processing (OLAP).
+> It enables real-time analytics on large datasets using standard SQL queries.
 
 ClickHouse offers two types of releases:
 

--- a/products/clickhouse.md
+++ b/products/clickhouse.md
@@ -6,7 +6,7 @@ iconSlug: clickhouse
 permalink: /clickhouse
 versionCommand: clickhouse-client --version
 releasePolicyLink: https://clickhouse.com/docs/faq/operations/production#how-to-choose-between-clickhouse-releases
-changelogTemplate: https://github.com/ClickHouse/ClickHouse/releases/tag/v__LATEST__
+changelogTemplate: https://github.com/ClickHouse/ClickHouse/blob/master/CHANGELOG.md
 eolColumn: Support Status
 
 identifiers:

--- a/products/clickhouse.md
+++ b/products/clickhouse.md
@@ -54,7 +54,7 @@ releases:
 
 ---
 
-> [ClickHouse](https://clickhouse.com/) is a high-performance, column-oriented SQL database management system (DBMS) for online analytical processing (OLAP).
+> [ClickHouse](https://clickhouse.com/) is an open-source, high-performance, column-oriented SQL database management system (DBMS) for online analytical processing (OLAP).
 > It enables real-time analytics on large datasets using standard SQL queries.
 
 ClickHouse offers two types of releases:

--- a/products/clickhouse.md
+++ b/products/clickhouse.md
@@ -59,20 +59,10 @@ releases:
 > [ClickHouse](https://clickhouse.com/) is an open-source, high-performance, column-oriented SQL database management system (DBMS) for online analytical processing (OLAP).
 > It enables real-time analytics on large datasets using standard SQL queries.
 
-ClickHouse offers two types of releases:
+ClickHouse uses [Calendar Versioning](https://calver.org/) with the format `Year.Month.Patch.Build` (e.g., `25.8.4.13`).
 
-## Stable Releases
+A new minor release is published approximately every month.
+The last three minor releases are supported with bug and security fixes.
 
-- Released approximately monthly
-- The **3 most recent stable releases** are supported
-- Recommended for most users who want access to new features
-- Receive security and bug fixes
-
-## Long-Term Support (LTS) Releases
-
-- Released **twice per year** (March and August)
-- Supported for **1 year** from the release date
-- Recommended for enterprises with policies restricting frequent upgrades
-- Only receive critical security and stability fixes
-
-ClickHouse uses a versioning scheme of `Year.Month.Patch.Build` format (e.g., `25.8.4.13`).
+Twice a year, typically in March and August, minor releases are designated Long-Term Support (LTS).
+Such releases are supported for 1 year with critical security and stability updates.

--- a/products/clickhouse.md
+++ b/products/clickhouse.md
@@ -1,0 +1,77 @@
+---
+title: ClickHouse
+addedAt: 2025-09-29
+category: database
+iconSlug: clickhouse
+permalink: /clickhouse
+versionCommand: clickhouse-client --version
+releasePolicyLink: https://clickhouse.com/docs/faq/operations/production#how-to-choose-between-clickhouse-releases
+changelogTemplate: https://github.com/ClickHouse/ClickHouse/releases/tag/v__LATEST__
+eolColumn: Support Status
+
+identifiers:
+  - purl: pkg:github/ClickHouse/ClickHouse
+  - purl: pkg:docker/library/clickhouse
+  - repology: clickhouse
+
+auto:
+  methods:
+    - git: https://github.com/ClickHouse/ClickHouse.git
+      regex: ^v(?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)\.(?P<build>\d+)-(stable|lts)$
+
+releases:
+  - releaseCycle: "25.9"
+    releaseDate: 2025-09-27
+    eol: false
+    latest: "25.9.2.1"
+    latestReleaseDate: 2025-09-27
+
+  - releaseCycle: "25.8"
+    lts: true
+    releaseDate: 2025-08-28
+    eol: 2026-08-28
+    latest: "25.8.7.3"
+    latestReleaseDate: 2025-09-25
+
+  - releaseCycle: "25.7"
+    releaseDate: 2025-07-29
+    eol: false
+    latest: "25.7.7.68"
+    latestReleaseDate: 2025-09-23
+
+  - releaseCycle: "25.6"
+    releaseDate: 2025-06-26
+    eol: false
+    latest: "25.6.12.10"
+    latestReleaseDate: 2025-09-16
+
+  - releaseCycle: "25.3"
+    lts: true
+    releaseDate: 2025-03-20
+    eol: 2026-03-20
+    latest: "25.3.2.39"
+    latestReleaseDate: 2025-03-27
+
+---
+
+> [ClickHouse](https://clickhouse.com/) is a high-performance, column-oriented SQL database
+> management system (DBMS) for online analytical processing (OLAP). It enables real-time
+> analytics on large datasets using standard SQL queries.
+
+ClickHouse offers two types of releases:
+
+## Stable Releases
+
+- Released approximately monthly
+- The **3 most recent stable releases** are supported
+- Recommended for most users who want access to new features
+- Receive security and bug fixes
+
+## Long-Term Support (LTS) Releases
+
+- Released **twice per year** (March and August)
+- Supported for **1 year** from the release date
+- Recommended for enterprises with policies restricting frequent upgrades
+- Only receive critical security and stability fixes
+
+ClickHouse uses a versioning scheme of `Year.Month.Patch.Build` format (e.g., `25.8.4.13`).

--- a/products/clickhouse.md
+++ b/products/clickhouse.md
@@ -22,42 +22,95 @@ auto:
 # Non-LTS : eol(x) = releaseDate(x+3)
 # LTS : eol(x) = releaseDate(x) + 1 year
 releases:
+  - releaseCycle: "26.2"
+    releaseDate: 2026-02-27
+    eol: false
+    latest: "26.2.4.23"
+    latestReleaseDate: 2026-03-05
+
+  - releaseCycle: "26.1"
+    releaseDate: 2026-01-30
+    eol: false
+    latest: "26.1.4.35"
+    latestReleaseDate: 2026-03-01
+
+  - releaseCycle: "25.12"
+    releaseDate: 2025-12-18
+    eol: false
+    latest: "25.12.8.9"
+    latestReleaseDate: 2026-03-01
+
+  - releaseCycle: "25.11"
+    releaseDate: 2025-11-27
+    eol: 2026-02-27
+    latest: "25.11.9.34"
+    latestReleaseDate: 2026-02-17
+
+  - releaseCycle: "25.10"
+    releaseDate: 2025-11-01
+    eol: 2026-01-30
+    latest: "25.10.6.36"
+    latestReleaseDate: 2026-02-02
+
   - releaseCycle: "25.9"
     releaseDate: 2025-09-27
-    eol: false
-    latest: "25.9.2.1"
-    latestReleaseDate: 2025-09-27
+    eol: 2025-12-18
+    latest: "25.9.7.56"
+    latestReleaseDate: 2025-12-19
 
   - releaseCycle: "25.8"
     lts: true
-    releaseDate: 2025-08-28
-    eol: 2026-08-28
-    latest: "25.8.7.3"
-    latestReleaseDate: 2025-09-25
+    releaseDate: 2025-08-29
+    eol: 2026-08-29
+    latest: "25.8.18.1"
+    latestReleaseDate: 2026-03-02
 
   - releaseCycle: "25.7"
     releaseDate: 2025-07-29
-    eol: false
-    latest: "25.7.7.68"
-    latestReleaseDate: 2025-09-23
+    eol: 2025-11-01
+    latest: "25.7.8.71"
+    latestReleaseDate: 2025-10-14
 
   - releaseCycle: "25.6"
     releaseDate: 2025-06-26
-    eol: false
-    latest: "25.6.12.10"
-    latestReleaseDate: 2025-09-16
+    eol: 2025-09-27
+    latest: "25.6.13.41"
+    latestReleaseDate: 2025-10-14
+
+  - releaseCycle: "25.5"
+    releaseDate: 2025-05-22
+    eol: 2025-08-29
+    latest: "25.5.11.15"
+    latestReleaseDate: 2025-10-15
+
+  - releaseCycle: "25.4"
+    releaseDate: 2025-04-22
+    eol: 2025-07-29
+    latest: "25.4.13.22"
+    latestReleaseDate: 2025-07-24
 
   - releaseCycle: "25.3"
     lts: true
     releaseDate: 2025-03-20
     eol: 2026-03-20
-    latest: "25.3.2.39"
-    latestReleaseDate: 2025-03-27
+    latest: "25.3.14.14"
+    latestReleaseDate: 2026-02-02
+
+  - releaseCycle: "25.2"
+    releaseDate: 2025-02-28
+    eol: 2025-05-22
+    latest: "25.2.2.39"
+    latestReleaseDate: 2025-03-13
+
+  - releaseCycle: "25.1"
+    releaseDate: 2025-01-28
+    eol: 2025-04-22
+    latest: "25.1.8.25"
+    latestReleaseDate: 2025-03-13
 
 ---
 
 > [ClickHouse](https://clickhouse.com/) is an open-source, high-performance, column-oriented SQL database management system (DBMS) for online analytical processing (OLAP).
-> It enables real-time analytics on large datasets using standard SQL queries.
 
 ClickHouse uses [Calendar Versioning](https://calver.org/) with the format `Year.Month.Patch.Build` (e.g., `25.8.4.13`).
 

--- a/products/clickhouse.md
+++ b/products/clickhouse.md
@@ -1,6 +1,6 @@
 ---
 title: ClickHouse
-addedAt: 2025-10-26
+addedAt: 2026-03-30
 category: database
 iconSlug: clickhouse
 permalink: /clickhouse

--- a/products/clickhouse.md
+++ b/products/clickhouse.md
@@ -118,4 +118,4 @@ A new minor release is published approximately every month.
 The last three minor releases are supported with bug and security fixes.
 
 Twice a year, typically in March and August, minor releases are designated Long-Term Support (LTS).
-Such releases are supported for 1 year with critical security and stability updates.
+Such releases are supported for 1 year.


### PR DESCRIPTION
Registering a new product for 'ClickHouse'.

Requested by:
- https://github.com/endoflife-date/endoflife.date/issues/8486
- https://github.com/endoflife-date/endoflife.date/issues/6849

This addresses all review feedback from #8588:
- Fix `eolColumn` to `Support`
- Fix `changelogTemplate` to point to `CHANGELOG.md` instead of per-tag URL
- Fix regex named group `build` → `tiny`
- Add comment explaining EOL policy before `releases:`
- Remove redundant description sentence
- Add EOL releases: 25.1, 25.2, 25.4, 25.5
- Add newer releases: 25.10, 25.11, 25.12, 26.1, 26.2
- Update EOL dates for 25.6, 25.7, 25.9 (now past EOL)
- Fix 25.8 release date to 2025-08-29 (verified from GitHub)
- Update latest versions for all active cycles to current data

Closes #8486
Closes #6849