### PR TITLE
[sonarqube-server] add 2026.3

### DIFF
--- a/products/sonarqube-server.md
+++ b/products/sonarqube-server.md
@@ -25,11 +25,11 @@ auto:
 # - eol(x) = releaseDate(x) + 18m
 releases:
   - releaseCycle: "2026.3"
-    releaseDate: 2026-05-18
+    releaseDate: 2026-05-21
     eoas: 2026-07-20
     eol: 2026-07-20
     latest: "2026.3"
-    latestReleaseDate: 2026-05-18
+    latestReleaseDate: 2026-05-21
 
   - releaseCycle: "2026.2"
     releaseDate: 2026-03-24 #https://community.sonarsource.com/t/sonarqube-server-2026-release-2-1/180528

--- a/products/sonarqube-server.md
+++ b/products/sonarqube-server.md
@@ -24,6 +24,13 @@ auto:
 # - eoas(x) = releaseDate(x) + 1y
 # - eol(x) = releaseDate(x) + 18m
 releases:
+  - releaseCycle: "2026.3"
+    releaseDate: 2026-05-18
+    eoas: 2026-07-20
+    eol: 2026-07-20
+    latest: "2026.3"
+    latestReleaseDate: 2026-05-18
+
   - releaseCycle: "2026.2"
     releaseDate: 2026-03-24 #https://community.sonarsource.com/t/sonarqube-server-2026-release-2-1/180528
     eoas: 2026-05-18


### PR DESCRIPTION
## Summary
- Add SonarQube Server 2026.3, released on 2026-05-18
- EOAS and EOL set to 2026-07-20 (next release)
- 2026.2 already had EOAS/EOL set to 2026-05-18, marking it as no longer supported

## Test plan
- [x] CI passes