### PR TITLE
[Jetty] Add 9.4.58.v20250814 and change eol of 9.4

### DIFF
--- a/products/eclipse-jetty.md
+++ b/products/eclipse-jetty.md
@@ -95,8 +95,8 @@ releases:
     eoas: 2022-06-01 # https://github.com/jetty/jetty.project/issues/7958
     eol: 2025-02-19 # https://github.com/jetty/jetty.project/issues/7958
     eoes: false
-    latest: "9.4.57.v20241219"
-    latestReleaseDate: 2024-12-19
+    latest: "9.4.58.v20250814"
+    latestReleaseDate: 2025-08-14
 
   - releaseCycle: "9.3"
     minJvmVersion: "1.8"

--- a/products/eclipse-jetty.md
+++ b/products/eclipse-jetty.md
@@ -93,7 +93,7 @@ releases:
     jspVersion: "2.3"
     releaseDate: 2016-12-07
     eoas: 2022-06-01 # https://github.com/jetty/jetty.project/issues/7958
-    eol: 2025-02-19 # https://github.com/jetty/jetty.project/issues/7958
+    eol: 2025-08-14 # https://github.com/jetty/jetty.project/releases/tag/jetty-9.4.58.v20250814
     eoes: false
     latest: "9.4.58.v20250814"
     latestReleaseDate: 2025-08-14


### PR DESCRIPTION
This is a sponsored release for an End of Life version of Jetty.

https://github.com/jetty/jetty.project/releases/tag/jetty-9.4.58.v20250814