### PR TITLE
[nixos] Add 26.05 release

### DIFF
--- a/products/nixos.md
+++ b/products/nixos.md
@@ -18,6 +18,11 @@ identifiers:
   - cpe: cpe:2.3:o:nixos:nixos
 
 releases:
+  - releaseCycle: "26.05"
+    codename: "Yarara"
+    releaseDate: 2026-05-30
+    eol: 2026-12-31
+
   - releaseCycle: "25.11"
     codename: "Xantusia"
     releaseDate: 2025-11-30


### PR DESCRIPTION
Hi, I'm the [release manager](https://nixos.org/community/teams/nixos-release/) of the upcoming NixOS release  26.05 ("Yarara"), which is scheduled to be released on 2026-05-30 and will be supported until 2026-12-31.