### PR TITLE
[plesk] Added versionCommand alternative for non-rooted environments

### DIFF
--- a/products/plesk.md
+++ b/products/plesk.md
@@ -5,6 +5,11 @@ category: server-app
 tags: php-runtime
 iconSlug: plesk
 permalink: /plesk
+versionCommand: |-
+  plesk version
+
+  # or (without root acces) alternatively
+  cat /etc/plesk-release
 versionCommand: cat /etc/plesk-release
 releasePolicyLink: https://www.plesk.com/lifecycle-policy/
 changelogTemplate: "https://docs.plesk.com/release-notes/obsidian/change-log/#plesk-{{'__RELEASE_CYCLE__'|replace:'.',''}}"

--- a/products/plesk.md
+++ b/products/plesk.md
@@ -10,7 +10,6 @@ versionCommand: |-
 
   # or (without root acces) alternatively
   cat /etc/plesk-release
-versionCommand: cat /etc/plesk-release
 releasePolicyLink: https://www.plesk.com/lifecycle-policy/
 changelogTemplate: "https://docs.plesk.com/release-notes/obsidian/change-log/#plesk-{{'__RELEASE_CYCLE__'|replace:'.',''}}"
 eolColumn: Support

--- a/products/plesk.md
+++ b/products/plesk.md
@@ -8,7 +8,7 @@ permalink: /plesk
 versionCommand: |-
   plesk version
 
-  # or (without root acces) alternatively
+  # or alternatively without root access / on Linux
   cat /etc/plesk-release
 releasePolicyLink: https://www.plesk.com/lifecycle-policy/
 changelogTemplate: "https://docs.plesk.com/release-notes/obsidian/change-log/#plesk-{{'__RELEASE_CYCLE__'|replace:'.',''}}"

--- a/products/plesk.md
+++ b/products/plesk.md
@@ -5,7 +5,7 @@ category: server-app
 tags: php-runtime
 iconSlug: plesk
 permalink: /plesk
-versionCommand: plesk version
+versionCommand: cat /etc/plesk-release
 releasePolicyLink: https://www.plesk.com/lifecycle-policy/
 changelogTemplate: "https://docs.plesk.com/release-notes/obsidian/change-log/#plesk-{{'__RELEASE_CYCLE__'|replace:'.',''}}"
 eolColumn: Support


### PR DESCRIPTION
### Changes

- Updated `versionCommand` for the **Plesk** product.
- Changed from `plesk version` (requires root) to `cat /etc/plesk-release` (works as regular user).

### Why

This method is more convenient in most scenarios because it does **not require root privileges**.

```
[cm@goofy-ritchie ~]$ plesk version
error: must run as root
```

```
[cm@goofy-ritchie ~]$ sudo plesk version
Product version: Plesk Obsidian 18.0.77.1
     OS version: AlmaLinux 9.6 x86_64
     Build date: 2026/04/05 05:00
       Revision: c20e276b8639bfdc44529377552ab630d71d375a
```

```
[cm@goofy-ritchie ~]$ cat /etc/plesk-release
18.0.77.1
Plesk Obsidian 18.0
```