### PR TITLE
[motorola-mobility] Update moto-g84-5g release date

### DIFF
--- a/products/motorola-mobility.md
+++ b/products/motorola-mobility.md
@@ -551,12 +551,6 @@ releases:
     eol: 2027-06-30
     link: https://en-us.support.motorola.com/app/software-security-update/g_id/7112/productid/11600
 
-  - releaseCycle: "moto-g84-5g"
-    releaseLabel: "Motorola Moto G84 5G"
-    releaseDate: 2023-08-01
-    eol: 2026-09-30
-    link: https://en-us.support.motorola.com/app/software-security-update/g_id/7112/productid/11601
-
   - releaseCycle: "motorola-edge-2023"
     releaseLabel: "Motorola Edge (2023)"
     releaseDate: 2023-09-01
@@ -574,6 +568,12 @@ releases:
     releaseDate: 2023-09-01
     eol: 2027-09-30
     link: https://en-us.support.motorola.com/app/software-security-update/g_id/7112/productid/11592
+
+  - releaseCycle: "moto-g84-5g"
+    releaseLabel: "Motorola Moto G84 5G"
+    releaseDate: 2023-08-01
+    eol: 2026-09-30
+    link: https://en-us.support.motorola.com/app/software-security-update/g_id/7112/productid/11601
 
   - releaseCycle: "moto-g14"
     releaseLabel: "Motorola Moto G14"

--- a/products/motorola-mobility.md
+++ b/products/motorola-mobility.md
@@ -545,17 +545,17 @@ releases:
     eol: 2027-11-30
     link: https://en-us.support.motorola.com/app/software-security-update/g_id/7112/productid/11651
 
-  - releaseCycle: "moto-g84-5g"
-    releaseLabel: "Motorola Moto G84 5G"
-    releaseDate: 2023-09-01
-    eol: 2026-09-30
-    link: https://en-us.support.motorola.com/app/software-security-update/g_id/7112/productid/11601
-
   - releaseCycle: "moto-g54-5g"
     releaseLabel: "Moto G54 5G"
     releaseDate: 2023-09-01
     eol: 2027-06-30
     link: https://en-us.support.motorola.com/app/software-security-update/g_id/7112/productid/11600
+
+  - releaseCycle: "moto-g84-5g"
+    releaseLabel: "Motorola Moto G84 5G"
+    releaseDate: 2023-08-01
+    eol: 2026-09-30
+    link: https://en-us.support.motorola.com/app/software-security-update/g_id/7112/productid/11601
 
   - releaseCycle: "motorola-edge-2023"
     releaseLabel: "Motorola Edge (2023)"


### PR DESCRIPTION
Looks like it was updated on https://en-us.support.motorola.com/app/software-security-update/g_id/7112/productid/11601, leading to a build issue caused by the release order (https://app.netlify.com/projects/endoflife-date/deploys/6a5feb925998360008d4074e).