### PR TITLE
[pan-os] Update 10.2: 10.2.18-h1 → 10.2.18-h5

### DIFF
--- a/products/pan-os.md
+++ b/products/pan-os.md
@@ -60,9 +60,9 @@ releases:
   - releaseCycle: "10.2"
     releaseDate: 2022-02-27
     eol: 2025-08-27
-    latest: "10.2.18-h1"
-    latestReleaseDate: 2025-12-02
-    link: https://docs.paloaltonetworks.com/pan-os/10-2/pan-os-release-notes/pan-os-10-2-18-known-and-addressed-issues/pan-os-10-2-18-h1-addressed-issues
+    latest: "10.2.18-h5"
+    latestReleaseDate: 2026-04-07
+    link: https://docs.paloaltonetworks.com/pan-os/10-2/pan-os-release-notes/pan-os-10-2-18-known-and-addressed-issues/pan-os-10-2-18-h5-addressed-issues
 
   - releaseCycle: "10.1"
     releaseDate: 2021-05-31


### PR DESCRIPTION
## Summary
Automated update of PAN-OS versions.

### Changes
10.2: 10.2.18-h1 -> 10.2.18-h5

---
Data sourced from [PaloAltoVersions.json](https://github.com/mrjcap/panos-versions/blob/master/PaloAltoVersions.json)