### PR TITLE
[mysql] Mark 9.7 cycle as a LTS cycle

### DIFF
--- a/products/mysql.md
+++ b/products/mysql.md
@@ -38,10 +38,10 @@ identifiers:
 releases:
   - releaseCycle: "9.7"
     releaseDate: 2026-04-21
-    eoas: false # releaseDate(x+1)
-    eol: false # releaseDate(x+1)
-    latest: "9.7.0"
     lts: true
+    eoas: false # releaseDate(x+1)
+    eol: 2034-04-21 # estimated eol date
+    latest: "9.7.0"
     latestReleaseDate: 2026-04-21
     link: https://dev.mysql.com/doc/relnotes/mysql/9.7/en/news-9-7-0.html
 

--- a/products/mysql.md
+++ b/products/mysql.md
@@ -41,6 +41,7 @@ releases:
     eoas: false # releaseDate(x+1)
     eol: false # releaseDate(x+1)
     latest: "9.7.0"
+    lts: true
     latestReleaseDate: 2026-04-21
     link: https://dev.mysql.com/doc/relnotes/mysql/9.7/en/news-9-7-0.html
 


### PR DESCRIPTION
# :grey_question: About

**🚀 MySQL 9.7.0 LTS** is now generally availablle, see [tweet](https://x.com/MySQL/status/2046881876292280638) and [announce](https://blogs.oracle.com/mysql/mysql-9-7-0-lts-is-now-available-expanded-community-capabilities-and-dynamic-data-masking-for-enterprise) : 

<img width="583" height="866" alt="image" src="https://github.com/user-attachments/assets/9101e780-3b10-48eb-b1e6-d8aa5b594717" />
