### PR TITLE
[nodejs] Update Clarify LTS status

### DIFF
--- a/products/nodejs.md
+++ b/products/nodejs.md
@@ -237,12 +237,9 @@ releases:
 > built on Chrome's V8 JavaScript engine that executes JavaScript code outside a browser.
 
 Major Node.js versions enter Current release status for six months, which gives library authors time to add support for them.
-After six months, odd-numbered releases (9, 11, etc.) become unsupported,
-and even-numbered releases (10, 12, etc.) move to Active LTS status and are ready for general use.
+After six months, releases after 26 move to Active LTS status and are ready for general use.
 LTS release status is "long-term support", which typically guarantees that critical bugs will be fixed for a total of 30 months.
 Production applications should only use Active LTS or Maintenance LTS releases.
-
-If an even-numbered release above is _not marked as LTS_, then it has not entered "Active LTS" and is not recommended for Production use.
 
 Node.js is part of the [OpenJS Foundation's Ecosystem Sustainability Program](https://openjsf.org/ecosystem-sustainability-program) (ESP).
 Commercial support is available for some deprecated LTS versions of Node.js through the


### PR DESCRIPTION
Updated LTS status explanation for Node.js releases.

From https://nodejs.org/en/about/previous-releases