### PR TITLE
[emberjs] Adds 6.12 and 7.0

### DIFF
--- a/products/emberjs.md
+++ b/products/emberjs.md
@@ -43,7 +43,7 @@ releases:
     releaseDate: 2026-05-29
     eoas: false
     eol: false
-    latest: "6.11.1"
+    latest: "7.0.0"
     latestReleaseDate: 2026-03-27
     link: https://blog.emberjs.com/ember-released-6-11/
   
@@ -52,7 +52,7 @@ releases:
     eoas: 2026-12-08
     eol: 2027-05-25
     lts: 2026-05-29
-    latest: "6.11.1"
+    latest: "6.12.0"
     latestReleaseDate: 2026-05-01
     link: https://blog.emberjs.com/ember-released-6-12/
     

--- a/products/emberjs.md
+++ b/products/emberjs.md
@@ -44,8 +44,8 @@ releases:
     eoas: false
     eol: false
     latest: "7.0.0"
-    latestReleaseDate: 2026-03-27
-    link: https://blog.emberjs.com/ember-released-6-11/
+    latestReleaseDate: 2026-05-29
+    link: https://blog.emberjs.com/ember-released-7-0/
   
   - releaseCycle: "6.12"
     releaseDate: 2026-05-01

--- a/products/emberjs.md
+++ b/products/emberjs.md
@@ -39,10 +39,27 @@ auto:
 # - eoas(x) = releaseDate(x+1)
 # - eol(x) = releaseDate(x+1)
 releases:
-  - releaseCycle: "6.11"
-    releaseDate: 2026-03-06
+  - releaseCycle: "7.0"
+    releaseDate: 2026-05-29
     eoas: false
     eol: false
+    latest: "6.11.1"
+    latestReleaseDate: 2026-03-27
+    link: https://blog.emberjs.com/ember-released-6-11/
+  
+  - releaseCycle: "6.12"
+    releaseDate: 2026-05-01
+    eoas: 2026-12-08
+    eol: 2027-05-25
+    lts: 2026-05-29
+    latest: "6.11.1"
+    latestReleaseDate: 2026-05-01
+    link: https://blog.emberjs.com/ember-released-6-12/
+    
+  - releaseCycle: "6.11"
+    releaseDate: 2026-03-06
+    eoas: 2026-05-01
+    eol: 2026-05-01
     latest: "6.11.1"
     latestReleaseDate: 2026-03-27
     link: https://blog.emberjs.com/ember-released-6-11/


### PR DESCRIPTION
https://blog.emberjs.com/ember-released-7-0/

https://blog.emberjs.com/ember-released-6-12/

> The Ember project is excited to announce the release of Ember v7.0. Following Ember's Major Version Policy, the major includes only the removal of features that were deprecated until 7.0 as well as other bugfixes. This release of Ember.js means the previous version, 6.12, is now an LTS (Long Term Support) version.

LTS promotion is thus releaseDate(7.0)