### PR TITLE
[New Product] Strapi

### DIFF
--- a/products/strapi.md
+++ b/products/strapi.md
@@ -1,0 +1,56 @@
+---
+title: Strapi
+addedAt: 2026-04-23
+category: framework
+tags: javascript-runtime
+iconSlug: strapi
+permalink: /strapi
+versionCommand: yarn strapi version
+releasePolicyLink: https://github.com/strapi/strapi/blob/develop/SECURITY.md
+changelogTemplate: https://github.com/strapi/strapi/releases/tag/v__LATEST__
+eoasColumn: true
+
+identifiers:
+  - purl: pkg:github/strapi/strapi
+  - purl: pkg:npm/%40strapi/strapi
+
+auto:
+  methods:
+    - git: https://github.com/strapi/strapi.git
+      regex: '^v(?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)$'
+    - npm: "@strapi/strapi"
+
+# From https://github.com/strapi/strapi/blob/develop/SECURITY.md:
+# - v5.x.x: GA since September 2024, LTS until further notice
+# - v4.x.x: GA since November 2021, active support ended October 2025,
+#            security-only fixes (high/critical) until April 2026
+# - v3.x.x: End of Life
+releases:
+  - releaseCycle: "5"
+    releaseDate: 2024-09-18
+    eoas: false
+    eol: false
+    latest: "5.43.0"
+    latestReleaseDate: 2026-04-22
+
+  - releaseCycle: "4"
+    releaseDate: 2021-11-30
+    eoas: 2025-10-01
+    eol: 2026-04-30
+    latest: "4.26.1"
+    latestReleaseDate: 2026-01-08
+
+  - releaseCycle: "3"
+    releaseDate: 2020-05-26
+    eoas: 2022-02-16
+    eol: 2022-02-16
+    latest: "3.6.9"
+    latestReleaseDate: 2022-02-16
+
+---
+
+> [Strapi](https://strapi.io/) is an open-source headless CMS built with JavaScript/TypeScript.
+> It is fully customizable and provides a content management API for web and mobile applications.
+
+Strapi uses major version numbers as release cycles.
+The [security policy](https://github.com/strapi/strapi/blob/develop/SECURITY.md) documents which versions receive active support and security fixes.

--- a/products/strapi.md
+++ b/products/strapi.md
@@ -1,6 +1,6 @@
 ---
 title: Strapi
-addedAt: 2026-04-23
+addedAt: 2026-07-01
 category: framework
 tags: javascript-runtime
 iconSlug: strapi
@@ -25,21 +25,22 @@ auto:
 # - v4.x.x: GA since November 2021, active support ended October 2025,
 #            security-only fixes (high/critical) until April 2026
 # - v3.x.x: End of Life
+
 releases:
   - releaseCycle: "5"
     releaseDate: 2024-09-18
     lts: true
     eoas: false
     eol: false
-    latest: "5.43.0"
-    latestReleaseDate: 2026-04-22
+    latest: "5.49.0"
+    latestReleaseDate: 2026-06-24
 
   - releaseCycle: "4"
     releaseDate: 2021-11-30
     eoas: 2025-10-01
-    eol: 2026-04-30
-    latest: "4.26.1"
-    latestReleaseDate: 2026-01-08
+    eol: 2026-06-09
+    latest: "4.26.2"
+    latestReleaseDate: 2026-06-09
 
   - releaseCycle: "3"
     releaseDate: 2020-05-26

--- a/products/strapi.md
+++ b/products/strapi.md
@@ -28,6 +28,7 @@ auto:
 releases:
   - releaseCycle: "5"
     releaseDate: 2024-09-18
+    lts: true
     eoas: false
     eol: false
     latest: "5.43.0"


### PR DESCRIPTION
Closes #5706

## What this PR adds

A new product page for [Strapi](https://strapi.io/), the open-source headless CMS built with JavaScript/TypeScript.

### Release cycles

Based on the [Strapi security policy](https://github.com/strapi/strapi/blob/develop/SECURITY.md):

| Cycle | Release Date | Active Support Until | EOL |
|-------|-------------|----------------------|-----|
| 5 | 2024-09-18 | TBD (LTS) | TBD |
| 4 | 2021-11-30 | October 2025 | April 2026 |
| 3 | 2020-05-26 | February 2022 | February 2022 |

- v5 is the current LTS (since September 2024)
- v4 active support ended October 2025; security-only (high/critical) until April 2026
- v3 is fully EOL

### Auto update

Uses both `git` tags and `npm` registry (`@strapi/strapi`) for release tracking.