### PR TITLE
[wagtail] Update auto configuration

### DIFF
--- a/products/wagtail.md
+++ b/products/wagtail.md
@@ -23,7 +23,7 @@ auto:
       fields:
         releaseCycle:
           column: "Version"
-          regex: '^(?P<value>\d+\.\d+).*$'
+          regex: '^(?P<value>[1-9]\d*\.\d+).*$'
         releaseDate: "Release date"
         eoas: "Active support"
         eol: "Security support"


### PR DESCRIPTION
Exclude 0.x releases from automation to stop having alerts about them during auto-update, such as in https://github.com/endoflife-date/endoflife.date/pull/10454.

0.x release are usually not documented except when they are "special", such as wagtail 0.8 which is an LTS.