### PR TITLE
[commvault] Update auto-configuration

### DIFF
--- a/products/commvault.md
+++ b/products/commvault.md
@@ -12,7 +12,7 @@ identifiers:
 
 auto:
   methods:
-    - release_table: https://documentation.commvault.com/v11/software/commvault_software_releases_release_types_and_release_tracks.html
+    - release_table: https://documentation.commvault.com/11.44/software/commvault_software_releases_release_types_and_release_tracks.html
       fields:
         releaseCycle: "Release"
         releaseDate: "Initial release date"


### PR DESCRIPTION
https://documentation.commvault.com/v11/software/commvault_software_releases_release_types_and_release_tracks.html content is now broken, use https://documentation.commvault.com/11.44/software/commvault_software_releases_release_types_and_release_tracks.html instead.

Note that the 11.46 content is also broken : 11.44 initial release data has been updated.