### PR TITLE
[Pixel] Mark Pixel 9 Pro Fold as discontinued

### DIFF
--- a/products/pixel.md
+++ b/products/pixel.md
@@ -83,7 +83,7 @@ releases:
     releaseDate: 2024-09-04
     eoas: 2031-09-01
     eol: 2031-09-01
-    discontinued: false
+    discontinued: true
     link: https://en.wikipedia.org/wiki/Pixel_9_Pro_Fold
     supportedAndroidVersions: "14 - 17" # https://www.gsmarena.com/google_pixel_9_pro_fold-13220.php
 


### PR DESCRIPTION
Pixel 9 Pro Fold is now marked as "no longer available"

https://store.google.com/us/magazine/compare_pixel?hl=en-US&toggler0=Pixel+10+Pro+Fold&toggler1=Pixel+10+Pro&toggler2=Pixel+9+Pro+Fold

<img width="462" height="566" alt="image" src="https://github.com/user-attachments/assets/a3da81ab-e147-4c2d-9327-ea8eaef1d673" />
