### PR TITLE
[Opensearch] Update latest opensearch version

### DIFF
--- a/products/opensearch.md
+++ b/products/opensearch.md
@@ -53,8 +53,8 @@ releases:
     releaseDate: 2022-05-26
     eoas: 2025-05-06
     eol: false
-    latest: "2.19.4"
-    latestReleaseDate: 2025-11-06
+    latest: "2.19.5"
+    latestReleaseDate: 2026-03-10
 
   - releaseCycle: "1"
     releaseDate: 2021-07-12

--- a/products/opensearch.md
+++ b/products/opensearch.md
@@ -47,7 +47,7 @@ releases:
     eol: false
     latest: "3.6.0"
     latestReleaseDate: 2026-04-07
-    link: https://opensearch.org/blog/opensearch-3-5-is-live/
+    link: https://opensearch.org/blog/introducing-opensearch-3-6/
 
   - releaseCycle: "2"
     releaseDate: 2022-05-26


### PR DESCRIPTION
The issue stems from the fact that version 2.19.5 has been released and is available [here](https://opensearch.org/artifacts/by-version/#release-2-19-5:~:text=Release%20v2%2E19%2E5), but it hasn't appeared in the GitHub releases yet, which is odd. I suggest manually adding the fix for now.

This PR is based on https://github.com/endoflife-date/endoflife.date/issues/10034.
Closes #10034