### PR TITLE
[amazon-glue] Automate releases update and add 5.1

### DIFF
--- a/products/amazon-glue.md
+++ b/products/amazon-glue.md
@@ -20,65 +20,103 @@ customFields:
     label: Spark
     description: Spark version
     link: https://docs.aws.amazon.com/glue/latest/dg/release-notes.html
+  - name: javaVersion
+    display: api-only
+    label: Java
+    description: Supported Java version
+    link: https://docs.aws.amazon.com/glue/latest/dg/release-notes.html
 
+auto:
+  methods:
+    - release_table: https://docs.aws.amazon.com/glue/latest/dg/release-notes.html
+      fields:
+        releaseCycle:
+          column: "AWS Glue version"
+          regex: '^AWS Glue (?P<value>\d+\.\d+).*$'
+        eol:
+          column: "AWS Glue version"
+          regex: '^.+\(end\s+of\s+life\s+on\s+(?P<value>.+)\).*$'
+        pythonVersion:
+          column: "Supported runtime environment versions"
+          regex: '(?s).*Python\s+(?P<value>\d+\.\d+).*'
+        sparkVersion:
+          column: "Supported runtime environment versions"
+          regex: '(?s).*Spark\s+(?P<value>\d+\.\d+\.\d+).*'
+        javaVersion:
+          column: "Supported Java version"
+          regex: '^(?:Java\s+(?P<value>\d+)|N/A)$'
+          template: "{% if value %}{{value}}{% else %}N/A{% endif %}"
+
+# Release dates can be found on https://aws.amazon.com/new/.
 # Versions taken from https://docs.aws.amazon.com/glue/latest/dg/release-notes.html
 # EOL dates from https://docs.aws.amazon.com/glue/latest/dg/glue-version-support-policy.html.
 releases:
+  - releaseCycle: "5.1"
+    sparkVersion: "3.5.6"
+    pythonVersion: "3.11"
+    javaVersion: '17'
+    releaseDate: 2025-11-26
+    eol: false
+    link: https://aws.amazon.com/about-aws/whats-new/2025/11/aws-glue-5-1/
+
   - releaseCycle: "5.0"
-    releaseLabel: "5.0"
+    sparkVersion: "3.5.4"
+    pythonVersion: "3.11"
+    javaVersion: '17'
     releaseDate: 2024-12-03
     eol: false
-    pythonVersion: "3.11"
-    sparkVersion: "3.5"
     link: https://aws.amazon.com/about-aws/whats-new/2024/12/aws-glue-5-0/
 
   - releaseCycle: "4.0"
-    releaseLabel: "4.0"
+    sparkVersion: "3.3.0"
+    pythonVersion: "3.10"
+    javaVersion: '8'
     releaseDate: 2022-11-28
     eol: false
-    pythonVersion: "3.10"
-    sparkVersion: "3.3"
     link: https://aws.amazon.com/about-aws/whats-new/2022/11/introducing-aws-glue-4-0/
 
   - releaseCycle: "3.0"
-    releaseLabel: "3.0"
+    sparkVersion: "3.1.1"
+    pythonVersion: "3.7"
+    javaVersion: '8'
     releaseDate: 2021-08-19
     eol: false
-    pythonVersion: "3.7"
-    sparkVersion: "3.1"
     link: https://aws.amazon.com/blogs/big-data/introducing-aws-glue-3-0-with-optimized-apache-spark-3-1-runtime-for-faster-data-integration/
 
   - releaseCycle: "2.0"
-    releaseLabel: "2.0"
-    releaseDate: 2020-08-10
-    eol: 2024-01-31
+    sparkVersion: "2.4.3"
     pythonVersion: "3.7"
-    sparkVersion: "2.4"
+    javaVersion: N/A
+    releaseDate: 2020-08-10
+    eol: 2026-04-01
     link: https://aws.amazon.com/blogs/aws/aws-glue-version-2-0-featuring-10x-faster-job-start-times-and-1-minute-minimum-billing-duration/
 
-  - releaseCycle: "1.0-python-3"
+  - releaseCycle: "1.0"
     releaseLabel: "1.0 (Python 3)"
-    releaseDate: 2019-07-25
-    eol: 2022-09-30
+    sparkVersion: "2.4.3"
     pythonVersion: "3.6"
-    sparkVersion: "2.4"
+    javaVersion: N/A
+    releaseDate: 2019-07-25
+    eol: 2026-04-01
     link: https://docs.aws.amazon.com/glue/latest/dg/glue-version-support-policy.html
 
   - releaseCycle: "1.0-python-2"
     releaseLabel: "1.0 (Python 2)"
-    releaseDate: 2019-07-25
-    eol: 2022-06-01
-    pythonVersion: "2.7"
     sparkVersion: "2.4"
+    pythonVersion: "2.7"
+    javaVersion: N/A
+    releaseDate: 2019-07-25
+    eol: 2026-04-01
     link: https://docs.aws.amazon.com/glue/latest/dg/glue-version-support-policy.html
 
   - releaseCycle: "0.9"
-    releaseLabel: "0.9"
-    releaseDate: 2019-07-25
-    eol: 2022-06-01
+    sparkVersion: "2.2.1"
     pythonVersion: "2.7"
-    sparkVersion: "2.2"
+    javaVersion: N/A
+    releaseDate: 2019-07-25
+    eol: 2026-04-01
     link: https://docs.aws.amazon.com/glue/latest/dg/glue-version-support-policy.html
+
 ---
 
 > [Amazon Glue](https://aws.amazon.com/glue/) is a serverless data integration service that makes
@@ -96,7 +134,7 @@ versions.
 ## [Compatibility Matrix](https://docs.aws.amazon.com/glue/latest/dg/release-notes.html)
 
 {% include table.html
-labels="Glue version,Python version,Spark version"
-fields="releaseLabel,pythonVersion,sparkVersion"
-types="string,string,string"
+labels="Glue version,Python version,Spark version,Java version"
+fields="releaseLabel,pythonVersion,sparkVersion,javaVersion"
+types="string,string,string,string"
 rows=page.releases %}


### PR DESCRIPTION
Automate eol, pythonVersion, sparkVersion, javaVersion retrieval.
Had to rename 1.0-python-3 to 1.0 so that automation does not detected an undeclared 1.0 release.

Also add 5.1, see https://aws.amazon.com/about-aws/whats-new/2025/11/aws-glue-5-1/.