### PR TITLE
[sonarqube-server] update link for 2026.1.3 LTA

### DIFF
--- a/products/sonarqube-server.md
+++ b/products/sonarqube-server.md
@@ -46,7 +46,7 @@ releases:
     eol: 2027-08-02
     latest: "2026.1.3"
     latestReleaseDate: 2026-05-21
-    link: https://community.sonarsource.com/t/sonarqube-server-2026-release-1-2/180529
+    link: https://community.sonarsource.com/t/sonarqube-server-2026-release-1-3-lta/182629
 
   - releaseCycle: "2025.6"
     releaseDate: 2025-12-12 # https://community.sonarsource.com/t/sonarqube-server-2025-release-6/153802


### PR DESCRIPTION
## Summary
- Update the link for SonarQube Server 2026.1 LTA release cycle to point to the 2026.1.3 LTA announcement (released on 2026-05-21)
- `latest` (`2026.1.3`) and `latestReleaseDate` (`2026-05-21`) were already updated by the auto-update bot

Announcement: https://community.sonarsource.com/t/sonarqube-server-2026-release-1-3-lta/182629

## Test plan
- [x] CI passes