### PR TITLE
Ansible 13 is now EOL after 13.8.0 release

### DIFF
--- a/products/ansible.md
+++ b/products/ansible.md
@@ -64,7 +64,7 @@ releases:
     pythonVersionsManagedNode: "3.9 - 3.14"
     powershellVersionsManagedNode: "5.1"
     releaseDate: 2025-11-19
-    eol: false
+    eol: 2026-06-18
     latest: "13.8.0"
     latestReleaseDate: 2026-06-18
 


### PR DESCRIPTION
Also Ansible 14.1.0 just got released as well.

Ref: https://forum.ansible.com/t/release-announcement-ansible-community-package-13-8-0/45944
Ref: https://forum.ansible.com/t/release-announcement-ansible-community-package-14-1-0/45945