### PR TITLE
[clickhouse] Switch to github_releases instead of git

### DIFF
--- a/products/clickhouse.md
+++ b/products/clickhouse.md
@@ -16,7 +16,7 @@ identifiers:
 
 auto:
   methods:
-    - git: https://github.com/ClickHouse/ClickHouse.git
+    - github_releases: ClickHouse/ClickHouse
       regex: ^v(?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)\.(?P<tiny>\d+)-(stable|lts)$
 
 # Non-LTS : eol(x) = releaseDate(x+3)


### PR DESCRIPTION
Versions retrieval using `git` is very long (more than one minutes in latest runs, such as https://github.com/endoflife-date/release-data/actions/runs/30142690731), versus 5 seconds using `github_releases`.

One downside: versions before 20.9 will not be retrieved anymore, but this is not an issue considering the oldest release on https://endoflife.date/clickhouse is 25.1.