### PR TITLE
[Prometheus] Added versionCommand

### DIFF
--- a/products/prometheus.md
+++ b/products/prometheus.md
@@ -4,6 +4,7 @@ addedAt: 2023-07-17
 category: server-app
 tags: linux-foundation
 iconSlug: prometheus
+versionCommand: prometheus --version
 permalink: /prometheus
 releasePolicyLink: https://prometheus.io/docs/introduction/release-cycle/
 changelogTemplate: https://github.com/prometheus/prometheus/releases/tag/v__LATEST__


### PR DESCRIPTION
Add Prometheus version check

Add command to check Prometheus version via `prometheus --version`.

Example:
```
/prometheus $ prometheus --version
prometheus, version 3.11.2 (branch: HEAD, revision: f0f0fdd679dcd6df320b0558b20919f7cd44c407)
  build user:       root@d2684485c347
  build date:       20260413-11:58:47
  go version:       go1.26.2
  platform:         linux/arm64
  tags:             netgo,builtinassets
```