### PR TITLE
[Samsung Galaxy Watch] Updated Release date for Watch9 and Ultra2

### DIFF
--- a/products/samsung-galaxy-watch.md
+++ b/products/samsung-galaxy-watch.md
@@ -25,14 +25,14 @@ staleReleaseThresholdDays: 1825 # devices have longer support periods
 releases:
   - releaseCycle: "galaxy-watch-ultra2"
     releaseLabel: "Galaxy Watch Ultra2"
-    releaseDate: 2026-07-22
+    releaseDate: 2026-08-07
     eoas: false
     eol: false
     link: https://www.samsung.com/watches/galaxy-watch-ultra2/
 
   - releaseCycle: "galaxy-watch9"
     releaseLabel: "Galaxy Watch9"
-    releaseDate: 2026-07-22
+    releaseDate: 2026-08-07
     eoas: false
     eol: false
     link: https://www.samsung.com/us/watches/galaxy-watch9/


### PR DESCRIPTION
Both of these devices are officially launching on August 7th, 2026

Here's their listings from BestBuy showing an August 7th release date:

<img width="500" alt="image" src="https://github.com/user-attachments/assets/eebab782-3086-42eb-9750-8ccbecebeca6" />
