### PR TITLE
[New Product] Amazon Aurora MySQL

### DIFF
--- a/products/amazon-aurora-mysql.md
+++ b/products/amazon-aurora-mysql.md
@@ -23,6 +23,13 @@ auto:
 
 # eoes(x) = eol(x) + 3 years
 releases:
+  - releaseCycle: "8.4"
+    releaseDate: 2024-04-30
+    eol: 2032-04-01
+    eoes: false
+    latest: "8.4.7"
+    latestReleaseDate: 2026-05-21
+    
   - releaseCycle: "8.0"
     releaseDate: 2022-04-15
     eol: 2028-04-30

--- a/products/amazon-aurora-mysql.md
+++ b/products/amazon-aurora-mysql.md
@@ -1,0 +1,74 @@
+---
+title: Amazon Aurora MySQL
+addedAt: 2026-05-20
+category: service
+tags: amazon database
+iconSlug: amazonrds
+permalink: /amazon-aurora-mysql
+releasePolicyLink: https://docs.aws.amazon.com/AmazonRDS/latest/AuroraMySQLReleaseNotes/AuroraMySQL.release-calendars.html
+eoesColumn: Extended Support
+
+auto:
+  methods:
+    - rds: https://docs.aws.amazon.com/AmazonRDS/latest/AuroraMySQLReleaseNotes/AuroraMySQL.release-calendars.html
+      regex: '(?P<version>\d+(\.\d+)*)'
+      template: "{{version}}"
+    - release_table: https://docs.aws.amazon.com/AmazonRDS/latest/AuroraMySQLReleaseNotes/AuroraMySQL.release-calendars.html
+      fields:
+        releaseCycle:
+          column: "Community major version"
+          regex: '^MySQL\s+(?P<value>\d+\.\d+).*$'
+        eol: "Aurora end of standard support date"
+        eoes: "RDS end of Extended Support date"
+
+# eoes(x) = eol(x) + 3 years
+releases:
+  - releaseCycle: "8.0"
+    releaseDate: 2022-04-15
+    eol: 2028-04-30
+    eoes: 2029-07-31
+    latest: "8.0.44"
+    latestReleaseDate: 2026-02-17
+
+  - releaseCycle: "5.7"
+    releaseDate: 2018-02-06
+    eol: 2024-10-31
+    eoes: 2027-02-28
+    latest: "5.7.44"
+    latestReleaseDate: 2023-07-25
+
+  - releaseCycle: "5.6"
+    releaseDate: 2015-07-27
+    eol: 2023-02-28
+    eoes: true
+    latest: "5.6"
+    latestReleaseDate: 2015-07-27
+---
+
+> [Amazon Aurora MySQL](https://aws.amazon.com/rds/aurora/) is a PaaS offering from Amazon
+> for creating serverless, managed MySQL-compatible databases. Aurora makes it easier
+> to set up, operate, and scale serverless MySQL deployments on AWS cloud.
+
+Aurora MySQL uses a versioning scheme distinct from community [MySQL](/mysql): Aurora major
+versions (`1`, `2`, `3`) map to community MySQL major versions (`5.6`, `5.7`, `8.0` respectively).
+Aurora MySQL minor versions (e.g. `3.10`) are released roughly quarterly, with each minor pinned
+to a specific community MySQL point release.
+
+Major versions are supported [at least until the community MySQL end of life](/mysql) for the
+corresponding community version. Certain minor versions are supported at least for 1 year after
+their release date on Amazon Aurora. Note that in some cases Amazon may deprecate specific major
+or minor versions sooner, such as when there are security issues.
+
+Depending on the configuration, the kind of version (major or minor) and their deprecation status,
+[upgrades can be manual, automatic, or forced](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/USER_UpgradeDBInstance.Maintenance.html#Aurora.Maintenance.AMVU).
+When a minor release is deprecated, users are expected to upgrade within a 3-month period. This
+period is increased to 6 months for major releases. Upgrades are performed during the configured
+scheduled maintenance windows. These windows are initially automatically set by AWS but can be
+overridden in the AWS console.
+
+For the most up-to-date information about the Amazon Aurora deprecation policy for MySQL, see
+[Amazon Aurora FAQs](https://aws.amazon.com/rds/aurora/faqs/).
+
+On the Aurora end of standard support date, Amazon Aurora automatically enrolls your databases in RDS Extended Support.
+RDS Extended Support is a paid offering available for up to 3 years past the Aurora end of standard support date for a major engine version, see
+[Using Amazon RDS Extended Support with Amazon Aurora](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/extended-support.html).


### PR DESCRIPTION
Adds `amazon-aurora-mysql`, a sibling page to the existing [`amazon-aurora-postgresql`](https://endoflife.date/amazon-aurora-postgresql).

   ### Why

   Aurora MySQL is a distinct product from both Aurora PostgreSQL (already tracked) and RDS for MySQL (already tracked) — it has its own release calendar and its own end-of-standard-support dates that do not match either. Today, `/api/v1/products/amazon-aurora-mysql/` returns 404, so tools that audit AWS accounts for EOL engines silently miss Aurora MySQL clusters.

   ### Source

   All dates are taken from the AWS release calendar:
   <https://docs.aws.amazon.com/AmazonRDS/latest/AuroraMySQLReleaseNotes/AuroraMySQL.release-calendars.html>

   ### Schema choice

   Following the convention used in both `amazon-aurora-postgresql.md` and `amazon-rds-mysql.md`, `releaseCycle` is the **community** MySQL major version (`8.0`, `5.7`, `5.6`). The Aurora major version (`3`, `2`, `1`) maps 1:1 to the community major, and the community version is what users typically reason about when looking up EOL.

   ### Auto-update

   Same two methods as Aurora PostgreSQL (`rds` + `release_table`), pointing at the Aurora MySQL release calendar. The `release_table` `releaseCycle` regex (`^MySQL\s+(?P<value>\d+\.\d+).*$`) matches both `MySQL 8.0` and `MySQL 5.6 (deprecated)` rows.

   ### Notes for reviewers

   - `eol` and `eoes` dates come directly from the AWS table.
   - `releaseDate` for the `5.6` and `5.7` cycles is approximate (Aurora v1 GA = 2015-07-27; Aurora v2 / MySQL 5.7 compatibility GA = 2018-02-06). Happy to refine if maintainers have a more precise source.
   - `latest` for `5.6` is just `5.6` since Aurora v1 was pinned to community 5.6.10a and no further patches were released.
   - Redshift is intentionally not included in this PR — it uses maintenance tracks and snapshot versions (`1.0.86530`) rather than versioned major releases with published EOL dates, so it doesn't fit the schema cleanly. Worth a separate discussion issue.

   ### Validation

   `bin/lint-product.sh products/amazon-aurora-mysql.md` passes (markdownlint-cli2: 0 errors; prettier: no changes).