### PR TITLE
[New Product] JRuby

### DIFF
--- a/products/jruby.md
+++ b/products/jruby.md
@@ -1,0 +1,92 @@
+---
+title: JRuby
+addedAt: 2026-04-29
+category: lang
+tags: java-runtime
+permalink: /jruby
+versionCommand: jruby --version
+releasePolicyLink: https://www.jruby.org/download
+changelogTemplate: "https://github.com/jruby/jruby/releases/tag/__LATEST__"
+eolColumn: Support
+
+identifiers:
+  - repology: jruby
+  - purl: pkg:github/jruby/jruby
+  - purl: pkg:maven/org.jruby/jruby
+
+auto:
+  methods:
+    - git: https://github.com/jruby/jruby.git
+      regex: ^(?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)\.(?P<tiny>\d+)$
+      template: "{{major}}.{{minor}}.{{patch}}.{{tiny}}"
+
+# JRuby does not publish a formal EOL policy. Release lines are marked active
+# (eol: false) while they still receive maintenance updates, otherwise eol: true.
+releases:
+  - releaseCycle: "10.1"
+    releaseDate: 2026-04-21
+    eol: false
+    latest: "10.1.0.0"
+    latestReleaseDate: 2026-04-21
+
+  - releaseCycle: "10.0"
+    releaseDate: 2025-04-14
+    eol: false
+    latest: "10.0.5.0"
+    latestReleaseDate: 2026-04-06
+
+  - releaseCycle: "9.4"
+    releaseDate: 2022-11-23
+    eol: false
+    latest: "9.4.14.0"
+    latestReleaseDate: 2025-08-28
+
+  - releaseCycle: "9.3"
+    releaseDate: 2021-09-22
+    eol: true
+    latest: "9.3.15.0"
+    latestReleaseDate: 2024-06-26
+
+  - releaseCycle: "9.2"
+    releaseDate: 2018-05-24
+    eol: true
+    latest: "9.2.21.0"
+    latestReleaseDate: 2022-06-27
+
+  - releaseCycle: "9.1"
+    releaseDate: 2016-05-02
+    eol: true
+    latest: "9.1.17.0"
+    latestReleaseDate: 2018-04-20
+
+  - releaseCycle: "9.0"
+    releaseDate: 2015-07-21
+    eol: true
+    latest: "9.0.5.0"
+    latestReleaseDate: 2016-01-30
+
+  - releaseCycle: "1.7"
+    releaseDate: 2012-10-22
+    eol: true
+    latest: "1.7.27"
+    latestReleaseDate: 2017-05-10
+
+---
+
+> [JRuby](https://www.jruby.org/) is a high-performance, stable, fully threaded Java implementation
+> of the Ruby programming language.
+
+JRuby does not publish a formal end-of-life policy. In practice, the JRuby team typically focuses
+maintenance on the most recent major release line, with occasional patch releases for the previous
+line while users migrate. Each major JRuby version targets a specific
+[MRI Ruby language level](https://www.jruby.org/download):
+
+| JRuby | Ruby compatibility | Minimum Java |
+| ----- | ------------------ | ------------ |
+| 10.x  | 3.4                | 21+          |
+| 9.4   | 3.1                | 8+           |
+| 9.3   | 2.6                | 8+           |
+| 9.2   | 2.5                | 8+           |
+| 9.1   | 2.3                | 7+           |
+| 9.0   | 2.2                | 7+           |
+| 1.7   | 1.9 / 2.0 / 2.1    | 6+           |

--- a/products/jruby.md
+++ b/products/jruby.md
@@ -14,62 +14,82 @@ identifiers:
   - purl: pkg:github/jruby/jruby
   - purl: pkg:maven/org.jruby/jruby
 
+customFields:
+  - name: supportedRubyVersion
+    display: after-release-column
+    label: Ruby Compatibility
+    description: Ruby version Compatibility
+  - name: minJavaVersion
+    display: after-release-column
+    label: Required Java Version
+    description: Required minimum Java for running JRuby
+
 auto:
   methods:
     - git: https://github.com/jruby/jruby.git
       regex: ^(?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)\.(?P<tiny>\d+)$
       template: "{{major}}.{{minor}}.{{patch}}.{{tiny}}"
 
-# JRuby does not publish a formal EOL policy. Release lines are marked active
-# (eol: false) while they still receive maintenance updates, otherwise eol: true.
+# Provide a new LTS baseline release every two years, starting in spring of 2027
+# Eol(x) = in_last_3_cycle ?  false  :  latestReleaseDate(x)
+# LTS Eol(x) = releaseDate(x)+2 years (starting with 2027)
 releases:
   - releaseCycle: "10.1"
     releaseDate: 2026-04-21
+    minJavaVersion: "21"
+    supportedRubyVersion: "4.0"
     eol: false
     latest: "10.1.0.0"
     latestReleaseDate: 2026-04-21
 
   - releaseCycle: "10.0"
     releaseDate: 2025-04-14
-    eol: false
+    lts: true
+    minJavaVersion: "21"
+    supportedRubyVersion: "3.4"
+    eol: 2028-04-01 # source : https://www.jruby.org/2026/04/21/jruby-10-1-0-0.html
     latest: "10.0.5.0"
     latestReleaseDate: 2026-04-06
 
   - releaseCycle: "9.4"
     releaseDate: 2022-11-23
+    minJavaVersion: "8"
+    supportedRubyVersion: "3.1"
     eol: false
     latest: "9.4.14.0"
     latestReleaseDate: 2025-08-28
 
   - releaseCycle: "9.3"
     releaseDate: 2021-09-22
-    eol: true
+    minJavaVersion: "8"
+    supportedRubyVersion: "2.6"
+    eol: 2024-06-26
     latest: "9.3.15.0"
     latestReleaseDate: 2024-06-26
 
   - releaseCycle: "9.2"
     releaseDate: 2018-05-24
-    eol: true
+    minJavaVersion: "8"
+    supportedRubyVersion: "2.5"
+    eol: 2022-06-27
     latest: "9.2.21.0"
     latestReleaseDate: 2022-06-27
 
   - releaseCycle: "9.1"
     releaseDate: 2016-05-02
-    eol: true
+    minJavaVersion: "7"
+    supportedRubyVersion: "2.3"
+    eol: 2018-04-20
     latest: "9.1.17.0"
     latestReleaseDate: 2018-04-20
 
   - releaseCycle: "9.0"
     releaseDate: 2015-07-21
-    eol: true
+    minJavaVersion: "7"
+    supportedRubyVersion: "2.2"
+    eol: 2016-01-30
     latest: "9.0.5.0"
     latestReleaseDate: 2016-01-30
-
-  - releaseCycle: "1.7"
-    releaseDate: 2012-10-22
-    eol: true
-    latest: "1.7.27"
-    latestReleaseDate: 2017-05-10
 
 ---
 
@@ -83,10 +103,11 @@ line while users migrate. Each major JRuby version targets a specific
 
 | JRuby | Ruby compatibility | Minimum Java |
 | ----- | ------------------ | ------------ |
-| 10.x  | 3.4                | 21+          |
-| 9.4   | 3.1                | 8+           |
-| 9.3   | 2.6                | 8+           |
-| 9.2   | 2.5                | 8+           |
-| 9.1   | 2.3                | 7+           |
-| 9.0   | 2.2                | 7+           |
-| 1.7   | 1.9 / 2.0 / 2.1    | 6+           |
+| 10.1  | 4.0                | 21           |
+| 10.0  | 3.4                | 21           |
+| 9.4   | 3.1                | 8            |
+| 9.3   | 2.6                | 8            |
+| 9.2   | 2.5                | 8            |
+| 9.1   | 2.3                | 7            |
+| 9.0   | 2.2                | 7            |
+| 1.7   | 1.9 / 2.0 / 2.1    | 6            |


### PR DESCRIPTION
## Summary

Adds JRuby ([jruby/jruby](https://github.com/jruby/jruby)), a Java implementation of the Ruby programming language. Includes release cycles from 1.7 through 10.1, with the corresponding latest patch versions and release dates.

JRuby does not publish a formal end-of-life policy, so the file marks each release line as `eol: true` or `eol: false` based on whether it is still receiving maintenance updates (matching the convention used by Apache Groovy). The product description includes a small compatibility table mapping each JRuby line to its target MRI Ruby and minimum Java version.

- **Category:** `lang`
- **Tags:** `java-runtime`
- **Auto-update:** git tags from `https://github.com/jruby/jruby.git`

## Test plan

- [ ] Netlify Deploy Preview renders the `/jruby` page
- [ ] Release table shows all eight cycles with correct dates
- [ ] `changelogTemplate` resolves to a valid GitHub release tag URL for each `latest` version
- [ ] JSON schema validation passes in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)