### PR TITLE
[anthropic-claude] Rework product

### DIFF
--- a/products/anthropic-claude.md
+++ b/products/anthropic-claude.md
@@ -9,8 +9,8 @@ alternate_urls:
   - /anthropic-claude
 releasePolicyLink: https://platform.claude.com/docs/en/about-claude/model-deprecations
 changelogTemplate: https://www.anthropic.com/news/__RELEASE_CYCLE__
-eoasColumn: Deprecated
-eolColumn: Retired
+eoasColumn: Active support
+eolColumn: Deprecated support
 latestColumn: false
 
 customFields:

--- a/products/anthropic-claude.md
+++ b/products/anthropic-claude.md
@@ -7,9 +7,11 @@ iconSlug: anthropic
 permalink: /claude
 alternate_urls:
   - /anthropic-claude
-releasePolicyLink: https://platform.claude.com/docs/en/about-claude/model-deprecations#deprecation-history
+releasePolicyLink: https://platform.claude.com/docs/en/about-claude/model-deprecations
+changelogTemplate: https://www.anthropic.com/news/__RELEASE_CYCLE__
 eoasColumn: Deprecated
 eolColumn: Retired
+latestColumn: false
 
 customFields:
   - name: recommendedReplacement
@@ -18,204 +20,242 @@ customFields:
     description: Replacement model from Anthropic deprecation history
     link: https://platform.claude.com/docs/en/about-claude/model-deprecations#deprecation-history
 
+auto:
+  methods:
+    - release_table: https://platform.claude.com/docs/en/about-claude/model-deprecations#deprecation-history
+      fields:
+        releaseCycle:
+          column: "Deprecated Model"
+          regex: "^(?P<value>.+)$"
+        eol: "Retirement Date"
+        recommendedReplacement: "Recommended Replacement"
+    - release_table: https://platform.claude.com/docs/en/about-claude/model-deprecations#model-status
+      fields:
+        releaseCycle:
+          column: "API Model Name"
+          regex: "^(?P<value>.+)$"
+        eoas: "Deprecated"
+        eol:
+          column: "Tentative Retirement Date"
+          regex: "^(Not sooner than )?(?P<value>.+)$"
+
 releases:
-  - releaseCycle: "sonnet-4.6"
+  - releaseCycle: "claude-opus-4-7"
+    releaseLabel: Claude Opus 4.7
+    releaseDate: 2026-04-16
+    eoas: false
+    eol: 2027-04-16
+    recommendedReplacement: "N/A"
+
+  - releaseCycle: "claude-sonnet-4-6"
     releaseLabel: Claude Sonnet 4.6
     releaseDate: 2026-02-17
     eoas: false
-    eol: false
-    latest: "claude-sonnet-4-6"
+    eol: 2027-02-17
     recommendedReplacement: "N/A"
-    latestReleaseDate: 2026-02-17
-    link: https://platform.claude.com/docs/en/about-claude/model-deprecations
 
-  - releaseCycle: "opus-4.6"
+  - releaseCycle: "claude-opus-4-6"
     releaseLabel: Claude Opus 4.6
     releaseDate: 2026-02-05
     eoas: false
-    eol: false
-    latest: "claude-opus-4-6"
+    eol: 2027-02-05
     recommendedReplacement: "N/A"
-    latestReleaseDate: 2026-02-05
-    link: https://platform.claude.com/docs/en/about-claude/model-deprecations
 
-  - releaseCycle: "opus-4.5"
+  - releaseCycle: "claude-opus-4-5-20251101"
     releaseLabel: Claude Opus 4.5
     releaseDate: 2025-11-24
     eoas: false
-    eol: false
-    latest: "claude-opus-4-5-20251101"
+    eol: 2026-11-24
     recommendedReplacement: "N/A"
-    latestReleaseDate: 2025-11-24
-    link: https://platform.claude.com/docs/en/about-claude/model-deprecations
+    link: https://www.anthropic.com/news/claude-opus-4-5
 
-  - releaseCycle: "haiku-4.5"
+  - releaseCycle: "claude-haiku-4-5-20251001"
     releaseLabel: Claude Haiku 4.5
     releaseDate: 2025-10-15
     eoas: false
-    eol: false
-    latest: "claude-haiku-4-5-20251001"
+    eol: 2026-10-15
     recommendedReplacement: "N/A"
-    latestReleaseDate: 2025-10-15
-    link: https://platform.claude.com/docs/en/about-claude/model-deprecations
+    link: https://www.anthropic.com/news/claude-haiku-4-5
 
-  - releaseCycle: "sonnet-4.5"
+  - releaseCycle: "claude-sonnet-4-5-20250929"
     releaseLabel: Claude Sonnet 4.5
     releaseDate: 2025-09-29
     eoas: false
