### PR TITLE
[zerto] Add 10.8.11 , 10.9 cycles and fix eoas and eol dates

### DIFF
--- a/products/zerto.md
+++ b/products/zerto.md
@@ -29,72 +29,87 @@ auto:
           column: "Version"
           regex: '^(?P<value>\d+\.\d+( Update \d+)?).*$'
         releaseDate: "General Availability (GA)"
-        eol: "End of Bug Fixes"
+        eoas: "End of Bug Fixes"
+        eol: "End of Support Life (EOSL)"
 
 releases:
+  - releaseCycle: "10.9"
+    releaseLabel: "10.9"
+    releaseDate: 2026-05-13
+    eoas: 2027-05-13
+    eol: 2028-05-13
+    link: "https://help.zerto.com/bundle/RN.HTML.10.9/page/release_notes_for_zerto_10_9.html"
+
+  - releaseCycle: "10.8.11"
+    releaseLabel: "10.8.11"
+    releaseDate: 2026-03-03
+    eoas: 2027-03-03
+    eol: 2028-03-03
+    link: "https://help.zerto.com/bundle/RN.HTML.10.8/page/release_notes_for_hpe_zerto_software_10_8_11.html"
+
   - releaseCycle: "10.8"
     releaseLabel: "10.8"
     releaseDate: 2025-10-28
-    eoas: false # Next GA date
-    eol: 2026-10-28
+    eoas: 2026-10-28
+    eol: 2027-10-28
     link: "https://help.zerto.com/bundle/RN.HTML.10.8/page/release_notes_for_zerto_10_8.html"
 
   - releaseCycle: "10.0_u7"
     releaseLabel: "10.0 Update 7"
     releaseDate: 2025-05-06
-    eoas: 2025-08-28
-    eol: 2026-05-06
+    eoas: 2026-05-06
+    eol: 2027-05-06
     link: "https://help.zerto.com/bundle/RN.HTML.10.0_U7/page/release_notes_for_zerto_10_0_update_7.html"
 
   - releaseCycle: "10.0_u6"
     releaseLabel: "10.0 Update 6"
     releaseDate: 2024-12-03
-    eoas: 2025-05-06
-    eol: 2026-12-03
+    eoas: 2026-12-03
+    eol: 2027-12-03
     link: "https://help.zerto.com/bundle/RN.HTML.10.0_U6/page/release_notes_for_zerto_10_0_update_6.html"
 
   - releaseCycle: "10.0_u5"
     releaseLabel: "10.0 Update 5"
     releaseDate: 2024-08-06
     eoas: 2024-12-03
-    eol: 2024-12-03
+    eol: 2026-08-06
     link: "https://help.zerto.com/bundle/RN.HTML.10.0_U5/page/release_notes_for_zerto_10_0_update_5.html"
 
   - releaseCycle: "10.0_u4"
     releaseLabel: "10.0 Update 4"
     releaseDate: 2024-05-15
     eoas: 2024-08-06
-    eol: 2024-08-06
+    eol: 2026-05-15
     link: "https://help.zerto.com/bundle/RN.HTML.10.0_U4/page/release_notes_for_zerto_10_0_update_4.html"
 
   - releaseCycle: "10.0_u3"
     releaseLabel: "10.0 Update 3"
     releaseDate: 2024-02-12
     eoas: 2024-05-15
-    eol: 2024-05-15
+    eol: 2026-02-12
     link: "https://help.zerto.com/bundle/RN.HTML.10.0_U3/page/what_s_new_in_zerto_10_0_update_3.html"
 
   - releaseCycle: "10.0_u2"
     releaseLabel: "10.0 Update 2"
     releaseDate: 2023-11-28
     eoas: 2024-02-12
-    eol: 2024-02-12
+    eol: 2024-12-31
     link: "https://help.zerto.com/bundle/RN.HTML.10.0_U2/page/what_s_new_in_zerto_10_0_update_2.html"
 
   - releaseCycle: "10.0_u1"
     releaseLabel: "10.0 Update 1"
     releaseDate: 2023-08-07
     eoas: 2023-11-28
-    eol: 2023-11-28
+    eol: 2024-08-07
     link: "https://help.zerto.com/bundle/RN.HTML.10.0_U1/page/what_s_new_in_zerto_10_0_update_1.html"
 
   - releaseCycle: "10.0"
+    releaseLabel: "10.0"
     releaseDate: 2023-07-05
     eoas: 2023-08-07
-    eol: 2023-08-07
+    eol: 2024-07-05
     link: "https://help.zerto.com/bundle/RN.HTML.10.0/page/10.0_Whats_New.htm"
 
-    releaseLabel: "10.0"
   - releaseCycle: "9.7"
     releaseDate: 2022-11-08
     eoas: 2023-12-31


### PR DESCRIPTION
* Added 10.8.11 as a seperate cycle
* Added 10.9 cycle
* Fixed all eol eoas dates according to https://captn3m0--6498b7f0494c11f0ad8a76b3cceeab13.web.val.run/
* Added/fixed eoas/eol syntax on auto part

@captn3m0 this might need a proper review, i'm not sure if i done everthing correctly ( because dates are all looks wrong before ) , so waiting your review