### PR TITLE
[beats][elasticsearch][kibana][logstash] Switch auto configuration from git to github_releases and fix EOL dates

### DIFF
--- a/products/beats.md
+++ b/products/beats.md
@@ -25,77 +25,78 @@ identifiers:
 
 auto:
   methods:
-    - git: https://github.com/elastic/beats.git
+    - github_releases: elastic/beats
 
-# For EOL, see https://www.elastic.co/support/eol
+# Elastic provide Maintenance to the most recent two Minor Releases of the then-current Major Release, and the final Minor Release of the previous Major Release.
+# For major EOL, see https://www.elastic.co/support/eol.
 releases:
   - releaseCycle: "9.4"
-    releaseDate: 2026-04-30
-    eol: false # later of 2027-10-15 or 18 months after the release date of 10.0
+    releaseDate: 2026-05-05
+    eol: false # releaseDate(9.6) until 10.0 is released
     latest: "9.4.4"
-    latestReleaseDate: 2026-07-15
+    latestReleaseDate: 2026-07-23
     link: https://www.elastic.co/docs/release-notes/beats#beats-__LATEST__-release-notes
 
   - releaseCycle: "9.3"
     releaseDate: 2026-02-03
-    eol: false # later of 2027-10-15 or 18 months after the release date of 10.0
+    eol: false # releaseDate(9.5) until 10.0 is released
     latest: "9.3.8"
-    latestReleaseDate: 2026-07-15
+    latestReleaseDate: 2026-07-21
     link: https://www.elastic.co/docs/release-notes/beats#beats-__LATEST__-release-notes
 
   - releaseCycle: "9.2"
-    releaseDate: 2025-10-20
-    eol: false # later of 2027-10-15 or 18 months after the release date of 10.0
+    releaseDate: 2025-10-23
+    eol: 2026-05-05
     latest: "9.2.8"
-    latestReleaseDate: 2026-04-01
+    latestReleaseDate: 2026-04-08
     link: https://www.elastic.co/docs/release-notes/beats#beats-__LATEST__-release-notes
 
   - releaseCycle: "9.1"
-    releaseDate: 2025-07-23
-    eol: 2026-01-07
+    releaseDate: 2025-07-29
+    eol: 2026-02-03
     latest: "9.1.10"
-    latestReleaseDate: 2026-01-07
+    latestReleaseDate: 2026-01-13
     link: https://www.elastic.co/docs/release-notes/beats#beats-__LATEST__-release-notes
 
   - releaseCycle: "8.19"
-    releaseDate: 2025-07-23
+    releaseDate: 2025-07-29
     eol: 2027-07-15
     latest: "8.19.19"
-    latestReleaseDate: 2026-07-15
+    latestReleaseDate: 2026-07-21
 
   - releaseCycle: "8.18"
-    releaseDate: 2025-04-09
+    releaseDate: 2025-04-15
     eol: 2025-10-20
     latest: "8.18.8"
-    latestReleaseDate: 2025-10-02
+    latestReleaseDate: 2025-10-06
 
   - releaseCycle: "9.0"
-    releaseDate: 2025-04-08
-    eol: 2025-10-02
+    releaseDate: 2025-04-15
+    eol: 2025-10-23
     latest: "9.0.8"
-    latestReleaseDate: 2025-10-02
+    latestReleaseDate: 2025-10-06
     link: https://www.elastic.co/docs/release-notes/beats#beats-__LATEST__-release-notes
 
   - releaseCycle: "8.17"
-    releaseDate: 2024-12-11
-    eol: 2025-08-08
+    releaseDate: 2024-12-12
+    eol: 2025-08-12
     latest: "8.17.10"
-    latestReleaseDate: 2025-08-08
+    latestReleaseDate: 2025-08-12
 
   - releaseCycle: "8.16"
-    releaseDate: 2024-11-07
-    eol: 2025-04-18
+    releaseDate: 2024-11-12
+    eol: 2025-04-15
     latest: "8.16.6"
-    latestReleaseDate: 2025-03-18
+    latestReleaseDate: 2025-03-25
 
   - releaseCycle: "7"
-    releaseDate: 2019-04-05
+    releaseDate: 2019-04-10
     eol: 2026-01-15
     latest: "7.17.29"
-    latestReleaseDate: 2025-06-18
+    latestReleaseDate: 2025-06-24
 
   - releaseCycle: "6"
