### PR TITLE
[looker] Add 26.8 and 26.10 cycles

### DIFF
--- a/products/looker.md
+++ b/products/looker.md
@@ -33,6 +33,16 @@ auto:
 # eol/esr dates on https://cloud.google.com/looker/docs/officially-supported-releases or https://cloud.google.com/looker/docs/release-notes
 # Link on https://discuss.google.dev/search?q=Looker%20release%20notes
 releases:
+  - releaseCycle: "26.10"
+    releaseDate: 2026-06-07
+    eol: 2026-08-31
+    link: https://docs.cloud.google.com/looker/docs/release-notes#June_04_2026
+
+  - releaseCycle: "26.8"
+    releaseDate: 2026-05-07
+    eol: 2026-07-31
+    link: https://docs.cloud.google.com/looker/docs/release-notes#May_07_2026
+
   - releaseCycle: "26.6"
     releaseDate: 2026-03-25
     lts: 2026-05-31


### PR DESCRIPTION
We need to wait 2 more days to merge this one ( it will release 2026-06-07 ) . So technically this is kind of future release but because of just 2 days i'm not making it as draft.

https://docs.cloud.google.com/looker/docs/release-notes#June_04_2026

https://docs.cloud.google.com/looker/docs/release-notes#May_07_2026