### PR TITLE
omnissa-horizon: correct 8.2503 eol, 8.2406 releaseDate and cycle 7 dates

### DIFF
--- a/products/omnissa-horizon.md
+++ b/products/omnissa-horizon.md
@@ -46,7 +46,7 @@ releases:
 
   - releaseCycle: "8.2503"
     releaseDate: 2025-04-15
-    eol: 2028-08-14
+    eol: 2028-04-15
     lts: true
     technicalGuidance: 2029-04-15
     latest: "8.2503.2"
@@ -62,11 +62,11 @@ releases:
     link: https://docs.omnissa.com/bundle/horizon8-rnV2412/page/Horizon8-ReleaseNotes.html
 
   - releaseCycle: "8.2406"
-    releaseDate: 2024-06-25
+    releaseDate: 2024-07-25
     eol: 2027-07-25
     technicalGuidance: 2028-07-25
     latest: "8.2406"
-    latestReleaseDate: 2024-06-25
+    latestReleaseDate: 2024-07-25
     link: https://docs.omnissa.com/bundle/horizon8-rnV2406/page/Horizon8-ReleaseNotes.html
 
   - releaseCycle: "8.2312"
@@ -189,8 +189,8 @@ releases:
   - releaseCycle: "7"
     releaseLabel: "7.X NonLTS branch"
     releaseDate: 2016-03-22
-    eol: 2022-10-15
-    technicalGuidance: 2023-03-23
+    eol: 2023-04-30
+    technicalGuidance: 2025-04-30
     latest: "7.13.2"
     latestReleaseDate: 2022-03-10
     link: https://docs.vmware.com/en/VMware-Horizon-7/7.13.2/rn/vmware-horizon-7-7132-release-notes/index.html


### PR DESCRIPTION
While cross-checking our data against vendor lifecycle pages, we found three Omnissa Horizon entries that have drifted from the vendor's published dates. All were re-verified on 2026-08-02 against the Omnissa Product Lifecycle Matrix (https://docs.omnissa.com/bundle/Product-Lifecycle-Matrix/page/lifecyclematrix.html, page last updated Jul 30, 2026):

- **8.2503**: `eol` 2028-08-14 → **2028-04-15**. The matrix lists Horizon 8 2503 End of General Support as 2028/04/15 (GA 2025/04/15 + 3 years, no extension noted). The existing `technicalGuidance: 2029-04-15` already matches the matrix EOTG.
- **8.2406**: `releaseDate` 2024-06-25 → **2024-07-25** (and `latestReleaseDate`, since 8.2406 is its own latest). The matrix lists GA as 2024/07/25, consistent with the existing `eol: 2027-07-25` (= GA + 3 years) and `technicalGuidance: 2028-07-25`.
- **7** (7.X branch, latest 7.13.2): `eol` 2022-10-15 → **2023-04-30**, `technicalGuidance` 2023-03-23 → **2025-04-30**. The matrix lists Horizon 7.13 EOGS as 2023/04/30 and EOTG as 2025/04/30; the current values predate the extension Omnissa published for 7.13.

For the record, we also checked rhel 4's `releaseDate` (2005-02-15) against https://access.redhat.com/articles/4038291, which says February 14, 2005 — but Red Hat's canonical release-dates article (https://access.redhat.com/articles/3078) says 2005-02-15, matching the current value, so we left it alone.

Happy to adjust anything to match project conventions.
