### PR TITLE
veeam-backup-and-replication: v13 end of support is November 2028

### DIFF
--- a/products/veeam-backup-and-replication.md
+++ b/products/veeam-backup-and-replication.md
@@ -22,7 +22,7 @@ releases:
   - releaseCycle: "13"
     releaseDate: 2025-09-03
     eoas: false # releaseDate(14)
-    eol: 2028-11-01 # November 2028 on https://www.veeam.com/product-lifecycle.html
+    eol: 2028-11-01
     link: https://www.veeam.com/kb4738
     latest: "13.0.2.29"
     latestReleaseDate: 2026-05-27

--- a/products/veeam-backup-and-replication.md
+++ b/products/veeam-backup-and-replication.md
@@ -22,7 +22,7 @@ releases:
   - releaseCycle: "13"
     releaseDate: 2025-09-03
     eoas: false # releaseDate(14)
-    eol: false # not yet documented on https://www.veeam.com/product-lifecycle.html
+    eol: 2028-11-01 # November 2028 on https://www.veeam.com/product-lifecycle.html
     link: https://www.veeam.com/kb4738
     latest: "13.0.2.29"
     latestReleaseDate: 2026-05-27


### PR DESCRIPTION
Veeam's product lifecycle page lists Backup & Replication v13 End of Support as **November 2028**; current data has `eol: false`. Used 2028-11-01 following the first-of-month convention of the existing entries in this file.

Source: https://www.veeam.com/product-lifecycle.html

Split out from #10512 as requested.