### PR TITLE
[elasticsearch] Update EOL dates for Elasticsearch release cycles (8.17/9.0/9.1)

### DIFF
--- a/products/elasticsearch.md
+++ b/products/elasticsearch.md
@@ -46,7 +46,7 @@ releases:
 
   - releaseCycle: "9.1"
     releaseDate: 2025-07-23
-    eol: false
+    eol: 2026-01-08
     latest: "9.1.10"
     latestReleaseDate: 2026-01-08
     link: https://www.elastic.co/docs/release-notes/elasticsearch#elasticsearch-__LATEST__-release-notes
@@ -65,14 +65,14 @@ releases:
 
   - releaseCycle: "9.0"
     releaseDate: 2025-04-08
-    eol: false
+    eol: 2025-10-02
     latest: "9.0.8"
     latestReleaseDate: 2025-10-02
     link: https://www.elastic.co/docs/release-notes/elasticsearch#elasticsearch-__LATEST__-release-notes
 
   - releaseCycle: "8.17"
     releaseDate: 2024-12-11
-    eol: false # Supposedly until 8.19 released, but they've released twice since
+    eol: 2025-08-05
     latest: "8.17.10"
     latestReleaseDate: 2025-08-05
 


### PR DESCRIPTION
https://www.elastic.co/support/eol got revamped again

And it seems it is easier to go by actual releases to determine which ones are still active. As all versions are released simultaneously.

As of April 2026, the active series are 9.3, 9.2, and 8.19.

Meaning 9.1, 9.0, and 8.17 are now EOL.