### PR TITLE
[apache-couchdb] Extend staleReleaseThresholdDays to 2 years

### DIFF
--- a/products/apache-couchdb.md
+++ b/products/apache-couchdb.md
@@ -10,7 +10,7 @@ alternate_urls:
 releasePolicyLink: https://docs.couchdb.org/en/stable/cve/index.html
 changelogTemplate: https://docs.couchdb.org/en/stable/whatsnew/__RELEASE_CYCLE__.html
 versionCommand: curl -s http://localhost:5984/ | jq -r '.version'
-staleReleaseThresholdDays: 500
+staleReleaseThresholdDays: 730
 
 identifiers:
   - purl: pkg:github/apache/couchdb


### PR DESCRIPTION
3.4 is still supported.