### PR TITLE
[iPad] Fix spelling issue

### DIFF
--- a/products/ipad.md
+++ b/products/ipad.md
@@ -383,7 +383,7 @@ releases:
     supportedIpadOsVersions: "3 - 5"
 ---
 
-> The [iPad](https://www.apple.com/ipad/)is a line of tablet-based computers designed and marketed by Apple Inc. that use Apple's
+> The [iPad](https://www.apple.com/ipad/) is a line of tablet-based computers designed and marketed by Apple Inc. that use Apple's
 > iOS and iPadOS mobile operating system.
 
 Apple maintains a list of supported iPad models [on its website](https://support.apple.com/en-in/guide/ipad/ipad213a25b2/ipados).


### PR DESCRIPTION
Added the missing space between "iPadis" on the [Apple iPad](https://endoflife.date/ipad) page

<img width="1498" height="328" alt="image" src="https://github.com/user-attachments/assets/fe084149-5924-42e0-8b9e-098a3c5f593c" />
