### PR TITLE
Update winget URL generation to use winstall.run

### DIFF
--- a/_plugins/identifier-to-url.rb
+++ b/_plugins/identifier-to-url.rb
@@ -137,7 +137,7 @@ class IdentifierToUrl
   end
 
   def _build_winget_url(purl)
-    return "https://winget.run/pkg/#{purl.name}"
+    return "https://winstall.app/apps/#{purl.name}"
   end
 
   def _build_maven_url(purl)


### PR DESCRIPTION
winget.run is unmaintained, abandoned, and its package list is out-of-date or broken: https://github.com/winget-run/wingetdotrun/issues/63