### PR TITLE
[aws-lambda:dotnet9] Increase staleReleaseThresholdDays to 600

### DIFF
--- a/products/aws-lambda.md
+++ b/products/aws-lambda.md
@@ -66,7 +66,7 @@ releases:
 
   - releaseCycle: "dotnet9"
     releaseLabel: ".NET 9 (container only)"
-    staleReleaseThresholdDays: 540 # Still "not scheduled" on https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html
+    staleReleaseThresholdDays: 600 # Still "not scheduled" on https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html
     releaseDate: 2024-12-09
     eoas: 2026-11-10
     eol: false


### PR DESCRIPTION
Updated stale release threshold for .NET 9 runtime.