### PR TITLE
[raspberry-pi] Unset EOL for 2-b

### DIFF
--- a/products/raspberry-pi.md
+++ b/products/raspberry-pi.md
@@ -151,7 +151,7 @@ releases:
     releaseLabel: "2 Model B"
     # https://www.raspberrypi.com/news/raspberry-pi-2-on-sale/
     releaseDate: 2015-02-02
-    eol: 2026-01-01
+    eol: false
     link: https://www.raspberrypi.com/products/raspberry-pi-2-model-b/
 
   - releaseCycle: "1-a+"

--- a/products/raspberry-pi.md
+++ b/products/raspberry-pi.md
@@ -151,7 +151,7 @@ releases:
     releaseLabel: "2 Model B"
     # https://www.raspberrypi.com/news/raspberry-pi-2-on-sale/
     releaseDate: 2015-02-02
-    eol: false
+    eol: false # Due to revision 1.3 still supported ( 14/07/2026 )
     link: https://www.raspberrypi.com/products/raspberry-pi-2-model-b/
 
   - releaseCycle: "1-a+"


### PR DESCRIPTION
On revision 1.1 and 1.2 have reached EOL, not 1.3. See https://www.raspberrypi.com/products/raspberry-pi-2-model-b/.

Closes #10366.