### PR TITLE
[commvault] Add 11.46 Innovation release and mark 11.44 as LTS

### DIFF
--- a/products/commvault.md
+++ b/products/commvault.md
@@ -21,7 +21,15 @@ auto:
         latestReleaseDate: "Maintenance release date"
 
 releases:
+  - releaseCycle: "11.46"
+    releaseDate: 2026-07-15
+    eol: false # not announced on https://documentation.commvault.com/11.46/software/commvault_software_releases_release_types_and_release_tracks.html yet
+    latest: "11.46.10"
+    latestReleaseDate: 2026-07-15
+    link: https://documentation.commvault.com/11.46/software/innovation_update_release_in_11_46.html
+
   - releaseCycle: "11.44"
+    lts: true
     releaseDate: 2026-06-15
     eol: 2028-12-15
     latest: "11.44.9"


### PR DESCRIPTION
Beginning June 15, 2024: The June releases will be designated as Long-Term Support Release (LTS) 11.nn, while the July releases will be designated as Innovation Release 11.nn. For example:

    Innovation Release 11.46
    Long Term Support Release 11.44

source: https://documentation.commvault.com/11.46/software/innovation_update_release_in_11_46.html