### PR TITLE
[apache-http-server] Add PURL identifier for Red Hat package

### DIFF
--- a/products/apache-http-server.md
+++ b/products/apache-http-server.md
@@ -21,6 +21,7 @@ identifiers:
   - cpe: cpe:2.3:a:apache:http_server
   - purl: pkg:github/apache/httpd
   - purl: pkg:rpm/fedora/httpd
+  - purl: pkg:rpm/redhat/httpd
 
 auto:
   methods:


### PR DESCRIPTION
Add PURL identifier for the `httpd` package shipped in Red Hat repositories (tested against UBI 7, 8, 9, and 10).