### PR TITLE
[ios] Mark 18, 16, 15 as security supported

### DIFF
--- a/products/ios.md
+++ b/products/ios.md
@@ -139,13 +139,15 @@ releases:
 > [iOS](https://www.apple.com/ios/) is a mobile operating system created by Apple and used in the company's mobile devices, including the iPhone.
 > It is the world's second-most widely installed operating system, after Android.
 
+{: .warning }
+
+> As of May 2026 iOS 15, 16, 18 and 26 appears to be receiving security fixes. Usually, only the latest iOS release is supported by Apple.
+> Apple occasionally backported critical security fixes to
+> [older iOS versions](https://9to5mac.com/2021/03/26/apple-releases-ios-14-4-2-and-ios-12-5-2-with-security-bug-fixes/) but such fixes
+> are not guaranteed.
+
 Major versions of iOS are released annually.
 Apple significantly extended the cycle of updates for iOS-supported devices over the years.
-Usually, only the latest iOS release is supported by Apple.
-Around iOS 15, Apple started to support [2 major versions of iOS](https://www.zdnet.com/article/still-running-ios-14-on-your-iphone-apple-brings-support-to-an-end/) **for a short period of time**.
-
-Apple has occasionally backported critical security fixes to [much older iOS versions](https://9to5mac.com/2021/03/26/apple-releases-ios-14-4-2-and-ios-12-5-2-with-security-bug-fixes/) but such fixes are not guaranteed.
-As of now, only iOS 18 appears to be receiving security fixes, as iOS 17 is missing fixes published in iOS 18.2.
 
 Support information for iPhone devices is available at [/iphone](/iphone).
 

--- a/products/ios.md
+++ b/products/ios.md
@@ -29,7 +29,7 @@ releases:
   - releaseCycle: "18"
     releaseDate: 2024-09-16
     eoas: 2025-09-15
-    eol: 2026-04-22
+    eol: false
     latest: "18.7.9"
     latestReleaseDate: 2026-05-11
 
@@ -43,7 +43,7 @@ releases:
   - releaseCycle: "16"
     releaseDate: 2022-09-12
     eoas: 2023-09-18
-    eol: 2026-03-11
+    eol: false
     latest: "16.7.16"
     latestReleaseDate: 2026-05-11
     link: https://developer.apple.com/documentation/ios-ipados-release-notes/ios-16-release-notes
@@ -51,7 +51,7 @@ releases:
   - releaseCycle: "15"
     releaseDate: 2021-09-20
     eoas: 2022-09-12
-    eol: 2026-03-11
+    eol: false
     latest: "15.8.8"
     latestReleaseDate: 2026-05-11
 


### PR DESCRIPTION
As current version of https://en.wikipedia.org/wiki/IOS_version_history#Overview
Still controversial see discussion in #9852

I also updated the notes and added a warning for current security support situation.