### PR TITLE
[etcd] fix exception dates for 3.4 and 3.5

### DIFF
--- a/products/etcd.md
+++ b/products/etcd.md
@@ -38,13 +38,13 @@ releases:
 
   - releaseCycle: "3.5"
     releaseDate: 2021-06-15
-    eol: 2026-07-08 # releaseDate(3.7)
+    eol: 2027-07-08 # releaseDate(3.7) + 1y, see https://etcd.io/blog/2026/etcd-370-beta/
     latest: "3.5.32"
     latestReleaseDate: 2026-07-01
 
   - releaseCycle: "3.4"
     releaseDate: 2019-08-30
-    eol: 2025-05-15 # releaseDate(3.6)
+    eol: 2026-06-01 # exception https://etcd.io/blog/2026/june-patch-release/
     latest: "3.4.45"
     latestReleaseDate: 2026-06-01
 


### PR DESCRIPTION
As discussed https://github.com/endoflife-date/endoflife.date/commit/9dd4d9c8503879cf13f1858abda62970defec6df#commitcomment-192110363

Sources:
- https://etcd.io/blog/2026/etcd-370-beta/
- https://etcd.io/blog/2026/june-patch-release/

Co-authored-by: acastong <acastong@users.noreply.github.com>
