### PR TITLE
ibm-i: add 7.4 Service Extension and 7.1 Program Support Extension dates

### DIFF
--- a/products/ibm-i.md
+++ b/products/ibm-i.md
@@ -50,6 +50,7 @@ releases:
   - releaseCycle: "7.4"
     releaseDate: 2019-06-21
     eol: 2026-09-30
+    eoes: 2029-09-30
     latest: "7.4.0"
     latestReleaseDate: 2019-06-21
     link: https://www.ibm.com/support/pages/customer-notices-and-information-ibm-i-74
@@ -73,6 +74,7 @@ releases:
   - releaseCycle: "7.1"
     releaseDate: 2010-04-23
     eol: 2018-04-30
+    eoes: 2024-04-30
     latest: "7.1.0"
     latestReleaseDate: 2010-04-23
     link: https://www.ibm.com/support/pages/customer-notices-and-information-ibm-i-71


### PR DESCRIPTION
Adds two `eoes` dates from IBM's [release life cycle page](https://www.ibm.com/support/pages/release-life-cycle) (document 668157, modified date 03 March 2026):

- **7.4** — `eoes: 2029-09-30`. Note 5 on the page: "IBM i 7.4 Service Extension Offering will start on October 1, 2026 and will end on September 30, 2029."
- **7.1** — `eoes: 2024-04-30`. The 7.1 row's "Program Support Extension Available" column reads "through 04/30/2024".

Both verified directly against the IBM page today. No other fields changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
