### PR TITLE
[gitlab] Update auto-configuration

### DIFF
--- a/products/gitlab.md
+++ b/products/gitlab.md
@@ -18,7 +18,7 @@ identifiers:
 
 auto:
   methods:
-    - git: https://gitlab.com/gitlab-org/gitlab.git
+    - gitlab_tags: gitlab-org/gitlab
       regex: '^v?(?P<major>[1-9]\d*)\.(?P<minor>\d+)\.(?P<patch>\d+)-ee?$'
 
 # eoas(x) = releaseDate(x+1)


### PR DESCRIPTION
Lately GitLab versions fetch using the git method started to fail, likely because the project became too big or because of some new limitations on gitlab.org.

This switch to using the new auto method, `gitlab_tags`, developed in https://github.com/endoflife-date/release-data/pull/595. This method is using GitLab's REST API to fetch, which is for this particular case faster and less subject to fail, but at the cost of being less generic.