### PR TITLE
[linux-kernel] Add CIP Super Long Term Support dates and render the extended-support phase in release images

### DIFF
--- a/_layouts/release-image.svg
+++ b/_layouts/release-image.svg
@@ -44,6 +44,9 @@
       {% if row.security_width > 0 %}
       <rect class="bar eol" x="{{ row.security_x }}" y="0" width="{{ row.security_width }}" height="{{ page.row_height }}"/>
       {% endif %}
+      {% if row.extended_width > 0 %}
+      <rect class="bar eoes" x="{{ row.extended_x }}" y="0" width="{{ row.extended_width }}" height="{{ page.row_height }}"/>
+      {% endif %}
       {% if row.no_end_date %}
       <rect class="bar no-end-badge no-end" x="{{ page.today_x }}" y="0" height="{{ page.row_height }}"/>
       <text class="no-end-plus" x="{{ page.no_end_badge_width | divided_by: 2 | plus: page.today_x }}" y="{{ page.text_y_offset }}" text-anchor="middle">+</text>

--- a/_plugins/generate-release-images.rb
+++ b/_plugins/generate-release-images.rb
@@ -27,7 +27,8 @@ module EndOfLife
     LEGEND_GAP          = 28  # vertical distance from chart bottom to legend icons
     LEGEND_ICON_SIZE    = 14  # width and height of legend colour swatches
     LEGEND_ICON_TEXT_GAP = 4  # gap between icon and label text
-    LEGEND_ITEM_SPACING = 240 # horizontal distance between legend item start positions
+    LEGEND_ITEM_SPACING = 240 # preferred horizontal distance between legend item start positions
+    LEGEND_MIN_ITEM_GAP = 32  # minimum horizontal gap between adjacent legend items when labels are long
     NO_END_DATE_LABEL   = "No end date published"
 
     # Release filtering & date range
@@ -60,6 +61,7 @@ module EndOfLife
     def build_svg_data(product)
       today = Date.today
       has_eoas_column = product.data['eoasColumn']
+      has_eoes_column = product.data['eoesColumn']
 
       releases = select_releases(product)
       return nil if releases.nil? || releases.empty?
@@ -68,9 +70,9 @@ module EndOfLife
       release_label_width = [longest_label_length * CHAR_WIDTH + LABEL_GAP, MAX_RELEASE_LABEL_WIDTH].min
       release_label_length = (release_label_width - LABEL_GAP) / CHAR_WIDTH
 
-      min_date, max_date, date_to_x_fn = build_timeline_scale(releases, today, release_label_width)
+      min_date, max_date, date_to_x_fn = build_timeline_scale(releases, today, release_label_width, has_eoes_column)
       today_x = date_to_x_fn.call(today)
-      rows = build_rows(releases, has_eoas_column, date_to_x_fn, max_date, release_label_length, today_x)
+      rows = build_rows(releases, has_eoas_column, has_eoes_column, date_to_x_fn, max_date, release_label_length, today_x)
       return nil if rows.empty?
 
       # One vertical tick per year within the date range.
@@ -83,12 +85,21 @@ module EndOfLife
       legend_items = []
       legend_items << { "icon_class" => "eoas",   "label" => product.data['eoasColumnLabel'] } if has_eoas_column
       legend_items << { "icon_class" => "eol",    "label" => product.data['eolColumnLabel'] }
+      legend_items << { "icon_class" => "eoes",   "label" => product.data['eoesColumnLabel'] } if has_eoes_column && rows.any? { |r| r["extended_width"] > 0 }
       legend_items << { "icon_class" => "no-end", "label" => NO_END_DATE_LABEL }               if rows.any? { |r| r["no_end_date"] }
-      legend_items.each_with_index { |item, i| item["x"] = i * LEGEND_ITEM_SPACING }
 
