### PR TITLE
[beats] Add release cycle for Beats 9.5 and update EOL for 9.3

### DIFF
--- a/products/beats.md
+++ b/products/beats.md
@@ -30,6 +30,13 @@ auto:
 # Elastic provide Maintenance to the most recent two Minor Releases of the then-current Major Release, and the final Minor Release of the previous Major Release.
 # For major EOL, see https://www.elastic.co/support/eol.
 releases:
+  - releaseCycle: "9.5"
+    releaseDate: 2026-07-29
+    eol: false # releaseDate(9.7) until 10.0 is released
+    latest: "9.5.0"
+    latestReleaseDate: 2026-07-29
+    link: https://www.elastic.co/docs/release-notes/beats#beats-__LATEST__-release-notes
+
   - releaseCycle: "9.4"
     releaseDate: 2026-05-05
     eol: false # releaseDate(9.6) until 10.0 is released
@@ -39,7 +46,7 @@ releases:
 
   - releaseCycle: "9.3"
     releaseDate: 2026-02-03
-    eol: false # releaseDate(9.5) until 10.0 is released
+    eol: 2026-07-29
     latest: "9.3.8"
     latestReleaseDate: 2026-07-21
     link: https://www.elastic.co/docs/release-notes/beats#beats-__LATEST__-release-notes

--- a/products/beats.md
+++ b/products/beats.md
@@ -31,10 +31,10 @@ auto:
 # For major EOL, see https://www.elastic.co/support/eol.
 releases:
   - releaseCycle: "9.5"
-    releaseDate: 2026-07-29
+    releaseDate: 2026-08-04
     eol: false # releaseDate(9.7) until 10.0 is released
     latest: "9.5.0"
-    latestReleaseDate: 2026-07-29
+    latestReleaseDate: 2026-08-04
     link: https://www.elastic.co/docs/release-notes/beats#beats-__LATEST__-release-notes
 
   - releaseCycle: "9.4"
@@ -46,7 +46,7 @@ releases:
 
   - releaseCycle: "9.3"
     releaseDate: 2026-02-03
-    eol: 2026-07-29
+    eol: 2026-08-04
     latest: "9.3.8"
     latestReleaseDate: 2026-07-21
     link: https://www.elastic.co/docs/release-notes/beats#beats-__LATEST__-release-notes


### PR DESCRIPTION
Updated release information for Beats, including new release cycle for 9.5 and adjusted EOL date for 9.3.