### PR TITLE
[chef-workstation] Update EOAS/EOL dates for cycle 24

### DIFF
--- a/products/chef-workstation.md
+++ b/products/chef-workstation.md
@@ -30,10 +30,9 @@ releases:
 
   - releaseCycle: "24"
     releaseLabel: "2024"
-    staleReleaseThresholdDays: 540 # Still listed on https://docs.chef.io/versions/#supported-commercial-distributions
     releaseDate: 2024-02-07
-    eoas: false
-    eol: false
+    eoas: 2026-04-30
+    eol: 2026-04-30
     latest: "24.12.1073"
     latestReleaseDate: 2024-12-16
 


### PR DESCRIPTION
version 24 is now marked as EOL

https://docs.chef.io/versions/#supported-commercial-distributions

<img width="1372" height="413" alt="image" src="https://github.com/user-attachments/assets/46623bd1-f3dc-48f1-81bc-40b0e9c0f806" />
