### PR TITLE
docs(renovate): correct pURL for Docker image

### DIFF
--- a/products/renovate.md
+++ b/products/renovate.md
@@ -13,8 +13,8 @@ eolColumn: Support
 
 identifiers:
   - purl: pkg:npm/renovate
-  - purl: pkg:docker/renovatebot/renovate
-  - purl: pkg:oci/renovate?repository_url=ghcr.io/renovate
+  - purl: pkg:docker/renovate/renovate
+  - purl: pkg:oci/renovate?repository_url=ghcr.io/renovatebot
   - purl: pkg:brew/renovate
   - repology: renovate
 

--- a/products/renovate.md
+++ b/products/renovate.md
@@ -13,7 +13,7 @@ eolColumn: Support
 
 identifiers:
   - purl: pkg:npm/renovate
-  - purl: pkg:docker/renovate/renovate
+  - purl: pkg:docker/renovatebot/renovate
   - purl: pkg:oci/renovate?repository_url=ghcr.io/renovate
   - purl: pkg:brew/renovate
   - repology: renovate


### PR DESCRIPTION
As noted in #9514, I'd incorrectly specified the Renovate Docker image's
pURL in b40eb74c4fdef7ecad2fa51e7e47f87480f97bcf.
