### PR TITLE
[amazon-opensearch] Fix iconSlug

### DIFF
--- a/products/amazon-opensearch.md
+++ b/products/amazon-opensearch.md
@@ -3,7 +3,7 @@ title: Amazon OpenSearch
 addedAt: 2026-03-09
 category: service
 tags: amazon database
-iconSlug: aws
+iconSlug: amazonaws
 permalink: /amazon-opensearch
 alternate_urls:
   - /amazon-opensearch-service


### PR DESCRIPTION
super minor - `iconSlug: aws` resolved to a non-existent Simple Icons slug, causing a broken image on the product page. Changed to amazonaws, consistent with other Amazon products without a dedicated icon. 

currently:
<img width="835" height="503" alt="Screenshot 2026-04-07 at 9 07 26 am" src="https://github.com/user-attachments/assets/b14be5d4-5b99-498f-8244-72578d431f09" />
