### PR TITLE
[gitlab-runner] Switch from docker_hub to gitlab_tags for auto update

### DIFF
--- a/products/gitlab-runner.md
+++ b/products/gitlab-runner.md
@@ -11,14 +11,14 @@ changelogTemplate: https://gitlab.com/gitlab-org/gitlab-runner/-/releases/v__LAT
 eoasColumn: true
 eolColumn: Maintenance Support
 
-auto:
-  methods:
-    - docker_hub: gitlab/gitlab-runner
-      regex: '^v(?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)$'
-
 identifiers:
   - purl: pkg:docker/gitlab/gitlab-runner
   - cpe: cpe:2.3:a:gitlab:runner
+
+auto:
+  methods:
+    - gitlab_tags: gitlab-org/gitlab-runner
+      regex: '^v?(?P<major>[1-9]\d*)\.(?P<minor>\d+)\.(?P<patch>\d+)?$'
 
 # GitLab Runner follows the same versioning and support policy as GitLab.
 # eoas(x) = releaseDate(x+1)


### PR DESCRIPTION
The docker_hub auto method may take really long time to execute, or even fail. For example in one of the last runs it took 5 minutes   before timing out (https://github.com/endoflife-date/release-data/actions/runs/30552323252). Switching to gitlab_tags reduces this to a few seconds.

Dates may be slightly off by a few days compared to actual releases (https://gitlab.com/gitlab-org/gitlab-runner/-/releases), but the benefits are great compared to this drawback.

A new auto method based on releases may also fix this in the future.