### PR TITLE
[activemq] Add changelogTemplate and set EOL for 6.1

### DIFF
--- a/products/apache-activemq.md
+++ b/products/apache-activemq.md
@@ -8,6 +8,7 @@ permalink: /apache-activemq
 alternate_urls:
   - /activemq
 releasePolicyLink: https://activemq.apache.org/support.html
+changelogTemplate: https://github.com/apache/activemq/releases/tag/activemq-__LATEST__
 # https://activemq.apache.org/activemq-command-line-tools-reference.html
 versionCommand: activemq --version
 eolColumn: Support
@@ -23,25 +24,24 @@ auto:
     - git: https://github.com/apache/activemq.git
       regex: '^activemq-(?P<major>\d+)\.(?P<minor>\d+)(\.(?P<patch>\d+))?$'
 
-# EOL status available on https://activemq.apache.org/components/classic/download/, should be close to eol(x) = releaseCycle(x+2)
+# EOL status available on https://activemq.apache.org/components/classic/download/,
+# should be close to eol(x) = releaseCycle(x+2)
 releases:
   - releaseCycle: "6.2"
     releaseDate: 2025-11-09
-    eol: false # still listed on https://activemq.apache.org/components/classic/download/
+    eol: false # still listed on https://github.com/apache/activemq-website/blame/main/src/_data/current_releases.yml
     latest: "6.2.8"
     latestReleaseDate: 2026-07-24
-    link: https://activemq.apache.org/components/classic/download/classic-06-02-0{{'__LATEST__'|split:'.'|last}}
 
   - releaseCycle: "5.19"
     releaseDate: 2025-03-07
-    eol: false # still listed on https://activemq.apache.org/components/classic/download/
+    eol: false # still listed on https://github.com/apache/activemq-website/blame/main/src/_data/current_releases.yml
     latest: "5.19.9"
     latestReleaseDate: 2026-07-24
-    link: https://activemq.apache.org/components/classic/download/classic-05-19-0{{'__LATEST__'|split:'.'|last}}
 
   - releaseCycle: "6.1"
     releaseDate: 2024-03-11
-    eol: false # still listed on https://activemq.apache.org/components/classic/download/
+    eol: 2025-12-02 # https://github.com/apache/activemq-website/commit/35990cf87236404711732c94df3d9e2d3f1541c7
     latest: "6.1.8"
     latestReleaseDate: 2025-10-19
     link: https://activemq.apache.org/components/classic/download/classic-06-01-0{{'__LATEST__'|split:'.'|last}}


### PR DESCRIPTION
5.19 and 6.2 release notes are now in https://github.com/apache/activemq/releases.