### PR TITLE
[freedesktop-sdk] Fix broken link for 22.08.28

### DIFF
--- a/products/freedesktop-sdk.md
+++ b/products/freedesktop-sdk.md
@@ -39,6 +39,7 @@ releases:
     eol: 2024-09-01
     latest: "22.08.28"
     latestReleaseDate: 2025-09-08
+    link: https://gitlab.com/freedesktop-sdk/freedesktop-sdk/-/merge_requests/28230
 
   - releaseCycle: "21.08"
     releaseDate: 2021-09-04


### PR DESCRIPTION
Actually not sure if it really released or passed version. All i can find is merge request about it but if you wish we can put link to 22.08.27