### PR TITLE
Update EOL dates for windows-server, centos-stream, kubernetes, ruby, go and veeam-backup-and-replication

### DIFF
--- a/products/centos-stream.md
+++ b/products/centos-stream.md
@@ -17,8 +17,8 @@ identifiers:
 releases:
   - releaseCycle: "10"
     releaseDate: 2024-12-12
-    eoas: 2030-01-01
-    eol: 2030-01-01
+    eoas: 2030-05-31
+    eol: 2030-05-31
     link: https://blog.centos.org/2024/12/introducing-centos-stream-10/
 
   - releaseCycle: "9"

--- a/products/go.md
+++ b/products/go.md
@@ -31,7 +31,7 @@ auto:
 # eol(x) = releaseDate(x+2)
 releases:
   - releaseCycle: "1.26"
-    releaseDate: 2026-02-11
+    releaseDate: 2026-02-10
     eol: false
     latest: "1.26.5"
     latestReleaseDate: 2026-07-07
@@ -45,7 +45,7 @@ releases:
 
   - releaseCycle: "1.24"
     releaseDate: 2025-02-11
-    eol: 2026-02-11
+    eol: 2026-02-10
     latest: "1.24.13"
     latestReleaseDate: 2026-02-04
 

--- a/products/kubernetes.md
+++ b/products/kubernetes.md
@@ -63,14 +63,14 @@ releases:
   - releaseCycle: "1.31"
     releaseDate: 2024-08-13
     eoas: 2025-08-28
-    eol: 2025-10-28
+    eol: 2025-11-11
     latest: "1.31.14"
     latestReleaseDate: 2025-11-11
 
   - releaseCycle: "1.30"
     releaseDate: 2024-04-17
     eoas: 2025-04-28
-    eol: 2025-06-28
+    eol: 2025-07-15
     latest: "1.30.14"
     latestReleaseDate: 2025-06-17
 

--- a/products/ruby.md
+++ b/products/ruby.md
@@ -54,7 +54,7 @@ releases:
 
   - releaseCycle: "3.1"
     releaseDate: 2021-12-25
-    eol: 2025-03-31
+    eol: 2025-03-26
     latest: "3.1.7"
     latestReleaseDate: 2025-03-26
 

--- a/products/veeam-backup-and-replication.md
+++ b/products/veeam-backup-and-replication.md
@@ -22,7 +22,7 @@ releases:
   - releaseCycle: "13"
     releaseDate: 2025-09-03
     eoas: false # releaseDate(14)
-    eol: false # not yet documented on https://www.veeam.com/product-lifecycle.html
+    eol: 2028-11-01 # November 2028 on https://www.veeam.com/product-lifecycle.html
     link: https://www.veeam.com/kb4738
     latest: "13.0.2.29"
     latestReleaseDate: 2026-05-27

--- a/products/windows-server.md
+++ b/products/windows-server.md
@@ -16,8 +16,8 @@ eoesColumn: Extended Security Updates
 releases:
   - releaseCycle: "2025"
     releaseDate: 2024-11-01
-    eoas: 2029-10-09
-    eol: 2034-10-10
+    eoas: 2029-11-13
+    eol: 2034-11-14
     latest: 10.0.26100
     lts: true
     link: https://learn.microsoft.com/windows/release-health/windows-server-release-info


### PR DESCRIPTION
While cross-checking our data against vendor lifecycle pages (a periodic pass we run —
see discussion #10064, where the team kindly encouraged us to send corrections upstream),
we found a handful of dates that have drifted from what the vendors currently publish.
All were re-verified against the vendor pages on 2026-07-18. One commit per product so
anything contentious can be dropped individually.

- **windows-server**: Microsoft revised the Windows Server 2025 lifecycle after GA.
  https://learn.microsoft.com/en-us/lifecycle/products/windows-server-2025 now lists
  Mainstream End 2029-11-13 and Extended End 2034-11-14 (was 2029-10-09 / 2034-10-10).
- **centos-stream**: Stream 10 support ends with the RHEL 10 Full Support phase, which
  Red Hat lists as 2030-05-31 (https://access.redhat.com/support/policy/updates/errata;
  see also https://www.centos.org/centos10/ — "contingent on the end of the Full Support
  phase of RHEL 10"). This matches the existing Stream 8/9 convention (2024-05-31,
  2027-05-31); 2030-01-01 appears to have been a placeholder.
- **kubernetes**: the Non-Active Branch history table on
  https://kubernetes.io/releases/patch-releases/#non-active-branch-history lists the
  1.31 End Of Life Date as 2025-11-11 (1.31.14 shipped that day — the file's own
  latestReleaseDate already sits after the current eol of 2025-10-28). Same table lists
  1.30 as 2025-07-15; included that too, but happy to drop it if you prefer scheduled
  dates for older branches.
- **ruby**: https://www.ruby-lang.org/en/downloads/branches/ lists the actual 3.1 EOL
  as 2025-03-26 (with 3.1.7), not the scheduled 2025-03-31 — consistent with how 3.0
  is already recorded (2024-04-23).
- **go**: https://go.dev/doc/devel/release says "go1.26.0 (released 2026-02-10)" and the
  go1.26.0 tag commit is dated 2026-02-10 UTC, so per the file's `eol(x) = releaseDate(x+2)`
  rule, 1.24's eol should be 2026-02-10. I also touched 1.26's releaseDate — if that field
  is owned by the git automation and it derives 2026-02-11, feel free to drop that hunk
  and keep just the 1.24 eol.
- **veeam-backup-and-replication**: https://www.veeam.com/product-lifecycle.html now
  documents v13 End of Support as November 2028, so `eol: false` can become
  `eol: 2028-11-01` following the file's first-of-month convention (as with v12's
  "February 2027" → 2027-02-01). Left `eoas` alone since the file derives End of Fix
  from the next version's release date.

Two things we checked but did not change, for the record:
- debian 12 (bookworm): wiki.debian.org/DebianReleases says 2026-07-12 but
  https://www.debian.org/releases/ (this repo's configured source) says 2026-07-11,
  so the current value matches the authoritative source and we left it.
- Related: #10508 is our earlier report on MariaDB 12.3 dates from the same
  cross-checking pass.

Happy to adjust anything to match project conventions.