-    eol: false
-    latest: "claude-sonnet-4-5-20250929"
+    eol: 2026-09-29
     recommendedReplacement: "N/A"
-    latestReleaseDate: 2025-09-29
     link: https://platform.claude.com/docs/en/about-claude/model-deprecations
 
-  - releaseCycle: "opus-4.1"
+  - releaseCycle: "claude-opus-4-1-20250805"
     releaseLabel: Claude Opus 4.1
     releaseDate: 2025-08-05
     eoas: false
-    eol: false
-    latest: "claude-opus-4-1-20250805"
+    eol: 2026-08-05
     recommendedReplacement: "N/A"
-    latestReleaseDate: 2025-08-05
-    link: https://platform.claude.com/docs/en/about-claude/model-deprecations
+    link: https://www.anthropic.com/news/claude-opus-4-1
 
-  - releaseCycle: "sonnet-4"
+  - releaseCycle: "claude-sonnet-4-20250514"
     releaseLabel: Claude Sonnet 4
     releaseDate: 2025-05-22
-    eoas: false
-    eol: false
-    latest: "claude-sonnet-4-20250514"
-    recommendedReplacement: "N/A"
-    latestReleaseDate: 2025-05-22
-    link: https://platform.claude.com/docs/en/about-claude/model-deprecations
+    eoas: 2026-04-14
+    eol: 2026-06-15
+    recommendedReplacement: "claude-sonnet-4-6"
+    link: https://www.anthropic.com/news/claude-4
 
-  - releaseCycle: "opus-4"
+  - releaseCycle: "claude-opus-4-20250514"
     releaseLabel: Claude Opus 4
     releaseDate: 2025-05-22
-    eoas: false
-    eol: false
-    latest: "claude-opus-4-20250514"
-    recommendedReplacement: "N/A"
-    latestReleaseDate: 2025-05-22
-    link: https://platform.claude.com/docs/en/about-claude/model-deprecations
+    eoas: 2026-04-14
+    eol: 2026-06-15
+    recommendedReplacement: "claude-opus-4-7"
+    link: https://www.anthropic.com/news/claude-4
 
-  - releaseCycle: "sonnet-3.7"
+  - releaseCycle: "claude-3-7-sonnet-20250219"
     releaseLabel: Claude Sonnet 3.7
     releaseDate: 2025-02-24
     eoas: 2025-10-28
     eol: 2026-02-19
-    latest: "claude-3-7-sonnet-20250219"
-    recommendedReplacement: "claude-opus-4-6"
-    latestReleaseDate: 2025-02-24
-    link: https://platform.claude.com/docs/en/about-claude/model-deprecations#2025-10-28-claude-sonnet-3-7-model
+    recommendedReplacement: "claude-sonnet-4-6"
+    link: https://www.anthropic.com/news/claude-3-7-sonnet
 
-  - releaseCycle: "haiku-3.5"
+  - releaseCycle: "claude-3-5-haiku-20241022"
     releaseLabel: Claude Haiku 3.5
     releaseDate: 2024-10-22
     eoas: 2025-12-19
     eol: 2026-02-19
-    latest: "claude-3-5-haiku-20241022"
     recommendedReplacement: "claude-haiku-4-5-20251001"
-    latestReleaseDate: 2024-10-22
-    link: https://platform.claude.com/docs/en/about-claude/model-deprecations#2025-12-19-claude-haiku-3-5-model
+    link: https://www.anthropic.com/news/3-5-models-and-computer-use
 
-  - releaseCycle: "sonnet-3.5"
-    releaseLabel: Claude Sonnet 3.5
-    releaseDate: 2024-06-20
+  - releaseCycle: "claude-3-5-sonnet-20241022"
+    releaseLabel: Claude Sonnet 3.5 (20241022)
+    releaseDate: 2024-10-22
     eoas: 2025-08-13
     eol: 2025-10-28
-    latest: "claude-3-5-sonnet-20241022"
-    recommendedReplacement: "claude-opus-4-6"
-    latestReleaseDate: 2024-10-22
-    link: https://platform.claude.com/docs/en/about-claude/model-deprecations#2025-08-13-claude-sonnet-3-5-models
+    recommendedReplacement: "claude-sonnet-4-6"
+    link: https://www.anthropic.com/news/3-5-models-and-computer-use
 
-  - releaseCycle: "haiku-3"
+  - releaseCycle: "claude-3-5-sonnet-20240620"
+    releaseLabel: Claude Sonnet 3.5 (20240620)
+    releaseDate: 2024-06-21
+    eoas: 2025-08-13
+    eol: 2025-10-28
+    recommendedReplacement: "claude-sonnet-4-6"
+    link: https://www.anthropic.com/news/claude-3-5-sonnet
+
+  - releaseCycle: "claude-3-haiku-20240307"
     releaseLabel: Claude Haiku 3
     releaseDate: 2024-03-13
     eoas: 2026-02-19
     eol: 2026-04-20
