### PR TITLE
[redhat-ansible-automation-platform] Fixed release info for 2.5 and updated Platform component versions for 2.6 and 2.5

### DIFF
--- a/products/red-hat-ansible-automation-platform.md
+++ b/products/red-hat-ansible-automation-platform.md
@@ -40,7 +40,6 @@ identifiers:
     - cpe: cpe:2.3:a:redhat:ansible_automation_platform
 
 releases:
-  # Info taken from https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.6/html/release_notes/platform-introduction#platform_services_in_2_6
   - releaseCycle: "2.6"
     releaseDate: 2025-10-01
     eoas: 2026-10-01
@@ -48,27 +47,25 @@ releases:
     eoes: 2028-10-01
     ansibleCoreVersion: "2.16"
     aapPLatformUIVersion: "2.6.1"
-    automationControllerVersion: "4.7.8"
-    automationHubVersion: "4.11.5"
-    eventDrivenAnsibleVersion: "1.2.4"
+    automationControllerVersion: "4.7.10"
+    automationHubVersion: "4.11.7"
+    eventDrivenAnsibleVersion: "1.2.7"
     platformGatewayVersion: "2.6.20251001"
-    link: https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.6/html/release_notes
+    link: https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.6/html/release_notes/patch_releases
 
-  # Info taken from https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.5/html/release_notes/platform-introduction#whats-included
   - releaseCycle: "2.5"
-    releaseDate: 2025-10-01
-    eoas: 2026-10-01
-    eol: 2027-10-01
-    eoes: 2028-10-01
+    releaseDate: 2025-09-30
+    eoas: 2026-10-02
+    eol: 2026-10-02
+    eoes: 2027-10-02
     ansibleCoreVersion: "2.16"
     aapPLatformUIVersion: "1.1"
-    automationControllerVersion: "4.6.25"
-    automationHubVersion: "4.10.11"
-    eventDrivenAnsibleVersion: "1.1.14"
+    automationControllerVersion: "4.6.27"
+    automationHubVersion: "4.10.13"
+    eventDrivenAnsibleVersion: "1.1.17"
     platformGatewayVersion: "N/A"
-    link: https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.5/html/release_notes
+    link: https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.5/html/release_notes/patch_releases
 
-  # Info taken from https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.4/html/red_hat_ansible_automation_platform_release_notes/platform-introduction#whats-included
   - releaseCycle: "2.4"
     releaseDate: 2023-06-27
     eoas: 2024-10-01
@@ -80,9 +77,8 @@ releases:
     automationHubVersion: "4.9.5"
     eventDrivenAnsibleVersion: "1.0.8"
     platformGatewayVersion: "N/A"
-    link: https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.4/html/red_hat_ansible_automation_platform_release_notes/index
+    link: https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.4/html/red_hat_ansible_automation_platform_release_notes/asynchronous_updates
 
-  # Info taken from https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.3/html/red_hat_ansible_automation_platform_release_notes/platform-introduction#whats-included
   - releaseCycle: "2.3"
     releaseDate: 2022-11-29
     eoas: 2023-06-30
@@ -94,7 +90,7 @@ releases:
     automationHubVersion: "4.6"
     eventDrivenAnsibleVersion: "N/A"
     platformGatewayVersion: "N/A"
-    link: https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.3/html/red_hat_ansible_automation_platform_release_notes
+    link: https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.3/html/red_hat_ansible_automation_platform_release_notes/platform-introduction#whats-included
 
 ---
 
@@ -108,17 +104,17 @@ The product life cycle for Red Hat Ansible Automation Platform is divided into t
 
 The **Full Support** phase begins at the GA/release.
 During the Full Support Phase, Qualified critical security fixes, Critical **and** important severity issue fixes will be released as they become available;
-as well as fixes to *Security Errata* ([RHEA][DEFINITION]) and *Bug Fix Errata* ([RHBAs][DEFINITION]).
+as well as fixes to _Security Errata_ ([RHEA][DEFINITION]) and _Bug Fix Errata_ ([RHBAs][DEFINITION]).
 Software Enhancements and new features are released when made available.
 
 The **Maintenance Support 1** phase starts after the Full Support phase.
 During this phase, Qualified critical security fixes, Critical severity issue fixes will be released as they become available;
-as well as fixes to *Security Errata* ([RHEA][DEFINITION]) and *Bug Fix Errata* ([RHBAs][DEFINITION]).
+as well as fixes to _Security Errata_ ([RHEA][DEFINITION]) and _Bug Fix Errata_ ([RHBAs][DEFINITION]).
 Software Enhancements or new features are not part of this Life Cycle phase.
 
 The **Maintenance Support 2** phase starts after the Maintenance Support 1 phase.
-Qualified critical security fixes and fixes to *Security Errata* ([RHEA][DEFINITION]) are released as they become available.
-Bug fixes by severity or *Bug Fix Errata* ([RHBAs][DEFINITION]) are not part of this Life Cycle phase; neither are Software Enhancements nor new features.
+Qualified critical security fixes and fixes to _Security Errata_ ([RHEA][DEFINITION]) are released as they become available.
+Bug fixes by severity or _Bug Fix Errata_ ([RHBAs][DEFINITION]) are not part of this Life Cycle phase; neither are Software Enhancements nor new features.
 
 The Ansible Automation Platform consists of multiple major services, each with their own versions.
 
@@ -128,6 +124,6 @@ fields="releaseCycle,ansibleCoreVersion,aapPLatformUIVersion,automationControlle
 types="string,string,string,string,string"
 rows=page.releases %}
 
-The latest version for each component can be found in the release notes under the *Patch releases* section.
+The latest version for each component can be found in the release notes under the _Patch releases_ section.
 
 [DEFINITION]: https://access.redhat.com/articles/2130961

--- a/products/red-hat-ansible-automation-platform.md
+++ b/products/red-hat-ansible-automation-platform.md
@@ -54,8 +54,8 @@ releases:
     link: https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.6/html/release_notes/patch_releases
 
   - releaseCycle: "2.5"
-    releaseDate: 2025-09-30
-    eoas: 2026-10-02
+    releaseDate: 2024-09-30
+    eoas: 2025-10-02
     eol: 2026-10-02
     eoes: 2027-10-02
     ansibleCoreVersion: "2.16"


### PR DESCRIPTION
Release dates for AAP 2.5 were wrongly copied from 2.6.
Updated release link to corresponding patch release pages, removed the comments with the same links. 
Minor changes to fix Markdown linting, using underscore instead of asterisk to italicize text as on other products.

Closes #9808 