### PR TITLE
[ros-2] Disable auto-update

### DIFF
--- a/products/ros-2.md
+++ b/products/ros-2.md
@@ -14,6 +14,7 @@ latestColumn: false
 eolColumn: End Of Life
 
 auto:
+  disabled: true # there are anti-bot protection measures on https://docs.ros.org
   methods:
     - release_table: https://docs.ros.org/en/rolling/Releases.html
       fields:


### PR DESCRIPTION
https://docs.ros.org is using [Anubis](https://anubis.techaro.lol/), which prevent the auto-update bot to get the page sources.