### PR TITLE
Drop vendor option from dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,8 +16,7 @@ updates:
         - "_data/release-data"
 
   - package-ecosystem: "bundler"
-    vendor: true
-    directory: "/" # Location of package manifests
+    directory: "/"
     schedule:
       interval: "weekly"
 


### PR DESCRIPTION
Dependencies are not vendored in this repository, so the vendor flag was a no-op.