### PR TITLE
[gradle] Update testedKotlinVersions and testedAndroidVersions fields

### DIFF
--- a/products/gradle.md
+++ b/products/gradle.md
@@ -54,16 +54,16 @@ auto:
 releases:
   - releaseCycle: "9"
     releaseDate: 2025-07-31
-    # Supported versions see https://docs.gradle.org/9.4.1/userguide/compatibility.html
+    # Supported versions see https://docs.gradle.org/9.5.0/userguide/compatibility.html
     runningJavaVersions: "17 - 26"
     testedJavaVersions: "8 - 26"
-    testedKotlinVersions: "2.0.0 - 2.3.0"
+    testedKotlinVersions: "2.0.0 - 2.3.20"
     testedGroovyVersions: "1.5.8 - 5.0.2"
-    testedAndroidVersions: "8.4 - 8.13"
+    testedAndroidVersions: "8.4 - 9.2.0-alpha05"
     eoas: false
     eol: false
-    latest: "9.4.1"
-    latestReleaseDate: 2026-03-18
+    latest: "9.5.0"
+    latestReleaseDate: 2026-04-28
 
   - releaseCycle: "8"
     releaseDate: 2023-02-10


### PR DESCRIPTION
Our bots will fetch 9.5.0 automatically on the other hand this patch still needed for its  testedKotlinVersions and testedAndroidVersions fields