### PR TITLE
[Prometheus] add 3.13 LTS

### DIFF
--- a/products/prometheus.md
+++ b/products/prometheus.md
@@ -36,6 +36,7 @@ auto:
 # For LTS, as per https://prometheus.io/docs/introduction/release-cycle/#long-term-support
 releases:
   - releaseCycle: "3.13"
+    lts: true
     releaseDate: 2026-07-01
     eol: 2027-07-31
     latest: "3.13.0"

--- a/products/prometheus.md
+++ b/products/prometheus.md
@@ -35,6 +35,12 @@ auto:
 # eol(x) = releaseDate(x) + 6w (non-LTS)
 # For LTS, as per https://prometheus.io/docs/introduction/release-cycle/#long-term-support
 releases:
+  - releaseCycle: "3.13"
+    releaseDate: 2026-07-01
+    eol: 2027-07-31
+    latest: "3.13.0"
+    latestReleaseDate: 2026-07-01
+
   - releaseCycle: "3.12"
     releaseDate: 2026-05-28
     eol: 2026-07-09


### PR DESCRIPTION
as per https://github.com/prometheus/prometheus/releases/tag/v3.13.0 added the 3.13 release to the product