### PR TITLE
Fix CPE 2.3 handling

### DIFF
--- a/_plugins/identifier-to-url.rb
+++ b/_plugins/identifier-to-url.rb
@@ -1,5 +1,6 @@
 require 'package_url'
 require 'pp'
+require 'uri'
 require 'jekyll'
 
 # Generate URLs for different package type, raising an error if the type is unknown or the identifier invalid.
@@ -13,17 +14,17 @@ class IdentifierToUrl
     type = identifier_hash.keys[0]
     identifier = identifier_hash.values[0]
     if ['cpe'].include?(type)
-      # Regex found on https://csrc.nist.gov/schema/cpe/2.3/cpe-naming_2.3.xsd.
-      # Regex for 2.3 has been simplified as I could not make it work with Ruby.
+      # Regex for CPE 2.2 from https://csrc.nist.gov/schema/cpe/2.3/cpe-naming_2.3.xsd.
       cpe2_2_regex = /^[c][pP][eE]:\/[AHOaho]?(:[A-Za-z0-9\._\-~%]*){0,6}$/
       if identifier.match(cpe2_2_regex)
         # No known way to generate URLs for CPEs
         return nil
       end
 
-      cpe2_3_regex = /^[c][pP][eE]:2\.3:[AHOaho]?(:[A-Za-z0-9\._\-~%]*){0,6}$/
+      # Regex for CPE 2.3 allows backslash-escaped printable chars per NIST IR 7695 section 6.2.3.
+      cpe2_3_regex = /^cpe:2\.3:[aho\*\-](:([\*\-]|(?:[A-Za-z0-9\._\-~%*?]|\\[\x21-\x7E])+)){1,10}$/i
       if identifier.match(cpe2_3_regex)
-        return "https://services.nvd.nist.gov/rest/json/cpes/2.0?cpeMatchString=#{identifier}"
+        return "https://services.nvd.nist.gov/rest/json/cpes/2.0?cpeMatchString=#{URI.encode_www_form_component(identifier)}"
       end
 
       raise "Invalid CPE: should match either #{cpe2_2_regex} for CPE 2.2 or #{cpe2_3_regex} for CPE 2.3"

--- a/products/erlang.md
+++ b/products/erlang.md
@@ -12,6 +12,7 @@ eoasColumn: true
 
 identifiers:
   - repology: erlang
+  - cpe: cpe:2.3:a:erlang:erlang\/otp
 
 auto:
   methods:

--- a/products/joomla.md
+++ b/products/joomla.md
@@ -11,6 +11,7 @@ eoasColumn: true
 
 identifiers:
   - repology: joomla
+  - cpe: cpe:2.3:a:joomla:joomla\!
 
 auto:
   methods:


### PR DESCRIPTION
The previous CPE 2.3 regex rejected valid identifiers containing backslash-escaped characters (e.g. joomla\! and erlang\/otp), which are allowed per NIST IR 7695 section 6.2.3.

- Fix CPE 2.3 regex to allow backslash-escaped printable chars
- Percent-encode the CPE string in the generated NVD API URL
- Add cpe:2.3:a:joomla:joomla\! identifier to joomla
- Add cpe:2.3:a:erlang:erlang\/otp identifier to erlang

Fixes #9582