### PR TITLE
Update latest releases for Mastodon

### DIFF
--- a/products/mastodon.md
+++ b/products/mastodon.md
@@ -27,20 +27,20 @@ releases:
   - releaseCycle: "4.5"
     releaseDate: 2025-11-06
     eol: false
-    latest: "4.5.7"
-    latestReleaseDate: 2026-02-24
+    latest: "4.5.8"
+    latestReleaseDate: 2026-03-24
 
   - releaseCycle: "4.4"
     releaseDate: 2025-07-08
     eol: false
-    latest: "4.4.14"
-    latestReleaseDate: 2026-02-24
+    latest: "4.4.15"
+    latestReleaseDate: 2026-03-24
 
   - releaseCycle: "4.3"
     releaseDate: 2024-10-08
     eol: 2026-05-06
-    latest: "4.3.20"
-    latestReleaseDate: 2026-02-24
+    latest: "4.3.21"
+    latestReleaseDate: 2026-03-24
 
   - releaseCycle: "4.2"
     releaseDate: 2023-09-21


### PR DESCRIPTION
Today (2026-03-24), the versions v4.3.21, v4.4.15 and v4.5.8 have been released