### PR TITLE
[nodejs] Adds TuxCare as commerial support partners

### DIFF
--- a/products/nodejs.md
+++ b/products/nodejs.md
@@ -241,5 +241,5 @@ LTS release status is "long-term support", which typically guarantees that criti
 Production applications should only use Active LTS or Maintenance LTS releases.
 
 Node.js is part of the [OpenJS Foundation's Ecosystem Sustainability Program](https://openjsf.org/ecosystem-sustainability-program) (ESP).
-Commercial support is available for some deprecated LTS versions of Node.js through the
-[HeroDevs Never-Ending Support](https://www.herodevs.com/support/node-nes) initiative. [TuxCare's Endless Lifecycle Support](https://tuxcare.com/endless-lifecycle-support/nodejs-eol-support/) also provides commercial support for Node.js.
+
+Commercial support is available for some deprecated LTS versions of Node.js through the [HeroDevs Never-Ending Support](https://www.herodevs.com/support/node-nes) initiative. Commercial support for Node.js is also available through [TuxCare's Endless Lifecycle Support](https://tuxcare.com/endless-lifecycle-support/nodejs-eol-support/).

--- a/products/nodejs.md
+++ b/products/nodejs.md
@@ -230,7 +230,6 @@ releases:
     link: https://github.com/nodejs/node/blob/main/doc/changelogs/CHANGELOG_IOJS.md#__LATEST__
     latest: "1.8.4"
     latestReleaseDate: 2015-07-09
-
 ---
 
 > [Node.js](https://nodejs.org/) is an open-source, cross-platform JavaScript run-time environment
@@ -243,4 +242,4 @@ Production applications should only use Active LTS or Maintenance LTS releases.
 
 Node.js is part of the [OpenJS Foundation's Ecosystem Sustainability Program](https://openjsf.org/ecosystem-sustainability-program) (ESP).
 Commercial support is available for some deprecated LTS versions of Node.js through the
-[HeroDevs Never-Ending Support](https://www.herodevs.com/support/node-nes) initiative.
+[HeroDevs Never-Ending Support](https://www.herodevs.com/support/node-nes) initiative. [TuxCare's Endless Lifecycle Support](https://tuxcare.com/endless-lifecycle-support/nodejs-eol-support/) also provides commercial support for Node.js.


### PR DESCRIPTION
This PR adds a link/info for TuxCare's support for Node.js. I would love for this to be merged into main. We are an [OpenJS Ecosystem Sustainability Program Partner](https://openjsf.org/partners).

<img width="500" height="249" alt="openjsfdntuxcare" src="https://github.com/user-attachments/assets/8710d763-0fbd-43a6-aa0b-c56b0e672ad4" />

Thanks!