### PR TITLE
[python] Add PURL identifiers for Red Hat packages

### DIFF
--- a/products/python.md
+++ b/products/python.md
@@ -79,6 +79,11 @@ identifiers:
   - purl: pkg:rpm/redhat/python
   - purl: pkg:rpm/redhat/python2
   - purl: pkg:rpm/redhat/python3
+  - purl: pkg:rpm/redhat/python27
+  - purl: pkg:rpm/redhat/python38
+  - purl: pkg:rpm/redhat/python39
+  - purl: pkg:rpm/redhat/python3.11
+  - purl: pkg:rpm/redhat/python3.12
   - purl: pkg:rpm/centos/python
   - purl: pkg:rpm/centos/python2
   - purl: pkg:rpm/centos/python3


### PR DESCRIPTION
Add PURL identifiers for RHEL Python packages, as available in Red Hat repositories (tested against UBI 7, 8, 9, and 10).

Note: Red Hat ships version-specific Python packages under two different naming
conventions depending on the RHEL version:

- RHEL 7/8: `python27`, `python38`, `python39` (no dot separator)
- RHEL 9+: `python3.11`, `python3.12` (dot separator)