### PR TITLE
Add HeroDevs commercial support info to Spring product pages

### DIFF
--- a/products/spring-boot.md
+++ b/products/spring-boot.md
@@ -206,6 +206,8 @@ more details about the support roadmap.
 A commercial offer for extended support is available
 [from VMWare](https://tanzu.vmware.com/content/blog/vmware-spring-runtime-extended-support).
 
+[HeroDevs](https://www.herodevs.com/support/spring-nes) provides additional commercial versions, extended support timelines, and full ecosystem support for Spring Boot.
+
 ## Java Compatibility
 
 {%- assign collapsedCycles = page.releases | collapse_cycles:"supportedJavaVersions"," - " %}

--- a/products/spring-cloud.md
+++ b/products/spring-cloud.md
@@ -114,3 +114,5 @@ for more details about the support roadmap.
 
 Spring Cloud release trains are designed to work with specific versions of [Spring Boot](/spring-boot).
 Refer to the table above or the [official compatibility matrix](https://spring.io/projects/spring-cloud#overview) for detailed information.
+
+[HeroDevs](https://www.herodevs.com/support/spring-nes) provides additional commercial versions, extended support timelines, and full ecosystem support for Spring Cloud.

--- a/products/spring-framework.md
+++ b/products/spring-framework.md
@@ -164,6 +164,8 @@ for more details about the support roadmap.
 Extended support is available
 [from VMWare](https://tanzu.vmware.com/content/blog/vmware-spring-runtime-extended-support).
 
+[HeroDevs](https://www.herodevs.com/support/spring-nes) provides additional commercial versions, extended support timelines, and full ecosystem support for Spring Framework.
+
 ## [JDK/Jakarta EE Compatibility](https://github.com/spring-projects/spring-framework/wiki/Spring-Framework-Versions#jdk-version-range)
 
 {% include table.html

--- a/products/spring-security.md
+++ b/products/spring-security.md
@@ -166,4 +166,4 @@ See [Spring Security Milestones page](https://github.com/spring-projects/spring-
 for upcoming releases and [Spring Security Support page](https://spring.io/projects/spring-security#support)
 for more details about the support roadmap.
 
-[HeroDevs](https://www.herodevs.com/support/spring-nes) provides additional commercial versions, extended support timelines, and full ecosystem support for Spring Boot.
+[HeroDevs](https://www.herodevs.com/support/spring-nes) provides additional commercial versions, extended support timelines, and full ecosystem support for Spring Security.

--- a/products/spring-security.md
+++ b/products/spring-security.md
@@ -165,3 +165,5 @@ releases:
 See [Spring Security Milestones page](https://github.com/spring-projects/spring-security/milestones)
 for upcoming releases and [Spring Security Support page](https://spring.io/projects/spring-security#support)
 for more details about the support roadmap.
+
+[HeroDevs](https://www.herodevs.com/support/spring-nes) provides additional commercial versions, extended support timelines, and full ecosystem support for Spring Boot.


### PR DESCRIPTION
## What changed
  - Added HeroDevs commercial support notes to: spring-boot, spring-security, spring-cloud and spring-framework

  ## Why
HeroDevs is another company that provides commercial support for the Spring projects listed above (among many other OSS projects). The difference between HeroDevs and VMWare, is that HeroDevs provides commercial support for EOL OSS projects that VMWare chooses not to support.