### PR TITLE
Jenkins: add LTS 2.568, mark 2.555 as EOL

### DIFF
--- a/products/jenkins.md
+++ b/products/jenkins.md
@@ -37,10 +37,17 @@ releases:
     latest: "2.576"
     latestReleaseDate: 2026-08-03
 
+  - releaseCycle: "2.568"
+    releaseDate: 2026-06-08
+    lts: 2026-07-09
+    eol: false
+    latest: "2.568.2"
+    latestReleaseDate: 2026-08-03
+
   - releaseCycle: "2.555"
     releaseDate: 2026-03-18
     lts: 2026-04-15
-    eol: false
+    eol: 2026-07-09
     latest: "2.555.3"
     latestReleaseDate: 2026-06-08
 


### PR DESCRIPTION
## Description

Jenkins picked **2.568** as the new LTS baseline: 2.568.1 shipped 2026-07-09 (git tag date; announced on [changelog-stable](https://www.jenkins.io/changelog-stable/) as July 8), superseding **2.555** per the [12-week rolling LTS policy](https://www.jenkins.io/download/lts/). The file's documented convention (`eol(x.y) = releaseDate(next LTS)`) gives 2.555 an EOL of 2026-07-09.

Dates follow the git-tag convention used throughout this product:

- `jenkins-2.568` tag: 2026-06-08 → releaseDate
- `jenkins-2.568.1` tag: 2026-07-09 → lts, and eol for 2.555
- `jenkins-2.568.2` tag: 2026-08-03 → latest / latestReleaseDate

(Verified the convention against the existing 2.555 row: its `lts: 2026-04-15` equals the `jenkins-2.555.1` tag date, and `latestReleaseDate: 2026-06-08` equals the `jenkins-2.555.3` tag date rather than the changelog date.)

## Checklist

- [x] Dates verified against jenkinsci/jenkins git tags and jenkins.io/changelog-stable
- [x] Follows the LTS modeling comment at the top of the releases list