### PR TITLE
[Samsung Mobile] Add Galaxy Z Flip8, Fold8, and Fold8 Ultra

### DIFF
--- a/products/samsung-mobile.md
+++ b/products/samsung-mobile.md
@@ -39,10 +39,31 @@ auto:
 # - https://www.androidupdatetracker.com/ (eoas)
 # - https://security.samsungmobile.com/workScope.smsb (eol status)
 # - https://doc.samsungmobile.com/ (link - search on Google with "<model> site:doc.samsungmobile.com")
-# 
+#
 # IMPORTANT: When adding a new model here, add it to the above regex exclude above
 # IF it is not listed at https://security.samsungmobile.com/workScope.smsb
 releases:
+  - releaseCycle: "galaxy-z-flip8"
+    releaseLabel: "Galaxy Z Flip8"
+    releaseDate: 2026-08-07 # https://news.samsung.com/global/samsung-galaxy-z-fold8-ultra-fold8-and-flip8foldables-perfected-for-every-way-of-living
+    eoas: 2033-07-31 # 7 android upgrade
+    eol: 2033-07-31 # 7 years of security support
+    link: null # not found
+
+  - releaseCycle: "galaxy-z-fold8"
+    releaseLabel: "Galaxy Z Fold8"
+    releaseDate: 2026-08-07 # https://news.samsung.com/global/samsung-galaxy-z-fold8-ultra-fold8-and-flip8foldables-perfected-for-every-way-of-living
+    eoas: 2033-07-31 # 7 android upgrade
+    eol: 2033-07-31 # 7 years of security support
+    link: null # not found
+
+  - releaseCycle: "galaxy-z-fold8-ultra"
+    releaseLabel: "Galaxy Z Fold8 Ultra"
+    releaseDate: 2026-08-07 # https://news.samsung.com/global/samsung-galaxy-z-fold8-ultra-fold8-and-flip8foldables-perfected-for-every-way-of-living
+    eoas: 2033-07-31 # 7 android upgrade
+    eol: 2033-07-31 # 7 years of security support
+    link: null # not found
+
   - releaseCycle: "galaxy-a57-5g"
     releaseLabel: "Galaxy A57 5G"
     releaseDate: 2026-04-10 # https://news.samsung.com/global/samsung-unveils-galaxy-a57-5g-and-galaxy-a37-5g-packing-pro-level-features-at-awesome-price

--- a/products/samsung-mobile.md
+++ b/products/samsung-mobile.md
@@ -46,22 +46,22 @@ releases:
   - releaseCycle: "galaxy-z-flip8"
     releaseLabel: "Galaxy Z Flip8"
     releaseDate: 2026-08-07 # https://news.samsung.com/global/samsung-galaxy-z-fold8-ultra-fold8-and-flip8foldables-perfected-for-every-way-of-living
-    eoas: 2033-07-31 # 7 android upgrade
-    eol: 2033-07-31 # 7 years of security support
+    eoas: 2033-07-31 # 7 https://sammyguru.com/galaxy-z-fold-8-fold-8-ultra-flip-8-software-updates/
+    eol: 2033-07-31 # https://security.samsungmobile.com/workScope.smsb
     link: null # not found
 
   - releaseCycle: "galaxy-z-fold8"
     releaseLabel: "Galaxy Z Fold8"
     releaseDate: 2026-08-07 # https://news.samsung.com/global/samsung-galaxy-z-fold8-ultra-fold8-and-flip8foldables-perfected-for-every-way-of-living
-    eoas: 2033-07-31 # 7 android upgrade
-    eol: 2033-07-31 # 7 years of security support
+    eoas: 2033-07-31 # https://sammyguru.com/galaxy-z-fold-8-fold-8-ultra-flip-8-software-updates/
+    eol: 2033-07-31 # https://security.samsungmobile.com/workScope.smsb
     link: null # not found
 
   - releaseCycle: "galaxy-z-fold8-ultra"
     releaseLabel: "Galaxy Z Fold8 Ultra"
     releaseDate: 2026-08-07 # https://news.samsung.com/global/samsung-galaxy-z-fold8-ultra-fold8-and-flip8foldables-perfected-for-every-way-of-living
