### PR TITLE
[big-ip] Add historic releases 9.0 to 11.5

### DIFF
--- a/products/big-ip.md
+++ b/products/big-ip.md
@@ -33,6 +33,9 @@ auto:
           regex: '^(?P<value>\d+\.\d+).x.*$'
         eoas: "End of Software Development"
         eol: "End of Technical Support"
+    - version_table: https://wtit.com/f5-big-ip-software-release-matrix/
+      name_column: "BIG-IP version"
+      date_column: "Release date"
     - version_table: https://my.f5.com/manage/s/article/K9412
       render_javascript: true
       render_javascript_wait_for: "table"
@@ -155,7 +158,7 @@ releases:
     link: https://techdocs.f5.com/kb/en-us/products/big-ip_ltm/releasenotes/related/relnote-supplement-bigip-12-1-6.html
 
   - releaseCycle: '12.0'
-    releaseDate: 2015-09-02
+    releaseDate: 2015-09-02 # https://wtit.com/f5-big-ip-software-release-matrix/
     eoas: 2016-12-02
     eol: 2017-12-02
     latest: "12.0.0"
@@ -163,12 +166,132 @@ releases:
     link: https://techdocs.f5.com/kb/en-us/products/big-ip_ltm/releasenotes/product/relnote-ltm-12-0-0.html
 
   - releaseCycle: '11.6'
-    releaseDate: 2014-08-25
+    releaseDate: 2014-08-25 # https://wtit.com/f5-big-ip-software-release-matrix/
     eoas: 2021-05-10
     eol: 2022-05-10
     latest: "11.6.5"
     latestReleaseDate: 2019-08-22
     link: https://techdocs.f5.com/kb/en-us/products/big-ip_ltm/releasenotes/product/relnote-bigip-11-6-5.html
+
+  - releaseCycle: '11.5'
+    releaseDate: 2014-01-31 # https://wtit.com/f5-big-ip-software-release-matrix/
+    eoas: 2019-04-08
+    eol: 2020-04-08
+    latest: "11.5.10"
+    latestReleaseDate: 2019-09-19
+    link: https://techdocs.f5.com/kb/en-us/products/big-ip_ltm/releasenotes/product/relnote-bigip-11-5-10.html
+
+  - releaseCycle: '11.4'
+    releaseDate: 2013-06-11 # https://wtit.com/f5-big-ip-software-release-matrix/
+    eoas: 2016-09-17
+    eol: 2017-09-17
+    latest: "11.4.1"
+    latestReleaseDate: 2013-09-17
+    link: null
+
+  - releaseCycle: '11.3'
+    releaseDate: 2012-12-17 # https://wtit.com/f5-big-ip-software-release-matrix/
+    eoas: 2014-12-17
+    eol: 2015-12-17
+    latest: "11.3.0"
+    latestReleaseDate: 2012-12-17
+    link: null
+
+  - releaseCycle: '11.2'
+    releaseDate: 2012-06-11 # https://wtit.com/f5-big-ip-software-release-matrix/
+    eoas: 2017-12-31
+    eol: 2018-12-31
+    latest: "11.2.1"
+    latestReleaseDate: 2012-09-25
+    link: null
+
+  - releaseCycle: '11.1'
+    releaseDate: 2011-11-28 # https://wtit.com/f5-big-ip-software-release-matrix/
+    eoas: 2013-11-28
+    eol: 2014-11-28
+    latest: "11.1.0"
+    latestReleaseDate: 2011-11-28
+    link: null
+
+  - releaseCycle: '11.0'
+    releaseDate: 2011-08-24 # https://wtit.com/f5-big-ip-software-release-matrix/
+    eoas: 2013-08-24
+    eol: 2014-08-24
+    latest: "11.0.0"
+    latestReleaseDate: 2011-08-24
+    link: null
+
+  - releaseCycle: '10.2'
+    releaseDate: 2010-05-04 # https://wtit.com/f5-big-ip-software-release-matrix/
+    eoas: 2015-12-31
+    eol: 2016-12-31
+    latest: "10.2.4"
+    latestReleaseDate: 2012-04-11
+    link: null
+
+  - releaseCycle: '10.1'
+    releaseDate: 2009-12-17 # https://wtit.com/f5-big-ip-software-release-matrix/
+    eoas: 2015-03-01
+    eol: 2016-03-01
+    latest: "10.1.0"
+    latestReleaseDate: 2009-12-17
+    link: null
+
+  - releaseCycle: '10.0'
+    releaseDate: 2009-03-12 # https://wtit.com/f5-big-ip-software-release-matrix/
+    eoas: 2012-08-31
+    eol: 2013-08-31
+    latest: "10.0.1"
+    latestReleaseDate: 2009-06-01
+    link: null
+
+  - releaseCycle: '9.6'
+    releaseDate: 2007-12-20 # https://wtit.com/f5-big-ip-software-release-matrix/
+    eoas: 2011-03-31
+    eol: 2012-03-31
+    latest: "9.6.1"
+    latestReleaseDate: 2008-04-17
+    link: null
+
+  - releaseCycle: '9.4'
+    releaseDate: 2006-12-20 # https://wtit.com/f5-big-ip-software-release-matrix/
+    eoas: 2012-08-31
+    eol: 2013-08-31
+    latest: "9.4.8"
+    latestReleaseDate: 2009-08-31
+    link: null
+
+  - releaseCycle: '9.3'
+    releaseDate: 2006-04-27 # minus 1 year so that 9.3 is before 9.4 - https://wtit.com/f5-big-ip-software-release-matrix/
+    eoas: 2011-03-31
+    eol: 2012-03-31
+    latest: "9.3.1"
+    latestReleaseDate: 2007-11-07
+    link: null
+
+  - releaseCycle: '9.2'
+    releaseDate: 2005-09-29 # https://wtit.com/f5-big-ip-software-release-matrix/
+    eoas: 2007-07-31
+    eol: 2008-07-31
+    latest: "9.2.5"
+    latestReleaseDate: 2007-01-22
+    link: null
+
+  - releaseCycle: '9.1'
+    releaseDate: 2005-07-26 # https://wtit.com/f5-big-ip-software-release-matrix/
+    eoas: 2008-04-30
+    eol: 2009-04-30
+    latest: "9.1.3"
+    latestReleaseDate: 2007-07-31
+    link: null
+
+  - releaseCycle: '9.0'
+    releaseDate: 2004-08-23 # https://wtit.com/f5-big-ip-software-release-matrix/
+    eoas: 2006-05-18
+    eol: 2007-05-18
+    latest: "9.0.5"
+    latestReleaseDate: 2005-05-12
+    link: null
 
 ---
 


### PR DESCRIPTION
Version dates based on https://wtit.com/f5-big-ip-software-release-matrix/. EOAS/EOL dates based on https://my.f5.com/manage/s/article/K5903.