### PR TITLE
ci: speed up builds by using precompiled ruby

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -4,6 +4,9 @@
   """
   publish = "_site/"
 
+[build.environment]
+  MISE_RUBY_COMPILE = "false"
+
 [context.deploy-preview]
   command = """
   ./bin/deploy.sh $DEPLOY_PRIME_URL


### PR DESCRIPTION
Sets MISE_RUBY_COMPILE to false in netlify.toml to skip the lengthy  compilation step during deployment.