### PR TITLE
[apache-ant] Switch from maven to git for auto update

### DIFF
--- a/products/apache-ant.md
+++ b/products/apache-ant.md
@@ -22,7 +22,12 @@ identifiers:
 
 auto:
   methods:
-    - maven: org.apache.ant/ant
+    - git: https://github.com/apache/ant.git
+      # tag dates for version 1.9.6 or before are wrong
+      regex:
+        - 'rel/(?P<major>1)\.(?P<minor>9)\.(?P<patch>([7-9]|\d{2,}))'
+        - 'rel/(?P<major>1)\.(?P<minor>\d{2,})\.(?P<patch>\d+)'
+        - 'rel/(?P<major>[2-9])\.(?P<minor>\d+)\.(?P<patch>\d+)'
 
 releases:
   - releaseCycle: "1.10"


### PR DESCRIPTION
The maven auto method takes really long time to execute lately, for example during one of the last runs it took 1 minute (https://github.com/endoflife-date/release-data/actions/runs/30682839770). Switching to git reduce the time to a few seconds.

One drawback : dates may be off by a few days, and tag dates for version before 1.9.6 is wrong. But given the maven auto method don't work very well anymore this is better than nothing.