### PR TITLE
[mastodon] Add EOL date for 4.4 cycle

### DIFF
--- a/products/mastodon.md
+++ b/products/mastodon.md
@@ -32,7 +32,7 @@ releases:
 
   - releaseCycle: "4.4"
     releaseDate: 2025-07-08
-    eol: false
+    eol: 2026-12-17
     latest: "4.4.18"
     latestReleaseDate: 2026-06-03
 


### PR DESCRIPTION
Source: https://github.com/mastodon/mastodon/security/policy#supported-versions