### PR TITLE
[anthropic] Adds Fable and Mythos

### DIFF
--- a/products/anthropic-claude.md
+++ b/products/anthropic-claude.md
@@ -40,6 +40,20 @@ auto:
           regex: "^(Not sooner than )?(?P<value>.+)$"
 
 releases:
+  - releaseCycle: "claude-mythos-5"
+    releaseLabel: Claude Mythos 5
+    releaseDate: 2026-06-09
+    eoas: false
+    eol: false
+    recommendedReplacement: "N/A"
+
+  - releaseCycle: "claude-fable-5"
+    releaseLabel: Claude Fable 5
+    releaseDate: 2026-06-09
+    eoas: false
+    eol: 2027-06-09
+    recommendedReplacement: "N/A"
+
   - releaseCycle: "claude-sonnet-5"
     releaseLabel: Claude Sonnet 5
     releaseDate: 2026-06-30
@@ -271,5 +285,6 @@ Anthropic recommends moving workloads to active models to maintain the highest l
 
 Customers with active deployments receive at least 60 days notice before retirement for publicly released models.
 Anthropic recommends auditing API usage to discover model usage and testing replacement models before retirement.
+Claude Mythos 5 is is offered in limited availability to approved customers and does not have a published retirement date.
 
 Anthropic has committed to preserve the weights of publicly released models and may make past models available again in the future.

--- a/products/anthropic-claude.md
+++ b/products/anthropic-claude.md
@@ -40,6 +40,13 @@ auto:
           regex: "^(Not sooner than )?(?P<value>.+)$"
 
 releases:
+  - releaseCycle: "claude-sonnet-5"
+    releaseLabel: Claude Sonnet 5
+    releaseDate: 2026-06-30
+    eoas: false
+    eol: 2027-06-30
+    recommendedReplacement: "N/A"
+
   - releaseCycle: "claude-mythos-5"
     releaseLabel: Claude Mythos 5
     releaseDate: 2026-06-09
@@ -52,13 +59,6 @@ releases:
     releaseDate: 2026-06-09
     eoas: false
     eol: 2027-06-09
-    recommendedReplacement: "N/A"
-
-  - releaseCycle: "claude-sonnet-5"
-    releaseLabel: Claude Sonnet 5
-    releaseDate: 2026-06-30
-    eoas: false
-    eol: 2027-06-30
     recommendedReplacement: "N/A"
 
   - releaseCycle: "claude-opus-4-8"

--- a/products/anthropic-claude.md
+++ b/products/anthropic-claude.md
@@ -53,6 +53,7 @@ releases:
     eoas: false
     eol: false
     recommendedReplacement: "N/A"
+    link: https://www.anthropic.com/news/claude-fable-5-mythos-5
 
   - releaseCycle: "claude-fable-5"
     releaseLabel: Claude Fable 5
@@ -60,6 +61,7 @@ releases:
     eoas: false
     eol: 2027-06-09
     recommendedReplacement: "N/A"
+    link: https://www.anthropic.com/news/claude-fable-5-mythos-5
 
   - releaseCycle: "claude-opus-4-8"
     releaseLabel: Claude Opus 4.8


### PR DESCRIPTION
Added both as per upstream. Release dates as per https://platform.claude.com/docs/en/about-claude/models/introducing-claude-fable-5-and-claude-mythos-5

Somewhat dicey about listing Mythos since is not GA, but its GA is less about stability in this case so I think it should count as production.