### PR TITLE
Add missing 'generated_at' field to OpenAPI spec

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,4 +19,4 @@ _data/gke.json
 node_modules
 .DS_Store
 .venv
-wiretap-report.json
+wiretap-report.*

--- a/CHANGELOG_API.md
+++ b/CHANGELOG_API.md
@@ -1,5 +1,10 @@
 # endoflife.date API Changelog
 
+## API v1.2.1
+
+- Declare `generated_at` in OpenAPI specification ([#9798](https://github.com/endoflife-date/endoflife.date/pull/9798)).
+  This field was always provided in responses, but was not declared in the OpenAPI specification.
+
 ## API v1.2.0
 
 - Introduce a new `/identifiers/{identifier}` API ([#7361](https://github.com/endoflife-date/endoflife.date/pull/7361))

--- a/_plugins/generate-api-v1.rb
+++ b/_plugins/generate-api-v1.rb
@@ -21,7 +21,7 @@ require 'jekyll'
 module ApiV1
 
   # This version must be kept in sync with the version in api_v1/openapi.yml.
-  VERSION = '1.2.0'
+  VERSION = '1.2.1'
   MAJOR_VERSION = VERSION.split('.')[0]
 
   STRIP_HTML_BLOCKS = Regexp.union(

--- a/api_v1/openapi.yml
+++ b/api_v1/openapi.yml
@@ -10,7 +10,7 @@ openapi: 3.1.1
 info:
   title: endoflife API
   # This version must be kept in sync with the version in _plugins/generate-api-v1.rb.
-  version: "1.2.0"
+  version: "1.2.1"
   license:
     name: MIT License
     url: "https://github.com/endoflife-date/endoflife.date/blob/master/LICENSE"
@@ -886,6 +886,7 @@ components:
       type: object
       required:
         - schema_version
+        - generated_at
         - total
         - result
       properties:
@@ -917,6 +918,7 @@ components:
       type: object
       required:
         - schema_version
+        - generated_at
         - total
         - result
       properties:
@@ -948,6 +950,7 @@ components:
       type: object
       required:
         - schema_version
+        - generated_at
         - total
         - result
       properties:
@@ -956,6 +959,12 @@ components:
           type: string
           examples:
             - "1.0.0"
+        generated_at:
+          description: The time this response was generated.
+          type: string
+          format: date-time
+          examples:
+            - "2023-03-01T14:05:52+01:00"
         total:
           description: Number of products in the list.
           type: integer
@@ -973,6 +982,7 @@ components:
       type: object
       required:
         - schema_version
+        - generated_at
         - result
       properties:
         schema_version:
@@ -994,6 +1004,7 @@ components:
       type: object
       required:
         - schema_version
+        - generated_at
         - last_modified
         - result
       properties:
@@ -1022,6 +1033,7 @@ components:
       type: object
       required:
         - schema_version
+        - generated_at
         - total
         - result
       properties:

--- a/api_v1/openapi.yml
+++ b/api_v1/openapi.yml
@@ -894,6 +894,12 @@ components:
           type: string
           examples:
             - "1.0.0"
+        generated_at:
+          description: The time this response was generated.
+          type: string
+          format: date-time
+          examples:
+            - "2023-03-01T14:05:52+01:00"
         total:
           description: Number of URIs in the list.
           type: integer
@@ -919,6 +925,12 @@ components:
           type: string
           examples:
             - "1.0.0"
+        generated_at:
+          description: The time this response was generated.
+          type: string
+          format: date-time
+          examples:
+            - "2023-03-01T14:05:52+01:00"
         total:
           description: Number of products in the list.
           type: integer
@@ -968,6 +980,12 @@ components:
           type: string
           examples:
             - "1.0.0"
+        generated_at:
+          description: The time this response was generated.
+          type: string
+          format: date-time
+          examples:
+            - "2023-03-01T14:05:52+01:00"
         result:
           $ref: "#/components/schemas/ProductRelease"
 
@@ -984,6 +1002,12 @@ components:
           type: string
           examples:
             - "1.0.0"
+        generated_at:
+          description: The time this response was generated.
+          type: string
+          format: date-time
+          examples:
+            - "2023-03-01T14:05:52+01:00"
         last_modified:
           description: The time this product was last modified.
           type: string
@@ -1006,6 +1030,12 @@ components:
           description: Version of this schema.
           examples:
             - 1.0.0
+        generated_at:
+          description: The time this response was generated.
+          type: string
+          format: date-time
+          examples:
+            - "2023-03-01T14:05:52+01:00"
         total:
           description: Number of identifiers in the list.
           type: integer


### PR DESCRIPTION
While playing around with the API, I found the field `generated_at` was not in the API spec. I'm maybe missing something, even though I tested it pretty thoroughly.
This fixes #9364 