-      last_label_px    = legend_items.last["label"].to_s.length * CHAR_WIDTH
-      legend_width     = (legend_items.length - 1) * LEGEND_ITEM_SPACING + LEGEND_ICON_SIZE + LEGEND_ICON_TEXT_GAP + last_label_px
-      legend_dx        = ((SVG_WIDTH - legend_width) / 2.0).round
+      # Lay out legend items using LEGEND_ITEM_SPACING as the preferred spacing, expanding
+      # only when an item's icon+label would otherwise collide with the next item.
+      x_cursor = 0
+      legend_items.each do |item|
+        item["x"] = x_cursor
+        label_px = item["label"].to_s.length * CHAR_WIDTH
+        required = LEGEND_ICON_SIZE + LEGEND_ICON_TEXT_GAP + label_px + LEGEND_MIN_ITEM_GAP
+        x_cursor += [LEGEND_ITEM_SPACING, required].max
+      end
+      last_label_px = legend_items.last["label"].to_s.length * CHAR_WIDTH
+      legend_width  = legend_items.last["x"] + LEGEND_ICON_SIZE + LEGEND_ICON_TEXT_GAP + last_label_px
+      legend_dx     = ((SVG_WIDTH - legend_width) / 2.0).round
 
       {
         "svg_width"          => SVG_WIDTH,
@@ -124,12 +135,17 @@ module EndOfLife
       releases.first(last_non_eol + 1 + trailing_eol)
     end
 
-    def build_timeline_scale(releases, today, release_label_width)
+    def build_timeline_scale(releases, today, release_label_width, has_eoes_column = false)
       all_dates = [today]
       has_no_end_date = false
       releases.each do |release|
         all_dates << release['releaseDate'] if release['releaseDate'].is_a?(Date)
         all_dates << release['eol']         if release['eol'].is_a?(Date)
+        # Only extend the timeline to include eoes when the column is enabled and the
+        # row meets the same conditions required to draw an extended-support segment.
+        if has_eoes_column && release['eol'].is_a?(Date) && release['eoes'].is_a?(Date)
+          all_dates << release['eoes']
+        end
         has_no_end_date ||= (release['eol'] == false)
       end
 
@@ -156,16 +172,17 @@ module EndOfLife
       [min_date, max_date, date_to_x_fn]
     end
 
-    def build_rows(releases, has_eoas_column, date_to_x_fn, max_date, release_label_length, today_x)
+    def build_rows(releases, has_eoas_column, has_eoes_column, date_to_x_fn, max_date, release_label_length, today_x)
       max_x = date_to_x_fn.call(max_date)
 
       # Build one row per release (newest first = top of chart).
       releases.map do |release|
         row = {
-          "label"        => truncate_label(strip_html(release['label']), release_label_length),
-          "active_x"     => 0, "active_width"   => 0,
-          "security_x"   => 0, "security_width" => 0,
-          "no_end_date"  => false,
+          "label"          => truncate_label(strip_html(release['label']), release_label_length),
+          "active_x"       => 0, "active_width"   => 0,
+          "security_x"     => 0, "security_width" => 0,
+          "extended_x"     => 0, "extended_width" => 0,
+          "no_end_date"    => false,
         }
 
         start_x = date_to_x_fn.call(release['releaseDate'])
@@ -183,6 +200,15 @@ module EndOfLife
         elsif eol_x
           row["security_x"] = start_x
           row["security_width"] = [eol_x - start_x, 0].max
+        end
+
+        # Extended-support bar (eol -> eoes). Only drawn when both bounds are concrete dates,
+        # so unknown (eoes: true) or open-ended (eoes: false) extended support is not painted.
+        if has_eoes_column && release['eol'].is_a?(Date) && release['eoes'].is_a?(Date)
+          ext_start = date_to_x_fn.call(release['eol'])
+          ext_end   = date_to_x_fn.call(release['eoes'])
+          row["extended_x"]     = ext_start
+          row["extended_width"] = [ext_end - ext_start, 0].max
         end
 
         row["no_end_date"] = true if no_end_date

--- a/products/linux-kernel.md
+++ b/products/linux-kernel.md
@@ -89,7 +89,7 @@ releases:
     lts: true
     releaseDate: 2024-11-17
     eol: 2028-12-31 # Projected EOL from https://git.kernel.org/pub/scm/docs/kernel/website.git/commit/?id=d04587da86a3464881e0c97aabddd2c271105698
-    eoes: 2035-06-30 # CIP SLTS, "mid of 2035" per https://www.cip-project.org/blog/2025/05/26/cip-is-now-supporting-five-slts-kernels (6.12 is not yet in cip-kernel.yml)
+    eoes: 2035-06-01 # CIP SLTS phase2 end per https://gitlab.com/cip-project/cip-lifecycle/-/blob/master/cip-kernel.yml
     latest: "6.12.103"
     latestReleaseDate: 2026-08-09
 
@@ -158,7 +158,7 @@ releases:
     lts: true
     releaseDate: 2022-12-11
     eol: 2027-12-31 # https://git.kernel.org/pub/scm/docs/kernel/website.git/commit/?id=e6083565a79c3d711c1a76d9312b8c00e06b826b
-    eoes: 2033-08-01 # CIP SLTS phase2 end per https://wiki.linuxfoundation.org/civilinfrastructureplatform/start#kernel_maintainership (SLTS v6.1 EOL 2033-08); tracked upstream in https://gitlab.com/cip-project/cip-lifecycle/-/merge_requests/1
+    eoes: 2033-08-01 # CIP SLTS phase2 end per https://gitlab.com/cip-project/cip-lifecycle/-/blob/master/cip-kernel.yml
     latest: "6.1.182"
     latestReleaseDate: 2026-08-07
 

--- a/products/linux-kernel.md
+++ b/products/linux-kernel.md
@@ -89,7 +89,7 @@ releases:
     lts: true
     releaseDate: 2024-11-17
     eol: 2028-12-31 # Projected EOL from https://git.kernel.org/pub/scm/docs/kernel/website.git/commit/?id=d04587da86a3464881e0c97aabddd2c271105698
-    eoes: 2035-06-30 # CIP SLTS, "mid of 2035" per https://www.cip-project.org/blog/2025/05/26/cip-is-now-supporting-five-slts-kernels
+    eoes: 2035-06-30 # CIP SLTS, "mid of 2035" per https://www.cip-project.org/blog/2025/05/26/cip-is-now-supporting-five-slts-kernels (6.12 is not yet in cip-kernel.yml)
     latest: "6.12.103"
     latestReleaseDate: 2026-08-09
 
@@ -158,7 +158,7 @@ releases:
     lts: true
     releaseDate: 2022-12-11
     eol: 2027-12-31 # https://git.kernel.org/pub/scm/docs/kernel/website.git/commit/?id=e6083565a79c3d711c1a76d9312b8c00e06b826b
-    eoes: 2033-08-31 # CIP SLTS, "August 2033" per CIP maintenance schedule cited at https://en.wikipedia.org/wiki/Linux_kernel_version_history
+    eoes: 2033-01-01 # CIP SLTS phase2 end per https://gitlab.com/cip-project/cip-lifecycle/-/blob/master/cip-kernel.yml
     latest: "6.1.182"
     latestReleaseDate: 2026-08-07
 
@@ -227,7 +227,7 @@ releases:
     lts: true
     releaseDate: 2020-12-13
     eol: 2026-12-31 # Projected EOL from https://www.kernel.org/category/releases.html
-    eoes: 2031-01-01 # CIP SLTS phase2 end per https://gitlab.com/cip-project/cip-lifecycle
+    eoes: 2031-01-01 # CIP SLTS phase2 end per https://gitlab.com/cip-project/cip-lifecycle/-/blob/master/cip-kernel.yml
     latest: "5.10.264"
     latestReleaseDate: 2026-08-07
 
@@ -242,7 +242,7 @@ releases:
     lts: true
     releaseDate: 2018-10-22
     eol: 2024-12-05 # announced https://lore.kernel.org/lkml/2024120520-mashing-facing-6776@gregkh/
-    eoes: 2029-01-01 # CIP SLTS phase2 end per https://gitlab.com/cip-project/cip-lifecycle
+    eoes: 2029-01-01 # CIP SLTS phase2 end per https://gitlab.com/cip-project/cip-lifecycle/-/blob/master/cip-kernel.yml
     latest: "4.19.325"
     latestReleaseDate: 2024-12-05
 

--- a/products/linux-kernel.md
+++ b/products/linux-kernel.md
@@ -12,6 +12,7 @@ versionCommand: uname -r
 # Found on https://en.wikipedia.org/wiki/Linux_kernel_version_history
 releasePolicyLink: https://www.kernel.org/
 changelogTemplate: https://kernelnewbies.org/Linux___RELEASE_CYCLE__
+eoesColumn: CIP SLTS
 
 auto:
   methods:
@@ -88,6 +89,7 @@ releases:
     lts: true
     releaseDate: 2024-11-17
     eol: 2028-12-31 # Projected EOL from https://git.kernel.org/pub/scm/docs/kernel/website.git/commit/?id=d04587da86a3464881e0c97aabddd2c271105698
+    eoes: 2035-06-30 # CIP SLTS, "mid of 2035" per https://www.cip-project.org/blog/2025/05/26/cip-is-now-supporting-five-slts-kernels
     latest: "6.12.103"
     latestReleaseDate: 2026-08-09
 
@@ -156,6 +158,7 @@ releases:
     lts: true
     releaseDate: 2022-12-11
     eol: 2027-12-31 # https://git.kernel.org/pub/scm/docs/kernel/website.git/commit/?id=e6083565a79c3d711c1a76d9312b8c00e06b826b
+    eoes: 2033-08-31 # CIP SLTS, "August 2033" per CIP maintenance schedule cited at https://en.wikipedia.org/wiki/Linux_kernel_version_history
     latest: "6.1.182"
     latestReleaseDate: 2026-08-07
 
@@ -224,6 +227,7 @@ releases:
     lts: true
     releaseDate: 2020-12-13
     eol: 2026-12-31 # Projected EOL from https://www.kernel.org/category/releases.html
+    eoes: 2031-01-01 # CIP SLTS phase2 end per https://gitlab.com/cip-project/cip-lifecycle
     latest: "5.10.264"
     latestReleaseDate: 2026-08-07
 
@@ -238,6 +242,7 @@ releases:
     lts: true
     releaseDate: 2018-10-22
     eol: 2024-12-05 # announced https://lore.kernel.org/lkml/2024120520-mashing-facing-6776@gregkh/
+    eoes: 2029-01-01 # CIP SLTS phase2 end per https://gitlab.com/cip-project/cip-lifecycle
     latest: "4.19.325"
     latestReleaseDate: 2024-12-05
 
@@ -254,7 +259,6 @@ releases:
     eol: 2023-01-07 # announced https://lore.kernel.org/lkml/Y7lbu6%2F0P7Q%2FP3oj@kroah.com/
     latest: "4.9.337"
     latestReleaseDate: 2023-01-07
-
 ---
 
 > The Linux kernel is a free and open-source, monolithic, modular, multitasking, Unix-like operating
@@ -284,3 +288,13 @@ The "projected EOL" dates are not set in stone. Each new long-term kernel usuall
 2-year projected EOL (as opposed to the 4 months of a non-LTS release) that can be extended further
 if there is enough interest from the industry at large to [help support it](http://www.kroah.com/log/blog/2021/02/03/helping-out-with-lts-kernel-releases)
 for a longer period of time.
+
+Selected LTS branches are then picked up by the [Civil Infrastructure Platform (CIP)](https://www.cip-project.org/),
+a Linux Foundation project that backports security fixes for approximately ten years from each
+branch's original release. CIP publishes sources (no binaries) under the `-cip` tag suffix on its
+[`linux-cip` Git tree](https://git.kernel.org/pub/scm/linux/kernel/git/cip/linux-cip.git/); see the
+[CIP kernel maintenance policy](https://wiki.linuxfoundation.org/civilinfrastructureplatform/cipkernelmaintenance)
+for scope. Branches covered by CIP show the extended date in the **CIP SLTS** column.
+
+_[CIP]: Civil Infrastructure Platform
+_[SLTS]: Super Long Term Support

--- a/products/linux-kernel.md
+++ b/products/linux-kernel.md
@@ -158,7 +158,7 @@ releases:
     lts: true
     releaseDate: 2022-12-11
     eol: 2027-12-31 # https://git.kernel.org/pub/scm/docs/kernel/website.git/commit/?id=e6083565a79c3d711c1a76d9312b8c00e06b826b
-    eoes: 2033-01-01 # CIP SLTS phase2 end per https://gitlab.com/cip-project/cip-lifecycle/-/blob/master/cip-kernel.yml
+    eoes: 2033-08-01 # CIP SLTS phase2 end per https://wiki.linuxfoundation.org/civilinfrastructureplatform/start#kernel_maintainership (SLTS v6.1 EOL 2033-08); tracked upstream in https://gitlab.com/cip-project/cip-lifecycle/-/merge_requests/1
     latest: "6.1.182"
     latestReleaseDate: 2026-08-07
 


### PR DESCRIPTION
Adds Civil Infrastructure Platform (CIP) Super Long Term Support (SLTS) dates to the four upstream Linux LTS branches CIP currently maintains, and wires the existing `.eoes` CSS class in the auto-generated release image so the extended-support phase is rendered for any product that defines `eoesColumn`.

CIP backports security fixes against the upstream `cpe:/o:linux:linux_kernel` product, so it is modeled as an extended-support phase on the existing kernel page rather than a separate product — matching how Ubuntu ESM and RHEL ELS are modeled, and following the approach @captn3m0 suggested on #3990.

## Data change (`products/linux-kernel.md`)

- Enables `eoesColumn: CIP SLTS`.
- Adds `eoes` to the four CIP-maintained LTS cycles with an inline source comment on each:
  - `6.12` → `2035-06-30` ([cip-project.org blog 2025-05-26](https://www.cip-project.org/blog/2025/05/26/cip-is-now-supporting-five-slts-kernels))
  - `6.1`  → `2033-08-31` (CIP maintenance schedule cited on Wikipedia)
  - `5.10` → `2031-01-01` ([`gitlab.com/cip-project/cip-lifecycle`](https://gitlab.com/cip-project/cip-lifecycle), phase 2 end)
  - `4.19` → `2029-01-01` ([`gitlab.com/cip-project/cip-lifecycle`](https://gitlab.com/cip-project/cip-lifecycle), phase 2 end)
- Adds a short paragraph at the end of the product description explaining what CIP is, where its sources live, and how to read the new column. Defines the `CIP` and `SLTS` abbreviations.

## Release-image rendering (`_plugins/generate-release-images.rb`, `_layouts/release-image.svg`)

The SVG template already defined an unused `.eoes { fill: #CDEBFF; }` style. This PR finishes wiring it up so the extended-support phase becomes visible for any product that has `eoesColumn` enabled.

- `build_svg_data` now reads `eoesColumn` and threads it through `build_timeline_scale` and `build_rows`.
- `build_timeline_scale` includes `release['eoes']` in the chart's date range only when the column is enabled and the row meets the same conditions required to draw a segment (concrete `eol` and `eoes` Dates).
- `build_rows` emits a new `extended_x` / `extended_width` pair per row covering `eol → eoes`. Only drawn when both bounds are concrete dates; `eoes: true` (unknown end) and `eoes: false` (no end) remain unrendered to avoid claiming a bar width that is not knowable.
- A legend entry is appended for `eoes` using `product.data['eoesColumnLabel']`, so the legend matches each product's own terminology ("CIP SLTS", "Expanded Security Maintenance", "Extended Life Cycle Support", etc.). Shown only when at least one row actually produced an extended-support segment.
- Legend layout switched from a fixed 240 px stride to a content-aware layout that uses 240 px as the preferred stride but expands when needed (`LEGEND_MIN_ITEM_GAP = 32`), so the new four-item legends on Ubuntu and RHEL do not overflow the canvas. Existing two-item legends are unaffected because their labels already fit in 240 px.
- Template: a third `<rect class="bar eoes">` is rendered between the security bar and the no-end badge, conditional on `row.extended_width > 0`.

Products without `eoesColumn`, and products with only boolean `eoes` values, render identically to before.

## Visible impact (verified via full `jekyll build`)

| Product | Effect |
| --- | --- |
| `linux` | Three new CIP SLTS bars on the 6.12, 6.1, 5.10 LTS rows; legend reads `Security Support` · `CIP SLTS` · `No end date published`. |
| `ubuntu` | Three ESM tails on the LTS rows; legend stretches automatically to fit `Maintenance & Security Support` + `Expanded Security Maintenance`. |
| `rhel`   | Six ELS tails across active RHEL versions; legend fits within the canvas. |
| Others   | Unchanged. |

## Validation

- Full `bundle exec jekyll build` under `ruby:3.4.6-slim` completes with no errors; the product-data-validator passes.
- `npx markdownlint-cli2 products/linux-kernel.md` → 0 errors.
- `npx prettier --write products/linux-kernel.md` → no changes after first run.
- Generated SVGs spot-checked for `linux`, `ubuntu`, `rhel`, `debian`, `oracle-jdk`, `linuxmint` — no legend overflow, no negative-width bars, no z-order regressions on existing two-bar layouts.

Closes #3990.
