### PR TITLE
[new product] PowerDNS Authoritative, Recusor and dnsdist

### DIFF
--- a/products/dnsdist.md
+++ b/products/dnsdist.md
@@ -1,0 +1,52 @@
+---
+title: dnsdist
+addedAt: 2026-04-27
+category: server-app
+permalink: /dnsdist
+alternate_urls:
+  - /powerdns-dnsdist
+versionCommand: dnsdist --version
+releasePolicyLink: https://www.dnsdist.org/eol.html
+eoasColumn: Full Support
+eolColumn: Critical Updates
+
+auto:
+  methods:
+    - git: https://github.com/PowerDNS/pdns.git
+      regex: '^dnsdist-(?P<version>\d+\.\d+\.\d+)$'
+      template: "{{version}}"
+
+# eoas(x) = releaseDate(x+1)
+# eol(x) = releaseDate(x+1) + 1 year
+releases:
+  - releaseCycle: "2.0"
+    releaseDate: 2025-07-21
+    eoas: false
+    eol: false
+    latest: "2.0.5"
+    latestReleaseDate: 2026-04-22
+
+  - releaseCycle: "1.9"
+    releaseDate: 2024-02-15
+    eoas: 2025-07-21
+    eol: 2026-07-21
+    latest: "1.9.14"
+    latestReleaseDate: 2026-04-22
+
+  - releaseCycle: "1.8"
+    releaseDate: 2023-03-28
+    eoas: 2024-02-15
+    eol: 2025-02-15
+    latest: "1.8.4"
+    latestReleaseDate: 2024-09-19
+---
+
+> [dnsdist](https://www.dnsdist.org/) is a highly DNS-, DoS- and abuse-aware loadbalancer.
+
+dnsdist aims to have a major release every six months. The latest major release
+train receives correctness, stability and security updates by way of minor
+releases.
+
+Older release trains receive critical updates for one year after the subsequent
+major release, then become end-of-life. Pre-releases do not receive immediate
+security updates.

--- a/products/powerdns-authoritative-server.md
+++ b/products/powerdns-authoritative-server.md
@@ -1,0 +1,69 @@
+---
+title: PowerDNS Authoritative Server
+addedAt: 2026-04-27
+category: server-app
+permalink: /powerdns-authoritative-server
+alternate_urls:
+  - /pdns-auth
+  - /powerdns-auth
+versionCommand: pdns_server --version
+releasePolicyLink: https://doc.powerdns.com/authoritative/appendices/EOL.html
+changelogTemplate: https://doc.powerdns.com/authoritative/changelog/__RELEASE_CYCLE__.html
+eoasColumn: Full Support
+eolColumn: Critical Updates
+
+auto:
+  methods:
+    - git: https://github.com/PowerDNS/pdns.git
+      regex: '^auth-(?P<version>\d+\.\d+\.\d+)$'
+      template: "{{version}}"
+
+# 4.9 and 5.0 follow the previous Authoritative Server policy.
+# Starting with 5.1, Authoritative Server follows the Recursor-style policy:
+# eoas(x) = releaseDate(x+1), eol(x) = releaseDate(x+1) + 1 year.
+releases:
+  - releaseCycle: "5.0"
+    releaseDate: 2025-08-22
+    eoas: false
+    eol: false
+    latest: "5.0.4"
+    latestReleaseDate: 2026-04-22
+
+  - releaseCycle: "4.9"
+    releaseDate: 2024-03-15
+    eoas: 2025-08-22
+    eol: false
+    latest: "4.9.14"
+    latestReleaseDate: 2026-04-22
+
+  - releaseCycle: "4.8"
+    releaseDate: 2023-06-01
+    eoas: 2024-03-15
+    eol: false
+    latest: "4.8.5"
+    latestReleaseDate: 2025-02-06
+
+  - releaseCycle: "4.7"
+    releaseDate: 2022-10-20
+    eoas: 2023-06-01
+    eol: true
+    latest: "4.7.5"
+    latestReleaseDate: 2025-02-06
+---
+
+> [PowerDNS Authoritative Server](https://doc.powerdns.com/authoritative/) is an
+> authoritative DNS server.
+
+PowerDNS Authoritative Server aims to have a major release every six months.
+The latest major release train receives correctness, stability and security
+updates by way of minor releases.
+
+PowerDNS Authoritative Server 4.9 will receive critical updates for one year
+after the 5.1.0 release. Version 5.0 will receive critical updates for one year
+after the 5.2.0 release.
+
+Starting with PowerDNS Authoritative Server 5.1, release trains receive critical
+updates for one year after the subsequent major release.
+
+Older releases are marked end-of-life and receive no updates at all.
+Pre-releases do not receive immediate security updates.

--- a/products/powerdns-recursor.md
+++ b/products/powerdns-recursor.md
@@ -1,0 +1,69 @@
+---
+title: PowerDNS Recursor
+addedAt: 2026-04-27
+category: server-app
+permalink: /powerdns-recursor
+alternate_urls:
+  - /pdns-recursor
+  - /pdns-rec
+versionCommand: pdns_recursor --version
+releasePolicyLink: https://doc.powerdns.com/recursor/appendices/EOL.html
+changelogTemplate: https://doc.powerdns.com/recursor/changelog/__RELEASE_CYCLE__.html
+eoasColumn: Full Support
+eolColumn: Critical Updates
+
+auto:
+  methods:
+    - git: https://github.com/PowerDNS/pdns.git
+      regex: '^rec-(?P<version>\d+\.\d+\.\d+)$'
+      template: "{{version}}"
+
+# eoas(x) = releaseDate(x+1)
+# eol(x) = releaseDate(x+1) + 1 year
+releases:
+  - releaseCycle: "5.4"
+    releaseDate: 2026-03-05
+    eoas: false
+    eol: false
+    latest: "5.4.1"
+    latestReleaseDate: 2026-04-07
+
+  - releaseCycle: "5.3"
+    releaseDate: 2025-08-27
+    eoas: 2026-03-05
+    eol: 2027-03-05
+    latest: "5.3.6"
+    latestReleaseDate: 2026-04-07
+
+  - releaseCycle: "5.2"
+    releaseDate: 2025-01-13
+    eoas: 2025-08-27
+    eol: 2026-08-27
+    latest: "5.2.9"
+    latestReleaseDate: 2026-04-07
+
+  - releaseCycle: "5.1"
+    releaseDate: 2024-07-09
+    eoas: 2025-01-13
+    eol: true
+    latest: "5.1.10"
+    latestReleaseDate: 2026-02-10
+
+  - releaseCycle: "5.0"
+    releaseDate: 2024-01-09
+    eoas: 2024-07-09
+    eol: true
+    latest: "5.0.9"
+    latestReleaseDate: 2024-09-17
+---
+
+> [PowerDNS Recursor](https://doc.powerdns.com/recursor/) is a resolving DNS
+> server.
+
+PowerDNS Recursor aims to have a major release every six months. The latest
+major release train receives correctness, stability and security updates by way
+of minor releases.
+
+Older release trains receive critical updates for one year after the subsequent
+major release, then become end-of-life. Pre-releases do not receive immediate
+security updates.


### PR DESCRIPTION
Adds endoflife.date pages for three separately released PowerDNS products:

  - PowerDNS Authoritative Server
  - PowerDNS Recursor
  - dnsdist

These are separate products because they are released independently from the PowerDNS/pdns monorepo and have different release trains.

Sources:

  - Auth EOL docs: https://doc.powerdns.com/authoritative/appendices/EOL.html
  - Recursor EOL docs: https://doc.powerdns.com/recursor/appendices/EOL.html
  - dnsdist EOL docs: https://www.dnsdist.org/eol.html
  - Release tags: https://github.com/PowerDNS/pdns/tags

Lifecycle notes:

- Recursor and dnsdist use the documented policy where older release trains
    receive critical updates for one year after the subsequent major release.
- Auth 4.9 and 5.0 intentionally keep the previous Auth lifecycle.
- Auth 5.1 and later move to the Recursor-style lifecycle; this is documented in
   PowerDNS/pdns#17247 (not yet merged, but approved)
- Pre-releases are intentionally excluded.
- Patch releases should be handled by the `auto` git tag configuration

Validation:

- `bin/lint-product.sh products/dnsdist.md`
- `bin/lint-product.sh products/powerdns-authoritative-server.md`
- `bin/lint-product.sh products/powerdns-recursor.md`