### PR TITLE
[pan-os] Update 10.2,11.1 11.2,12.1 (4 cycles)

### DIFF
--- a/products/pan-os.md
+++ b/products/pan-os.md
@@ -32,23 +32,23 @@ releases:
   - releaseCycle: "12.1"
     releaseDate: 2025-08-28
     eol: 2028-08-28
-    latest: "12.1.7-h1"
-    latestReleaseDate: 2026-06-22
-    link: https://docs.paloaltonetworks.com/ngfw/release-notes/12-1/pan-os-12-1-7-known-and-addressed-issues/pan-os-12-1-7-h1-addressed-issues
+    latest: "12.1.8"
+    latestReleaseDate: 2026-07-07
+    link: https://docs.paloaltonetworks.com/ngfw/release-notes/12-1/pan-os-12-1-8-known-and-addressed-issues/pan-os-12-1-8-addressed-issues
 
   - releaseCycle: "11.2"
     releaseDate: 2024-05-02
     eol: 2027-05-02
-    latest: "11.2.12"
-    latestReleaseDate: 2026-05-26
-    link: https://docs.paloaltonetworks.com/pan-os/11-2/pan-os-release-notes/pan-os-11-2-12-known-and-addressed-issues/pan-os-11-2-12-addressed-issues
+    latest: "11.2.13"
+    latestReleaseDate: 2026-07-07
+    link: https://docs.paloaltonetworks.com/pan-os/11-2/pan-os-release-notes/pan-os-11-2-13-known-and-addressed-issues/pan-os-11-2-13-addressed-issues
 
   - releaseCycle: "11.1"
     releaseDate: 2023-11-03
     eol: 2027-05-03
-    latest: "11.1.15"
-    latestReleaseDate: 2026-05-27
-    link: https://docs.paloaltonetworks.com/pan-os/11-1/pan-os-release-notes/pan-os-11-1-15-known-and-addressed-issues/pan-os-11-1-15-addressed-issues
+    latest: "11.1.16"
+    latestReleaseDate: 2026-07-07
+    link: https://docs.paloaltonetworks.com/pan-os/11-1/pan-os-release-notes/pan-os-11-1-16-known-and-addressed-issues/pan-os-11-1-16-addressed-issues
 
   - releaseCycle: "11.0"
     releaseDate: 2022-11-17
@@ -60,9 +60,9 @@ releases:
   - releaseCycle: "10.2"
     releaseDate: 2022-02-27
     eol: 2025-08-27
-    latest: "10.2.18-h7"
-    latestReleaseDate: 2026-05-29
-    link: https://docs.paloaltonetworks.com/pan-os/10-2/pan-os-release-notes/pan-os-10-2-18-known-and-addressed-issues/pan-os-10-2-18-h7-addressed-issues
+    latest: "10.2.18-h8"
+    latestReleaseDate: 2026-07-05
+    link: https://docs.paloaltonetworks.com/pan-os/10-2/pan-os-release-notes/pan-os-10-2-18-known-and-addressed-issues/pan-os-10-2-18-h8-addressed-issues
 
   - releaseCycle: "10.1"
     releaseDate: 2021-05-31


### PR DESCRIPTION
## Summary
Automated update of PAN-OS versions.

### Changes
10.2: 10.2.18-h7 -> 10.2.18-h8
11.1: 11.1.15 -> 11.1.16
11.2: 11.2.12 -> 11.2.13
12.1: 12.1.7-h1 -> 12.1.8

---
Data sourced from [PaloAltoVersions.json](https://github.com/mrjcap/panos-versions/blob/master/PaloAltoVersions.json)