### PR TITLE
[pan-os] Update 11.2,12.1 (2 cycles)

### DIFF
--- a/products/pan-os.md
+++ b/products/pan-os.md
@@ -32,16 +32,16 @@ releases:
   - releaseCycle: "12.1"
     releaseDate: 2025-08-28
     eol: 2028-08-28
-    latest: "12.1.5"
-    latestReleaseDate: 2026-03-05
-    link: https://docs.paloaltonetworks.com/ngfw/release-notes/12-1/pan-os-12-1-5-known-and-addressed-issues/pan-os-12-1-5-addressed-issues
+    latest: "12.1.6"
+    latestReleaseDate: 2026-03-28
+    link: https://docs.paloaltonetworks.com/ngfw/release-notes/12-1/pan-os-12-1-6-known-and-addressed-issues/pan-os-12-1-6-addressed-issues
 
   - releaseCycle: "11.2"
     releaseDate: 2024-05-02
     eol: 2027-05-02
-    latest: "11.2.10-h4"
-    latestReleaseDate: 2026-03-06
-    link: https://docs.paloaltonetworks.com/pan-os/11-2/pan-os-release-notes/pan-os-11-2-10-known-and-addressed-issues/pan-os-11-2-10-h4-addressed-issues
+    latest: "11.2.11"
+    latestReleaseDate: 2026-03-24
+    link: https://docs.paloaltonetworks.com/pan-os/11-2/pan-os-release-notes/pan-os-11-2-11-known-and-addressed-issues/pan-os-11-2-11-addressed-issues
 
   - releaseCycle: "11.1"
     releaseDate: 2023-11-03


### PR DESCRIPTION
## Summary
Automated update of PAN-OS versions.

### Changes
11.2: 11.2.10-h4 -> 11.2.11
12.1: 12.1.5 -> 12.1.6

---
Data sourced from [PaloAltoVersions.json](https://github.com/mrjcap/panos-versions/blob/master/PaloAltoVersions.json)