### PR TITLE
Hcl notes new product

### DIFF
--- a/products/hcl-notes.md
+++ b/products/hcl-notes.md
@@ -28,7 +28,7 @@ releases:
 
   - releaseCycle: "14.0.x"
     releaseLabel: "HCL Notes 14.0.x"
-    releaseDate: 2023-07-12
+    releaseDate: 2023-12-07
     lts: false
     eol: false
     link: https://www.hcl-software.com/resources/product-release/product-lifecycle-table?searchTerm=hcl-notes
@@ -42,7 +42,7 @@ releases:
 
   - releaseCycle: "11.0.x"
     releaseLabel: "HCL Notes 11.0.x"
-    releaseDate: 2019-20-12
+    releaseDate: 2019-12-20
     lts: false
     eol: 2025-06-26
     eoes: 2025-06-30
@@ -53,7 +53,7 @@ releases:
     releaseDate: 2018-10-10
     lts: false
     eol: 2024-01-06
-    eoes: 2030-30-06
+    eoes: 2030-06-30
     link: https://support.hcl-software.com/csm?id=kb_article&sysparm_article=KB0099055
 
   - releaseCycle: "9.0.x"
@@ -61,7 +61,7 @@ releases:
     releaseDate: 2013-12-04
     lts: false
     eol: 2024-01-06
-    eoes: 2030-30-06
+    eoes: 2030-06-30
     link: https://support.hcl-software.com/csm?id=kb_article&sysparm_article=KB0099055
 
 ---

--- a/products/hcl-notes.md
+++ b/products/hcl-notes.md
@@ -1,0 +1,74 @@
+---
+
+title: Hcl Notes
+
+addedAt: 2026-04-20
+category: app
+tags: hcl 
+
+permalink: /hcl-notes
+
+alternate_urls:
+-   /lotus-notes
+-   /hcl-domino
+
+versionCommand: Menu "?"> "About"
+
+
+releasePolicyLink: https://www.hcl-software.com/resources/product-release/standard-and-enhanced
+
+releases:
+  - releaseCycle: "14.5.x"
+    releaseLabel: "HCL Notes 14.5.x"
+    releaseDate: 2025-06-17
+    lts: false
+    eol: false
+    link: https://www.hcl-software.com/resources/product-release/product-lifecycle-table?searchTerm=hcl-notes
+    
+
+  - releaseCycle: "14.0.x"
+    releaseLabel: "HCL Notes 14.0.x"
+    releaseDate: 2023-07-12
+    lts: false
+    eol: false
+    link: https://www.hcl-software.com/resources/product-release/product-lifecycle-table?searchTerm=hcl-notes
+
+  - releaseCycle: "12.0.x"
+    releaseLabel: "HCL Notes 12.0.x"
+    releaseDate: 2021-05-27
+    lts: false
+    eol: false
+    link: https://www.hcl-software.com/resources/product-release/product-lifecycle-table?searchTerm=hcl-notes
+
+  - releaseCycle: "11.0.x"
+    releaseLabel: "HCL Notes 11.0.x"
+    releaseDate: 2019-20-12
+    lts: false
+    eol: 2025-06-26
+    eoes: 2025-06-30
+    link: https://support.hcl-software.com/csm?id=kb_article&sysparm_article=KB0114064    
+
+  - releaseCycle: "10.0.x"
+    releaseLabel: "HCL Notes 10.0.x"
+    releaseDate: 2018-10-10
+    lts: false
+    eol: 2024-01-06
+    eoes: 2030-30-06
+    link: https://support.hcl-software.com/csm?id=kb_article&sysparm_article=KB0099055
+
+  - releaseCycle: "9.0.x"
+    releaseLabel: "HCL Notes 9.0.x"
+    releaseDate: 2013-12-04
+    lts: false
+    eol: 2024-01-06
+    eoes: 2030-30-06
+    link: https://support.hcl-software.com/csm?id=kb_article&sysparm_article=KB0099055
+
+---
+
+> HCL Notes is the email client software that gives teams access to email, calendar, and contact management capabilities, 
+> and seamlessly integrates other collaboration tools and HCL Domino business applications. 
+
+HCLSoftware releases products with predictable, consistent and transparent lifecycle policies for software support and servicing. The supported lifecycle policies are Standard Support (3+2), Enhanced Support (5+3), Other Support (applicable for acquired products) and Continuous Delivery (2+1).
+
+HCL Notes (formerly Lotus Notes then IBM Notes) is a proprietary collaborative software platform for Unix (AIX), IBM i, Windows, Linux, and macOS, sold by HCLTech. The client application is called Notes while the server component is branded HCL Domino. 


### PR DESCRIPTION


-     hcl notes/domino (email/groupware)
-     version 9 to 14.5
-     source https://www.hcl-software.com/resources/product-release/product-lifecycle-table?searchTerm=hcl-notes

