### PR TITLE
[Rust] Add 1.97 cycle

### DIFF
--- a/products/rust.md
+++ b/products/rust.md
@@ -23,9 +23,17 @@ identifiers:
 
 # eol(x) = releaseDate(x+1)
 releases:
+
+  - releaseCycle: "1.97"
+    releaseDate: 2026-07-09
+    eol: false
+    latest: "1.97.0"
+    latestReleaseDate: 2026-07-09
+    link: https://blog.rust-lang.org/2026/07/09/Rust-1.97.0/
+    
   - releaseCycle: "1.96"
     releaseDate: 2026-05-28
-    eol: false
+    eol: 2026-07-09
     latest: "1.96.1"
     latestReleaseDate: 2026-06-30
     link: https://doc.rust-lang.org/stable/releases.html#version-1960-2026-05-28

--- a/products/rust.md
+++ b/products/rust.md
@@ -23,20 +23,18 @@ identifiers:
 
 # eol(x) = releaseDate(x+1)
 releases:
-
   - releaseCycle: "1.97"
     releaseDate: 2026-07-09
     eol: false
     latest: "1.97.0"
     latestReleaseDate: 2026-07-09
-    link: https://blog.rust-lang.org/2026/07/09/Rust-1.97.0/
     
   - releaseCycle: "1.96"
     releaseDate: 2026-05-28
     eol: 2026-07-09
     latest: "1.96.1"
     latestReleaseDate: 2026-06-30
-    link: https://doc.rust-lang.org/stable/releases.html#version-1960-2026-05-28
+    link: https://doc.rust-lang.org/stable/releases.html#version-1961-2026-06-30
 
   - releaseCycle: "1.95"
     releaseDate: 2026-04-16


### PR DESCRIPTION
# :grey_question: About

According to this [tweet](https://x.com/rustjobs_dev/status/2075537403524116483) and [official releaseNote](https://blog.rust-lang.org/2026/07/09/Rust-1.97.0/) Rust 1.97.0 is out

<img width="603" height="1005" alt="image" src="https://github.com/user-attachments/assets/06087804-c079-4dac-9363-e3fe35c3800f" />
