### PR TITLE
[oneplus] Fix releasecycle names for pad series and fix link for 13T

### DIFF
--- a/products/oneplus.md
+++ b/products/oneplus.md
@@ -39,13 +39,14 @@ releases:
     discontinued: false
     supportedOxygenOSVersions: "16"
 
-  - releaseCycle: "pad-3"
+  - releaseCycle: "pad3"
     releaseLabel: "Pad 3"
     releaseDate: 2025-06-05
     eoas: 2029-06-05 # approximation "4 major Android updates"
     eol: 2031-06-19
     discontinued: false
     supportedOxygenOSVersions: "15 - 16"
+    link: https://www.oneplus.com/us/oneplus-pad-3
 
   - releaseCycle: "13t"
     releaseLabel: "13T"
@@ -71,13 +72,14 @@ releases:
     discontinued: false
     supportedOxygenOSVersions: "15 - 16"
 
-  - releaseCycle: "pad-2"
+  - releaseCycle: "pad2"
     releaseLabel: "Pad 2"
     releaseDate: 2024-07-16
     eoas: 2027-07-16 # approximation "3 major Android updates"
     eol: 2028-07-16 # approximation "4 years of security updates"
     discontinued: false
     supportedOxygenOSVersions: "14 - 16"
+    link: https://www.oneplus.com/us/oneplus-pad-2
 
   - releaseCycle: "12r"
     releaseLabel: "12R"
@@ -94,13 +96,14 @@ releases:
     discontinued: true #
     supportedOxygenOSVersions: "14 - 16"
 
-  - releaseCycle: "pad"
+  - releaseCycle: "pad1"
     releaseLabel: "Pad"
     releaseDate: 2023-05-01
     eoas: 2026-05-01 # 3 years Android updates
     eol: 2026-05-01 # Security updates end
     discontinued: true
     supportedOxygenOSVersions: "13 - 16"
+    link: https://www.oneplus.com/us/oneplus-pad
 
   - releaseCycle: "11r"
     releaseLabel: "11R"

--- a/products/oneplus.md
+++ b/products/oneplus.md
@@ -39,7 +39,7 @@ releases:
     discontinued: false
     supportedOxygenOSVersions: "16"
 
-  - releaseCycle: "pad3"
+  - releaseCycle: "pad-3"
     releaseLabel: "Pad 3"
     releaseDate: 2025-06-05
     eoas: 2029-06-05 # approximation "4 major Android updates"
@@ -69,8 +69,9 @@ releases:
     eol: 2030-10-31 # 6 years of security updates
     discontinued: false
     supportedOxygenOSVersions: "15 - 16"
+    link: https://www.opposhop.cn/cn/web/products/39296.html # Only available on chinese market's webpage on oppo
 
-  - releaseCycle: "pad2"
+  - releaseCycle: "pad-2"
     releaseLabel: "Pad 2"
     releaseDate: 2024-07-16
     eoas: 2027-07-16 # approximation "3 major Android updates"
@@ -93,7 +94,7 @@ releases:
     discontinued: true #
     supportedOxygenOSVersions: "14 - 16"
 
-  - releaseCycle: "pad1"
+  - releaseCycle: "pad"
     releaseLabel: "Pad"
     releaseDate: 2023-05-01
     eoas: 2026-05-01 # 3 years Android updates

--- a/products/oneplus.md
+++ b/products/oneplus.md
@@ -54,6 +54,7 @@ releases:
     eol: 2031-04-24 # approximation "6 years of security updates"
     discontinued: false
     supportedOxygenOSVersions: "15 - 16"
+    link: https://www.opposhop.cn/cn/web/products/39296.html # Only available on chinese market's webpage on oppo
 
   - releaseCycle: "13r"
     releaseLabel: "13R"
@@ -69,7 +70,6 @@ releases:
     eol: 2030-10-31 # 6 years of security updates
     discontinued: false
     supportedOxygenOSVersions: "15 - 16"
-    link: https://www.opposhop.cn/cn/web/products/39296.html # Only available on chinese market's webpage on oppo
 
   - releaseCycle: "pad-2"
     releaseLabel: "Pad 2"


### PR DESCRIPTION
pad1 -> pad
pad2 -> pad-2
pad3 -> pad-3
These changes are not just to fix their product name also to fix their links.
On the other hand this is kind of breaking-change

13T doesnt exist on international websites so changed its link to oppo's chines one [ real protuct page ]