### PR TITLE
[beats,kibana,logstash] Update EOL dates for the rest of the Elastic products

### DIFF
--- a/products/beats.md
+++ b/products/beats.md
@@ -45,7 +45,7 @@ releases:
 
   - releaseCycle: "9.1"
     releaseDate: 2025-07-23
-    eol: false # later of 2027-10-15 or 18 months after the release date of 10.0
+    eol: 2026-01-07
     latest: "9.1.10"
     latestReleaseDate: 2026-01-07
     link: https://www.elastic.co/docs/release-notes/beats#beats-__LATEST__-release-notes
@@ -64,14 +64,14 @@ releases:
 
   - releaseCycle: "9.0"
     releaseDate: 2025-04-08
-    eol: false # later of 2027-10-15 or 18 months after the release date of 10.0
+    eol: 2025-10-02
     latest: "9.0.8"
     latestReleaseDate: 2025-10-02
     link: https://www.elastic.co/docs/release-notes/beats#beats-__LATEST__-release-notes
 
   - releaseCycle: "8.17"
     releaseDate: 2024-12-11
-    eol: false # Supposedly until 8.19 released, but they've released twice since
+    eol: 2025-08-08
     latest: "8.17.10"
     latestReleaseDate: 2025-08-08
 

--- a/products/kibana.md
+++ b/products/kibana.md
@@ -36,7 +36,7 @@ releases:
 
   - releaseCycle: "9.1"
     releaseDate: 2025-07-23
-    eol: false # later of 2027-10-15 or 18 months after the release date of 10.0
+    eol: 2026-01-08
     latest: "9.1.10"
     latestReleaseDate: 2026-01-08
     link: https://www.elastic.co/docs/release-notes/kibana#kibana-__LATEST__-release-notes
@@ -49,7 +49,7 @@ releases:
 
   - releaseCycle: "9.0"
     releaseDate: 2025-04-10
-    eol: false # later of 2027-10-15 or 18 months after the release date of 10.0
+    eol: 2025-10-02
     latest: "9.0.8"
     latestReleaseDate: 2025-10-02
     link: https://www.elastic.co/docs/release-notes/kibana#kibana-__LATEST__-release-notes
@@ -62,7 +62,7 @@ releases:
 
   - releaseCycle: "8.17"
     releaseDate: 2024-12-11
-    eol: false # Supposedly until 8.19 released, but they've released twice since
+    eol: 2025-08-07
     latest: "8.17.10"
     latestReleaseDate: 2025-08-07
 

--- a/products/logstash.md
+++ b/products/logstash.md
@@ -34,7 +34,7 @@ releases:
 
   - releaseCycle: "9.1"
     releaseDate: 2025-07-22
-    eol: false # later of 2027-10-15 or 18 months after the release date of 10.0
+    eol: 2026-01-07
     latest: "9.1.10"
     latestReleaseDate: 2026-01-07
 
@@ -54,13 +54,13 @@ releases:
 
   - releaseCycle: "9.0"
     releaseDate: 2025-03-17
-    eol: false # later of 2027-10-15 or 18 months after the release date of 10.0
+    eol: 2025-09-30
     latest: "9.0.8"
     latestReleaseDate: 2025-09-30
 
   - releaseCycle: "8.17"
     releaseDate: 2024-12-04
-    eol: 2025-07-14
+    eol: 2025-08-06
     latest: "8.17.10"
     latestReleaseDate: 2025-08-06
     link: https://www.elastic.co/guide/en/logstash/8.17/logstash-8-17-10.html


### PR DESCRIPTION
Similar to the recent:
- #9993

beats, kibana, and logstash all have had their final releases of 9.1, 9.0 and 8.17 series which are now all EOL as well.

This update brings these products up to date with the elasticsearch
page.

cc @chenrui333 
