### PR TITLE
[oracle-database] Update documentation link

### DIFF
--- a/products/oracle-database.md
+++ b/products/oracle-database.md
@@ -32,7 +32,7 @@ releases:
     lts: true
     eol: 2031-12-31
     eoes: false
-    link: https://docs.oracle.com/en/database/oracle/oracle-database/23/nfcoa/release_updates.html
+    link: https://docs.oracle.com/en/database/oracle/oracle-database/26/
 
   - releaseCycle: "21"
     releaseLabel: "21c"

--- a/products/oracle-database.md
+++ b/products/oracle-database.md
@@ -32,7 +32,7 @@ releases:
     lts: true
     eol: 2031-12-31
     eoes: false
-    link: https://docs.oracle.com/en/database/oracle/oracle-database/26/
+    link: https://docs.oracle.com/en/database/oracle/oracle-database/26/nfcoa/index.html
 
   - releaseCycle: "21"
     releaseLabel: "21c"


### PR DESCRIPTION
Old link is returning 404.
There is no whats-new page as for older versions