### PR TITLE
[apache-spark] Update eol dates for 3.5 cycle to 2027-11-30 (extended LTS)

### DIFF
--- a/products/apache-spark.md
+++ b/products/apache-spark.md
@@ -42,7 +42,7 @@ releases:
   - releaseCycle: "3.5"
     lts: true
     releaseDate: 2023-09-09
-    eol: 2026-04-12 # https://github.com/apache/spark-website/commit/f06babdb98c4d97163c405622b2cc06c9d3c5797
+    eol: 2027-11-30 # https://spark.apache.org/versioning-policy.html - extended LTS to allow migrations
     latest: "3.5.8"
     latestReleaseDate: 2026-01-12
 
@@ -159,5 +159,9 @@ Apache Spark follows [semantic versioning](https://semver.org). Minor releases h
 
 The last minor release within a major release will typically be maintained for longer as an LTS
 release. For example, 2.4 was released on November 2nd 2018 and has been maintained for 31 months.
+
+As an exception, 3.5.x has an extended LTS period (security fixes only) ending November 2027 to
+allow time for migrations. This extension does not apply to Spark sub-projects with separate
+repositories (Spark Connect for Swift/Rust/Go, Spark Kubernetes Operator).
 
 *[LTS]: Long-Term Support


### PR DESCRIPTION
Apache Spark 3.5.x has an extended LTS period ending November 2027 (security fixes only), as documented in the official versioning policy. The previous eol date of 2026-04-12 was the standard 31-month cutoff, but the project made an exception to allow time for migrations.

Source: https://spark.apache.org/versioning-policy.html

> Maintenance releases and EOL
> Feature release branches will, generally, be maintained with bug fix releases for a period of 18 months. For example, branch 2.3.x is no longer considered maintained as of September 2019, 18 months after the release of 2.3.0 in February 2018. No more 2.3.x releases should be expected after that point, even for bug fixes.
> 
> The last minor release within a major release will typically be maintained for longer as an “LTS” release. For example, 3.5.0 was released on September 13th 2023 and would normally be maintained for 31 months until April 12th 2026.
> 
> As an exception from the normal versioning policy, version 3.5.x has an “extended” LTS period to allow for migrations to be completed. This extended LTS period will end November 2027. During the 3.5.x extended LTS period, we will only include security fixes. This extend LTS only applies to the primary Apache Spark project/repo and does not apply to sub projects with separate repos/releases (namely: Spark Connect for Swift/Rust/Go and Spark Kubernetes operator). Additionally, as Java 8 support may be removed from other projects (including Hadoop), should a dependency have a security fix that is not backported to a Java 8 compatible version we may decide to mark that vulnerability as a won’t fix or release the new version without Java 8 support.