### PR TITLE
Update Node.js version in lint workflow to 24

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -16,7 +16,7 @@ jobs:
 
       - uses: actions/setup-node@v7
         with:
-          node-version: 20
+          node-version: 24
           cache: "npm"
 
       - name: Setup ruby


### PR DESCRIPTION
Currently, the linting runs using Node v20, which is now EOL.

Furthermore, three of the packages being used in the linting workflow no longer support Node v20. I chose to upgrade to Node v24 as that is the newest LTS version that is supported by all three packages.

The two markdown linting packages require Node v22 or higher, and the vacuum package being used for OpenAPI verification requires at least Node v24.

```
npm warn EBADENGINE Unsupported engine {
npm warn EBADENGINE   package: &#39;markdownlint-cli2@0.23.1&#39;,
npm warn EBADENGINE   required: { node: &#39;&gt;=22&#39; },
npm warn EBADENGINE   current: { node: &#39;v20.20.2&#39;, npm: &#39;10.8.2&#39; }
npm warn EBADENGINE }
npm warn EBADENGINE Unsupported engine {
npm warn EBADENGINE   package: &#39;markdownlint@0.41.1&#39;,
npm warn EBADENGINE   required: { node: &#39;&gt;=22&#39; },
npm warn EBADENGINE   current: { node: &#39;v20.20.2&#39;, npm: &#39;10.8.2&#39; }
npm warn EBADENGINE }
```

```
npm warn EBADENGINE Unsupported engine {
npm warn EBADENGINE   package: &#39;@quobix/vacuum@0.29.10&#39;,
npm warn EBADENGINE   required: { node: &#39;&gt;=24.16.0&#39; },
npm warn EBADENGINE   current: { node: &#39;v20.20.2&#39;, npm: &#39;10.8.2&#39; }
npm warn EBADENGINE }
```