### PR TITLE
[redis] Automate EOL retrieval

### DIFF
--- a/products/redis.md
+++ b/products/redis.md
@@ -5,7 +5,7 @@ category: database
 iconSlug: redis
 permalink: /redis
 versionCommand: redis-server --version
-releasePolicyLink: https://github.com/redis/redis/security
+releasePolicyLink: https://redis.io/docs/latest/operate/oss_and_stack/install/version-mgmt/
 changelogTemplate: https://raw.githubusercontent.com/redis/redis/__RELEASE_CYCLE__/00-RELEASENOTES
 eoasColumn: true
 
@@ -29,10 +29,13 @@ identifiers:
 auto:
   methods:
     - git: https://github.com/redis/redis.git
+    - release_table: https://redis.io/docs/latest/operate/oss_and_stack/install/version-mgmt/
+      fields:
+        releaseCycle:
+          column: "Version"
+          regex: '^Redis (?P<value>\d+\.\d+)$'
+        eol: "EOL Date"
 
-# EOL documented on https://github.com/redis/redis/security, but as a rule of thumb:
-# - eoas(x) = release(x+1)
-# - eol(x) = release(x+3)
 releases:
   - releaseCycle: "8.8"
     releaseDate: 2026-05-25
@@ -58,28 +61,28 @@ releases:
   - releaseCycle: "8.2"
     releaseDate: 2025-08-04
     eoas: 2025-11-18
-    eol: false
+    eol: 2030-09-01
     latest: "8.2.8"
     latestReleaseDate: 2026-07-23
 
   - releaseCycle: "8.0"
     releaseDate: 2025-05-02
     eoas: 2025-08-04
-    eol: 2026-02-11
+    eol: 2026-12-01
     latest: "8.0.6"
     latestReleaseDate: 2026-02-22
 
   - releaseCycle: "7.4"
     releaseDate: 2024-07-29
     eoas: 2025-05-02
-    eol: false # still supported according to https://github.com/redis/redis/security
+    eol: 2029-12-01
     latest: "7.4.10"
     latestReleaseDate: 2026-07-24
 
   - releaseCycle: "7.2"
     releaseDate: 2023-08-15
     eoas: 2024-07-29
-    eol: false # still supported according to https://github.com/redis/redis/security
+    eol: 2029-12-01
     latest: "7.2.15"
     latestReleaseDate: 2026-07-24
 
@@ -93,7 +96,7 @@ releases:
   - releaseCycle: "6.2"
     releaseDate: 2021-02-22
     eoas: 2022-04-27
-    eol: false # still supported according to https://github.com/redis/redis/security
+    eol: 2027-04-01
     latest: "6.2.23"
     latestReleaseDate: 2026-07-24
 
@@ -110,6 +113,7 @@ releases:
     eol: 2022-04-27
     latest: "5.0.14"
     latestReleaseDate: 2021-10-04
+
 ---
 
 > [Redis](https://redis.io/) is an in-memory data structure store, used
@@ -135,5 +139,3 @@ Open Source Redis releases are subject to the following licenses:
 - Version 7.2.x and prior releases are subject to BSDv3.
 - Versions 7.4.x to 7.8.x are subject to your choice of RSALv2 or SSPLv1; and
 - Version 8.0.x and subsequent releases are subject to the tri-license RSALv2/SSPLv1/AGPLv3 at your option.
-
-[Security Overview](https://github.com/redis/redis/security) with the actual list of supported versions and advisories.


### PR DESCRIPTION
Based on https://redis.io/docs/latest/operate/oss_and_stack/install/version-mgmt/.

Also update changelogTemplate to https://redis.io/docs/latest/operate/oss_and_stack/install/version-mgmt/, as it contains date (https://github.com/redis/redis/security/policy does not).