-    releaseDate: 2017-11-08
+    releaseDate: 2017-11-14
     eol: 2022-02-10
     latest: "6.8.23"
     latestReleaseDate: 2022-01-13

--- a/products/elasticsearch.md
+++ b/products/elasticsearch.md
@@ -26,77 +26,75 @@ identifiers:
 
 auto:
   methods:
-    - git: https://github.com/elastic/elasticsearch.git
+    - github_releases: elastic/elasticsearch
 
-# For EOL, see https://www.elastic.co/support/eol
-# eol(x.last-minor) = max(releaseDate+30m, releaseDate(x+y.0)+18m)
-# eol(x.not-last-minor) = latestReleaseDate(x.y)
-
+# Elastic provide Maintenance to the most recent two Minor Releases of the then-current Major Release, and the final Minor Release of the previous Major Release.
+# For major EOL, see https://www.elastic.co/support/eol.
 releases:
   - releaseCycle: "9.4"
     releaseDate: 2026-05-05
-    eol: false
+    eol: false # releaseDate(9.6) until 10.0 is released
     latest: "9.4.4"
-    latestReleaseDate: 2026-07-15
+    latestReleaseDate: 2026-07-21
     link: https://www.elastic.co/docs/release-notes/elasticsearch#elasticsearch-__LATEST__-release-notes
 
   - releaseCycle: "9.3"
     releaseDate: 2026-02-03
-    eol: 2026-05-26
+    eol: false # releaseDate(9.5) until 10.0 is released
     latest: "9.3.8"
-    latestReleaseDate: 2026-07-15
+    latestReleaseDate: 2026-07-21
     link: https://www.elastic.co/docs/release-notes/elasticsearch#elasticsearch-__LATEST__-release-notes
 
   - releaseCycle: "9.2"
-    releaseDate: 2025-10-21
+    releaseDate: 2025-10-23
     eol: 2026-05-05
     latest: "9.2.8"
-    latestReleaseDate: 2026-04-02
+    latestReleaseDate: 2026-04-08
     link: https://www.elastic.co/docs/release-notes/elasticsearch#elasticsearch-__LATEST__-release-notes
 
   - releaseCycle: "9.1"
-    releaseDate: 2025-07-23
+    releaseDate: 2025-07-29
     eol: 2026-02-03
     latest: "9.1.10"
-    latestReleaseDate: 2026-01-08
+    latestReleaseDate: 2026-01-13
     link: https://www.elastic.co/docs/release-notes/elasticsearch#elasticsearch-__LATEST__-release-notes
 
   - releaseCycle: "8.19"
-    releaseDate: 2025-07-23
+    releaseDate: 2025-07-29
     eol: 2027-07-15
     latest: "8.19.19"
-    latestReleaseDate: 2026-07-15
+    latestReleaseDate: 2026-07-21
 
   - releaseCycle: "8.18"
-    releaseDate: 2025-04-10
+    releaseDate: 2025-04-15
     eol: 2025-10-21
     latest: "8.18.8"
-    latestReleaseDate: 2025-10-02
+    latestReleaseDate: 2025-10-06
 
   - releaseCycle: "9.0"
-    releaseDate: 2025-04-08
-    eol: 2025-10-02
+    releaseDate: 2025-04-15
+    eol: 2025-10-23
     latest: "9.0.8"
-    latestReleaseDate: 2025-10-02
+    latestReleaseDate: 2025-10-06
     link: https://www.elastic.co/docs/release-notes/elasticsearch#elasticsearch-__LATEST__-release-notes
 
   - releaseCycle: "8.17"
-    releaseDate: 2024-12-11
-    eol: 2025-08-05
+    releaseDate: 2024-12-12
+    eol: 2025-08-12
     latest: "8.17.10"
-    latestReleaseDate: 2025-08-05
+    latestReleaseDate: 2025-08-12
 
   - releaseCycle: "8.16"
-    releaseDate: 2024-11-08
+    releaseDate: 2024-11-12
     eol: 2025-04-15
     latest: "8.16.6"
-    latestReleaseDate: 2025-03-19
+    latestReleaseDate: 2025-03-25
 
   - releaseCycle: "7"
     releaseDate: 2019-04-10
     eol: 2026-01-15
     latest: "7.17.29"
-    latestReleaseDate: 2025-06-18
+    latestReleaseDate: 2025-06-24
 
   - releaseCycle: "6"
     releaseDate: 2017-11-14

