### PR TITLE
[apache-struts] Switch from maven to git for auto update

### DIFF
--- a/products/apache-struts.md
+++ b/products/apache-struts.md
@@ -19,9 +19,8 @@ identifiers:
 
 auto:
   methods:
-    - maven: struts/struts
-    - maven: org.apache.struts/struts-core
-    - maven: org.apache.struts/struts2-core
+    - git: https://github.com/apache/struts.git
+      regex: '^STRUTS_(?P<major>\d+)_(?P<minor>\d+)_(?P<patch>\d+)(_(?P<tiny>\d+))?$'
 
 # EOL as per announcements on https://struts.apache.org/.
 releases:


### PR DESCRIPTION
The maven auto method takes really long time to execute lately, for example during one of the last runs it took 2 minutes (https://github.com/endoflife-date/release-data/actions/runs/30552323252). Switching to git reduce the time to a few seconds.

Moreover some release were not picked up lately. This fixes it, while also requiring one git execution over three maven executions before.

Note that I did not used the releases (https://github.com/apache/struts/releases) because some are missing, and tag dates are more aligned with dates on https://struts.apache.org/index.html.