### PR TITLE
[azul-zulu] Update Java 11 EOL/EOES dates and fix Java 25 EOES

### DIFF
--- a/products/azul-zulu.md
+++ b/products/azul-zulu.md
@@ -53,7 +53,7 @@ releases:
     lts: true
     releaseDate: 2025-09-16 # https://docs.azul.com/core/release/25-ga/release-notes/release-notes
     eol: 2033-09-30
-    eoes: 2033-09-30
+    eoes: 2035-09-30
     latest: "25.32.21"
     latestJdkVersion: "25.0.2+10"
     latestReleaseDate: 2026-01-30
@@ -187,8 +187,8 @@ releases:
   - releaseCycle: "11"
     lts: true
     releaseDate: 2018-09-25
-    eol: 2026-09-30
-    eoes: 2028-09-30
+    eol: 2032-01-31
+    eoes: 2034-01-31
     latest: "11.86.21"
     latestJdkVersion: "11.0.30+7"
     latestReleaseDate: 2026-01-30


### PR DESCRIPTION
Update Java 11 Production Support end date from 2026-09-30 to 2032-01-31 and Extended Support from 2028-09-30 to 2034-01-31, reflecting Azul's revised LTS roadmap aligned with Oracle's extended Java 11 support timeline (13.5 years from GA).

Also correct Java 25 EOES from 2033-09-30 to 2035-09-30 — it was incorrectly set to the same date as EOL rather than +2 years per the standard LTS extended support policy.

Source: https://www.azul.com/products/azul-support-roadmap/