### PR TITLE
ci: silence ActiveSupport dependency deprecation warning

### DIFF
--- a/_plugins/active_support_compatibility.rb
+++ b/_plugins/active_support_compatibility.rb
@@ -1,0 +1,13 @@
+require "active_support"
+
+# Although this is a Jekyll project, several of our dependencies (like jekyll-feed 
+# or html-pipeline) rely on 'ActiveSupport' (a component of Rails).
+#
+# ActiveSupport 8.0+ issues a warning about a change in how dates are 
+# converted to time objects. We are explicitly opting into the new 
+# behavior (:zone) to:
+# 1. Clear the noisy deprecation warnings from our build logs.
+# 2. Ensure date consistency across different build environments.
+if ActiveSupport.respond_to?(:to_time_preserves_timezone=)
+  ActiveSupport.to_time_preserves_timezone = :zone
+end


### PR DESCRIPTION
Some of our underlying dependencies use ActiveSupport (a core Ruby  library from the Rails ecosystem). Recent updates to this library  introduced a deprecation warning regarding timezone handling during  date conversions.

Even though we don't use Rails directly, this warning clutters our  CI/CD logs. This patch opts into the future-standard ':zone' behavior.

Benefits:
- Cleans up build logs in GitHub Actions/Netlify.
- Ensures dates are processed consistently by preserving their  original timezone, preventing potential "day-shift" bugs during  site generation.