### PR TITLE
[New product] Cisco IOS

### DIFF
--- a/products/cisco-ios.md
+++ b/products/cisco-ios.md
@@ -37,7 +37,7 @@ releases:
     eos: 2027-06-30
     latest: "15.8(3)M9"
     latestReleaseDate: 2022-09-12
-    link: "https://www.cisco.com/c/en/us/products/collateral/ios-nx-os-software/ios-15-3m-t/15-9-3-m-software-release-eol.html"
+    link: "https://www.cisco.com/c/en/us/products/collateral/ios-nx-os-software/ios-15-8m-t/15-8-3m-software-release-eol.html"
 
 ---
 

--- a/products/cisco-ios.md
+++ b/products/cisco-ios.md
@@ -1,0 +1,48 @@
+---
+title: Cisco IOS
+category: os
+tags: cisco
+iconSlug: cisco
+permalink: /cisco-ios
+alternate_urls:
+  - /ciscoios
+releasePolicyLink: https://sec.cloudapps.cisco.com/security/center/resources/ios_nx_os_reference_guide
+eoasColumn: Maintenance Support
+eolColumn: Security Support
+latestColumn: true
+
+customFields:
+  - name: eos
+    display: api-only
+    label: Service Support Ends
+    display: after-release-column
+    description: Service Support (no more software updates) from Cisco
+
+releases:
+  - releaseCycle: "15.9"
+    releaseLabel: "15.9"
+    releaseDate: 2019-07-31
+    eoas: 2027-07-28
+    eol: 2029-07-27
+    eos: 2031-07-31
+    latest: "15.9(3)M13"
+    latestReleaseDate: 2026-04-09
+    link: "https://www.cisco.com/c/en/us/products/collateral/ios-nx-os-software/ios-15-3m-t/15-9-3-m-software-release-eol.html"
+
+  - releaseCycle: "15.8"
+    releaseLabel: "15.8"
+    releaseDate: 2017-07-30
+    eoas: 2022-12-14
+    eol: 2022-12-14
+    eos: 2027-06-30
+    latest: "15.8(3)M9"
+    latestReleaseDate: 2022-09-12
+    link: "https://www.cisco.com/c/en/us/products/collateral/ios-nx-os-software/ios-15-3m-t/15-9-3-m-software-release-eol.html"
+
+---
+
+Cisco IOS is a network operating system that is using it's own proprietary kernel and architecture.
+
+It is used on a variety of Cisco products, including routers and switches.
+
+It is currently in it's final phase of support, with minimal software updates expected, as all new products use IOS-XE.


### PR DESCRIPTION
Adds EOL data for Cisco IOS releases, which are in their final stage of support.

The data is gathered from these Cisco sites:

https://sec.cloudapps.cisco.com/security/center/resources/ios_nx_os_reference_guide

https://www.cisco.com/c/en/us/products/ios-nx-os-software/ios-15-8m-t/eos-eol-notice-listing.html

Partially solves issue #8194 .
