### PR TITLE
[amazon-opensearch] Add 3.3 and 3.5 cycles

### DIFF
--- a/products/amazon-opensearch.md
+++ b/products/amazon-opensearch.md
@@ -14,14 +14,15 @@ eolColumn: Standard Support
 eoesColumn: Extended Support
 staleReleaseThresholdDays: 2000
 
+# EOL can be found on https://docs.aws.amazon.com/opensearch-service/latest/developerguide/what-is.html#end-of-support
 releases:
   - releaseCycle: "3.5"
-    releaseDate: 2026-03-17
+    releaseDate: 2026-03-18 # https://aws.amazon.com/about-aws/whats-new/2026/03/amazon-opensearch-service-version-3-5/
     eol: false
     eoes: false
 
   - releaseCycle: "3.3"
-    releaseDate: 2025-11-19
+    releaseDate: 2025-11-24 # https://aws.amazon.com/about-aws/whats-new/2025/11/amazon-opensearch-service-opensearch-version-3-3/
     eol: false
     eoes: false
 

--- a/products/amazon-opensearch.md
+++ b/products/amazon-opensearch.md
@@ -15,6 +15,16 @@ eoesColumn: Extended Support
 staleReleaseThresholdDays: 2000
 
 releases:
+  - releaseCycle: "3.5"
+    releaseDate: 2026-03-17
+    eol: false
+    eoes: false
+
+  - releaseCycle: "3.3"
+    releaseDate: 2025-11-19
+    eol: false
+    eoes: false
+
   - releaseCycle: "3.1"
     releaseDate: 2025-09-09
     eol: false


### PR DESCRIPTION
## Summary

Add OpenSearch 3.3 and 3.5 which are available on Amazon OpenSearch Service but were missing from this page.

## Release dates

Both dates come from the [AWS OpenSearch Service release notes](https://docs.aws.amazon.com/opensearch-service/latest/developerguide/release-notes.html):

| Version | AWS Release Date | Standard Support | Extended Support |
|---------|-----------------|------------------|------------------|
| **3.5** (includes 3.4) | March 17, 2026 | Active | N/A |
| **3.3** (includes 3.2) | November 19, 2025 | Active | N/A |

No EOL dates have been announced for either version.

## Notes

- AWS releases OpenSearch versions in pairs (3.2+3.3, 3.4+3.5) but only the even-numbered versions are listed as supported upgrade targets, following the existing pattern on this page.
- The [supported versions page](https://docs.aws.amazon.com/opensearch-service/latest/developerguide/what-is.html#choosing-version) lists: 3.5, 3.3, 3.1, 2.19, 2.17, 2.15, 2.13, 2.11, 2.9, 2.7, 2.5, 2.3, 1.3, 1.2, 1.1, and 1.0.