### PR TITLE
[apache-hop] Switch from maven to release_table for auto update

### DIFF
--- a/products/apache-hop.md
+++ b/products/apache-hop.md
@@ -12,7 +12,9 @@ eolColumn: Support
 
 auto:
   methods:
-    - maven: "org.apache.hop/hop-engine"
+    - version_table: https://hop.apache.org/download/
+      name_column: "Version"
+      date_column: "Date"
 
 # eol(x) = releaseDate(x+1)
 releases:


### PR DESCRIPTION
The maven auto method takes really long time to execute lately, for example one of the last runs took 30 seconds (https://github.com/endoflife-date/release-data/actions/runs/30461365814). Switching to release_table will just take a few seconds.

Moreover last run did return the 2.18.x version, despite those being release almost two month ago. This also fixes this, and using https://hop.apache.org/download/ will enable us to get the official release dates.

One little downside : we will only get the active versions release date. This does not really matter considering release-data sole purpose is to be used by endoflife.date.