### PR TITLE
[nextcloud] Add 34 cycle

### DIFF
--- a/products/nextcloud.md
+++ b/products/nextcloud.md
@@ -24,10 +24,10 @@ auto:
 
 releases:
   - releaseCycle: "34"
-    releaseDate: 2026-06-08
-    eol: 2027-06-08
+    releaseDate: 2026-06-09
+    eol: 2027-06-30
     latest: "34.0.0"
-    latestReleaseDate: 2026-06-08
+    latestReleaseDate: 2026-06-09
 
   - releaseCycle: "33"
     releaseDate: 2026-02-18

--- a/products/nextcloud.md
+++ b/products/nextcloud.md
@@ -23,6 +23,12 @@ auto:
         eol: "End of life"
 
 releases:
+  - releaseCycle: "34"
+    releaseDate: 2026-06-08
+    eol: 2027-06-08
+    latest: "34.0.0"
+    latestReleaseDate: 2026-06-08
+
   - releaseCycle: "33"
     releaseDate: 2026-02-18
     eol: 2027-02-28


### PR DESCRIPTION
The announcement doesnt exist on its webpage ( yet ) on the other hand it is downloadable through https://download.nextcloud.com/server/releases/nextcloud-34.0.0.tar.bz2