### PR TITLE
[ruby] Update link tag to point correct changelog for 4.0 cycle

### DIFF
--- a/products/ruby.md
+++ b/products/ruby.md
@@ -32,6 +32,7 @@ releases:
     eol: 2029-03-31
     latest: "4.0.6"
     latestReleaseDate: 2026-07-14
+    link: https://github.com/ruby/ruby/releases/tag/v__LATEST__
 
   - releaseCycle: "3.4"
     releaseDate: 2024-12-24

--- a/products/ruby.md
+++ b/products/ruby.md
@@ -30,9 +30,8 @@ releases:
   - releaseCycle: "4.0"
     releaseDate: 2025-12-25
     eol: 2029-03-31
-    latest: "4.0.5"
-    latestReleaseDate: 2026-05-19
-    link: https://www.ruby-lang.org/en/news/2025/12/25/ruby-4-0-0-released/
+    latest: "4.0.6"
+    latestReleaseDate: 2026-07-14
 
   - releaseCycle: "3.4"
     releaseDate: 2024-12-24


### PR DESCRIPTION
* Remove tag so it will not point to 4.0.0  announcement
* Update to 4.0.6 version