### PR TITLE
ruby: 3.1 reached EOL on 2025-03-26 per ruby-lang.org branches page

### DIFF
--- a/products/ruby.md
+++ b/products/ruby.md
@@ -54,7 +54,7 @@ releases:
 
   - releaseCycle: "3.1"
     releaseDate: 2021-12-25
-    eol: 2025-03-31
+    eol: 2025-03-26
     latest: "3.1.7"
     latestReleaseDate: 2025-03-26
 


### PR DESCRIPTION
The official branches page lists Ruby 3.1 EOL as **2025-03-26**; current data has 2025-03-31.

Source: https://www.ruby-lang.org/en/downloads/branches/

Split out from #10512 as requested.