### PR TITLE
[discourse] Add 2026.3 and update EOL for older releases

### DIFF
--- a/products/discourse.md
+++ b/products/discourse.md
@@ -38,7 +38,7 @@ releases:
   - releaseCycle: "2026.1"
     lts: true
     releaseDate: 2026-01-28
-    eol: 2026-09-31 # planned on https://releases.discourse.org/, to be updated once known
+    eol: 2026-09-30 # planned on https://releases.discourse.org/, to be updated once known
     latest: "2026.1.3"
     latestReleaseDate: 2026-03-31
 

--- a/products/discourse.md
+++ b/products/discourse.md
@@ -23,22 +23,28 @@ auto:
 
 # EOL documented on https://releases.discourse.org/
 releases:
+  - releaseCycle: "2026.3"
+    releaseDate: 2026-03-31
+    eol: 2026-05-31 # planned on https://releases.discourse.org/, to be updated once known
+    latest: "2026.3.0"
+    latestReleaseDate: 2026-03-31
+
   - releaseCycle: "2026.2"
     releaseDate: 2026-02-26
-    eol: false
+    eol: 2026-04-30 # planned on https://releases.discourse.org/, to be updated once known
     latest: "2026.2.2"
     latestReleaseDate: 2026-03-31
 
   - releaseCycle: "2026.1"
     lts: true
     releaseDate: 2026-01-28
-    eol: false
+    eol: 2026-09-31 # planned on https://releases.discourse.org/, to be updated once known
     latest: "2026.1.3"
     latestReleaseDate: 2026-03-31
 
   - releaseCycle: "2025.12"
     releaseDate: 2025-12-30
-    eol: false
+    eol: 2026-02-26
     latest: "2025.12.2"
     latestReleaseDate: 2026-02-26
 


### PR DESCRIPTION
https://releases.discourse.org/#version-2026.3