### PR TITLE
[rocky-linux] Update latest for 9 and 10

### DIFF
--- a/products/rocky-linux.md
+++ b/products/rocky-linux.md
@@ -36,15 +36,15 @@ releases:
     releaseDate: 2025-06-11
     eoas: 2030-05-31
     eol: 2035-05-31
-    latest: "10.1"
-    latestReleaseDate: 2025-11-25
+    latest: "10.2"
+    latestReleaseDate: 2026-05-29
 
   - releaseCycle: "9"
     releaseDate: 2022-07-14
     eoas: 2027-05-31
     eol: 2032-05-31
-    latest: "9.7"
-    latestReleaseDate: 2025-12-01
+    latest: "9.8"
+    latestReleaseDate: 2026-05-28
 
   - releaseCycle: "8"
     releaseDate: 2021-05-01


### PR DESCRIPTION
See https://rockylinux.org/news/rocky-linux-9-8-ga-release and https://rockylinux.org/news/rocky-linux-10-2-ga-release.

Relates to https://github.com/endoflife-date/release-data/issues/584.