### PR TITLE
[samsung-mobile] Remove Galaxy Z Flip8, Fold8, and Fold8 Ultra

### DIFF
--- a/products/samsung-mobile.md
+++ b/products/samsung-mobile.md
@@ -27,9 +27,6 @@ auto:
         - "^galaxy-m13-india$" # still available, according to https://www.gsmarena.com/samsung_galaxy_m13_(india)-11654.php
         - "^galaxy-a13-sm-a137$" # still available, according to https://www.gsmarena.com/samsung_galaxy_a13_(sm_a137)-11665.php
         - "^galaxy-a-quantum2$" # still available, according to https://www.gsmarena.com/samsung_galaxy_quantum_2-10850.php
-        - "^galaxy-z-flip8$" # just released, not yet listed
-        - "^galaxy-z-fold8$"  # just released, not yet listed
-        - "^galaxy-z-fold8-ultra$" # just released, not yet listed
 
 # eoas(x) = end of android upgrade
 # eol(x) = end of security support
@@ -46,27 +43,6 @@ auto:
 # IMPORTANT: When adding a new model here, add it to the above regex exclude above
 # IF it is not listed at https://security.samsungmobile.com/workScope.smsb
 releases:
-  - releaseCycle: "galaxy-z-flip8"
-    releaseLabel: "Galaxy Z Flip8"
-    releaseDate: 2026-07-22 # https://news.samsung.com/global/samsung-galaxy-z-fold8-ultra-fold8-and-flip8foldables-perfected-for-every-way-of-living
-    eoas: 2033-07-31 # 7 android upgrade
-    eol: 2033-07-31 # 7 years of security support
-    link: null # not found
-
-  - releaseCycle: "galaxy-z-fold8"
-    releaseLabel: "Galaxy Z Fold8"
-    releaseDate: 2026-07-22 # https://news.samsung.com/global/samsung-galaxy-z-fold8-ultra-fold8-and-flip8foldables-perfected-for-every-way-of-living
-    eoas: 2033-07-31 # 7 android upgrade
-    eol: 2033-07-31 # 7 years of security support
-    link: null # not found
-
-  - releaseCycle: "galaxy-z-fold8-ultra"
-    releaseLabel: "Galaxy Z Fold8 Ultra"
-    releaseDate: 2026-07-22 # https://news.samsung.com/global/samsung-galaxy-z-fold8-ultra-fold8-and-flip8foldables-perfected-for-every-way-of-living
-    eoas: 2033-07-31 # 7 android upgrade
-    eol: 2033-07-31 # 7 years of security support
-    link: null # not found
-
   - releaseCycle: "galaxy-a57-5g"
     releaseLabel: "Galaxy A57 5G"
     releaseDate: 2026-04-10 # https://news.samsung.com/global/samsung-unveils-galaxy-a57-5g-and-galaxy-a37-5g-packing-pro-level-features-at-awesome-price


### PR DESCRIPTION
Those models are not yet released, see https://www.phonearena.com/galaxy-z-flip-8-release-date-price-features-news (expected release date is August 7, 2026).

This reverts https://github.com/endoflife-date/endoflife.date/pull/10536.