-    latest: "claude-3-haiku-20240307"
     recommendedReplacement: "claude-haiku-4-5-20251001"
-    latestReleaseDate: 2024-03-13
-    link: https://platform.claude.com/docs/en/about-claude/model-deprecations#2026-02-19-claude-haiku-3-model
+    link: https://www.anthropic.com/news/claude-3-haiku
 
-  - releaseCycle: "opus-3"
+  - releaseCycle: "claude-3-opus-20240229"
     releaseLabel: Claude Opus 3
     releaseDate: 2024-03-04
     eoas: 2025-06-30
     eol: 2026-01-05
-    latest: "claude-3-opus-20240229"
-    recommendedReplacement: "claude-opus-4-6"
-    latestReleaseDate: 2024-03-04
-    link: https://platform.claude.com/docs/en/about-claude/model-deprecations#2025-06-30-claude-opus-3-model
+    recommendedReplacement: "claude-opus-4-7"
+    link: https://www.anthropic.com/news/claude-3-family
 
-  - releaseCycle: "sonnet-3"
+  - releaseCycle: "claude-3-sonnet-20240229"
     releaseLabel: Claude Sonnet 3
     releaseDate: 2024-03-04
     eoas: 2025-01-21
     eol: 2025-07-21
-    latest: "claude-3-sonnet-20240229"
-    recommendedReplacement: "claude-opus-4-6"
-    latestReleaseDate: 2024-03-04
-    link: https://platform.claude.com/docs/en/about-claude/model-deprecations#2025-01-21-claude-2-claude-2-1-and-claude-sonnet-3-models
+    recommendedReplacement: "claude-sonnet-4-6"
+    link: https://www.anthropic.com/news/claude-3-family
 
   - releaseCycle: "claude-2.1"
     releaseLabel: Claude 2.1
     releaseDate: 2023-11-21
     eoas: 2025-01-21
     eol: 2025-07-21
-    latest: "claude-2.1"
-    recommendedReplacement: "claude-opus-4-6"
+    recommendedReplacement: "claude-opus-4-7"
     link: https://platform.claude.com/docs/en/about-claude/model-deprecations#2025-01-21-claude-2-claude-2-1-and-claude-sonnet-3-models
 
-  - releaseCycle: "claude-instant-1"
-    releaseLabel: Claude Instant 1
+  - releaseCycle: "claude-instant-1.2"
+    releaseLabel: Claude Instant 1.2
     releaseDate: 2023-08-09
-    eoas: 2024-09-04
+    eoas: 2024-11-06
     eol: 2024-11-06
-    latest: "claude-instant-1.2"
     recommendedReplacement: "claude-haiku-4-5-20251001"
-    link: https://platform.claude.com/docs/en/about-claude/model-deprecations#2024-09-04-claude-1-and-instant-models
+    link: https://www.anthropic.com/news/releasing-claude-instant-1-2
 
   - releaseCycle: "claude-2.0"
     releaseLabel: Claude 2.0
     releaseDate: 2023-07-11
     eoas: 2025-01-21
     eol: 2025-07-21
-    latest: "claude-2.0"
-    recommendedReplacement: "claude-opus-4-6"
-    link: https://platform.claude.com/docs/en/about-claude/model-deprecations#2025-01-21-claude-2-claude-2-1-and-claude-sonnet-3-models
+    recommendedReplacement: "claude-opus-4-7"
+    link: https://www.anthropic.com/news/claude-2
 
-  - releaseCycle: "claude-1"
-    releaseLabel: Claude 1
+  - releaseCycle: "claude-1.3"
+    releaseLabel: Claude 1.3
+    releaseDate: 2023-04-18
+    eoas: 2024-09-04
+    eol: 2024-11-06
+    recommendedReplacement: "claude-haiku-4-5-20251001"
+    link: https://www.maginative.com/article/anthropic-releases-safer-improved-version-of-ai-assistant-claude/
+
+  - releaseCycle: "claude-instant-1.1"
+    releaseLabel: Claude Instant 1.1
+    releaseDate: 2023-03-31 # no exact date - https://www.reddit.com/r/ClaudeAI/comments/1fddk0h/any_info_when_the_claude_35_opus_will_be_released/
+    eoas: 2024-11-06
+    eol: 2024-11-06
+    recommendedReplacement: "claude-haiku-4-5-20251001"
+    link: null
+
+  - releaseCycle: "claude-1.2"
+    releaseLabel: Claude 1.2
+    releaseDate: 2023-03-14 # unknown date
+    eoas: 2024-09-04
+    eol: 2024-11-06
+    recommendedReplacement: "claude-haiku-4-5-20251001"
+    link: null
+
+  - releaseCycle: "claude-1.1"
+    releaseLabel: Claude 1.1
+    releaseDate: 2023-03-14 # unknown date
+    eoas: 2024-09-04
+    eol: 2024-11-06
+    recommendedReplacement: "claude-haiku-4-5-20251001"
+    link: null
+
+  - releaseCycle: "claude-instant-1.0"
+    releaseLabel: Claude Instant 1.0
     releaseDate: 2023-03-14
     eoas: 2024-09-04
     eol: 2024-11-06
