### PR TITLE
fix: correct LibreOffice historical version numbers and release dates

### DIFF
--- a/products/libreoffice.md
+++ b/products/libreoffice.md
@@ -38,44 +38,44 @@ releases:
   - releaseCycle: "25.2"
     releaseDate: 2024-12-22 # https://blog.documentfoundation.org/blog/2025/02/06/libreoffice-25-2/
     eol: 2025-11-30
-    latest: "25.2.7.2"
-    latestReleaseDate: 2025-12-11
+    latest: "25.2.7"
+    latestReleaseDate: 2025-10-30
 
   - releaseCycle: "24.8"
     releaseDate: 2024-07-09 # https://blog.documentfoundation.org/blog/2024/08/22/libreoffice-248/
     eol: 2025-06-12
-    latest: "24.8.7.2"
-    latestReleaseDate: 2025-05-14
+    latest: "24.8.7"
+    latestReleaseDate: 2025-05-08
 
   - releaseCycle: "24.2"
     releaseDate: 2024-01-08 # https://blog.documentfoundation.org/blog/2024/01/31/libreoffice-24-2/
     eol: 2024-11-30
-    latest: "24.2.7.2"
-    latestReleaseDate: 2024-10-30
+    latest: "24.2.7"
+    latestReleaseDate: 2024-10-31
 
   - releaseCycle: "7.6"
     releaseDate: 2023-07-10 # https://blog.documentfoundation.org/blog/2023/08/21/libreoffice-7-6-community/
     eol: 2024-06-12
-    latest: "7.6.7.2"
-    latestReleaseDate: 2024-05-21
+    latest: "7.6.7"
+    latestReleaseDate: 2024-05-10
 
   - releaseCycle: "7.5"
     releaseDate: 2022-12-26 # https://blog.documentfoundation.org/blog/2023/02/02/tdf-announces-libreoffice-75-community/
     eol: 2023-12-07 # https://blog.documentfoundation.org/blog/2023/12/07/libreoffice-764-and-759/
-    latest: "7.5.9.2"
-    latestReleaseDate: 2023-12-04
+    latest: "7.5.9"
+    latestReleaseDate: 2023-12-07
 
   - releaseCycle: "7.4"
     releaseDate: 2022-07-10 # https://blog.documentfoundation.org/blog/2022/08/18/libreoffice-7-4-community/
     eol: 2023-06-12
-    latest: "7.4.7.2"
-    latestReleaseDate: 2023-05-23
+    latest: "7.4.7"
+    latestReleaseDate: 2023-05-11
 
   - releaseCycle: "7.3"
     releaseDate: 2021-12-23 # https://blog.documentfoundation.org/blog/2022/02/02/libreoffice-73-community/
     eol: 2022-11-30
-    latest: "7.3.7.2"
-    latestReleaseDate: 2022-12-08
+    latest: "7.3.7"
+    latestReleaseDate: 2022-11-03
 
 ---
 


### PR DESCRIPTION
## Summary

Fixes the wrong LibreOffice version numbers and release dates for the seven historical cycles on https://endoflife.date/libreoffice, as reported in #10209.

The `latest` fields carried a spurious fourth build-number component (e.g. `25.2.7.2`), which The Document Foundation does not use in its public release communication (releases are announced as `X.Y.Z`), and each `latestReleaseDate` reflected a download-archive build date rather than the official TDF announcement date.

PR #10210 already corrected the two then-current cycles (`26.2`, `25.8`) using the same convention (3-part version, blog-announcement date); this change applies that same fix to the seven older cycles that were left untouched, which still visibly exhibited the reported bug. The `26.2` and `25.8` rows are unchanged.

Each corrected value is taken from the official TDF release announcement:

| Cycle | `latest` | `latestReleaseDate` | Source |
|-------|----------|---------------------|--------|
| 25.2 | `25.2.7` | 2025-10-30 | https://blog.documentfoundation.org/blog/2025/10/30/libreoffice-25-2-7/ |
| 24.8 | `24.8.7` | 2025-05-08 | https://blog.documentfoundation.org/blog/2025/05/08/libreoffice-24-8-7/ |
| 24.2 | `24.2.7` | 2024-10-31 | https://blog.documentfoundation.org/blog/2024/10/31/libreoffice-24-2-7-is-now-available-the-last-release-in-the-24-2-branch/ |
| 7.6 | `7.6.7` | 2024-05-10 | https://blog.documentfoundation.org/blog/2024/05/10/libreoffice-7-6-7/ |
| 7.5 | `7.5.9` | 2023-12-07 | https://blog.documentfoundation.org/blog/2023/12/07/libreoffice-764-and-759/ |
| 7.4 | `7.4.7` | 2023-05-11 | https://blog.documentfoundation.org/blog/2023/05/11/libreoffice-7-4-7/ |
| 7.3 | `7.3.7` | 2022-11-03 | https://blog.documentfoundation.org/blog/2022/11/03/libreoffice-7-3-7-community/ |

## Why this matters

The page currently shows version numbers that never existed in any TDF public release and release dates that are off by days from the actual announcements. Users relying on endoflife.date for accurate LibreOffice version/EOL information get incorrect data. This aligns the seven historical cycles with the official The Document Foundation announcements and with the convention already merged in #10210.

Closes #10209
