### PR TITLE
[libreoffice] Disable auto-update

### DIFF
--- a/products/libreoffice.md
+++ b/products/libreoffice.md
@@ -14,6 +14,7 @@ identifiers:
   - cpe: cpe:2.3:a:libreoffice:libreoffice
 
 auto:
+  disabled: true # prereleases not listed anymore, the script is failing
   methods:
     - libreoffice: https://downloadarchive.documentfoundation.org/libreoffice/old/
       prereleases_url: https://www.libreoffice.org/download/download-libreoffice/


### PR DESCRIPTION
https://www.libreoffice.org/download/download-libreoffice/ does not list pre-releases anymore, which makes the script fail.