### PR TITLE
Fix iCalendar EOL events

### DIFF
--- a/_plugins/create-icalendar-files.rb
+++ b/_plugins/create-icalendar-files.rb
@@ -85,19 +85,19 @@ def process_product(product)
       next if key != 'eol'
       event.alarm do |a|
         a.action = 'DISPLAY'
-        a.trigger = Icalendar::Values::DateTime.new((item << 12).to_datetime + Rational(9, 24))
+        a.trigger = Icalendar::Values::DateTime.new((item << 12).to_datetime + Rational(9, 24), 'tzid' => 'UTC')
       end
       event.alarm do |a|
         a.action = 'DISPLAY'
-        a.trigger = Icalendar::Values::DateTime.new((item << 6).to_datetime + Rational(9, 24))
+        a.trigger = Icalendar::Values::DateTime.new((item << 6).to_datetime + Rational(9, 24), 'tzid' => 'UTC')
       end
       event.alarm do |a|
         a.action = 'DISPLAY'
-        a.trigger = Icalendar::Values::DateTime.new((item << 3).to_datetime + Rational(9, 24))
+        a.trigger = Icalendar::Values::DateTime.new((item << 3).to_datetime + Rational(9, 24), 'tzid' => 'UTC')
       end
       event.alarm do |a|
         a.action = 'DISPLAY'
-        a.trigger = Icalendar::Values::DateTime.new((item << 1).to_datetime + Rational(9, 24))
+        a.trigger = Icalendar::Values::DateTime.new((item << 1).to_datetime + Rational(9, 24), 'tzid' => 'UTC')
       end
       event.alarm do |a|
         a.action = 'DISPLAY'


### PR DESCRIPTION
## Problem

iCalendar events for EOL dates don’t show up in Google Calendar

## Reproduction

1. Subscribe to one of the iCalendar endpoints (e.g. `webcal://endoflife.date/calendar/nodejs.ics`) in Google Calendar
2. Notice that ‘EOAS’ events exist, but ‘EOL’ events do not
3. Re-generate the iCalendar file with the proposed fix
4. Create a new calendar in Google Calendar
5. Import the new iCalendar file to the new calendar
6. Notice that ‘EOL’ events exist

## Cause

TLDR: The date-time values of the alarm triggers for EOL events are missing the `Z` at the end.

### Details

The value for an alarm trigger must be in **DATE-TIME FORM #2 (‘DATE WITH UTC TIME’)**

> The value type can be set to a DATE-TIME value type, in which case the value MUST specify a UTC-formatted DATE-TIME value.
>
> [iCalendar RFC 5545 §3.8.6.3 Trigger](https://icalendar.org/iCalendar-RFC-5545/3-8-6-3-trigger.html)

> The date with UTC time, or absolute time, is identified by a LATIN CAPITAL LETTER Z suffix character, the UTC designator, appended to the time value.
>
> [iCalendar RFC 5545 §3.3.5 Date-Time](https://icalendar.org/iCalendar-RFC-5545/3-3-5-date-time.html)

But the value for the alarm trigger is currently in **DATE-TIME FORM #1 (‘DATE WITH LOCAL TIME’)**

> The date with local time form is simply a DATE-TIME value that does not contain the UTC designator nor does it reference a time zone.
>
> [iCalendar RFC 5545 §3.3.5 Date-Time](https://icalendar.org/iCalendar-RFC-5545/3-3-5-date-time.html)

## Solution

Add `tzid` parameter to `Icalendar::Values::DateTime.new` calls

Here’s what an alarm looks like before and after:

```diff
 BEGIN:VALARM
 ACTION:DISPLAY
-TRIGGER;VALUE=DATE-TIME:20250601T090000
+TRIGGER;VALUE=DATE-TIME:20250601T090000Z
 END:VALARM
```