### PR TITLE
[ClickHouse] Add 26.4 and mark 26.1 as EOL

### DIFF
--- a/products/clickhouse.md
+++ b/products/clickhouse.md
@@ -22,6 +22,12 @@ auto:
 # Non-LTS : eol(x) = releaseDate(x+3)
 # LTS : eol(x) = releaseDate(x) + 1 year
 releases:
+  - releaseCycle: "26.4"
+    releaseDate: 2026-05-05
+    eol: false
+    latest: "26.4.1.1141"
+    latestReleaseDate: 2026-05-05
+
   - releaseCycle: "26.3"
     lts: true
     releaseDate: 2026-03-26
@@ -37,7 +43,7 @@ releases:
 
   - releaseCycle: "26.1"
     releaseDate: 2026-01-30
-    eol: false
+    eol: 2026-05-05
     latest: "26.1.11.9"
     latestReleaseDate: 2026-04-16
 


### PR DESCRIPTION
## Summary

- Add ClickHouse 26.4 release cycle (released 2026-05-05)
- Mark 26.1 as EOL on 2026-05-05 (3rd release after it: 26.2, 26.3, 26.4)
- 26.2 and 26.3 remain supported (last three non-LTS minor releases are 26.2, 26.3, 26.4)

## References

- [ClickHouse 26.4 community release call](https://clickhouse.com/company/events/v26-4-community-release-call)
- [GitHub release v26.4.1.1141-stable](https://github.com/ClickHouse/ClickHouse/releases/tag/v26.4.1.1141-stable)