### PR TITLE
[eslint] Move eoesProvider to api-only

### DIFF
--- a/products/eslint.md
+++ b/products/eslint.md
@@ -13,7 +13,7 @@ eoesColumn: Extended Long Term Support
 
 customFields:
   - name: eoesProvider
-    display: before-latest-column
+    display: api-only
     label: Extended Support Provider
     description: Companies that provide extended EOL support for eslint.
 


### PR DESCRIPTION
With current limitations related column forces latest version infos to shift to invisible part ( without scrolling )