### PR TITLE
[New Product] Amazon ElastiCache for Valkey

### DIFF
--- a/products/amazon-elasticache-redis.md
+++ b/products/amazon-elasticache-redis.md
@@ -55,10 +55,11 @@ releases:
 > Redis OSS-compatible in-memory data store from Amazon Web Services.
 
 {: .note }
-> This page only tracks the Elasticache Redis OSS offering, and not the Valkey variant. The highest
-> upgrade possible for Redis OSS is 7.1. 7.2 and higher versions are Valkey only. An upgrade from
-> Redis OSS to Valkey 7.2 is [supported](https://docs.aws.amazon.com/AmazonElastiCache/latest/dg/VersionManagement.HowTo.html#VersionManagement.HowTo.cross-engine-upgrade).
-> A downgrade from Valkey 7.2 to Redis OSS 7.1 is also supported.
+> This page only tracks the ElastiCache for Redis OSS engine. For the Valkey engine, see
+> [Amazon ElastiCache for Valkey](/amazon-elasticache-valkey). The highest supported Redis OSS
+> version is 7.1 — versions 7.2 and higher are Valkey only. Upgrades from Redis OSS to Valkey
+> are [supported](https://docs.aws.amazon.com/AmazonElastiCache/latest/dg/VersionManagement.HowTo.html#VersionManagement.HowTo.cross-engine-upgrade),
+> as are downgrades from Valkey back to Redis OSS.
 
 Amazon ElastiCache for Redis OSS does not follow the same support lifecycle as open-source Redis. 
 ElastiCache v7.1 is compatible with Redis OSS v7.0.

--- a/products/amazon-elasticache-valkey.md
+++ b/products/amazon-elasticache-valkey.md
@@ -45,11 +45,11 @@ releases:
 ---
 
 > [Amazon ElastiCache for Valkey](https://aws.amazon.com/elasticache/what-is-valkey/) is a fully managed,
-> Valkey-compatible in-memory data store from Amazon Web Services. Valkey is an open source,
-> high-performance key/value datastore stewarded by the Linux Foundation.
+> Valkey-compatible caching service that delivers microsecond latency and scales to hundreds of millions
+> of operations per second. It offers serverless and node-based deployment options.
 
 {: .note }
-> This page tracks the ElastiCache Valkey offering. For the Redis OSS variant, see
+> This page tracks the Amazon ElastiCache for Valkey offering. For the Redis OSS variant, see
 > [Amazon ElastiCache for Redis OSS](/amazon-elasticache-redis).
 
 Amazon ElastiCache for Valkey does not currently have an announced end-of-life or Extended Support

--- a/products/amazon-elasticache-valkey.md
+++ b/products/amazon-elasticache-valkey.md
@@ -11,7 +11,7 @@ eolColumn: Standard Support
 
 auto:
   methods:
-    - release_table: https://docs.aws.amazon.com/AmazonElastiCache/latest/dg/supported-engine-versions.html
+    - release_table: https://docs.aws.amazon.com/AmazonElastiCache/latest/dg/engine-versions.html
       fields:
         releaseCycle:
           column: "Major Engine Version"

--- a/products/amazon-elasticache-valkey.md
+++ b/products/amazon-elasticache-valkey.md
@@ -26,10 +26,10 @@ releases:
     latestReleaseDate: 2025-10-13
 
   - releaseCycle: "8.1"
-    releaseDate: 2025-07-23
+    releaseDate: 2025-07-24
     eol: false
     latest: "8.1"
-    latestReleaseDate: 2025-07-23
+    latestReleaseDate: 2025-07-24
 
   - releaseCycle: "8.0"
     releaseDate: 2024-11-21

--- a/products/amazon-elasticache-valkey.md
+++ b/products/amazon-elasticache-valkey.md
@@ -1,0 +1,56 @@
+---
+title: Amazon ElastiCache for Valkey
+addedAt: 2026-04-29
+category: service
+tags: amazon database
+iconSlug: amazonelasticache
+permalink: /amazon-elasticache-valkey
+releasePolicyLink: https://docs.aws.amazon.com/AmazonElastiCache/latest/dg/engine-versions.html
+latestColumn: false
+eolColumn: Standard Support
+
+auto:
+  methods:
+    - release_table: https://docs.aws.amazon.com/AmazonElastiCache/latest/dg/supported-engine-versions.html
+      fields:
+        releaseCycle:
+          column: "Major Engine Version"
+          regex: '^Valkey v(?P<value>\d+(\.\d+)?)$'
+        eol: "End of Standard Support"
+
+releases:
+  - releaseCycle: "8.2"
+    releaseDate: 2025-10-13
+    eol: false
+    latest: "8.2"
+    latestReleaseDate: 2025-10-13
+
+  - releaseCycle: "8.1"
+    releaseDate: 2025-07-23
+    eol: false
+    latest: "8.1"
+    latestReleaseDate: 2025-07-23
+
+  - releaseCycle: "8.0"
+    releaseDate: 2024-11-21
+    eol: false
+    latest: "8.0"
+    latestReleaseDate: 2024-11-21
+
+  - releaseCycle: "7.2"
+    releaseDate: 2024-10-08
+    eol: false
+    latest: "7.2"
+    latestReleaseDate: 2024-10-08
+---
+
+> [Amazon ElastiCache for Valkey](https://aws.amazon.com/elasticache/valkey/) is a fully managed,
+> Valkey-compatible in-memory data store from Amazon Web Services. Valkey is an open source,
+> high-performance key/value datastore stewarded by the Linux Foundation.
+
+{: .note }
+> This page tracks the ElastiCache Valkey offering. For the Redis OSS variant, see
+> [Amazon ElastiCache for Redis OSS](/amazon-elasticache-redis).
+
+Amazon ElastiCache for Valkey does not currently have an announced end-of-life or Extended Support
+schedule. All listed versions are under active standard support.

--- a/products/amazon-elasticache-valkey.md
+++ b/products/amazon-elasticache-valkey.md
@@ -44,7 +44,7 @@ releases:
     latestReleaseDate: 2024-10-08
 ---
 
-> [Amazon ElastiCache for Valkey](https://aws.amazon.com/elasticache/valkey/) is a fully managed,
+> [Amazon ElastiCache for Valkey](https://aws.amazon.com/elasticache/what-is-valkey/) is a fully managed,
 > Valkey-compatible in-memory data store from Amazon Web Services. Valkey is an open source,
 > high-performance key/value datastore stewarded by the Linux Foundation.
 


### PR DESCRIPTION
Add tracking for Amazon ElastiCache for Valkey lifecycle.

Covers Valkey engine versions 7.2, 8.0, 8.1, and 8.2. No end-of-life or Extended Support schedule has been announced for Valkey versions yet.

## Release date sources

- **7.2** (2024-10-08): [Announcing Amazon ElastiCache for Valkey](https://aws.amazon.com/about-aws/whats-new/2024/10/amazon-elasticache-valkey/)
- **8.0** (2024-11-21): [ElastiCache version 8.0 for Valkey](https://aws.amazon.com/about-aws/whats-new/2024/11/elasticache-version-8-0-for-valkey-scaling-memory-efficiency/)
- **8.1** (2025-07-24): [Amazon ElastiCache now supports Valkey 8.1](https://aws.amazon.com/about-aws/whats-new/2025/07/amazon-elasticache-valkey-8-1/)
- **8.2** (2025-10-13): [Announcing vector search for Amazon ElastiCache](https://aws.amazon.com/about-aws/whats-new/2025/10/amazon-elasticache-vector-search/)

## Notes

- Follows the same structure as the existing [amazon-elasticache-redis.md](https://github.com/endoflife-date/endoflife.date/blob/master/products/amazon-elasticache-redis.md)
- Cross-links to the Redis OSS page, matching the note on the Redis page that points users to Valkey
- No Extended Support program exists for Valkey (unlike Redis OSS), so only `eolColumn` is included
- Includes `auto` config to scrape the AWS supported versions page for future updates

Related: #9552 (added the ElastiCache for Redis OSS product page, with ElastiCache for Valkey left as a follow-up)
Fixes #9851