--- a/products/kibana.md
+++ b/products/kibana.md
@@ -16,86 +16,87 @@ identifiers:
 
 auto:
   methods:
-    - git: https://github.com/elastic/kibana.git
+    - github_releases: elastic/kibana
 
-# For EOL, see https://www.elastic.co/support/eol
+# Elastic provide Maintenance to the most recent two Minor Releases of the then-current Major Release, and the final Minor Release of the previous Major Release.
+# For major EOL, see https://www.elastic.co/support/eol.
 releases:
   - releaseCycle: "9.4"
-    releaseDate: 2026-04-30
-    eol: false
+    releaseDate: 2026-05-05
+    eol: false # releaseDate(9.6) until 10.0 is released
     latest: "9.4.4"
-    latestReleaseDate: 2026-07-15
+    latestReleaseDate: 2026-07-21
     link: https://www.elastic.co/docs/release-notes/kibana#kibana-__LATEST__-release-notes
 
   - releaseCycle: "9.3"
     releaseDate: 2026-02-03
-    eol: false # later of 2027-10-15 or 18 months after the release date of 10.0
+    eol: false # releaseDate(9.5) until 10.0 is released
     latest: "9.3.8"
-    latestReleaseDate: 2026-07-15
+    latestReleaseDate: 2026-07-21
     link: https://www.elastic.co/docs/release-notes/kibana#kibana-__LATEST__-release-notes
 
   - releaseCycle: "9.2"
-    releaseDate: 2025-10-21
-    eol: false # later of 2027-10-15 or 18 months after the release date of 10.0
+    releaseDate: 2025-10-23
+    eol: 2026-05-05
     latest: "9.2.8"
-    latestReleaseDate: 2026-04-02
+    latestReleaseDate: 2026-04-08
     link: https://www.elastic.co/docs/release-notes/kibana#kibana-__LATEST__-release-notes
 
   - releaseCycle: "9.1"
-    releaseDate: 2025-07-23
-    eol: 2026-01-08
+    releaseDate: 2025-07-29
+    eol: 2026-02-03
     latest: "9.1.10"
-    latestReleaseDate: 2026-01-08
+    latestReleaseDate: 2026-01-13
     link: https://www.elastic.co/docs/release-notes/kibana#kibana-__LATEST__-release-notes
 
   - releaseCycle: "8.19"
-    releaseDate: 2025-07-23
+    releaseDate: 2025-07-29
     eol: 2027-07-15
     latest: "8.19.19"
-    latestReleaseDate: 2026-07-15
+    latestReleaseDate: 2026-07-21
 
   - releaseCycle: "9.0"
-    releaseDate: 2025-04-10
-    eol: 2025-10-02
+    releaseDate: 2025-04-15
+    eol: 2025-10-23
     latest: "9.0.8"
-    latestReleaseDate: 2025-10-02
+    latestReleaseDate: 2025-10-06
     link: https://www.elastic.co/docs/release-notes/kibana#kibana-__LATEST__-release-notes
 
   - releaseCycle: "8.18"
-    releaseDate: 2025-04-10
+    releaseDate: 2025-04-15
     eol: 2025-10-21
     latest: "8.18.8"
-    latestReleaseDate: 2025-10-02
+    latestReleaseDate: 2025-10-06
 
   - releaseCycle: "8.17"
-    releaseDate: 2024-12-11
-    eol: 2025-08-07
+    releaseDate: 2024-12-12
+    eol: 2025-08-12
     latest: "8.17.10"
-    latestReleaseDate: 2025-08-07
+    latestReleaseDate: 2025-08-12
 
   - releaseCycle: "8.16"
-    releaseDate: 2024-11-07
-    eol: true
+    releaseDate: 2024-11-12
+    eol: 2025-04-15
     latest: "8.16.6"
-    latestReleaseDate: 2025-03-19
+    latestReleaseDate: 2025-03-25
 
   - releaseCycle: "8.15"
-    releaseDate: 2024-08-03
-    eol: true
+    releaseDate: 2024-08-08
+    eol: 2024-12-12
     latest: "8.15.5"
-    latestReleaseDate: 2024-11-21
+    latestReleaseDate: 2024-11-26
 
   - releaseCycle: "8.14"
     releaseDate: 2024-06-05
-    eol: true
+    eol: 2024-11-12
     latest: "8.14.3"
-    latestReleaseDate: 2024-07-08
+    latestReleaseDate: 2024-07-11
 
   - releaseCycle: "7"
     releaseDate: 2019-04-10
     eol: 2026-01-15
     latest: "7.17.29"
