### PR TITLE
[akeneo-pim] Ignore 1.0 in release_table

### DIFF
--- a/products/akeneo-pim.md
+++ b/products/akeneo-pim.md
@@ -21,8 +21,10 @@ auto:
       selector: "table:nth-of-type(1)"
       fields:
         releaseCycle:
+          # 2.1 to 2.3 only contained enterprise fixes or improvements.
+          # 1.0 release dates are incorrect in table
           column: "Version"
-          regex_exclude: "^2.[1-3]" # 2.1 to 2.3 only contained enterprise fixes or improvements.
+          regex_exclude: "^(1.0|2.[1-3])" 
         releaseDate: "Release date"
         eol: "End of support date"
 
@@ -158,7 +160,7 @@ releases:
 > This page mainly tracks releases for the free and open-source offering named _Akeneo PIM Community
 > Edition_.
 
-Akeneo PIM does not follow a documented release policy. But looking at the latest releases, it seems
-that there is a new major release every year, with frequent patch versions containing bug fixes for
-supported releases in between. All active releases, along with their EOL dates, are documented
-[on their help center](https://help.akeneo.com/en_US/akeneo-pim/akeneo-pim-product-support-dates).
+Akeneo is migrating to Calendar Versioning (vYYYY.Minor) in 2026. Breaking changes may be introduced in any release (e.g., from v2026.1 to v2026.2). It is recommended to lock your dependency (in `composer.json`) to a specific version instead of a range.
+
+All active releases, along with their EOL dates, are documented
+[on the help center](https://help.akeneo.com/en_US/akeneo-pim/akeneo-pim-product-support-dates).

--- a/products/akeneo-pim.md
+++ b/products/akeneo-pim.md
@@ -141,14 +141,6 @@ releases:
     latest: "1.1.3"
     latestReleaseDate: 2014-07-22
 
-  - releaseCycle: "1.0"
-    codename: "Hare We Go"
-    releaseDate: 2014-03-06
-    eol: 2016-03-31
-    link: https://help.akeneo.com/en_US/everything-you-need-to-know-about-our-pim-versions#v10
-    latest: "1.0.3"
-    latestReleaseDate: 2014-03-27
-
 ---
 
 > [Akeneo PIM](https://www.akeneo.com/akeneo-pim-community-edition/) is a Product Information


### PR DESCRIPTION
Broke the build. Also mentions the new calver scheme, which isn't documented completely upstream, so just a soft mention. There is a 2026.3 tag, but waiting for a well announced release seems right here.