### PR TITLE
[ClickHouse] Add 26.3 LTS and mark 25.12 as EOL

### DIFF
--- a/products/clickhouse.md
+++ b/products/clickhouse.md
@@ -22,6 +22,13 @@ auto:
 # Non-LTS : eol(x) = releaseDate(x+3)
 # LTS : eol(x) = releaseDate(x) + 1 year
 releases:
+  - releaseCycle: "26.3"
+    lts: true
+    releaseDate: 2026-03-26
+    eol: 2027-03-26
+    latest: "26.3.2.3"
+    latestReleaseDate: 2026-03-27
+
   - releaseCycle: "26.2"
     releaseDate: 2026-02-27
     eol: false
@@ -36,7 +43,7 @@ releases:
 
   - releaseCycle: "25.12"
     releaseDate: 2025-12-18
-    eol: false
+    eol: 2026-03-26
     latest: "25.12.8.9"
     latestReleaseDate: 2026-03-01
 


### PR DESCRIPTION
## Summary

- Add ClickHouse 26.3 LTS release cycle (released 2026-03-26, EOL 2027-03-26)
- Mark 25.12 as EOL on 2026-03-26 (3rd release after it: 26.1, 26.2, 26.3)
- 26.1 and 26.2 remain supported (last three non-LTS minor releases are 26.1, 26.2, 26.3)

## References

- [ClickHouse 26.3 community release call](https://clickhouse.com/company/events/v26-3-community-release-call)
- [GitHub release v26.3.2.3-lts](https://github.com/ClickHouse/ClickHouse/releases/tag/v26.3.2.3-lts)