### PR TITLE
[new product] Adds Oniguruma

### DIFF
--- a/products/oniguruma.md
+++ b/products/oniguruma.md
@@ -2,6 +2,7 @@
 title: Oniguruma
 addedAt: 2026-04-09
 category: framework
+tags: discontinued
 permalink: /oniguruma
 releasePolicyLink: https://github.com/kkos/oniguruma
 changelogTemplate: https://github.com/kkos/oniguruma/releases/tag/v__LATEST__/
@@ -19,6 +20,7 @@ identifiers:
   - cpe: cpe:2.3:a:oniguruma_project:oniguruma
 
 auto:
+  disabled: true # the product is discontinued
   methods:
     - git: https://github.com/kkos/oniguruma
 
@@ -28,6 +30,7 @@ releases:
     eol: 2025-04-24
     latest: "6.9.10"
     latestReleaseDate: 2025-01-01
+
   - releaseCycle: "5"
     eol: 2016-05-09
     releaseDate: 2006-10-19
@@ -36,7 +39,7 @@ releases:
 
 ---
 
-> [Oniguruma](https://github.com/kkos/oniguruma) was a regular expression library by K. Kosako that supported a
-> variety of character encodings and backtracking. It is used in many projects including Ruby, PHP, and uutils.
+> [Oniguruma](https://github.com/kkos/oniguruma) was a regular expression library by K. Kosako that supported a variety of character encodings and backtracking.
+> It is used in many projects including Ruby, PHP, and uutils.
 
 Oniguruma was archived in April 2025.

--- a/products/oniguruma.md
+++ b/products/oniguruma.md
@@ -1,0 +1,42 @@
+---
+title: Oniguruma
+addedAt: 2026-04-09
+category: framework
+permalink: /oniguruma
+releasePolicyLink: https://github.com/kkos/oniguruma
+changelogTemplate: https://github.com/kkos/oniguruma/releases/tag/v__LATEST__/
+eolColumn: Support
+
+identifiers:
+  - repology: oniguruma
+  - purl: pkg:github/kkos/oniguruma
+  - purl: pkg:deb/debian/libonig
+  - purl: pkg:deb/ubuntu/libonig
+  - purl: pkg:rpm/fedora/oniguruma
+  - purl: pkg:apk/alpine/oniguruma
+  - purl: pkg:apk/alpine/oniguruma-dev
+  - purl: pkg:alpm/arch/oniguruma
+  - cpe: cpe:2.3:a:oniguruma_project:oniguruma
+
+auto:
+  methods:
+    - git: https://github.com/kkos/oniguruma
+
+releases:
+  - releaseCycle: "6"
+    releaseDate: 2016-05-09
+    eol: 2025-04-24
+    latest: "6.9.10"
+    latestReleaseDate: 2025-01-01
+  - releaseCycle: "5"
+    eol: 2016-05-09
+    releaseDate: 2006-10-19
+    latest: "5.9.6"
+    latestReleaseDate: 2015-09-07
+
+---
+
+> [Oniguruma](https://github.com/kkos/oniguruma) was a regular expression library by K. Kosako that supported a
+> variety of character encodings and backtracking. It is used in many projects including Ruby, PHP, and uutils.
+
+Oniguruma was archived in April 2025.


### PR DESCRIPTION
Found out about Oniguruma today, and think it deserves a page as it was very widely used.

Has its own wikipedia page: https://en.wikipedia.org/wiki/Oniguruma

Not trying to add 4.x or older, they were pre-2006.

- https://news.ycombinator.com/item?id=43782732
- https://lobste.rs/s/t4oq5z/oniguruma_popular_regex_library_is