### PR TITLE
[New Product] Sophos Firewall OS (SFOS)

### DIFF
--- a/products/sophos-firewall.md
+++ b/products/sophos-firewall.md
@@ -8,24 +8,31 @@ releases:
   - releaseCycle: "22.0"
     releaseDate: 2025-12-09
     eol: false
+    latest: "22.0.2"
   - releaseCycle: "21.5"
     releaseDate: 2025-06-02
     eol: false
+    latest: "21.5.2"
   - releaseCycle: "21.0"
     releaseDate: 2024-10-17
     eol: false
+    latest: "21.0.2"
   - releaseCycle: "20.0"
     releaseDate: 2023-11-06
     eol: false
+    latest: "20.0.3"
   - releaseCycle: "19.5"
     releaseDate: 2022-11-17
     eol: 2025-04-30
+    latest: "19.5.4"
   - releaseCycle: "19.0"
     releaseDate: 2022-04-21
     eol: 2024-04-30
+    latest: "19.0.3"
   - releaseCycle: "18.5"
     releaseDate: 2020-11-18
     eol: 2025-04-30
+    latest: "18.5.5"
 ---
 
 > [Sophos Firewall OS (SFOS)](https://www.sophos.com/en-us/products/next-gen-firewall)

--- a/products/sophos-firewall.md
+++ b/products/sophos-firewall.md
@@ -1,0 +1,37 @@
+---
+title: Sophos Firewall
+addedAt: 2026-07-24
+category: os
+permalink: /sophos-firewall
+releasePolicyLink: https://support.sophos.com/support/s/article/KBA-000003353
+releases:
+  - releaseCycle: "22.0"
+    releaseDate: 2025-12-09
+    eol: false
+  - releaseCycle: "21.5"
+    releaseDate: 2025-06-02
+    eol: false
+  - releaseCycle: "21.0"
+    releaseDate: 2024-10-17
+    eol: false
+  - releaseCycle: "20.0"
+    releaseDate: 2023-11-06
+    eol: false
+  - releaseCycle: "19.5"
+    releaseDate: 2022-11-17
+    eol: 2025-04-30
+  - releaseCycle: "19.0"
+    releaseDate: 2022-04-21
+    eol: 2024-04-30
+  - releaseCycle: "18.5"
+    releaseDate: 2020-11-18
+    eol: 2025-04-30
+---
+
+> [Sophos Firewall OS (SFOS)](https://www.sophos.com/en-us/products/next-gen-firewall)
+> is the operating system for Sophos Firewall (XGS-series hardware and
+> virtual/software appliances).
+
+Sophos maintains the current feature release plus one earlier feature release,
+per its [retirement calendar](https://support.sophos.com/support/s/article/KBA-000003353),
+which is the authoritative source for end-of-life dates.

--- a/products/sophos-firewall.md
+++ b/products/sophos-firewall.md
@@ -1,5 +1,5 @@
 ---
-title: Sophos Firewall
+title: Sophos Firewall OS (SFOS)
 addedAt: 2026-07-24
 category: os
 permalink: /sophos-firewall


### PR DESCRIPTION
Adds **Sophos Firewall OS (SFOS)** lifecycle data.

Sophos Firewall is a widely deployed next-gen firewall (XGS-series hardware and virtual/software appliances). Sophos maintains the current feature release plus one earlier feature release; the authoritative lifecycle source is the [retirement calendar (KBA-000003353)](https://support.sophos.com/support/s/article/KBA-000003353), which is unfortunately a JavaScript app rather than a machine-readable feed — hence contributing the data here.

### Data & sources
| Cycle | GA | EOL | Source |
|---|---|---|---|
| 22.0 | 2025-12-09 | active | [v22 GA announcement](https://news.sophos.com/en-us/2025/12/09/sophos-firewall-v22-is-now-available/) |
| 21.5 | 2025-06-02 | active | [v21.5 GA announcement](https://news.sophos.com/en-us/2025/06/02/sophos-firewall-v21-5-is-now-available/) |
| 21.0 | 2024-10-17 | active | v21 GA announcement |
| 20.0 | 2023-11-06 | active | [v20 GA announcement](https://news.sophos.com/en-us/2023/11/06/sophos-firewall-v20-is-now-available/) |
| 19.5 | 2022-11-17 | 2025-04-30 | GA blog; [v18.5/19.5 EOL notice](https://www.sophos.com/en-us/partner-news/sophos-firewall-os-sfos-v18-5-and-19-5-eol-and-upcoming-license-compliance-changes) |
| 19.0 | 2022-04-21 | 2024-04-30 | [v19.0 EOL notice](https://partnernews.sophos.com/en-us/2024/02/products/network-lifecycle-news-sophos-firewall-os-sfos-v19-0-eol-and-other-updates/) |
| 18.5 | 2020-11-18 | 2025-04-30 | v18.5/19.5 EOL notice (GA date approximate) |

Notes for maintainers:
- I used `category: os` (SFOS is a firewall appliance OS); happy to change to `server-app` to match OPNsense if you prefer.
- No `iconSlug` — I couldn't find a Sophos icon in the asset set; glad to add one if there's a preferred source.
- No `auto:` method — Sophos has no machine-readable release feed, so this would be community-maintained.
- The v18.5 GA date is best-effort (Nov 2020); its EOL (2025-04-30) is confirmed.