### PR TITLE
Improve release timeline SVG images for releases having no end of support date

### DIFF
--- a/_layouts/release-image.svg
+++ b/_layouts/release-image.svg
@@ -15,6 +15,9 @@
     .eoas { fill: #0A2472; }
     .eol { fill: #1E96FC; }
     .eoes { fill: #CDEBFF; }
+    .no-end { fill: #C8C8C8; }
+    .no-end-badge { width: {{ page.no_end_badge_width }}px; stroke: #ccc; stroke-width: 1; stroke-dasharray: 2,3; }
+    .no-end-plus { font-size: 14px; font-weight: bold; fill: white; }
     .legend-icon { width: 14px; height: 14px; rx: 2; ry: 2; }
   </style>
 
@@ -41,6 +44,10 @@
       {% if row.security_width > 0 %}
       <rect class="bar eol" x="{{ row.security_x }}" y="0" width="{{ row.security_width }}" height="{{ page.row_height }}"/>
       {% endif %}
+      {% if row.no_end_date %}
+      <rect class="bar no-end-badge no-end" x="{{ page.today_x }}" y="0" height="{{ page.row_height }}"/>
+      <text class="no-end-plus" x="{{ page.no_end_badge_width | divided_by: 2 | plus: page.today_x }}" y="{{ page.text_y_offset }}" text-anchor="middle">+</text>
+      {% endif %}
     </g>
     {% endfor %}
 
@@ -49,15 +56,10 @@
 
     <!-- Legend -->
     <g transform="translate({{ page.legend_dx }}, {{ page.legend_y }})">
-      {% if page.has_eoas_column %}
-      <rect class="legend-icon eoas" x="0" y="0"/>
-      <text class="label" x="18" y="11">{{ page.eoas_label | xml_escape }}</text>
-      <rect class="legend-icon eol" x="240" y="0"/>
-      <text class="label" x="258" y="11">{{ page.eol_label | xml_escape }}</text>
-      {% else %}
-      <rect class="legend-icon eol" x="0" y="0"/>
-      <text class="label" x="18" y="11">{{ page.eol_label | xml_escape }}</text>
-      {% endif %}
+      {% for item in page.legend_items %}
+      <rect class="legend-icon {{ item.icon_class }}" x="{{ item.x }}" y="0"/>
+      <text class="label" x="{{ item.x | plus: 18 }}" y="11">{{ item.label | xml_escape }}</text>
+      {% endfor %}
     </g>
   </g>
 </svg>

--- a/_plugins/generate-release-images.rb
+++ b/_plugins/generate-release-images.rb
@@ -28,7 +28,7 @@ module EndOfLife
     LEGEND_ICON_SIZE    = 14  # width and height of legend colour swatches
     LEGEND_ICON_TEXT_GAP = 4  # gap between icon and label text
     LEGEND_ITEM_SPACING = 240 # horizontal distance between legend item start positions
-    NO_END_DATE_LABEL   = "Unknown end date"
+    NO_END_DATE_LABEL   = "No end date published"
 
     # Release filtering & date range
     MAX_NON_EOL        = 10  # refuse to generate image if non-EOL releases exceed this

--- a/_plugins/generate-release-images.rb
+++ b/_plugins/generate-release-images.rb
@@ -17,22 +17,25 @@ module EndOfLife
     ROW_HEIGHT              = 25                 # height of each release bar in pixels
     ROW_GAP                 = 4                  # vertical gap between rows in pixels
     LABEL_GAP               = 8                  # gap between label text and the chart area
-    CHAR_WIDTH              = 7                  # estimated pixel width per character at 12px sans-serif
+    CHAR_WIDTH              = 8                  # estimated pixel width per character at 12px sans-serif
     MAX_RELEASE_LABEL_WIDTH = 200                # maximum space reserved on the left for release labels
+    NO_END_BADGE_WIDTH      = 32                 # pixel width of the badge
     TEXT_Y_OFFSET           = ROW_HEIGHT / 2 + 4 # vertical offset to center label text in a row
 
     # Axis & legend
-    YEAR_LABEL_GAP     = 16  # vertical distance from chart bottom to year label baseline
-    LEGEND_GAP         = 28  # vertical distance from chart bottom to legend icons
-    LEGEND_EOAS_OFFSET = 195 # distance from center to legend left edge (two-item: EOAS + EOL)
-    LEGEND_EOL_OFFSET  = 70  # distance from center to legend left edge (one-item: EOL only)
+    YEAR_LABEL_GAP      = 16  # vertical distance from chart bottom to year label baseline
+    LEGEND_GAP          = 28  # vertical distance from chart bottom to legend icons
+    LEGEND_ICON_SIZE    = 14  # width and height of legend colour swatches
+    LEGEND_ICON_TEXT_GAP = 4  # gap between icon and label text
+    LEGEND_ITEM_SPACING = 240 # horizontal distance between legend item start positions
+    NO_END_DATE_LABEL   = "No end date"
 
     # Release filtering & date range
-    MAX_NON_EOL       = 10  # refuse to generate image if non-EOL releases exceed this
-    MAX_TRAILING_EOL  = 3   # maximum EOL releases kept at the bottom for context
-    SOFT_MAX_ROWS     = 10  # EOL releases beyond this total row count are dropped
-    DATE_PADDING_DAYS = 60  # padding added to the right end of the visible date range
-    MIN_FUTURE_DAYS   = 182 # chart always extends at least this many days past today
+    MAX_NON_EOL        = 10  # refuse to generate image if non-EOL releases exceed this
+    MAX_TRAILING_EOL   = 3   # maximum EOL releases kept at the bottom for context
+    SOFT_MAX_ROWS      = 10  # EOL releases beyond this total row count are dropped
+    DATE_PADDING_DAYS  = 60  # padding added to the right end of the visible date range
+    MIN_FUTURE_DAYS    = 182 # chart always extends at least this many days past today
 
     def generate(site)
       start = Time.now
@@ -66,7 +69,8 @@ module EndOfLife
       release_label_length = (release_label_width - LABEL_GAP) / CHAR_WIDTH
 
       min_date, max_date, date_to_x_fn = build_timeline_scale(releases, today, release_label_width)
-      rows = build_rows(releases, has_eoas_column, date_to_x_fn, max_date, release_label_length)
+      today_x = date_to_x_fn.call(today)
+      rows = build_rows(releases, has_eoas_column, date_to_x_fn, max_date, release_label_length, today_x)
       return nil if rows.empty?
 
       # One vertical tick per year within the date range.
@@ -75,10 +79,20 @@ module EndOfLife
       end
 
       chart_height = rows.length * (ROW_HEIGHT + ROW_GAP) - ROW_GAP
-      legend_x = SVG_WIDTH / 2 - (has_eoas_column ? LEGEND_EOAS_OFFSET : LEGEND_EOL_OFFSET)
+
+      legend_items = []
+      legend_items << { "icon_class" => "eoas",   "label" => product.data['eoasColumnLabel'] } if has_eoas_column
+      legend_items << { "icon_class" => "eol",    "label" => product.data['eolColumnLabel'] }
+      legend_items << { "icon_class" => "no-end", "label" => NO_END_DATE_LABEL }               if rows.any? { |r| r["no_end_date"] }
+      legend_items.each_with_index { |item, i| item["x"] = i * LEGEND_ITEM_SPACING }
+
+      last_label_px    = legend_items.last["label"].to_s.length * CHAR_WIDTH
+      legend_width     = (legend_items.length - 1) * LEGEND_ITEM_SPACING + LEGEND_ICON_SIZE + LEGEND_ICON_TEXT_GAP + last_label_px
+      legend_dx        = ((SVG_WIDTH - legend_width) / 2.0).round
 
       {
         "svg_width"          => SVG_WIDTH,
+        "no_end_badge_width" => NO_END_BADGE_WIDTH,
         "svg_height"         => TOP_PADDING + chart_height + BOTTOM_PADDING,
         "top_padding"        => TOP_PADDING,
         "label_x"            => release_label_width - LABEL_GAP,
@@ -87,14 +101,12 @@ module EndOfLife
         "text_y_offset"      => TEXT_Y_OFFSET,
         "chart_height"       => chart_height,
         "year_label_y"       => chart_height + YEAR_LABEL_GAP,
-        "legend_dx"          => legend_x,
+        "legend_dx"          => legend_dx,
         "legend_y"           => chart_height + LEGEND_GAP,
-        "today_x"            => date_to_x_fn.call(today),
+        "today_x"            => today_x,
         "year_ticks"         => year_ticks,
         "rows"               => rows,
-        "has_eoas_column"    => !!has_eoas_column,
-        "eoas_label"         => product.data['eoasColumnLabel'],
-        "eol_label"          => product.data['eolColumnLabel'],
+        "legend_items"       => legend_items,
         "title"              => product.data['title'],
       }
     end
@@ -114,33 +126,51 @@ module EndOfLife
 
     def build_timeline_scale(releases, today, release_label_width)
       all_dates = [today]
+      has_no_end_date = false
       releases.each do |release|
         all_dates << release['releaseDate'] if release['releaseDate'].is_a?(Date)
         all_dates << release['eol']         if release['eol'].is_a?(Date)
+        has_no_end_date ||= (release['eol'] == false)
       end
 
       min_date = all_dates.min
-      max_date = [all_dates.max + DATE_PADDING_DAYS, today + MIN_FUTURE_DAYS].max
-      total_days    = (max_date - min_date).to_f
       drawable_width = SVG_WIDTH - release_label_width
+
+      max_date = if has_no_end_date
+        # Compute the minimum future span so the badge's right edge lands at SVG_WIDTH.
+        past_days  = (today - min_date).to_f
+        badge_days = (past_days * NO_END_BADGE_WIDTH / (drawable_width - NO_END_BADGE_WIDTH)).ceil
+        # Only extend further when future-dated events exist and need breathing room.
+        if all_dates.max > today
+          [all_dates.max + DATE_PADDING_DAYS, today + badge_days].max
+        else
+          today + badge_days
+        end
+      else
+        [all_dates.max + DATE_PADDING_DAYS, today + MIN_FUTURE_DAYS].max
+      end
+
+      total_days    = (max_date - min_date).to_f
       date_to_x_fn = ->(date) { (release_label_width + (date - min_date) / total_days * drawable_width).round(1) }
 
       [min_date, max_date, date_to_x_fn]
     end
 
-    def build_rows(releases, has_eoas_column, date_to_x_fn, max_date, release_label_length)
+    def build_rows(releases, has_eoas_column, date_to_x_fn, max_date, release_label_length, today_x)
       max_x = date_to_x_fn.call(max_date)
 
       # Build one row per release (newest first = top of chart).
       releases.map do |release|
         row = {
-          "label"      => truncate_label(strip_html(release['label']), release_label_length),
-          "active_x"   => 0, "active_width"   => 0,
-          "security_x" => 0, "security_width" => 0,
+          "label"        => truncate_label(strip_html(release['label']), release_label_length),
+          "active_x"     => 0, "active_width"   => 0,
+          "security_x"   => 0, "security_width" => 0,
+          "no_end_date"  => false,
         }
 
         start_x = date_to_x_fn.call(release['releaseDate'])
-        eol_x  = resolve_value_to_x(release['eol'], date_to_x_fn, max_x)
+        no_end_date = release['eol'] == false
+        eol_x  = no_end_date ? today_x : resolve_value_to_x(release['eol'], date_to_x_fn, max_x)
         eoas_x = has_eoas_column ? resolve_value_to_x(release['eoas'], date_to_x_fn, eol_x || max_x) : nil
         if eoas_x
           row["active_x"] = start_x
@@ -155,6 +185,7 @@ module EndOfLife
           row["security_width"] = [eol_x - start_x, 0].max
         end
 
+        row["no_end_date"] = true if no_end_date
         row
       end
     end

--- a/_plugins/generate-release-images.rb
+++ b/_plugins/generate-release-images.rb
@@ -28,7 +28,7 @@ module EndOfLife
     LEGEND_ICON_SIZE    = 14  # width and height of legend colour swatches
     LEGEND_ICON_TEXT_GAP = 4  # gap between icon and label text
     LEGEND_ITEM_SPACING = 240 # horizontal distance between legend item start positions
-    NO_END_DATE_LABEL   = "No end date"
+    NO_END_DATE_LABEL   = "Unknown end date"
 
     # Release filtering & date range
     MAX_NON_EOL        = 10  # refuse to generate image if non-EOL releases exceed this


### PR DESCRIPTION
When a release has eol: false (no end-of-life date), the support bar now stops at today's date and a '+' badge is rendered to its right. This still indicates support did not end, but it does not give the false impression that the release will be supported indefinitely.

Relates to https://github.com/endoflife-date/endoflife.date/issues/9861#issuecomment-4215000030