### PR TITLE
[windows-server] add 2016 EOES (Extended Support Updates)

### DIFF
--- a/products/windows-server.md
+++ b/products/windows-server.md
@@ -107,6 +107,7 @@ releases:
     lts: true
     eoas: 2022-01-11
     eol: 2027-01-12
+    eoes: 2030-01-12
     latest: 10.0.14393
     link: https://learn.microsoft.com/windows/release-health/windows-server-release-info
 


### PR DESCRIPTION
Added ESU date based on this documentation, specifically this line: Extended Security Updates are available for purchase for up to three years after the end of the mainstream support date.

https://techcommunity.microsoft.com/blog/windows-itpro-blog/plan-for-windows-server-2016-and-windows-10-2016-ltsb-end-of-support/4496136