-    eoas: 2033-07-31 # 7 android upgrade
-    eol: 2033-07-31 # 7 years of security support
+    eoas: 2033-07-31 # https://sammyguru.com/galaxy-z-fold-8-fold-8-ultra-flip-8-software-updates/
+    eol: 2033-07-31 # https://security.samsungmobile.com/workScope.smsb
     link: null # not found
 
   - releaseCycle: "galaxy-a57-5g"

--- a/products/samsung-mobile.md
+++ b/products/samsung-mobile.md
@@ -46,22 +46,22 @@ releases:
   - releaseCycle: "galaxy-z-flip8"
     releaseLabel: "Galaxy Z Flip8"
     releaseDate: 2026-08-07 # https://news.samsung.com/global/samsung-galaxy-z-fold8-ultra-fold8-and-flip8foldables-perfected-for-every-way-of-living
-    eoas: 2033-07-31 # 7 https://sammyguru.com/galaxy-z-fold-8-fold-8-ultra-flip-8-software-updates/
-    eol: 2033-07-31 # https://security.samsungmobile.com/workScope.smsb
+    eoas: 2033-07-31 # 7 years - https://en.wikipedia.org/wiki/Samsung_Galaxy_Z_Flip_8#Software
+    eol: 2033-07-31 # 7 years - https://en.wikipedia.org/wiki/Samsung_Galaxy_Z_Flip_8#Software
     link: null # not found
 
   - releaseCycle: "galaxy-z-fold8"
     releaseLabel: "Galaxy Z Fold8"
     releaseDate: 2026-08-07 # https://news.samsung.com/global/samsung-galaxy-z-fold8-ultra-fold8-and-flip8foldables-perfected-for-every-way-of-living
-    eoas: 2033-07-31 # https://sammyguru.com/galaxy-z-fold-8-fold-8-ultra-flip-8-software-updates/
-    eol: 2033-07-31 # https://security.samsungmobile.com/workScope.smsb
+    eoas: 2033-07-31 # 7 years - https://en.wikipedia.org/wiki/Samsung_Galaxy_Z_Fold_8#Software
+    eol: 2033-07-31 # 7 years - https://en.wikipedia.org/wiki/Samsung_Galaxy_Z_Fold_8#Software
     link: null # not found
 
   - releaseCycle: "galaxy-z-fold8-ultra"
     releaseLabel: "Galaxy Z Fold8 Ultra"
     releaseDate: 2026-08-07 # https://news.samsung.com/global/samsung-galaxy-z-fold8-ultra-fold8-and-flip8foldables-perfected-for-every-way-of-living
-    eoas: 2033-07-31 # https://sammyguru.com/galaxy-z-fold-8-fold-8-ultra-flip-8-software-updates/
-    eol: 2033-07-31 # https://security.samsungmobile.com/workScope.smsb
+    eoas: 2033-07-31 # 7 years - https://en.wikipedia.org/wiki/Samsung_Galaxy_Z_Fold_8#Software
+    eol: 2033-07-31 # 7 years - https://en.wikipedia.org/wiki/Samsung_Galaxy_Z_Fold_8#Software
     link: null # not found
 
   - releaseCycle: "galaxy-a57-5g"


### PR DESCRIPTION
This pull request updates the products/samsung-mobile.md file to add information about three upcoming Samsung Galaxy foldable devices, including their release dates and end-of-support timelines.

New device releases:

   * Added entries for Galaxy Z Flip8, Galaxy Z Fold8, and Galaxy Z Fold8 Ultra, each with:
       * Release date set to 2026-08-07 per countdown on their website 
       * End of Android support (eoas) and end of life (eol) set to 2033-07-31 (7 years of support)

Security Support EOL is 2033-07-31 because that is the date listed on the specs page for each device

The devices are all now listed on: https://security.samsungmobile.com/workScope.smsb, so it should not break the automated releases.