### PR TITLE
[openwrt] Fix purl which broke our yaml scanner

### DIFF
--- a/products/openwrt.md
+++ b/products/openwrt.md
@@ -17,7 +17,7 @@ auto:
     - git: https://github.com/openwrt/openwrt.git
 
 identifiers:
-  - purl: pkg:github/openwrt/openwrt	
+  - purl: pkg:github/openwrt/openwrt
 
 # eol(x) = MAX(releaseDate(x+1)+6m, releaseDate(x)+1y)
 # eoas(x) = releaseDate(x+1)


### PR DESCRIPTION
The \t at the end of purl statement broke our ruamel.yaml.scanner