### PR TITLE
kubernetes: update 1.31 and 1.30 eol to match k8s.io non-active branch history

### DIFF
--- a/products/kubernetes.md
+++ b/products/kubernetes.md
@@ -63,14 +63,14 @@ releases:
   - releaseCycle: "1.31"
     releaseDate: 2024-08-13
     eoas: 2025-08-28
-    eol: 2025-10-28
+    eol: 2025-11-11
     latest: "1.31.14"
     latestReleaseDate: 2025-11-11
 
   - releaseCycle: "1.30"
     releaseDate: 2024-04-17
     eoas: 2025-04-28
-    eol: 2025-06-28
+    eol: 2025-07-15
     latest: "1.30.14"
     latestReleaseDate: 2025-06-17
 


### PR DESCRIPTION
The Non-Active Branch history table on kubernetes.io lists 1.31 EOL **2025-11-11** (final patch 1.31.14) and 1.30 EOL **2025-07-15** (final patch 1.30.14); current data has the originally scheduled 2025-10-28 / 2025-06-28. Note that 1.31's existing `latestReleaseDate: 2025-11-11` already sits after its recorded `eol`.

Source: https://kubernetes.io/releases/patch-releases/#non-active-branch-history

Split out from #10512 as requested.