### PR TITLE
[Keycloak] added maven identifier

### DIFF
--- a/products/keycloak.md
+++ b/products/keycloak.md
@@ -11,6 +11,7 @@ eolColumn: Supported
 
 identifiers:
   - purl: pkg:github/keycloak/keycloak
+  - purl: pkg:maven/org.keycloak/keycloak-core
   - repology: keycloak
   - cpe: cpe:2.3:a:redhat:keycloak
 


### PR DESCRIPTION
Added a purl identifier when Keycloak is installed via Maven