### PR TITLE
[gorilla] Mark cycle as not EOL — repositories are not archived and packages still receive releases

### DIFF
--- a/products/gorilla.md
+++ b/products/gorilla.md
@@ -2,7 +2,6 @@
 title: Gorilla Toolkit
 addedAt: 2022-12-15
 category: framework
-tags: discontinued
 iconSlug: go
 permalink: /gorilla
 releasePolicyLink: https://github.com/gorilla/
@@ -48,7 +47,7 @@ identifiers:
 releases:
   - releaseCycle: "1"
     releaseDate: 2016-04-28
-    eol: true
+    eol: false
     latest: 1.5.0
     latestReleaseDate: 2022-01-04
     link: https://github.com/gorilla#gorilla-toolkit


### PR DESCRIPTION
## Summary

PR #8896 marked the Gorilla Toolkit as `discontinued` with release cycle `1`
set to `eol: true`. Because this page lists per-package `purl` identifiers,
that status propagates to PURL-based SCA tools, which then report individual
Gorilla modules as hard end-of-life ("expired").

The underlying repositories do not support an end-of-life classification:

- **None of the 11 Gorilla repositories are archived.**
- The toolkit was revived in July 2023
  (https://gorilla.github.io/blog/2023-07-17-project-status-update/) under new
  core maintainers, and every package was re-released on 2023-11-05.
- Several packages shipped releases well into 2024–2025.

| package | archived | latest release | release date | last push |
|---|---|---|---|---|
| context | no | v1.1.2 | 2023-11-05 | 2023-11-05 |
| csrf | no | v1.7.3 | 2025-04-14 | 2025-04-14 |
| css | no | v1.0.1 | 2023-11-05 | 2023-11-05 |
| handlers | no | v1.5.2 | 2023-11-05 | 2024-02-20 |
| mux | no | v1.8.1 | 2023-11-05 | 2024-08-15 |
| pat | no | v1.0.2 | 2023-11-05 | 2023-12-07 |
| rpc | no | v1.2.1 | 2023-11-05 | 2024-07-19 |
| schema | no | v1.4.1 | 2024-06-29 | 2024-08-19 |
| securecookie | no | v1.1.2 | 2023-11-05 | 2023-11-08 |
| sessions | no | v1.4.0 | 2024-08-20 | 2024-08-20 |
| websocket | no | v1.5.3 | 2024-06-14 | 2025-03-19 |

(Data from the GitHub REST API, 2026-06-05.)

The page also records `latest: 1.5.0 / latestReleaseDate: 2022-01-04`, which
predates the revival and all of the 2023–2025 releases above.

## Concrete impact

Scanning `pkg:golang/github.com/gorilla/websocket@v1.5.1` (published 2023-11-05,
after the revival) yields a hard end-of-life finding, because cycle `1` matches
any `1.x` version and is flagged `eol: true`. The module is not archived and has
since shipped v1.5.3 (2024-06), so this is a false positive.

## Proposed change

Set the cycle to `eol: false` and drop the `discontinued` tag.

If you prefer to keep `discontinued` as a low-activity editorial signal at the
toolkit level, an alternative that still avoids the per-package false positives
is to drop the per-package `purl:` identifiers (or split the maintained modules
into their own products), since those identifiers are what drive automated
per-package EOL detection. Happy to adjust in whichever direction you prefer.
