### PR TITLE
[apache-groovy] Switch from maven to git for auto update

### DIFF
--- a/products/apache-groovy.md
+++ b/products/apache-groovy.md
@@ -24,8 +24,8 @@ identifiers:
 
 auto:
   methods:
-    - maven: org.apache.groovy/groovy
-    - maven: org.codehaus.groovy/groovy
+    - git: https://github.com/apache/groovy.git
+      regex: ^GROOVY_(?P<major>\d+)_(?P<minor>\d+)_(?P<patch>\d+)$
 
 # eoas(x) = releaseDate(x+1)
 # eol(x) documented on https://github.com/apache/groovy?tab=security-ov-file#readme


### PR DESCRIPTION
The maven auto method takes really long time to execute lately, for example one of the last runs took 60 seconds (https://github.com/endoflife-date/release-data/actions/runs/30461365814). Switching to git and it will just take a few seconds.

Moreover some release were not picked up lately. This fixes it, while also requiring one git execution over two maven executions before.