### PR TITLE
[github-actions-runner-images] Update staleReleaseThresholdDays

### DIFF
--- a/products/github-actions-runner-images.md
+++ b/products/github-actions-runner-images.md
@@ -8,6 +8,7 @@ permalink: /github-actions-runner-images
 eoasColumn: Deprecated
 eolColumn: Removed
 latestColumn: false
+staleReleaseThresholdDays: 720
 
 auto:
   methods:
@@ -81,6 +82,7 @@ releases:
     eoas: false
     eol: false
     link: https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2204-Readme.md
+    staleReleaseThresholdDays: 1825 # still not announced
 
   - releaseCycle: "macos-12"
     releaseLabel: "macOS 12"
@@ -95,6 +97,7 @@ releases:
     eoas: false
     eol: false
     link: https://github.com/actions/runner-images/blob/main/images/windows/Windows2022-Readme.md
+    staleReleaseThresholdDays: 1825 # still not announced
 
   - releaseCycle: "ubuntu-20.04"
     releaseLabel: "Ubuntu 20.04"


### PR DESCRIPTION
To avoid those warnings:

```
github-actions-runner-images:windows-2025 is not EOL and is 376 days old
github-actions-runner-images:macos-15 is not EOL and is 376 days old
github-actions-runner-images:ubuntu-24.04 is not EOL and is 707 days old
github-actions-runner-images:ubuntu-22.04 is not EOL and is 1351 days old
github-actions-runner-images:windows-2022 is not EOL and is 1617 days old
```