### PR TITLE
[amazon-opensearch] Set staleReleaseThreshold to 1000

### DIFF
--- a/products/amazon-opensearch.md
+++ b/products/amazon-opensearch.md
@@ -12,6 +12,7 @@ releasePolicyLink: https://docs.aws.amazon.com/opensearch-service/latest/develop
 latestColumn: false
 eolColumn: Standard Support
 eoesColumn: Extended Support
+staleReleaseThresholdDays: 1000
 
 # EOL can be found on https://docs.aws.amazon.com/opensearch-service/latest/developerguide/what-is.html#end-of-support
 releases:


### PR DESCRIPTION
Because of those warnings:

```
amazon-opensearch:2.17 is not EOL and is 524 days old
amazon-opensearch:2.15 is not EOL and is 557 days old
amazon-opensearch:2.13 is not EOL and is 700 days old
amazon-opensearch:2.11 is not EOL and is 886 days old
```