### PR TITLE
[ubuntu] Fix EOL and EOAS dates for Ubuntu 26.04

### DIFF
--- a/products/ubuntu.md
+++ b/products/ubuntu.md
@@ -35,9 +35,9 @@ releases:
     codename: "Resolute Raccoon"
     lts: true
     releaseDate: 2026-04-23
-    eoas: 2031-05-31
-    eol: 2031-05-31
-    eoes: 2031-05-31
+    eoas: 2031-04-30
+    eol: 2031-04-30
+    eoes: 2036-04-30
     latest: "26.04"
     latestReleaseDate: 2026-04-23
     


### PR DESCRIPTION
The extended support period for Ubuntu Resolute was set to five years, same as it's standard support date.

According to [the release notes](https://documentation.ubuntu.com/release-notes/26.04/),

> With an Ubuntu Pro subscription, access to ESM (Expanded Security Maintenance) updates will be available for ten years.

Furthermore, the EOL dates were set to May 31 (the same day as for the previous LTS, Noble, with an updated year). The Noble release notes specified an EOL of 31 May 2029, but [the Resolute release notes](https://documentation.ubuntu.com/release-notes/26.04/) state a different EOL date for this release.

> Ubuntu 26.04 LTS will be supported until April 2031.