### PR TITLE
netapp-ontap: correct 9.18.1 end of full support to 2029-01-31

### DIFF
--- a/products/netapp-ontap.md
+++ b/products/netapp-ontap.md
@@ -22,7 +22,7 @@ releases:
 
   - releaseCycle: "9.18.1"
     releaseDate: 2026-02-04 # estimated date from https://docs.netapp.com/us-en/ontap/release-notes/release-support-reference.html
-    eol: 2028-09-30
+    eol: 2029-01-31
 
   - releaseCycle: "9.17.1"
     releaseDate: 2026-01-15 # estimated date from https://docs.netapp.com/us-en/ontap/release-notes/release-support-reference.html


### PR DESCRIPTION
NetApp's KB ["What are the ONTAP Software Version Support dates"](https://kb.netapp.com/on-prem/ontap/Ontap_OS/OS-KBs/What_are_the_ONTAP_Software_Version_Support_dates) (Last Updated: 6/26/2026) lists ONTAP 9.18.1 as:

| Version | End of Full Support | End of Limited Support | End of Self-Service Support |
|---|---|---|---|
| 9.18.1 | 31-Jan-2029 | 31-Jan-2031 | 31-Jan-2034 |

The current value here (2028-09-30) is identical to 9.17.1's date and appears to be a duplicate. 2029-01-31 also matches NetApp's 3-years-of-full-support policy from the 9.18.1 GA date (2026-02-04).

Note: 9.19.1 is not yet listed in the KB table; its entry is left unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)