### PR TITLE
[zookeeper] Switch from maven to git for auto update

### DIFF
--- a/products/zookeeper.md
+++ b/products/zookeeper.md
@@ -22,7 +22,8 @@ identifiers:
 
 auto:
   methods:
-    - maven: org.apache.zookeeper/zookeeper
+    - git: https://github.com/apache/zookeeper.git
+      regex: ^release-(?P<major>\d+).(?P<minor>\d+).(?P<patch>\d{1,3})$
 
 # support(X) = releaseDate(X+2)
 # eol(X) ~= releaseDate(X+2)+6m, unless declared


### PR DESCRIPTION
The maven auto method takes really long time to execute lately, for example one of the last runs took 30 seconds (https://github.com/endoflife-date/release-data/actions/runs/30461365814). Switching to git and it will just take a few seconds.

Moreover the dates returned will be more aligned with those visible on https://zookeeper.apache.org/news and more versions will be retrieved this way.