### PR TITLE
[quasar] Fix auto configuration

### DIFF
--- a/products/quasar.md
+++ b/products/quasar.md
@@ -17,15 +17,6 @@ identifiers:
 auto:
   methods:
     - npm: quasar
-    - release_table: https://collected.press/github/quasarframework/quasar/ROADMAP.md
-      selector: "table:nth-of-type(1)"
-      fields:
-        releaseCycle:
-          column: "Version"
-          regex: '^(?P<value>\d+)\.x$'
-        releaseDate: "Released"
-        eoas: "Active support ends"
-        eol: "LTS support ends"
 
 releases:
   - releaseCycle: "2"


### PR DESCRIPTION
Auto-update of quasar always fails.

Parsing of https://collected.press/github/quasarframework/quasar/ROADMAP.md cannot work : releaseCycle regex is wrong, and there is currently no way of only targeting the "Quasar UI (quasar)" lines in the table.