### PR TITLE
windows-server: update 2025 eoas/eol to revised Microsoft lifecycle dates

### DIFF
--- a/products/windows-server.md
+++ b/products/windows-server.md
@@ -16,8 +16,8 @@ eoesColumn: Extended Security Updates
 releases:
   - releaseCycle: "2025"
     releaseDate: 2024-11-01
-    eoas: 2029-10-09
-    eol: 2034-10-10
+    eoas: 2029-11-13
+    eol: 2034-11-14
     latest: 10.0.26100
     lts: true
     link: https://learn.microsoft.com/windows/release-health/windows-server-release-info


### PR DESCRIPTION
Microsoft revised the Windows Server 2025 lifecycle after GA. The official lifecycle page now lists Mainstream End **2029-11-13** and Extended End **2034-11-14**; current data carries the pre-GA projections (2029-10-09 / 2034-10-10).

Source: https://learn.microsoft.com/en-us/lifecycle/products/windows-server-2025

Split out from #10512 as requested.