### PR TITLE
Fix search indexing for product metadata

### DIFF
--- a/_includes/lunr/custom-data.json
+++ b/_includes/lunr/custom-data.json
@@ -7,6 +7,6 @@
 {% endfor -%}
 "category": {{ include.page.category | markdownify | replace:newline,' ' | strip_html | normalize_whitespace | strip | jsonify }},
 "tags": {{ include.page.tags | markdownify | replace:newline,' ' | strip_html | normalize_whitespace | strip | jsonify }},
-"iconSlug": {{ include.page.search_terms | markdownify | replace:newline,' ' | strip_html | normalize_whitespace | strip | jsonify }},
+"iconSlug": {{ include.page.iconSlug | markdownify | replace:newline,' ' | strip_html | normalize_whitespace | strip | jsonify }},
 "alternate_urls": {{ include.page.alternate_urls | markdownify | replace:newline,' ' | strip_html | normalize_whitespace | strip | jsonify }},
 "identifiers": {{  identifiers | markdownify | replace:newline,' ' | strip_html | normalize_whitespace | strip | jsonify }},

--- a/_includes/lunr/custom-index.js
+++ b/_includes/lunr/custom-index.js
@@ -4,6 +4,6 @@ const content_to_merge = [
   docs[i].tags,
   docs[i].alternate_urls,
   docs[i].iconSlug,
-  docs[i].identifier,
+  docs[i].identifiers,
 ];
 docs[i].content = content_to_merge.join(' ');


### PR DESCRIPTION
## Summary

- Index product identifiers in Lunr search content.
- Populate the indexed icon slug from product front matter.

## Root cause

The search-data template emitted `identifiers`, but the index hook read a singular `identifier` field. The same template read a nonexistent `search_terms` field instead of `iconSlug`.

## Verification

- `bundle exec jekyll build`
- Rebuilt search data contains Wireshark's CPE and Control-M's `bmcsoftware` icon slug.
- Rebuilt Lunr index finds Wireshark for `cpe:2.3:a:wireshark:wireshark` and Control-M for `bmcsoftware`.
- `node --check _includes/lunr/custom-index.js`
- `npx prettier@latest --check _includes/lunr/custom-data.json _includes/lunr/custom-index.js`
