### PR TITLE
[liquibase] Switch from maven to github_releases for auto update

### DIFF
--- a/products/liquibase.md
+++ b/products/liquibase.md
@@ -14,7 +14,7 @@ identifiers:
 
 auto:
   methods:
-    - maven: org.liquibase/liquibase-core
+    - github_releases: liquibase/liquibase
 
 # eol(x) = releaseDate(x+1)
 releases:


### PR DESCRIPTION
The maven auto method takes really long time to execute lately, for example one of the last runs took 60 seconds (https://github.com/endoflife-date/release-data/actions/runs/30461365814). Switching to release_table will just take a few seconds.

Moreover last run did return the 5.x version, despite those being released a few month ago. This also fixes this.

One little downside : we lose some history in release-data. This does not really matter considering release-data sole purpose is to be used by endoflife.date.