-    latest: "claude-1.3"
     recommendedReplacement: "claude-haiku-4-5-20251001"
-    link: https://platform.claude.com/docs/en/about-claude/model-deprecations#2024-09-04-claude-1-and-instant-models
+    link: https://www.anthropic.com/news/introducing-claude
+
+  - releaseCycle: "claude-1.0"
+    releaseLabel: Claude 1.0
+    releaseDate: 2023-03-14
+    eoas: 2024-09-04
+    eol: 2024-11-06
+    recommendedReplacement: "claude-haiku-4-5-20251001"
+    link: https://www.anthropic.com/news/introducing-claude
+
 ---
 
 > [Anthropic Claude](https://platform.claude.com/docs/en/about-claude/models/overview) is a family of large language models provided by Anthropic.
 
 {: .warning }
-> This page tracks Claude model availability on the Anthropic API. This does not include the Claude app,
-> Claude Code, or third-party integrations such as Amazon Bedrock and Google Cloud Vertex AI.
+> This page tracks Claude model availability on the Anthropic API.
+> This does not include the Claude app, Claude Code, or third-party integrations such as Amazon Bedrock and Google Cloud Vertex AI.
 
-## Lifecycle states
+Anthropic uses the following terms to describe the model lifecycle:
 
 - **Active**: The model is fully supported and recommended for use.
-- **Legacy**: The model will no longer receive updates and may be deprecated in the future.
-- **Deprecated**: The model is no longer available for new customers but continues to be available
-  for existing users until retirement. Anthropic assigns a retirement date at this point.
+- **Deprecated**: The model is no longer available for new customers but continues to be available for existing users until retirement.
+  Anthropic assigns a retirement date at this point.
 - **Retired**: The model is no longer available for use. Requests to retired models will fail.
 
 **Note** Deprecated models are likely to be less reliable than active models.
 Anthropic recommends moving workloads to active models to maintain the highest level of support and reliability.
 
-Customers with active deployments receive at least 60 days' notice before retirement for publicly released models.
+Customers with active deployments receive at least 60 days notice before retirement for publicly released models.
 Anthropic recommends auditing API usage to discover model usage and testing replacement models before retirement.
 
 Anthropic has committed to preserve the weights of publicly released models and may make past models available again in the future.
-
-Retirement is treated as EOL and Deprecation as End-of-Active-support in the above table and endoflife.date API.

--- a/products/anthropic-claude.md
+++ b/products/anthropic-claude.md
@@ -248,9 +248,9 @@ releases:
 Anthropic uses the following terms to describe the model lifecycle:
 
 - **Active**: The model is fully supported and recommended for use.
-- **Deprecated**: The model is no longer available for new customers but continues to be available for existing users until retirement.
+- **Deprecated**: The model is no longer available for new customers but continues to be available for existing users until retirement. Deprecation date is same as the "Active Support" end date in the above table.
   Anthropic assigns a retirement date at this point.
-- **Retired**: The model is no longer available for use. Requests to retired models will fail.
+- **Retired**: The model is no longer available for use. Requests to retired models will fail. Retirement date is same as the "Deprecated Support" end date in the above table.
 
 **Note** Deprecated models are likely to be less reliable than active models.
 Anthropic recommends moving workloads to active models to maintain the highest level of support and reliability.


### PR DESCRIPTION
- Drop latest / latestReleaseDate and treat each model as a release: there is no notion of "patch" versions for models, each model has it's own retirement / deprecation date.
- Update release with the latest information from https://platform.claude.com/docs/en/about-claude/model-deprecations.
- Add automation to automatically update releases based on https://platform.claude.com/docs/en/about-claude/model-deprecations, so that we are aware of new releases and don't need to manually maintain existing releases.
- Update links to point to announcement blog posts.
- Drop the "legacy" lifecycle states : it's explained in the Anthropic documentation, but never used.
- Drop the explanation of endoflife.date columns : those columns are already properly named after Anthropic concepts of retirement / deprecation.
- Reformat description.

This is a breaking change.