### PR TITLE
[jenkins] Add 2.555 LTS

### DIFF
--- a/products/jenkins.md
+++ b/products/jenkins.md
@@ -37,10 +37,17 @@ releases:
     latest: "2.570"
     latestReleaseDate: 2026-06-23
 
+  - releaseCycle: "2.555"
+    releaseDate: 2026-03-18
+    lts: 2026-04-15
+    eol: false
+    latest: "2.555.3"
+    latestReleaseDate: 2026-06-10
+
   - releaseCycle: "2.541"
     releaseDate: 2025-12-10
     lts: 2026-01-21
-    eol: false
+    eol: 2026-04-15
     latest: "2.541.3"
     latestReleaseDate: 2026-03-16
 


### PR DESCRIPTION
Fixes #10234.

See also [Upgrading to Jenkins LTS 2.541.x](https://www.jenkins.io/doc/upgrade-guide/2.541/) and [LTS Changelog](https://www.jenkins.io/changelog-stable/).

Based on #9352.