### PR TITLE
[New Product] Apple TV

### DIFF
--- a/products/apple-tv.md
+++ b/products/apple-tv.md
@@ -1,0 +1,82 @@
+---
+title: Apple TV
+addedAt: 2026-07-03
+category: device
+tags: apple tv
+iconSlug: apple
+permalink: /apple-tv
+releasePolicyLink: https://support.apple.com/tv
+discontinuedColumn: true
+eolColumn: Supported
+latestColumn: false
+staleReleaseThresholdDays: 2000
+
+customFields:
+  - name: supportedTvOsVersions
+    display: api-only
+    label: tvOS
+    description: Supported tvOS versions
+
+# Links send to the Technical Specifications of each model.
+# All links can be found on https://support.apple.com/en-us/docs/apple-tv.
+# All supported tvOS versions can be found on https://en.wikipedia.org/wiki/TvOS#Supported_OS_releases.
+releases:
+  - releaseCycle: "4k-3"
+    releaseLabel: "4k (3rd generation)"
+    releaseDate: 2022-11-04
+    discontinued: false
+    eol: false
+    link: https://support.apple.com/en-us/111839
+    supportedTvOsVersions: "16, 17, 18, 26"
+
+  - releaseCycle: "4k-2"
+    releaseLabel: "4k (2nd generation)"
+    releaseDate: 2021-05-21
+    discontinued: 2022-10-18
+    eol: false
+    link: https://support.apple.com/en-us/111922
+    supportedTvOsVersions: "14, 15, 16, 17, 18, 26"
+
+  - releaseCycle: "4k-1"
+    releaseLabel: "4k (1st generation)"
+    releaseDate: 2017-09-22
+    discontinued: 2021-04-20
+    eol: false
+    link: https://support.apple.com/en-us/111929
+    supportedTvOsVersions: "11, 12, 13, 14, 15, 16, 17, 18, 26"
+
+  - releaseCycle: "hd"
+    releaseLabel: "HD"
+    releaseDate: 2015-10-30
+    discontinued: 2022-10-18
+    eol: false
+    link: https://support.apple.com/en-us/111928
+    supportedTvOsVersions: "9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 26"
+
+  - releaseCycle: "3"
+    releaseLabel: "3rd generation"
+    releaseDate: 2012-03-07
+    discontinued: 2016-09-08
+    eol: 2022-03-14
+    link: https://support.apple.com/en-us/112429
+
+  - releaseCycle: "2"
+    releaseLabel: "2nd generation"
+    releaseDate: 2010-09-01
+    discontinued: 2012-03-07
+    eol: 2014-09-17
+    link: https://support.apple.com/en-us/112428
+
+  - releaseCycle: "1"
+    releaseLabel: "1st generation"
+    releaseDate: 2007-01-09
+    discontinued: 2010-09-01
+    eol: 2010-09-01
+    link: https://support.apple.com/en-us/112555
+---
+
+> The Apple TV is a line of digital media players and streaming devices produced by Apple Inc.
+> It runs tvOS, integrates with the Apple ecosystem including iTunes, Apple Music, Apple TV+,
+> and other streaming services, and supports AirPlay for streaming content from Apple devices.
+
+Support information for tvOS versions is also available at [/tvos](/tvos).


### PR DESCRIPTION
I added all 7 of the different Apple TV models from 2007 to the most current model.

For the 1st-3rd Generation (non 4k) I set the EOL  to be the date they last received a software update. Though I am unsure if the first 3 generations need to be included.

Added based on Issue #6993 