### PR TITLE
go: go1.26.0 was released 2026-02-10; adjust 1.24 eol accordingly

### DIFF
--- a/products/go.md
+++ b/products/go.md
@@ -31,7 +31,7 @@ auto:
 # eol(x) = releaseDate(x+2)
 releases:
   - releaseCycle: "1.26"
-    releaseDate: 2026-02-11
+    releaseDate: 2026-02-10
     eol: false
     latest: "1.26.5"
     latestReleaseDate: 2026-07-07
@@ -45,7 +45,7 @@ releases:
 
   - releaseCycle: "1.24"
     releaseDate: 2025-02-11
-    eol: 2026-02-11
+    eol: 2026-02-10
     latest: "1.24.13"
     latestReleaseDate: 2026-02-04
 


### PR DESCRIPTION
Per Go's release policy, 1.24 support ended when go1.26.0 shipped. The release history lists go1.26.0 as **2026-02-10**; current data has 2026-02-11 for both 1.26's `releaseDate` and 1.24's `eol`. If these fields are auto-generated and the offset is intentional, happy to close.

Source: https://go.dev/doc/devel/release

Split out from #10512 as requested.