### PR TITLE
[Grafana] Added versionCommand alternative for newest versions

### DIFF
--- a/products/grafana.md
+++ b/products/grafana.md
@@ -5,11 +5,12 @@ category: server-app
 iconSlug: grafana
 permalink: /grafana
 versionCommand: |-
+  # For Grafana >= 13
+  grafana --version
+
   # For Grafana < 13
   grafana-server -v
 
-  # For Grafana >= 13 (new CLI)
-  grafana --version
 changelogTemplate: https://github.com/grafana/grafana/releases/tag/v__LATEST__
 eoasColumn: true
 

--- a/products/grafana.md
+++ b/products/grafana.md
@@ -4,7 +4,12 @@ addedAt: 2022-11-02
 category: server-app
 iconSlug: grafana
 permalink: /grafana
-versionCommand: grafana-server -v
+versionCommand: |-
+  # For Grafana < 13
+  grafana-server -v
+
+  # For Grafana >= 13 (new CLI)
+  grafana --version
 changelogTemplate: https://github.com/grafana/grafana/releases/tag/v__LATEST__
 eoasColumn: true
 


### PR DESCRIPTION
Update version detection to use new Grafana CLI

Grafana v13 removed the `grafana-server` command and deprecated the old binaries in favor of the new `grafana` CLI. This change updates the `versionCommand` to use `grafana --version` instead of `grafana-server -v`, which is required for Grafana ≥13.

References:
- https://grafana.com/whats-new/2026-04-14-removal-of-grafana-cli-and-grafana-server-commands/
- Output from my environment: 

**Grafana**
```
$ grafana --version grafana version 13.1.0-24876902987 
```
```
$ grafana-server --version sh: 4: grafana-server: not found
```

**Grafana EE**
```
/usr/share/grafana $ grafana --version
grafana version 13.0.1
```
```
/usr/share/grafana $ grafana-server --version
sh: grafana-server: not found
```