### PR TITLE
Fix mongodb data update failure in endoflife-date/release-data

### DIFF
--- a/products/mongodb.md
+++ b/products/mongodb.md
@@ -32,6 +32,8 @@ auto:
     - git: https://github.com/mongodb/mongo.git
       regex: ^r(?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)$
     - release_table: https://www.mongodb.com/legal/support-policy/lifecycles
+      render_javascript: true
+      render_javascript_wait_for: "table"
       header_selector: "tr:nth-of-type(1)"
       fields:
         releaseCycle:


### PR DESCRIPTION
## Why
Mongodb release data has not been updated for two months due to the below error.
https://github.com/endoflife-date/release-data/actions/runs/27648912377/job/81767796386
<img width="1642" height="813" alt="image" src="https://github.com/user-attachments/assets/ecb7a410-b412-412f-b143-3abded794406" />


Copilot provide the solution:
https://github.com/copilot/share/c23312a4-4124-8497-a151-a409e0444133