### PR TITLE
centos-stream: set Stream 10 eoas/eol to RHEL 10 full-support end (2030-05-31)

### DIFF
--- a/products/centos-stream.md
+++ b/products/centos-stream.md
@@ -17,8 +17,8 @@ identifiers:
 releases:
   - releaseCycle: "10"
     releaseDate: 2024-12-12
-    eoas: 2030-01-01
-    eol: 2030-01-01
+    eoas: 2030-05-31
+    eol: 2030-05-31
     link: https://blog.centos.org/2024/12/introducing-centos-stream-10/
 
   - releaseCycle: "9"


### PR DESCRIPTION
CentOS Stream support ends with the corresponding RHEL release's Full Support phase. Red Hat lists RHEL 10 Full Support ending **2030-05-31**; the current 2030-01-01 appears to be a year placeholder. This matches the existing pattern in the file (Stream 9 = 2027-05-31, Stream 8 = 2024-05-31).

Sources: https://access.redhat.com/support/policy/updates/errata · https://www.centos.org/centos10/

Split out from #10512 as requested.