### PR TITLE
[vinyl-cache] Rename varnish page after the project rebrand to vinyl-cache

### DIFF
--- a/products/vinyl-cache.md
+++ b/products/vinyl-cache.md
@@ -1,12 +1,14 @@
 ---
-title: Varnish
+title: Vinyl Cache
 addedAt: 2022-07-05
 category: server-app
 tags: web-server
-permalink: /varnish
+permalink: /vinyl-cache
+alternate_urls:
+  - /varnish
 versionCommand: varnishd -V
-releasePolicyLink: https://varnish-cache.org/releases/
-changelogTemplate: https://varnish-cache.org/releases/rel__LATEST__.html
+releasePolicyLink: https://vinyl-cache.org/releases/index.html
+changelogTemplate: https://vinyl-cache.org/releases/rel__LATEST__.html
 
 identifiers:
   - repology: varnish
@@ -17,21 +19,31 @@ identifiers:
 
 auto:
   methods:
-    - git: https://github.com/varnishcache/varnish-cache.git
-      regex: ^varnish-(?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)$
-    - release_table: https://varnish-cache.org/releases/
+    - release_table: https://vinyl-cache.org/releases/index.html
       fields:
         releaseCycle:
           column: "Release"
-          regex: '(?P<value>\d+\.\d+).*'
+          regex: '^(Vinyl|Varnish) Cache (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)$'
+          template: "{{major}}.{{minor}}"
         eol: "EOL Date"
+    - version_table: https://vinyl-cache.org/releases/index.html
+      name_column: "Release"
+      regex: '^(Vinyl|Varnish) Cache (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)$'
+      template: "{{major}}.{{minor}}.{{patch}}"
+      date_column: "Date"
 
 releases:
+  - releaseCycle: "9.0"
+    releaseDate: 2026-03-16
+    eol: 2027-03-16
+    latest: "9.0.0"
+    latestReleaseDate: 2026-03-16
+
   - releaseCycle: "8.0"
     releaseDate: 2025-09-15
     eol: 2026-09-15
-    latest: "8.0.0"
-    latestReleaseDate: 2025-09-15
+    latest: "8.0.1"
+    latestReleaseDate: 2026-03-16
 
   - releaseCycle: "7.7"
     releaseDate: 2025-03-17
@@ -85,12 +97,12 @@ releases:
     lts: true
     releaseDate: 2018-03-15
     eol: false
-    latest: "6.0.16"
-    latestReleaseDate: 2025-08-20
+    latest: "6.0.17"
+    latestReleaseDate: 2026-03-16
 
 ---
 
-> [Varnish](https://varnish-cache.org/) is a caching HTTP reverse proxy.
+> [Vinyl Cache](https://vinyl-cache.org/index.html) (formerly known as “Varnish Cache”) is a web application accelerator also known as a caching HTTP reverse proxy.
 
 A new minor version is released every 6 months.
 


### PR DESCRIPTION
Rename the tracked product page from varnish to vinyl-cache and update the content to reflect the project rename and migration away from GitHub. See https://vinyl-cache.org/organization/20-years.html and https://vinyl-cache.org/index.html#vinyl-cache-has-left-github-your-action-is-required.

Also add 9.0 (https://vinyl-cache.org/index.html#vinyl-cache-9-0-0-is-released) and update latest versions.