### PR TITLE
[oracle-linux] Update latest 9 to 9.8

### DIFF
--- a/products/oracle-linux.md
+++ b/products/oracle-linux.md
@@ -38,8 +38,8 @@ releases:
     releaseDate: 2022-07-06
     eol: 2032-06-30
     eoes: 2035-06-30
-    latest: "9.7"
-    latestReleaseDate: 2025-11-26
+    latest: "9.8"
+    latestReleaseDate: 2026-06-23
 
   - releaseCycle: "8"
     releaseDate: 2019-07-19


### PR DESCRIPTION
Update the Oracle Linux 9 cycle from 9.7 to 9.8 and set the latest release date to 2026-06-23.