-    latestReleaseDate: 2025-06-17
+    latestReleaseDate: 2025-06-24
 
   - releaseCycle: "6"
     releaseDate: 2017-11-14

--- a/products/logstash.md
+++ b/products/logstash.md
@@ -16,68 +16,67 @@ identifiers:
 
 auto:
   methods:
-    - git: https://github.com/elastic/logstash.git
+    - github_releases: elastic/logstash
 
-# For EOL, see https://www.elastic.co/support/eol
-# if it doesnt mentioned directly on website follow
-# hint : EOL(x) = MAX(latestReleaseDate(x), releaseDate(x+1))
+# Elastic provide Maintenance to the most recent two Minor Releases of the then-current Major Release, and the final Minor Release of the previous Major Release.
+# For major EOL, see https://www.elastic.co/support/eol.
 releases:
   - releaseCycle: "9.4"
-    releaseDate: 2026-05-08
-    eol: false # later of 2027-10-15 or 18 months after the release date of 10.0
+    releaseDate: 2026-05-05
+    eol: false # releaseDate(9.6) until 10.0 is released
     latest: "9.4.4"
-    latestReleaseDate: 2026-07-14
+    latestReleaseDate: 2026-07-21
 
   - releaseCycle: "9.3"
     releaseDate: 2026-02-03
-    eol: 2026-05-08
+    eol: false # releaseDate(9.5) until 10.0 is released
     latest: "9.3.8"
-    latestReleaseDate: 2026-07-14
+    latestReleaseDate: 2026-07-21
 
   - releaseCycle: "9.2"
-    releaseDate: 2025-10-21
-    eol: 2026-03-31
+    releaseDate: 2025-10-23
+    eol: 2026-05-05
     latest: "9.2.8"
-    latestReleaseDate: 2026-03-31
+    latestReleaseDate: 2026-04-08
 
   - releaseCycle: "9.1"
-    releaseDate: 2025-07-22
-    eol: 2026-01-07
+    releaseDate: 2025-07-29
+    eol: 2026-02-03
     latest: "9.1.10"
-    latestReleaseDate: 2026-01-07
+    latestReleaseDate: 2026-01-13
 
   - releaseCycle: "8.19"
-    releaseDate: 2025-07-14
+    releaseDate: 2025-07-29
     eol: 2027-07-15
     latest: "8.19.19"
-    latestReleaseDate: 2026-07-14
+    latestReleaseDate: 2026-07-21
     link: https://www.elastic.co/guide/en/logstash/8.19/logstash-{{'__LATEST__'|replace:'.','-'}}.html
 
   - releaseCycle: "8.18"
-    releaseDate: 2025-04-09
+    releaseDate: 2025-04-15
     eol: 2025-10-21
     latest: "8.18.8"
-    latestReleaseDate: 2025-09-30
+    latestReleaseDate: 2025-10-06
     link: https://www.elastic.co/guide/en/logstash/8.18/logstash-{{'__LATEST__'|replace:'.','-'}}.html
 
   - releaseCycle: "9.0"
-    releaseDate: 2025-03-17
-    eol: 2025-09-30
+    releaseDate: 2025-04-15
+    eol: 2025-10-23
     latest: "9.0.8"
-    latestReleaseDate: 2025-09-30
+    latestReleaseDate: 2025-10-06
 
   - releaseCycle: "8.17"
-    releaseDate: 2024-12-04
-    eol: 2025-08-06
+    releaseDate: 2024-12-12
+    eol: 2025-08-12
     latest: "8.17.10"
-    latestReleaseDate: 2025-08-06
+    latestReleaseDate: 2025-08-12
     link: https://www.elastic.co/guide/en/logstash/8.17/logstash-8-17-10.html
 
   - releaseCycle: "7"
     releaseDate: 2019-04-05
     eol: 2026-01-15
     latest: "7.17.29"
-    latestReleaseDate: 2025-04-10
+    latestReleaseDate: 2025-06-24
     link: https://www.elastic.co/guide/en/logstash/7.17/logstash-7-17-29.html
 
   - releaseCycle: "6"


### PR DESCRIPTION
Dates will be more accurate this way.

Also updated dates following this change, and set EOL dates according to the support policy, which is according to https://www.elastic.co/support/eol:

> Elastic will provide Maintenance to the most recent two Minor Releases of the then-current Major Release, and the final Minor Release of the previous Major Release.