### PR TITLE
[apache-spark] Fix link for 4.1.x

### DIFF
--- a/products/apache-spark.md
+++ b/products/apache-spark.md
@@ -31,6 +31,7 @@ releases:
     eol: 2027-06-11 # estimated
     latest: "4.1.1"
     latestReleaseDate: 2026-01-02
+    link: https://spark.apache.org/downloads.html
 
   - releaseCycle: "4.0"
     releaseDate: 2025-05-19


### PR DESCRIPTION
4.1.x 's release documentation never published so we need to change its link to download page instead of letting it as 404.

this aproach looks better than just making it null for a still not eoled cycle