### PR TITLE
Normalize the use of watch / smartwatch tags

### DIFF
--- a/products/samsung-galaxy-watch.md
+++ b/products/samsung-galaxy-watch.md
@@ -2,7 +2,7 @@
 title: Samsung Galaxy Watch
 addedAt: 2025-05-09
 category: device
-tags: smartwatch
+tags: watch
 iconSlug: samsung
 permalink: /samsung-galaxy-watch
 releasePolicyLink: https://security.samsungmobile.com/workScope.smsb

--- a/products/watchos.md
+++ b/products/watchos.md
@@ -2,7 +2,7 @@
 title: Apple watchOS
 addedAt: 2022-10-08
 category: os
-tags: apple smartwatch
+tags: apple
 iconSlug: apple
 permalink: /watchos
 changelogTemplate: https://developer.apple.com/documentation/watchos-release-notes/watchos-__RELEASE_CYCLE__-release-notes


### PR DESCRIPTION
Use `watch` for samsung-galaxy-watch, as this tag is already used for apple and google watches.

Drop `smartwatch` tag for watchos : this is an OS, not a device.

Closes #10085