### PR TITLE
[gradle] Update AGP and testedKotlinVersions info

### DIFF
--- a/products/gradle.md
+++ b/products/gradle.md
@@ -54,12 +54,12 @@ auto:
 releases:
   - releaseCycle: "9"
     releaseDate: 2025-07-31
-    # Supported versions see https://docs.gradle.org/9.5.0/userguide/compatibility.html
+    # Supported versions see https://docs.gradle.org/9.7.0/userguide/compatibility.html
     runningJavaVersions: "17 - 26"
     testedJavaVersions: "8 - 26"
-    testedKotlinVersions: "2.0.0 - 2.3.20"
+    testedKotlinVersions: "2.0.0 - 2.4.20-Beta1"
     testedGroovyVersions: "1.5.8 - 5.0.2"
-    testedAndroidVersions: "8.4 - 9.2.0-alpha05"
+    testedAndroidVersions: "9.0 - 9.4.0-alpha03"
     eoas: false
     eol: false
     latest: "9.7.0"


### PR DESCRIPTION
This PR is not for adding 9.7 but instead fixing its testedAndroidVersions and testedKotlinVersions fields