### PR TITLE
[fortios] update EOAS/EOL of FortiOS 7.4 and 7.6

### DIFF
--- a/products/fortios.md
+++ b/products/fortios.md
@@ -17,8 +17,8 @@ identifiers:
 releases:
   - releaseCycle: "7.6"
     releaseDate: 2024-07-25
-    eoas: 2027-07-25
-    eol: 2029-01-25
+    eoas: 2028-07-25
+    eol: 2030-01-25
 
   - releaseCycle: "7.4"
     releaseDate: 2023-05-11

--- a/products/fortios.md
+++ b/products/fortios.md
@@ -22,8 +22,8 @@ releases:
 
   - releaseCycle: "7.4"
     releaseDate: 2023-05-11
-    eoas: 2026-05-11
-    eol: 2027-11-11
+    eoas: 2027-05-11
+    eol: 2028-11-11
 
   - releaseCycle: "7.2"
     releaseDate: 2022-03-31


### PR DESCRIPTION
Fortinet released new EOAS and EOL dates for FortiOS 7.4 and 7.6.
They are delaying both dates of both versions by one year.

source:

https://www.reddit.com/r/fortinet/comments/1s3lzco/fortinet_extends_fortios_74/
https://support.fortinet.com/support/#/lifecycle
