### PR TITLE
ci: fix release-data submodule auto-updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,6 +11,9 @@ updates:
     schedule:
       interval: "cron"
       cronjob: "0 0 * * *" # every day at midnight UTC
+    cooldown:
+      exclude:
+        - "_data/release-data"
 
   - package-ecosystem: "bundler"
     vendor: true

--- a/.github/workflows/auto-merge-release-updates.yml
+++ b/.github/workflows/auto-merge-release-updates.yml
@@ -1,5 +1,8 @@
 name: Dependabot auto-merge release-updates
-on: pull_request
+on:
+  pull_request:
+    paths:
+      - '_data/release-data'
 
 # Based on https://docs.github.com/en/code-security/dependabot/working-with-dependabot/automating-dependabot-with-github-actions#enable-auto-merge-on-a-pull-request
 permissions:
@@ -7,22 +10,9 @@ permissions:
   contents: write
 
 jobs:
-  metadata:
+  update-release-data:
     runs-on: ubuntu-latest
     if: ${{ github.actor == 'dependabot[bot]' }}
-    outputs:
-      dependency-names: ${{ steps.metadata.outputs.dependency-names }}
-    steps:
-      - id: metadata
-        name: Dependabot metadata
-        uses: dependabot/fetch-metadata@25dd0e34f4fe68f24cc83900b1fe3fe149efef98 # v3.1.0
-        with:
-          github-token: "${{ secrets.GITHUB_TOKEN }}"
-
-  update-release-data:
-    needs: metadata
-    runs-on: ubuntu-latest
-    if: ${{ contains(needs.metadata.outputs.dependency-names, '_data/release-data') }}
     steps:
       - name: Clone self repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v6


### PR DESCRIPTION
The daily _data/release-data bump PR stopped being opened with the latest release-data changes.
GitHub now applies a default 3-day cooldown to version updates (see https://github.blog/changelog/2026-07-14-dependabot-version-updates-introduce-default-package-cooldown/).
This excludes _data/release-data from the cooldown to restore the daily bump.

Also update the auto-merge workflow so that it does not run on PRs not touching _data/release-data.
