### PR TITLE
[traefik] > Add Docker package URL (purl)

### DIFF
--- a/products/traefik.md
+++ b/products/traefik.md
@@ -16,6 +16,7 @@ identifiers:
   - purl: pkg:brew/traefik
   - purl: pkg:github/traefik/traefik
   - purl: pkg:generic/traefik
+  - purl: pkg:docker/library/traefik
   - cpe: cpe:2.3:a:traefik:traefik
 
 auto:


### PR DESCRIPTION
# :grey_question: About

Since [today's announce about 3.7 release](https://x.com/linuxiac/status/2052402656727998624) : 

<img width="612" height="639" alt="image" src="https://github.com/user-attachments/assets/d8c54624-5df3-44c6-9827-f029b50cc461" />

I figued out that we did not have the docker purl : https://hub.docker.com/_/traefik