### PR TITLE
[coder] fix CPE and add container and winget identifiers

### DIFF
--- a/products/coder.md
+++ b/products/coder.md
@@ -15,7 +15,9 @@ identifiers:
   - repology: coder
   - purl: pkg:github/coder/coder
   - purl: pkg:generic/coder
-  - cpe: cpe:2.3:a:coder:code-server
+  - purl: pkg:oci/coder?repository_url=ghcr.io/coder
+  - purl: pkg:winget/Coder.Coder
+  - cpe: cpe:2.3:a:coder:coder
 
 auto:
   methods:


### PR DESCRIPTION
## Problem

`cpe:2.3:a:coder:code-server` identifies [code-server](https://github.com/coder/code-server), a different product from the Coder platform tracked on this page. SBOM and CVE tooling matching on this page maps Coder deployments to code-server advisories.

NVD has a dedicated CPE for this product: 358 `cpe:2.3:a:coder:coder` entries exist, covering `0.1.0` through the current `2.x` line (for example `cpe:2.3:a:coder:coder:2.24.4:*:*:*:*:go:*:*`).

## Fix

| Identifier | Change | Why |
|---|---|---|
| `cpe:2.3:a:coder:coder` | replaces `cpe:2.3:a:coder:code-server` | Correct NVD vendor/product pair for the Coder platform |
| `pkg:oci/coder?repository_url=ghcr.io/coder` | added | Official container image, not covered by Repology |
| `pkg:winget/Coder.Coder` | added | Published in `microsoft/winget-pkgs`, not covered by Repology |

## Not added

- Homebrew, Scoop, nixpkgs and AUR (`coder-oss`, `coder-bin`) already appear on the [Repology page](https://repology.org/project/coder/packages), so per CONTRIBUTING they are intentionally left out.
- `codercom/coder` on Docker Hub is Coder v1 (`1.44.x`), a different product line.
- `Coder.CoderDesktop` on winget is a separate desktop application.

> [!NOTE]
> The winget manifest is stale (latest published version is `2.9.4`), but the package identifier is still valid for detection.

> 🤖 This PR was created with the help of Coder Agents, and needs a human review.  🧑‍💻