### PR TITLE
[duckdb] Update DuckDB identifiers and latest `1.5.2` version

### DIFF
--- a/products/duckdb.md
+++ b/products/duckdb.md
@@ -12,6 +12,7 @@ eolColumn: Support Status
 identifiers:
   - repology: duckdb
   - cpe: cpe:2.3:a:duckdb:duckdb
+  - purl: pkg:brew/duckdb
 
 auto:
   methods:
@@ -22,8 +23,8 @@ releases:
     codename: "Variegata"
     releaseDate: 2026-03-09
     eol: false
-    latest: "1.5.1"
-    latestReleaseDate: 2026-03-23
+    latest: "1.5.2"
+    latestReleaseDate: 2026-04-13
 
   - releaseCycle: "1.4"
     codename: "Andium"


### PR DESCRIPTION
# :grey_question: About

As per [tweet](https://x.com/duckdb/status/2043681268051624380) and [annoucement](https://duckdb.org/2026/04/13/announcing-duckdb-152): 

<img width="609" height="371" alt="image" src="https://github.com/user-attachments/assets/8c392fef-0056-451a-8cd2-9ed360095341" />

This PR : 

- :heavy_check_mark: Adds the missing data in the `yaml` (while the web version was up-to-date)
- :heavy_check_mark: Add the `brew` package