### PR TITLE
[New Product] Apple MacBooks

### DIFF
--- a/products/macbook.md
+++ b/products/macbook.md
@@ -1,0 +1,233 @@
+---
+title: Apple MacBook
+addedAt: 2026-07-05
+category: device
+tags: apple
+iconSlug: apple
+permalink: /macbook
+discontinuedColumn: true
+eolColumn: Supported
+latestColumn: false
+staleReleaseThresholdDays: 2555 # 7 years, most MacBooks get 7-8 years of software updates on average
+# Though Apple Silicon Macs may end up getting updates for a longer period of time
+
+customFields:
+  - name: supportedMacOsVersions
+    display: after-release-column
+    label: Supported MacOS
+    description: Supported MacOS versions
+    link: https://endoflife.date/macos
+
+# Links send to the Technical Specifications of each model.
+# All links can be found on https://support.apple.com/docs/mac.
+# All supported MacOS versions can be found on:
+# - MacBook Pro https://en.wikipedia.org/wiki/MacBook_Pro_(Apple_silicon)#Software_and_operating_systems.
+# - MacBook Air https://en.wikipedia.org/wiki/MacBook_Air_(Apple_silicon)#Software_and_operating_systems.
+releases:
+  - releaseCycle: "neo-a18"
+    releaseLabel: "MacBook Neo"
+    releaseDate: 2026-03-11
+    discontinued: false
+    eol: false
+    link: https://support.apple.com/126322
+    supportedMacOsVersions: "26"
+
+  - releaseCycle: "pro-14in-m5pro-m5max"
+    releaseLabel: "MacBook Pro (14-inch, M5 Pro/Max)"
+    releaseDate: 2026-03-11
+    discontinued: false
+    eol: false
+    link: https://support.apple.com/126318
+    supportedMacOsVersions: "26"
+
+  - releaseCycle: "pro-16-m5pro-m5max"
+    releaseLabel: "MacBook Pro (16-inch, M5 Pro/Max)"
+    releaseDate: 2026-03-11
+    discontinued: false
+    eol: false
+    link: https://support.apple.com/126319
+    supportedMacOsVersions: "26"
+
+  - releaseCycle: "air-13-m5"
+    releaseLabel: "MacBook Air (13-inch, M5)"
+    releaseDate: 2026-03-11
+    discontinued: false
+    eol: false
+    link: https://support.apple.com/126320
+    supportedMacOsVersions: "26"
+
+  - releaseCycle: "air-15-m5"
+    releaseLabel: "MacBook Air (15-inch, M5)"
+    releaseDate: 2026-03-11
+    discontinued: false
+    eol: false
+    link: https://support.apple.com/126321
+    supportedMacOsVersions: "26"
+
+  - releaseCycle: "pro-14-m5"
+    releaseLabel: "MacBook Pro (14-inch, M5)"
+    releaseDate: 2025-10-22
+    discontinued: false
+    eol: false
+    link: https://support.apple.com/125405
+    supportedMacOsVersions: "26"
+
+  - releaseCycle: "air-13-m4"
+    releaseLabel: "MacBook Air (13-inch, M4)"
+    releaseDate: 2025-03-12
+    discontinued: 2025-03-03
+    eol: false
+    link: https://support.apple.com/122209
+    supportedMacOsVersions: "15 - 26"
+
+  - releaseCycle: "air-15-m4"
+    releaseLabel: "MacBook Air (15-inch, M4)"
+    releaseDate: 2025-03-12
+    discontinued: 2025-03-03
+    eol: false
+    link: https://support.apple.com/122210
+    supportedMacOsVersions: "15 - 26"
+
+  - releaseCycle: "pro-14-m4"
+    releaseLabel: "MacBook Pro (14-inch, M4)"
+    releaseDate: 2024-11-08
+    discontinued: 2025-10-15
+    eol: false
+    link: https://support.apple.com/121552
+    supportedMacOsVersions: "15 - 26"
+
+  - releaseCycle: "pro-14-m4pro-m4max"
+    releaseLabel: "MacBook Pro (14-inch, M4 Pro/Max)"
+    releaseDate: 2024-11-08
+    discontinued: 2026-03-03
+    eol: false
+    link: https://support.apple.com/121553
+    supportedMacOsVersions: "15 - 26"
+
+  - releaseCycle: "pro-16-m4pro-m4max"
+    releaseLabel: "MacBook Pro (16-inch, M4 Pro/Max)"
+    releaseDate: 2024-11-08
+    discontinued: 2026-03-03
+    eol: false
+    link: https://support.apple.com/121554
+    supportedMacOsVersions: "15 - 26"
+
+  - releaseCycle: "air-13-m3"
+    releaseLabel: "MacBook Air (13-inch, M3)"
+    releaseDate: 2024-03-08
+    discontinued: 2025-03-05
+    eol: false
+    link: https://support.apple.com/118551
+    supportedMacOsVersions: "14 - 26"
+
+  - releaseCycle: "air-15-m3"
+    releaseLabel: "MacBook Air (15-inch, M3)"
+    releaseDate: 2024-03-08
+    discontinued: 2025-03-05
+    eol: false
+    link: https://support.apple.com/118552
+    supportedMacOsVersions: "14 - 26"
+
+  - releaseCycle: "pro-14-m3"
+    releaseLabel: "MacBook Pro (14-inch, M3)"
+    releaseDate: 2023-11-07
+    discontinued: 2024-10-30
+    eol: false
+    link: https://support.apple.com/121552
+    supportedMacOsVersions: "13 - 26"
+
+  - releaseCycle: "pro-14-m3pro-m3max"
+    releaseLabel: "MacBook Pro (14-inch, M3 Pro/Max)"
+    releaseDate: 2023-11-07
+    discontinued: 2024-10-30
+    eol: false
+    link: https://support.apple.com/121553
+    supportedMacOsVersions: "14 - 26"
+
+  - releaseCycle: "pro-16-m3pro-m3max"
+    releaseLabel: "MacBook Pro (16-inch, M3 Pro/Max)"
+    releaseDate: 2023-11-07
+    discontinued: 2024-10-30
+    eol: false
+    link: https://support.apple.com/121554
+    supportedMacOsVersions: "14 - 26"
+
+  - releaseCycle: "air-15-m2"
+    releaseLabel: "MacBook Air (15-inch, M2)"
+    releaseDate: 2023-06-13
+    discontinued: 2024-03-04
+    eol: false
+    link: https://support.apple.com/111346
+    supportedMacOsVersions: "13 - 26"
+
+  - releaseCycle: "pro-14-m2pro-m2max"
+    releaseLabel: "MacBook Pro (14-inch, M2 Pro/Max)"
+    releaseDate: 2023-01-24
+    discontinued: 2023-10-30
+    eol: false
+    link: https://support.apple.com/111340
+    supportedMacOsVersions: "13 - 26"
+
+  - releaseCycle: "pro-16-m2pro-m2max"
+    releaseLabel: "MacBook Pro (16-inch, M2 Pro/Max)"
+    releaseDate: 2023-01-24
+    discontinued: 2023-10-30
+    eol: false
+    link: https://support.apple.com/111838
+    supportedMacOsVersions: "13 - 26"
+
+  - releaseCycle: "air-13-m2"
+    releaseLabel: "MacBook Air (13-inch, M2)"
+    releaseDate: 2022-07-15
+    discontinued: 2024-03-04
+    eol: false
+    link: https://support.apple.com/111867
+    supportedMacOsVersions: "12 - 26"
+
+  - releaseCycle: "pro-13-m2"
+    releaseLabel: "MacBook Pro (13-inch, M2)"
+    releaseDate: 2022-06-24
+    discontinued: 2023-10-30
+    eol: false
+    link: https://support.apple.com/111869
+    supportedMacOsVersions: "12 - 26"
+
+  - releaseCycle: "pro-14-m1pro-m1max"
+    releaseLabel: "MacBook Pro (14-inch, M1 Pro/Max)"
+    releaseDate: 2021-10-26
+    discontinued: 2023-01-17
+    eol: false
+    link: https://support.apple.com/111902
+    supportedMacOsVersions: "12 - 26"
+
+  - releaseCycle: "pro-16-m1pro-m1max"
+    releaseLabel: "MacBook Pro (16-inch, M1 Pro/Max)"
+    releaseDate: 2021-10-26
+    discontinued: 2023-01-17
+    eol: false
+    link: https://support.apple.com/111901
+    supportedMacOsVersions: "12 - 26"
+
+  - releaseCycle: "pro-13-m1"
+    releaseLabel: "MacBook Pro (13-inch, M1)"
+    releaseDate: 2020-11-17
+    discontinued: 2022-06-06
+    eol: false
+    link: https://support.apple.com/111893
+    supportedMacOsVersions: "11 - 26"
+
+  - releaseCycle: "air-13-m1"
+    releaseLabel: "MacBook Air (13-inch, M1)"
+    releaseDate: 2020-11-17
+    discontinued: 2024-03-04
+    eol: false
+    link: https://support.apple.com/111883
+    supportedMacOsVersions: "11 - 26"
+---
+
+> The [MacBook](https://www.apple.com/mac/) is a line of laptop computers designed and marketed by Apple Inc. that use Apple's
+> MacOS operating system.
+
+Support information for MacOS versions is also available at [/macos](/macos).
+
+A detailed list of all MacBook models can also be found on [Wikipedia](https://wikipedia.org/wiki/List_of_iPad_models#iPad).


### PR DESCRIPTION
Added the Apple Silicon MacBooks to the device section, would love any feedback about it's current state. I have done the Air, Pro, and Neo all on the same page as they are all different tiers of the same product line. Similar to the different versions of iPhones or iPads. Based on Issue #10324

If this gets approval, I'll start working back even more adding the MacBooks that came before the Apple Silicon ones.

<img width="500" alt="image" src="https://github.com/user-attachments/assets/cd2e7cc3-2821-411d-989b-ec65083da663" />

