### PR TITLE
[roundcube] add 1.7.0

### DIFF
--- a/products/roundcube.md
+++ b/products/roundcube.md
@@ -19,9 +19,17 @@ auto:
     - git: https://github.com/roundcube/roundcubemail.git
 
 releases:
+  - releaseCycle: "1.7"
+    releaseDate: 2026-05-10
+    eoas: false
+    eol: false
+    latest: "1.7.0"
+    latestReleaseDate: 2026-05-10
+
   - releaseCycle: "1.6"
     releaseDate: 2022-07-25
-    eoas: false
+    lts: 2026-05-10 # https://github.com/roundcube/roundcubemail/releases/tag/1.7.0
+    eoas: 2026-05-10 # https://github.com/roundcube/roundcubemail/releases/tag/1.7.0
     eol: false
     latest: "1.6.15"
     latestReleaseDate: 2026-03-29
@@ -29,8 +37,8 @@ releases:
   - releaseCycle: "1.5"
     releaseDate: 2021-10-18
     lts: 2022-07-25 # https://github.com/roundcube/roundcubemail/releases/tag/1.6.0
-    eoas: false
-    eol: false
+    eoas: 2022-07-25 # https://github.com/roundcube/roundcubemail/releases/tag/1.6.0
+    eol: 2026-05-10 # https://github.com/roundcube/roundcubemail/releases/tag/1.7.0
     latest: "1.5.15"
     latestReleaseDate: 2026-03-29
 

--- a/products/roundcube.md
+++ b/products/roundcube.md
@@ -83,6 +83,15 @@ releases:
 > application-like user interface. It provides full functionality you expect from an email client,
 > including MIME support, address book, folder manipulation, message searching and spell checking.
 
+{: .note-title }
+
+> Important Changes
+>
+> Starting with 1.70 cycle:
+> Dropped support for PHP < 8.1.
+> Dropped support for Internet Explorer.
+> Dropped support for MS SQL Server and Oracle.
+
 As of the last release, the project supports the last two release branches in an "LTS low-maintenance
 mode", which only includes important security updates only. Regular improvement updates are only
 available in the latest stable release.

--- a/products/roundcube.md
+++ b/products/roundcube.md
@@ -88,8 +88,11 @@ releases:
 > Important Changes
 >
 > Starting with 1.70 cycle:
+> 
 > Dropped support for PHP < 8.1.
+> 
 > Dropped support for Internet Explorer.
+> 
 > Dropped support for MS SQL Server and Oracle.
 
 As of the last release, the project supports the last two release branches in an "LTS low-maintenance


### PR DESCRIPTION
add 1.7.0
mark 1.6.0 as lts with security support only
https://github.com/roundcube/roundcubemail/releases/tag/1.7.0

EOL for 1.5.0