### PR TITLE
[Opensearch] Added versionCommand

### DIFF
--- a/products/opensearch.md
+++ b/products/opensearch.md
@@ -4,6 +4,13 @@ addedAt: 2022-08-26
 category: database
 tags: amazon java-runtime linux-foundation
 iconSlug: opensearch
+versionCommand: |-
+  # Preferred method
+  curl -k -u 'user:password' https://opensearch_ip:port/
+
+  # CLI method (may use significant memory due to JVM)
+  # WARNING: large heap settings (e.g. Xmx = 50% RAM) may trigger extra allocation and OOM killer
+  opensearch --version
 permalink: /opensearch
 releasePolicyLink: https://www.opensearch.org/releases.html
 changelogTemplate: "https://github.com/opensearch-project/opensearch-build/blob/main/release-notes/opensearch-release-notes-__LATEST__.md"

--- a/products/opensearch.md
+++ b/products/opensearch.md
@@ -10,7 +10,7 @@ versionCommand: |-
 
   # CLI method (may use significant memory due to JVM)
   # WARNING: large heap settings (e.g. Xmx = 50% RAM) may trigger extra allocation and OOM killer
-  opensearch --version
+  opensearch --version 2>/dev/null
 permalink: /opensearch
 releasePolicyLink: https://www.opensearch.org/releases.html
 changelogTemplate: "https://github.com/opensearch-project/opensearch-build/blob/main/release-notes/opensearch-release-notes-__LATEST__.md"


### PR DESCRIPTION
Added version command instructions for OpenSearch.

Output from my environment:
```
[opensearch@0db3b323993a ~]$ opensearch --version
WARNING: Using incubator modules: jdk.incubator.vector WARNING: Unknown module: org.apache.arrow.memory.core specified to --add-opens WARNING: A terminally deprecated method in sun.misc.Unsafe has been called WARNING: sun.misc.Unsafe::objectFieldOffset has been called by net.bytebuddy.dynamic.loading.ClassInjector$UsingUnsafe$Dispatcher$CreationAction WARNING: Please consider reporting this to the maintainers of class net.bytebuddy.dynamic.loading.ClassInjector$UsingUnsafe$Dispatcher$CreationAction WARNING: sun.misc.Unsafe::objectFieldOffset will be removed in a future release Version: 3.6.0, Build: tar/4ca747d8d47f80162db323019357447126732e35/2026-04-04T06:02:53.715432718Z, JVM: 25.0.2
```
###Warning
The CLI starts the JVM and may allocate a large heap (per jvm.options), which can lead to high memory usage and OOM killer in low-memory environments.


```
❯ curl -k -u '*:*' https://127.0.0.1:9200/
{
  "name" : "c3d430274549",
  "cluster_name" : "docker-cluster",
  "cluster_uuid" : "q2eNdQqmSfiFVBjgg-0Y8w",
  "version" : {
    "distribution" : "opensearch",
    "number" : "3.6.0",
    "build_type" : "tar",
    "build_hash" : "4ca747d8d47f80162db323019357447126732e35",
    "build_date" : "2026-04-04T06:02:53.715432718Z",
    "build_snapshot" : false,
    "lucene_version" : "10.4.0",
    "minimum_wire_compatibility_version" : "2.19.0",
    "minimum_index_compatibility_version" : "2.0.0"
  },
  "tagline" : "The OpenSearch Project: https://opensearch.org/"
}
```