### PR TITLE
[looker] Restore release dates and stop auto-detecting end-of-month dates

### DIFF
--- a/products/looker.md
+++ b/products/looker.md
@@ -19,9 +19,6 @@ auto:
     - release_table: https://cloud.google.com/looker/docs/officially-supported-releases
       fields:
         releaseCycle: "Looker release version"
-        releaseDate:
-          column: "Standard release support period"
-          regex: '^(?P<value>\w+ \d{4}) -.+$'
         eol:
           column: "Standard release support period"
           regex: '^.+- (?P<value>\w+ \d{4})$'
@@ -61,71 +58,71 @@ releases:
     link: https://docs.cloud.google.com/looker/docs/release-notes#March_05_2026
 
   - releaseCycle: "26.2"
-    releaseDate: 2026-02-28
+    releaseDate: 2026-02-09
     eol: 2026-04-30
     link: https://docs.cloud.google.com/looker/docs/release-notes#February_09_2026
 
   - releaseCycle: "26.0"
-    releaseDate: 2026-01-31
+    releaseDate: 2026-01-08
     lts: 2026-02-28
     eol: 2026-06-30
     link: https://docs.cloud.google.com/looker/docs/release-notes#January_08_2026
 
   - releaseCycle: "25.20"
-    releaseDate: 2025-11-30
+    releaseDate: 2025-11-05
     eol: 2026-03-31
     link: https://cloud.google.com/looker/docs/release-notes#November_05_2025
 
   - releaseCycle: "25.18"
-    releaseDate: 2025-10-31
+    releaseDate: 2025-10-06
     lts: 2025-11-30
     eol: 2026-02-28
     link: https://cloud.google.com/looker/docs/release-notes#October_06_2025
 
   - releaseCycle: "25.16"
-    releaseDate: 2025-09-30
+    releaseDate: 2025-09-10
     eol: 2025-12-31
     link: https://cloud.google.com/looker/docs/release-notes#September_10_2025
 
   - releaseCycle: "25.14"
-    releaseDate: 2025-08-31
+    releaseDate: 2025-08-13
     eol: 2025-11-30
     link: https://discuss.google.dev/t/looker-25-14-release-notes/254350
 
   - releaseCycle: "25.12"
-    releaseDate: 2025-07-31
+    releaseDate: 2025-07-24
     lts: 2025-08-31
     eol: 2025-11-30
     link: https://discuss.google.dev/t/looker-25-12-release-notes/245841
 
   - releaseCycle: "25.10"
-    releaseDate: 2025-06-30
+    releaseDate: 2025-06-11
     eol: 2025-09-30
     link: https://cloud.google.com/looker/docs/release-notes#June_11_2025
 
   - releaseCycle: "25.8"
-    releaseDate: 2025-05-31
+    releaseDate: 2025-05-14
     eol: 2025-08-31
     link: https://discuss.google.dev/t/looker-25-8-release-notes/189625
 
   - releaseCycle: "25.6"
-    releaseDate: 2025-04-30
+    releaseDate: 2025-04-09
     lts: 2025-05-31
     eol: 2025-08-31
     link: https://discuss.google.dev/t/looker-25-6-release-notes/186433
 
   - releaseCycle: "25.4"
-    releaseDate: 2025-03-31
+    releaseDate: 2025-03-12
     eol: 2025-06-30
     link: https://discuss.google.dev/t/looker-25-4-release-notes/185240
 
   - releaseCycle: "25.2"
-    releaseDate: 2025-02-28
+    releaseDate: 2025-02-12
     eol: 2025-05-31
     link: https://discuss.google.dev/t/looker-25-2-release-notes/182687
 
   - releaseCycle: "25.0"
-    releaseDate: 2025-01-31
+    releaseDate: 2025-01-08
     lts: 2025-02-28
     eol: 2025-05-31
     link: https://www.googlecloudcommunity.com/gc/News-Announcements/Looker-25-0-Release-Notes/m-p/860290


### PR DESCRIPTION
The auto-update bot was deriving release dates from the "Standard release support period" column, which only contains month-year ranges, so releases disapearing from https://cloud.google.com/feeds/looker-release-notes.xml were overwritten with end-of-month dates instead of their actual release date. This was not desired, but also it could also break the site build (such as in https://github.com/endoflife-date/endoflife.date/pull/10685).

Restore the real release dates for 25.0-25.20, 26.0 and 26.2, and remove the releaseDate field from the release_table auto-detection so it no longer overwrites release dates with approximate end-of-month values.