### PR TITLE
feat: add Jenkins 2.568 LTS release

### DIFF
--- a/products/jenkins.md
+++ b/products/jenkins.md
@@ -39,7 +39,7 @@ releases:
 
   - releaseCycle: "2.568"
     releaseDate: 2026-06-10
-    lts: 2026-07-08
+    lts: 2026-07-09
     eol: false
     latest: "2.568.2"
     latestReleaseDate: 2026-08-05

--- a/products/jenkins.md
+++ b/products/jenkins.md
@@ -47,7 +47,7 @@ releases:
   - releaseCycle: "2.555"
     releaseDate: 2026-03-18
     lts: 2026-04-15
-    eol: true
+    eol: 2026-06-10
     latest: "2.555.3"
     latestReleaseDate: 2026-06-08
 

--- a/products/jenkins.md
+++ b/products/jenkins.md
@@ -47,7 +47,7 @@ releases:
   - releaseCycle: "2.555"
     releaseDate: 2026-03-18
     lts: 2026-04-15
-    eol: 2026-07-09
+    eol: 2026-06-10
     latest: "2.555.3"
     latestReleaseDate: 2026-06-08
 

--- a/products/jenkins.md
+++ b/products/jenkins.md
@@ -47,7 +47,7 @@ releases:
   - releaseCycle: "2.555"
     releaseDate: 2026-03-18
     lts: 2026-04-15
-    eol: 2026-06-10
+    eol: 2026-07-09
     latest: "2.555.3"
     latestReleaseDate: 2026-06-08
 

--- a/products/jenkins.md
+++ b/products/jenkins.md
@@ -37,10 +37,17 @@ releases:
     latest: "2.576"
     latestReleaseDate: 2026-08-03
 
+  - releaseCycle: "2.568"
+    releaseDate: 2026-06-10
+    lts: 2026-07-08
+    eol: false
+    latest: "2.568.2"
+    latestReleaseDate: 2026-08-05
+
   - releaseCycle: "2.555"
     releaseDate: 2026-03-18
     lts: 2026-04-15
-    eol: false
+    eol: true
     latest: "2.555.3"
     latestReleaseDate: 2026-06-08
 


### PR DESCRIPTION
Hello,

A new release of Jenkins LTS has been released:

- https://www.jenkins.io/doc/upgrade-guide/2.568/
- https://www.jenkins.io/changelog-stable/

This PR adds this new version and declare the old lts version as eol.

Regards