### PR TITLE
[jreleaser] Switch from maven to git for auto update

### DIFF
--- a/products/jreleaser.md
+++ b/products/jreleaser.md
@@ -12,7 +12,7 @@ eolColumn: Security Support
 
 auto:
   methods:
-    - maven: org.jreleaser/jreleaser
+    - git: https://github.com/jreleaser/jreleaser.git
 
 releases:
   - releaseCycle: "1"


### PR DESCRIPTION
The maven auto method takes really long time to execute lately, for example the last run took 5 minutes (https://github.com/endoflife-date/release-data/actions/runs/30369517137). Switching to git will just take a few seconds for the exact same result.

Also the maven coordinates for jreleaser were updated to `jrelease/jreleaser` from 1.19.0 onward. Relying on git tags will fix this as well.