### PR TITLE
[coder] mark 2.34 as an ESR release

### DIFF
--- a/products/coder.md
+++ b/products/coder.md
@@ -32,9 +32,11 @@ releases:
     latestReleaseDate: 2026-07-27
 
   - releaseCycle: "2.34"
+    lts: true
     releaseDate: 2026-06-02
     eoas: false # releaseDate(2.36)
     eol: false # releaseDate(2.37)
+    eoes: 2027-06-02
     latest: "2.34.7"
     latestReleaseDate: 2026-07-28
 


### PR DESCRIPTION
Coder 2.34 is the current Extended Support Release, but the page still shows it as a regular cycle.

From [the release channel docs](https://coder.com/docs/install/releases#extended-support-release): "The latest ESR version is Coder 2.34", and the release calendar lists 2.34 as `Stable (ESR)`.

## Changes

- Mark 2.34 as `lts: true`
- Set `eoes: 2027-06-02`, 12 months from the 2026-06-02 release date

This matches the extended support window already recorded for the previous ESR cycles:

| Cycle | Release date | eoes |
|-------|--------------|------------|
| 2.24  | 2025-07-01   | 2026-07-01 |
| 2.29  | 2025-12-02   | 2026-12-02 |
| 2.34  | 2026-06-02   | 2027-06-02 |

`eoas` and `eol` stay `false` because 2.34 is also the current stable cycle and still follows the regular support schedule.

Continuation of #10099.

> 🤖 This PR was created with the help of Coder Agents, and needs a human review.  🧑‍💻