### PR TITLE
[apache-lucene] Switch from maven to github_releases for auto update

### DIFF
--- a/products/apache-lucene.md
+++ b/products/apache-lucene.md
@@ -15,7 +15,8 @@ identifiers:
 
 auto:
   methods:
-    - maven: org.apache.lucene/lucene-core
+    - github_releases: apache/lucene
+      regex: '^releases/lucene/(?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)$'
 
 releases:
   - releaseCycle: "10"


### PR DESCRIPTION
The maven auto method takes really long time to execute lately, for example one of the last runs took 30 seconds (https://github.com/endoflife-date/release-data/actions/runs/30552323252). Switching to github_releases reduces this to a few seconds.

Moreover last run did return the 10.5.0 version, a version released last month. This also fixes this.

One little downside : we lose some history for EOL releases in release-data. This does not really matter considering release-data sole purpose is to be used by endoflife.date.