### PR TITLE
[log4j] Switch from maven to github_releases for auto update

### DIFF
--- a/products/log4j.md
+++ b/products/log4j.md
@@ -21,7 +21,7 @@ identifiers:
 
 auto:
   methods:
-    - maven: org.apache.logging.log4j/log4j-core
+    - github_releases: apache/logging-log4j2
 
 releases:
   - releaseCycle: "2"


### PR DESCRIPTION
The maven auto method takes really long time to execute lately, for example during one of the last runs it took 30 seconds (https://github.com/endoflife-date/release-data/actions/runs/30682839770). Switching to github_releases reduce the time to a few seconds.

Moreover some versions were not picked up lately. This fixes it.