### PR TITLE
[coder] add ESR support dates

### DIFF
--- a/products/coder.md
+++ b/products/coder.md
@@ -7,7 +7,9 @@ permalink: /coder
 versionCommand: coder version
 releasePolicyLink: https://coder.com/docs/install/releases
 changelogTemplate: https://github.com/coder/coder/releases/tag/v__LATEST__
+LTSLabel: "<abbr title='Extended Support Release'>ESR</abbr>"
 eoasColumn: true
+eoesColumn: Extended Support
 
 identifiers:
   - repology: coder
@@ -65,9 +67,11 @@ releases:
     latestReleaseDate: 2026-05-18
 
   - releaseCycle: "2.29"
+    lts: true
     releaseDate: 2025-12-02
     eoas: 2026-02-23
     eol: 2026-04-14
+    eoes: 2026-12-02
     latest: "2.29.19"
     latestReleaseDate: 2026-06-27
 
@@ -100,9 +104,11 @@ releases:
     latestReleaseDate: 2025-10-01
 
   - releaseCycle: "2.24"
+    lts: true
     releaseDate: 2025-07-01
     eoas: 2025-09-03
     eol: 2025-10-07
+    eoes: 2026-07-01
     latest: "2.24.6"
     latestReleaseDate: 2026-05-18
 
@@ -224,7 +230,6 @@ releases:
     eol: 2024-04-03
     latest: "2.7.3"
     latestReleaseDate: 2024-03-04
-
 ---
 
 > [Coder](https://coder.com) is an open-source platform for creating and managing developer workspaces on your preferred
@@ -233,3 +238,9 @@ releases:
 There is a new minor release of Coder on the first Tuesday of each month. Minor releases are
 supported for three months with bug and security fixes the first month, major bug and security
 fixes the second month, and only security fixes the third month.
+
+Coder also publishes Extended Support Releases (ESR) twice a year for customers who need a slower
+upgrade cadence. ESR releases receive critical bugfixes and security patches for 12 months from
+their release date as paid extended support. See the [Coder ESR announcement](https://coder.com/blog/esr)
+and [release channel documentation](https://coder.com/docs/install/releases#extended-support-release)
+for details.


### PR DESCRIPTION
Adds Coder's Extended Support Release (ESR) track to endoflife.date. ESR releases are paid extended support releases, so this marks 2.24 and 2.29 as ESR and tracks their 12-month support window under the Extended Support column.

This also documents the ESR cadence on the Coder page and links to Coder's ESR announcement and release channel docs.

References:
- Coder release channels: https://coder.com/docs/install/releases#extended-support-release
- ESR announcement: https://coder.com/blog/esr