### PR TITLE
[samsung-galaxy-tab] Set Galaxy Tab S9 FE eol to 2028-10-04

### DIFF
--- a/products/samsung-galaxy-tab.md
+++ b/products/samsung-galaxy-tab.md
@@ -150,7 +150,7 @@ releases:
     releaseLabel: "Galaxy Tab S9 FE"
     releaseDate: 2023-10-04 # https://news.samsung.com/global/samsung-galaxy-s23-fe-galaxy-tab-s9-fe-and-galaxy-buds-fe-bring-standout-features-to-even-more-users
     eoas: 2027-10-04 # https://news.samsung.com/global/samsung-galaxy-s23-fe-galaxy-tab-s9-fe-and-galaxy-buds-fe-bring-standout-features-to-even-more-users
-    eol: false      # https://news.samsung.com/global/samsung-galaxy-s23-fe-galaxy-tab-s9-fe-and-galaxy-buds-fe-bring-standout-features-to-even-more-users
+    eol: 2028-10-04 # https://news.samsung.com/global/samsung-galaxy-s23-fe-galaxy-tab-s9-fe-and-galaxy-buds-fe-bring-standout-features-to-even-more-users
     link: https://doc.samsungmobile.com/SM-X510/ZTO/doc.html
 
   - releaseCycle: "galaxy-tab-s9-ultra"


### PR DESCRIPTION
When Samsung announced the S9 FE they promised 5 years of security updates for both S9 FE and S9 FE+.  The S9 FE+ was already correct. This patch catpures the EOL date for S9 FE as well