### PR TITLE
[nodejs] Add PURL identifier for Red Hat packages

### DIFF
--- a/products/nodejs.md
+++ b/products/nodejs.md
@@ -19,6 +19,8 @@ identifiers:
   - purl: pkg:docker/library/node
   - purl: pkg:docker/cimg/node
   - purl: pkg:docker/bitnami/node
+  - purl: pkg:rpm/redhat/nodejs
+  - purl: pkg:rpm/redhat/nodejs24
   - cpe: cpe:2.3:a:nodejs:node.js
   - repology: nodejs
 


### PR DESCRIPTION
Add PURL identifiers for Red Hat Enterprise Linux packages for Node.js (tested against UBI 7, 8, 9, and 10).

Note: Red Hat ships a generic `nodejs` package and a version-specific package `nodejs24` in RHEL 10, hence two separate identifiers.