### PR TITLE
[New Product] Grafana Tempo, Grafana Alloy, Artifactory Xray, Garage, GitLab-Runner and Ansible AWX

### DIFF
--- a/products/awx.md
+++ b/products/awx.md
@@ -67,7 +67,6 @@ releases:
     eol: 2024-03-12
     latest: "23.9.0"
     latestReleaseDate: 2024-02-27
-
 ---
 
 > [AWX](https://github.com/ansible/awx) provides a web-based user interface, REST API, and task
@@ -78,5 +77,6 @@ AWX is a rolling-release project. Only the latest release is supported. Releases
 frequently and users are expected to upgrade to the latest version.
 
 {: .warning }
+
 > As of July 2024, AWX releases are **paused** during a large-scale architectural refactoring.
 > See the [AWX Forum](https://forum.ansible.com/tag/awx) for updates.

--- a/products/awx.md
+++ b/products/awx.md
@@ -1,0 +1,82 @@
+---
+title: Ansible AWX
+addedAt: 2026-06-08
+category: server-app
+iconSlug: ansible
+permalink: /ansible-awx
+alternate_urls:
+  - /awx
+changelogTemplate: https://github.com/ansible/awx/releases/tag/__LATEST__
+releasePolicyLink: https://github.com/ansible/awx/blob/devel/README.md
+
+auto:
+  methods:
+    - docker_hub: ansible/awx
+      regex: '^(?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)$'
+
+identifiers:
+  - purl: pkg:github/ansible/awx
+  - purl: pkg:docker/ansible/awx
+
+# AWX is a rolling-release project: only the latest release is supported.
+releases:
+  - releaseCycle: "24.6"
+    releaseDate: 2024-06-21
+    eol: false
+    latest: "24.6.1"
+    latestReleaseDate: 2024-07-02
+
+  - releaseCycle: "24.5"
+    releaseDate: 2024-06-04
+    eol: 2024-06-21
+    latest: "24.5.0"
+    latestReleaseDate: 2024-06-04
+
+  - releaseCycle: "24.4"
+    releaseDate: 2024-05-22
+    eol: 2024-06-04
+    latest: "24.4.0"
+    latestReleaseDate: 2024-05-22
+
+  - releaseCycle: "24.3"
+    releaseDate: 2024-04-23
+    eol: 2024-05-22
+    latest: "24.3.1"
+    latestReleaseDate: 2024-04-30
+
+  - releaseCycle: "24.2"
+    releaseDate: 2024-04-09
+    eol: 2024-04-23
+    latest: "24.2.0"
+    latestReleaseDate: 2024-04-09
+
+  - releaseCycle: "24.1"
+    releaseDate: 2024-03-26
+    eol: 2024-04-09
+    latest: "24.1.0"
+    latestReleaseDate: 2024-03-26
+
+  - releaseCycle: "24.0"
+    releaseDate: 2024-03-12
+    eol: 2024-03-26
+    latest: "24.0.0"
+    latestReleaseDate: 2024-03-12
+
+  - releaseCycle: "23.9"
+    releaseDate: 2024-02-27
+    eol: 2024-03-12
+    latest: "23.9.0"
+    latestReleaseDate: 2024-02-27
+
+---
+
+> [AWX](https://github.com/ansible/awx) provides a web-based user interface, REST API, and task
+> engine built on top of [Ansible](https://www.ansible.com/). It is the upstream open-source
+> project for [Red Hat Ansible Automation Platform](https://www.ansible.com/products/automation-platform).
+
+AWX is a rolling-release project. Only the latest release is supported. Releases are published
+frequently and users are expected to upgrade to the latest version.
+
+{: .warning }
+> As of July 2024, AWX releases are **paused** during a large-scale architectural refactoring.
+> See the [AWX Forum](https://forum.ansible.com/tag/awx) for updates.

--- a/products/garage.md
+++ b/products/garage.md
@@ -1,0 +1,48 @@
+---
+title: Garage
+addedAt: 2026-06-08
+category: server-app
+permalink: /garage
+changelogTemplate: https://git.deuxfleurs.fr/Deuxfleurs/garage/releases/tag/__LATEST__
+releasePolicyLink: https://garagehq.deuxfleurs.fr/
+
+auto:
+  methods:
+    - git: https://git.deuxfleurs.fr/Deuxfleurs/garage.git
+
+identifiers:
+  - purl: pkg:docker/dxflrs/garage
+
+releases:
+  - releaseCycle: "2"
+    releaseDate: 2025-06-14
+    eol: false
+    latest: "2.3.0"
+    latestReleaseDate: 2026-04-16
+
+  - releaseCycle: "1"
+    releaseDate: 2024-04-10
+    eol: false
+    latest: "1.3.1"
+    latestReleaseDate: 2026-01-24
+
+  - releaseCycle: "0.9"
+    releaseDate: 2023-08-01
+    eol: 2025-06-14
+    latest: "0.9.4"
+    latestReleaseDate: 2024-04-08
+
+  - releaseCycle: "0.8"
+    releaseDate: 2022-12-05
+    eol: 2025-06-14
+    latest: "0.8.7"
+    latestReleaseDate: 2024-03-04
+
+---
+
+> [Garage](https://garagehq.deuxfleurs.fr/) is a lightweight, open-source distributed object
+> storage service, designed for self-hosting. It is S3-compatible and built for geo-distributed
+> deployments across multiple datacenters or home servers.
+
+Garage follows a major version support model. Both the current major version and the previous
+major version receive maintenance releases.

--- a/products/garage.md
+++ b/products/garage.md
@@ -37,7 +37,6 @@ releases:
     eol: 2025-06-14
     latest: "0.8.7"
     latestReleaseDate: 2024-03-04
-
 ---
 
 > [Garage](https://garagehq.deuxfleurs.fr/) is a lightweight, open-source distributed object

--- a/products/gitlab-runner.md
+++ b/products/gitlab-runner.md
@@ -1,0 +1,130 @@
+---
+title: GitLab Runner
+addedAt: 2026-06-08
+category: server-app
+tags: gitlab
+iconSlug: gitlab
+permalink: /gitlab-runner
+versionCommand: gitlab-runner --version
+releasePolicyLink: https://docs.gitlab.com/runner/#gitlab-runner-versions
+changelogTemplate: https://gitlab.com/gitlab-org/gitlab-runner/-/releases/v__LATEST__
+eoasColumn: true
+eolColumn: Maintenance Support
+
+auto:
+  methods:
+    - docker_hub: gitlab/gitlab-runner
+      regex: '^v(?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)$'
+
+identifiers:
+  - purl: pkg:docker/gitlab/gitlab-runner
+  - cpe: cpe:2.3:a:gitlab:runner
+
+# GitLab Runner follows the same versioning and support policy as GitLab.
+# eoas(x) = releaseDate(x+1)
+# eol(x) = releaseDate(x+3)
+releases:
+  - releaseCycle: "19.0"
+    releaseDate: 2026-05-21
+    eoas: 2026-06-18 # releaseDate(19.1)
+    eol: 2026-08-20 # releaseDate(19.3)
+    latest: "19.0.1"
+    latestReleaseDate: 2026-06-01
+
+  - releaseCycle: "18.11"
+    releaseDate: 2026-04-16
+    eoas: 2026-05-21 # releaseDate(19.0)
+    eol: 2026-07-16 # releaseDate(19.2)
+    latest: "18.11.3"
+    latestReleaseDate: 2026-05-12
+
+  - releaseCycle: "18.10"
+    releaseDate: 2026-03-19
+    eoas: 2026-04-16 # releaseDate(18.11)
+    eol: 2026-06-18 # releaseDate(19.1)
+    latest: "18.10.1"
+    latestReleaseDate: 2026-04-06
+
+  - releaseCycle: "18.9"
+    releaseDate: 2026-02-19
+    eoas: 2026-03-19 # releaseDate(18.10)
+    eol: 2026-05-21 # releaseDate(19.0)
+    latest: "18.9.0"
+    latestReleaseDate: 2026-02-20
+
+  - releaseCycle: "18.8"
+    releaseDate: 2026-01-15
+    eoas: 2026-02-19 # releaseDate(18.9)
+    eol: 2026-04-16 # releaseDate(18.11)
+    latest: "18.8.0"
+    latestReleaseDate: 2026-01-15
+
+  - releaseCycle: "18.7"
+    releaseDate: 2025-12-18
+    eoas: 2026-01-15 # releaseDate(18.8)
+    eol: 2026-03-19 # releaseDate(18.10)
+    latest: "18.7.2"
+    latestReleaseDate: 2026-01-09
+
+  - releaseCycle: "18.6"
+    releaseDate: 2025-11-20
+    eoas: 2025-12-18 # releaseDate(18.7)
+    eol: 2026-02-19 # releaseDate(18.9)
+    latest: "18.6.6"
+    latestReleaseDate: 2025-12-09
+
+  - releaseCycle: "18.5"
+    releaseDate: 2025-10-16
+    eoas: 2025-11-20 # releaseDate(18.6)
+    eol: 2026-01-15 # releaseDate(18.8)
+    latest: "18.5.0"
+    latestReleaseDate: 2025-10-16
+
+  - releaseCycle: "18.4"
+    releaseDate: 2025-09-18
+    eoas: 2025-10-16 # releaseDate(18.5)
+    eol: 2025-12-18 # releaseDate(18.7)
+    latest: "18.4.0"
+    latestReleaseDate: 2025-09-18
+
+  - releaseCycle: "18.3"
+    releaseDate: 2025-08-21
+    eoas: 2025-09-18 # releaseDate(18.4)
+    eol: 2025-11-20 # releaseDate(18.6)
+    latest: "18.3.0"
+    latestReleaseDate: 2025-08-21
+
+  - releaseCycle: "18.2"
+    releaseDate: 2025-07-16
+    eoas: 2025-08-21 # releaseDate(18.3)
+    eol: 2025-10-16 # releaseDate(18.5)
+    latest: "18.2.0"
+    latestReleaseDate: 2025-07-16
+
+  - releaseCycle: "18.1"
+    releaseDate: 2025-06-18
+    eoas: 2025-07-16 # releaseDate(18.2)
+    eol: 2025-09-18 # releaseDate(18.4)
+    latest: "18.1.0"
+    latestReleaseDate: 2025-06-18
+
+  - releaseCycle: "18.0"
+    releaseDate: 2025-05-14
+    eoas: 2025-06-18 # releaseDate(18.1)
+    eol: 2025-08-21 # releaseDate(18.3)
+    latest: "18.0.0"
+    latestReleaseDate: 2025-05-14
+
+---
+
+> [GitLab Runner](https://docs.gitlab.com/runner/) is the open-source agent that runs CI/CD jobs
+> defined in a GitLab project's `.gitlab-ci.yml` file. It can run jobs locally, in Docker
+> containers, on Kubernetes, or via SSH on remote servers.
+
+GitLab Runner uses the same versioning scheme as GitLab (`major.minor.patch`), with a new minor
+version released on the 3rd Thursday of each month. For compatibility, it is recommended to use
+a runner version no more than one major version behind the GitLab instance.
+
+GitLab Runner follows GitLab's [maintenance policy](https://docs.gitlab.com/policy/maintenance.html):
+the current minor version and the two previous minor versions receive security and bug fixes
+(three supported versions at any time).

--- a/products/gitlab-runner.md
+++ b/products/gitlab-runner.md
@@ -114,7 +114,6 @@ releases:
     eol: 2025-08-21 # releaseDate(18.3)
     latest: "18.0.0"
     latestReleaseDate: 2025-05-14
-
 ---
 
 > [GitLab Runner](https://docs.gitlab.com/runner/) is the open-source agent that runs CI/CD jobs

--- a/products/grafana-alloy.md
+++ b/products/grafana-alloy.md
@@ -1,0 +1,94 @@
+---
+title: Grafana Alloy
+addedAt: 2026-06-08
+category: server-app
+iconSlug: grafana
+tags: grafana
+permalink: /grafana-alloy
+alternate_urls:
+  - /alloy
+changelogTemplate: https://github.com/grafana/alloy/releases/tag/v__LATEST__
+releasePolicyLink: https://grafana.com/docs/alloy/latest/reference/release-information/release-cadence/
+
+auto:
+  methods:
+    - docker_hub: grafana/alloy
+      regex: '^v(?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)$'
+
+identifiers:
+  - purl: pkg:github/grafana/alloy
+  - purl: pkg:docker/grafana/alloy
+  - cpe: cpe:2.3:a:grafana:alloy
+
+# eol(x) = releaseDate(x+2), same policy as Grafana Loki and Tempo.
+# The two most recent minor versions are actively maintained.
+releases:
+  - releaseCycle: "1.16"
+    releaseDate: 2026-04-23
+    eol: false
+    latest: "1.16.2"
+    latestReleaseDate: 2026-06-02
+
+  - releaseCycle: "1.15"
+    releaseDate: 2026-03-30
+    eol: false
+    latest: "1.15.1"
+    latestReleaseDate: 2026-04-14
+
+  - releaseCycle: "1.14"
+    releaseDate: 2026-03-09
+    eol: 2026-04-23
+    latest: "1.14.2"
+    latestReleaseDate: 2026-03-24
+
+  - releaseCycle: "1.13"
+    releaseDate: 2026-02-05
+    eol: 2026-03-30
+    latest: "1.13.2"
+    latestReleaseDate: 2026-02-23
+
+  - releaseCycle: "1.12"
+    releaseDate: 2025-12-01
+    eol: 2026-02-05
+    latest: "1.12.2"
+    latestReleaseDate: 2026-01-08
+
+  - releaseCycle: "1.11"
+    releaseDate: 2025-09-30
+    eol: 2025-12-01
+    latest: "1.11.3"
+    latestReleaseDate: 2025-10-27
+
+  - releaseCycle: "1.10"
+    releaseDate: 2025-07-16
+    eol: 2025-09-30
+    latest: "1.10.2"
+    latestReleaseDate: 2025-08-20
+
+  - releaseCycle: "1.9"
+    releaseDate: 2025-06-02
+    eol: 2025-07-16
+    latest: "1.9.2"
+    latestReleaseDate: 2025-06-26
+
+  - releaseCycle: "1.8"
+    releaseDate: 2025-04-09
+    eol: 2025-06-02
+    latest: "1.8.3"
+    latestReleaseDate: 2025-05-05
+
+---
+
+> [Grafana Alloy](https://grafana.com/docs/alloy/latest/) is an open-source,
+> OpenTelemetry-native distribution of the OpenTelemetry Collector. It is the successor to
+> Grafana Agent and supports collecting, transforming, and forwarding telemetry data including
+> metrics, logs, traces, and profiles.
+
+Alloy follows the same support policy as other Grafana OSS projects: the two most recent minor
+versions receive bug fixes and security patches.
+
+A new minor release is published approximately every three weeks. Patch releases are published
+every one to two weeks. The cadence is best-effort and may shift as needed.
+
+Minor releases published on cadence include updated OpenTelemetry Collector dependencies when
+new upstream versions are available. Patch and security releases may be created at any time.

--- a/products/grafana-alloy.md
+++ b/products/grafana-alloy.md
@@ -76,7 +76,6 @@ releases:
     eol: 2025-06-02
     latest: "1.8.3"
     latestReleaseDate: 2025-05-05
-
 ---
 
 > [Grafana Alloy](https://grafana.com/docs/alloy/latest/) is an open-source,

--- a/products/grafana-loki.md
+++ b/products/grafana-loki.md
@@ -3,6 +3,7 @@ title: Grafana Loki
 addedAt: 2024-08-04
 category: server-app
 iconSlug: grafana
+tags: grafana
 permalink: /grafana-loki
 alternate_urls:
   - /loki

--- a/products/grafana-tempo.md
+++ b/products/grafana-tempo.md
@@ -1,0 +1,73 @@
+---
+title: Grafana Tempo
+addedAt: 2026-06-08
+category: server-app
+iconSlug: grafana
+tags: grafana
+permalink: /grafana-tempo
+alternate_urls:
+  - /tempo
+changelogTemplate: https://github.com/grafana/tempo/releases/tag/v__LATEST__
+releasePolicyLink: https://grafana.com/docs/tempo/latest/release-notes/
+
+auto:
+  methods:
+    - git: https://github.com/grafana/tempo.git
+
+identifiers:
+  - purl: pkg:github/grafana/tempo
+  - purl: pkg:docker/grafana/tempo
+
+# eol(x) = releaseDate(x+2), same policy as Grafana Loki and Alloy.
+# The two most recent minor versions are actively maintained.
+releases:
+  - releaseCycle: "3.0"
+    releaseDate: 2026-05-28
+    eol: false
+    latest: "3.0.0"
+    latestReleaseDate: 2026-05-28
+
+  - releaseCycle: "2.10"
+    releaseDate: 2026-01-26
+    eol: false
+    latest: "2.10.5"
+    latestReleaseDate: 2026-04-23
+
+  - releaseCycle: "2.9"
+    releaseDate: 2025-10-13
+    eol: 2026-01-26
+    latest: "2.9.2"
+    latestReleaseDate: 2026-04-23
+
+  - releaseCycle: "2.8"
+    releaseDate: 2025-06-10
+    eol: 2025-10-13
+    latest: "2.8.4"
+    latestReleaseDate: 2026-04-23
+
+  - releaseCycle: "2.7"
+    releaseDate: 2025-01-13
+    eol: 2025-06-10
+    latest: "2.7.2"
+    latestReleaseDate: 2025-03-25
+
+  - releaseCycle: "2.6"
+    releaseDate: 2024-09-03
+    eol: 2025-01-13
+    latest: "2.6.1"
+    latestReleaseDate: 2024-10-22
+
+  - releaseCycle: "2.5"
+    releaseDate: 2024-05-31
+    eol: 2024-09-03
+    latest: "2.5.0"
+    latestReleaseDate: 2024-05-31
+
+---
+
+> [Grafana Tempo](https://grafana.com/oss/tempo/) is an open-source, high-volume distributed
+> tracing backend. It is designed to be cost-efficient, requiring only object storage to operate,
+> and integrates natively with Grafana, Prometheus, and Loki.
+
+Tempo follows the same support policy as other Grafana OSS projects: the two most recent minor
+versions receive bug fixes and security patches.

--- a/products/grafana-tempo.md
+++ b/products/grafana-tempo.md
@@ -62,7 +62,6 @@ releases:
     eol: 2024-09-03
     latest: "2.5.0"
     latestReleaseDate: 2024-05-31
-
 ---
 
 > [Grafana Tempo](https://grafana.com/oss/tempo/) is an open-source, high-volume distributed

--- a/products/grafana.md
+++ b/products/grafana.md
@@ -4,6 +4,7 @@ addedAt: 2022-11-02
 category: server-app
 iconSlug: grafana
 permalink: /grafana
+tags: grafana
 versionCommand: |-
   # For Grafana >= 13
   grafana --version

--- a/products/jfrog-xray.md
+++ b/products/jfrog-xray.md
@@ -1,0 +1,245 @@
+---
+title: JFrog Xray
+addedAt: 2026-06-08
+category: server-app
+iconSlug: jfrog
+permalink: /jfrog-xray
+alternate_urls:
+  - /artifactory-xray
+  - /xray
+changelogTemplate: https://docs.jfrog.com/releases/docs/security-self-managed-releases
+releasePolicyLink: https://docs.jfrog.com/releases/docs/security-end-of-life
+eolColumn: Support
+
+auto:
+  methods:
+    - git: https://github.com/jfrog/charts.git
+      regex: '^xray-103\.(?P<minor>\d+)\.(?P<patch>\d+)$'
+      template: '3.{{minor}}.{{patch}}'
+
+# EOL documented on https://docs.jfrog.com/releases/docs/security-end-of-life.
+# New release cycles (~quarterly) must be added manually from
+# https://docs.jfrog.com/releases/docs/security-self-managed-releases.
+# Patch versions are tracked automatically via the jfrog/charts git tags.
+releases:
+  - releaseCycle: "3.143"
+    releaseDate: 2026-04-28
+    eol: 2027-10-28
+    latest: "3.143.20"
+    latestReleaseDate: 2026-05-24
+
+  - releaseCycle: "3.137"
+    releaseDate: 2026-02-03
+    eol: 2027-08-03
+    latest: "3.137.31"
+    latestReleaseDate: 2026-05-06
+
+  - releaseCycle: "3.131"
+    releaseDate: 2025-11-09
+    eol: 2027-05-09
+    latest: "3.131.42"
+    latestReleaseDate: 2026-04-19
+
+  - releaseCycle: "3.124"
+    releaseDate: 2025-07-29
+    eol: 2027-01-29
+    latest: "3.124.42"
+    latestReleaseDate: 2026-04-19
+
+  - releaseCycle: "3.118"
+    releaseDate: 2025-04-28
+    eol: 2026-10-28
+    latest: "3.118.44"
+    latestReleaseDate: 2026-05-24
+
+  - releaseCycle: "3.111"
+    releaseDate: 2025-01-30
+    eol: 2026-07-30
+    latest: "3.111.31"
+    latestReleaseDate: 2025-08-06
+
+  - releaseCycle: "3.107"
+    releaseDate: 2024-11-25
+    eol: 2026-05-25
+    latest: "3.107.36"
+    latestReleaseDate: 2025-05-15
+
+  - releaseCycle: "3.104"
+    releaseDate: 2024-10-06
+    eol: 2026-04-06
+    latest: "3.104.19"
+    latestReleaseDate: 2024-11-20
+
+  - releaseCycle: "3.103"
+    releaseDate: 2024-08-27
+    eol: 2026-02-27
+    latest: "3.103.6"
+    latestReleaseDate: 2024-08-27
+
+  - releaseCycle: "3.102"
+    releaseDate: 2024-08-13
+    eol: 2026-02-13
+    latest: "3.102.3"
+    latestReleaseDate: 2024-08-13
+
+  - releaseCycle: "3.101"
+    releaseDate: 2024-07-28
+    eol: 2026-01-28
+    latest: "3.101.5"
+    latestReleaseDate: 2024-07-28
+
+  - releaseCycle: "3.100"
+    releaseDate: 2024-07-18
+    eol: 2026-01-18
+    latest: "3.100.4"
+    latestReleaseDate: 2025-04-06
+
+  - releaseCycle: "3.98"
+    releaseDate: 2024-07-07
+    eol: 2026-01-07
+    latest: "3.98.5"
+    latestReleaseDate: 2024-07-12
+
+  - releaseCycle: "3.97"
+    releaseDate: 2024-06-23
+    eol: 2025-12-23
+    latest: "3.97.3"
+    latestReleaseDate: 2024-06-23
+
+  - releaseCycle: "3.96"
+    releaseDate: 2024-05-27
+    eol: 2025-11-27
+    latest: "3.96.1"
+    latestReleaseDate: 2024-05-27
+
+  - releaseCycle: "3.95"
+    releaseDate: 2024-05-05
+    eol: 2025-11-05
+    latest: "3.95.7"
+    latestReleaseDate: 2024-05-15
+
+  - releaseCycle: "3.94"
+    releaseDate: 2024-04-18
+    eol: 2025-10-18
+    latest: "3.94.5"
+    latestReleaseDate: 2024-04-23
+
+  - releaseCycle: "3.92"
+    releaseDate: 2024-04-01
+    eol: 2025-10-01
+    latest: "3.92.7"
+    latestReleaseDate: 2024-04-01
+
+  - releaseCycle: "3.91"
+    releaseDate: 2024-03-12
+    eol: 2025-09-12
+    latest: "3.91.3"
+    latestReleaseDate: 2024-03-12
+
+  - releaseCycle: "3.90"
+    releaseDate: 2024-02-26
+    eol: 2025-08-26
+    latest: "3.90.1"
+    latestReleaseDate: 2024-02-26
+
+  - releaseCycle: "3.89"
+    releaseDate: 2024-02-15
+    eol: 2025-08-15
+    latest: "3.89.5"
+    latestReleaseDate: 2024-02-15
+
+  - releaseCycle: "3.88"
+    releaseDate: 2024-02-06
+    eol: 2025-08-06
+    latest: "3.88.12"
+    latestReleaseDate: 2024-02-06
+
+  - releaseCycle: "3.87"
+    releaseDate: 2023-12-08
+    eol: 2025-06-08
+    latest: "3.87.10"
+    latestReleaseDate: 2024-02-01
+
+  - releaseCycle: "3.86"
+    releaseDate: 2023-10-29
+    eol: 2025-04-29
+    latest: "3.86.10"
+    latestReleaseDate: 2023-12-25
+
+  - releaseCycle: "3.85"
+    releaseDate: 2023-10-02
+    eol: 2025-04-02
+    latest: "3.85.7"
+    latestReleaseDate: 2023-11-23
+
+  - releaseCycle: "3.83"
+    releaseDate: 2023-09-12
+    eol: 2025-03-12
+    latest: "3.83.10"
+    latestReleaseDate: 2023-10-20
+
+  - releaseCycle: "3.82"
+    releaseDate: 2023-08-10
+    eol: 2025-02-10
+    latest: "3.82.10"
+    latestReleaseDate: 2023-09-19
+
+  - releaseCycle: "3.81"
+    releaseDate: 2023-07-31
+    eol: 2025-01-31
+    latest: "3.81.8"
+    latestReleaseDate: 2023-08-31
+
+  - releaseCycle: "3.80"
+    releaseDate: 2023-07-17
+    eol: 2025-01-17
+    latest: "3.80.9"
+    latestReleaseDate: 2023-08-17
+
+  - releaseCycle: "3.79"
+    releaseDate: 2023-07-07
+    eol: 2025-01-07
+    latest: "3.79.11"
+    latestReleaseDate: 2023-08-07
+
+  - releaseCycle: "3.78"
+    releaseDate: 2023-06-11
+    eol: 2024-12-11
+    latest: "3.78.10"
+    latestReleaseDate: 2023-07-18
+
+  - releaseCycle: "3.77"
+    releaseDate: 2023-06-04
+    eol: 2024-12-04
+    latest: "3.77.4"
+    latestReleaseDate: 2023-07-04
+
+  - releaseCycle: "3.76"
+    releaseDate: 2023-05-27
+    eol: 2024-11-27
+    latest: "3.76.7"
+    latestReleaseDate: 2023-06-27
+
+  - releaseCycle: "3.75"
+    releaseDate: 2023-05-06
+    eol: 2024-11-06
+    latest: "3.75.12"
+    latestReleaseDate: 2023-06-06
+
+  - releaseCycle: "3.74"
+    releaseDate: 2023-04-28
+    eol: 2024-10-28
+    latest: "3.74.8"
+    latestReleaseDate: 2023-05-28
+
+---
+
+> [JFrog Xray](https://jfrog.com/xray/) is an enterprise-grade software composition analysis (SCA)
+> tool that identifies, prioritizes, and remediates security vulnerabilities and license compliance
+> issues in open source software and third-party components integrated via JFrog Artifactory.
+
+Xray is available in self-hosted and SaaS editions. This page only tracks releases for the
+self-hosted offering. Note that not all releases are made available to self-hosted customers, hence
+the gaps between the release cycles.
+
+JFrog supports all versions of Xray from their date of release going forward 18 months.


### PR DESCRIPTION
This pull request adds support for several new server applications by introducing metadata files that track their release cycles, support policies, and versioning details. It also standardizes tagging for Grafana-related products for improved discoverability.

**New product metadata additions:**

* Added `products/grafana-alloy.md` to track Grafana Alloy releases, support policy, and versioning, following the same maintenance cadence as other Grafana OSS projects.
* Added `products/grafana-tempo.md` for Grafana Tempo, including release cycles and maintenance policy consistent with Grafana Loki and Alloy.
* Added `products/garage.md` for the Garage distributed object storage project, outlining its major version support model and release history.
* Added `products/gitlab-runner.md` to track GitLab Runner releases and support lifecycle, matching GitLab’s versioning and maintenance policy.
* Added `products/awx.md` to track Ansible AWX, including its rolling-release policy and notice about the current release pause due to refactoring.
* Added `products/jfrog-xray.md` for JFrog Xray, detailing quarterly release cycles and the 18-month support window for self-hosted editions.

**Tagging and discoverability improvements:**

* Added or standardized the `tags: grafana` field to `products/grafana.md` [[1]](diffhunk://#diff-d2112644b68b376d9de44f400cf00af7d5c4d52e52c670ba55315c394e778e94R7) and `products/grafana-loki.md` [[2]](diffhunk://#diff-e6bba1c1beb4d765f4f6210eb5b87b790d84d4b8178d3e236d7e5470ec646fb3R6) for better grouping and searchability of Grafana-related products.

These changes enhance the coverage and accuracy of product lifecycle tracking and improve the organization of related software entries.