### PR TITLE
[ubuntu] Update link to most recent LTS documentation

### DIFF
--- a/products/ubuntu.md
+++ b/products/ubuntu.md
@@ -464,7 +464,7 @@ This offer is only available for Ubuntu Pro paying customers.
 For package-specific support details, the following commands are available:
 
 - `ubuntu-security-status` command (`ubuntu-support-status` on versions before `20.04`) for non-ESM.
-- [`pro security-status`](https://manpages.ubuntu.com/manpages/kinetic/en/man1/ubuntu-advantage.1.html) for ESM.
+- [`pro security-status`](https://web.archive.org/web/20241109012358/http://manpages.ubuntu.com/manpages/kinetic/en/man1/ubuntu-advantage.1.htmlhttps://manpages.ubuntu.com/manpages/kinetic/en/man1/ubuntu-advantage.1.html) for ESM.
 
 ---
 

--- a/products/ubuntu.md
+++ b/products/ubuntu.md
@@ -464,7 +464,7 @@ This offer is only available for Ubuntu Pro paying customers.
 For package-specific support details, the following commands are available:
 
 - `ubuntu-security-status` command (`ubuntu-support-status` on versions before `20.04`) for non-ESM.
-- [`pro security-status`](https://web.archive.org/web/20241109012358/http://manpages.ubuntu.com/manpages/kinetic/en/man1/ubuntu-advantage.1.htmlhttps://manpages.ubuntu.com/manpages/kinetic/en/man1/ubuntu-advantage.1.html) for ESM.
+- [`pro security-status`](https://web.archive.org/web/20241109012358/http://manpages.ubuntu.com/manpages/kinetic/en/man1/ubuntu-advantage.1.html) for ESM.
 
 ---
 

--- a/products/ubuntu.md
+++ b/products/ubuntu.md
@@ -464,7 +464,7 @@ This offer is only available for Ubuntu Pro paying customers.
 For package-specific support details, the following commands are available:
 
 - `ubuntu-security-status` command (`ubuntu-support-status` on versions before `20.04`) for non-ESM.
-- [`pro security-status`](https://web.archive.org/web/20241109012358/http://manpages.ubuntu.com/manpages/kinetic/en/man1/ubuntu-advantage.1.html) for ESM.
+- [`pro security-status`](https://manpages.ubuntu.com/manpages/resolute/man1/ubuntu-advantage.1.html) for ESM.
 
 ---
 


### PR DESCRIPTION
~looks like manpages.ubuntu.com subdomain not exist anymore~
Change link to most recent LTS version's link