### PR TITLE
[cockroachdb] Update auto configuration

### DIFF
--- a/products/cockroachdb.md
+++ b/products/cockroachdb.md
@@ -20,6 +20,8 @@ auto:
   methods:
     - git: https://github.com/cockroachdb/cockroach.git
     - release_table: https://www.cockroachlabs.com/docs/releases/release-support-policy#1
+      render_javascript: true
+      render_javascript_wait_until: networkidle
       fields:
         releaseCycle:
           column: "Major Version"
@@ -28,6 +30,8 @@ auto:
         eoas: "Maintenance Support ends"
         eol: "Assistance Support ends"
     - release_table: https://www.cockroachlabs.com/docs/releases/release-support-policy#2
+      render_javascript: true
+      render_javascript_wait_until: networkidle
       fields:
         releaseCycle:
           column: "Major Version"


### PR DESCRIPTION
Parsing of the releaseCycle column started to fail recently (ex. https://github.com/endoflife-date/release-data/actions/runs/30205157430).

The failure is caused by the "Major Version" column being empty when downloading https://www.cockroachlabs.com/docs/releases/release-support-policy sources. Rendering JavaScript fix this issue.