### PR TITLE
[pan-os] Update 11.1: 11.1.16 → 11.1.16-h1

### DIFF
--- a/products/pan-os.md
+++ b/products/pan-os.md
@@ -53,9 +53,9 @@ releases:
   - releaseCycle: "11.1"
     releaseDate: 2023-11-03
     eol: 2027-05-03
-    latest: "11.1.16"
-    latestReleaseDate: 2026-07-07
-    link: https://docs.paloaltonetworks.com/pan-os/11-1/pan-os-release-notes/pan-os-11-1-16-known-and-addressed-issues/pan-os-11-1-16-addressed-issues
+    latest: "11.1.16-h1"
+    latestReleaseDate: 2026-08-10
+    link: https://docs.paloaltonetworks.com/pan-os/11-1/pan-os-release-notes/pan-os-11-1-16-known-and-addressed-issues/pan-os-11-1-16-h1-addressed-issues
 
   - releaseCycle: "11.0"
     releaseDate: 2022-11-17


### PR DESCRIPTION
## Summary
Automated update of PAN-OS versions.

### Changes
11.1: 11.1.16 -> 11.1.16-h1

---
Data sourced from [PaloAltoVersions.json](https://github.com/mrjcap/panos-versions/blob/master/PaloAltoVersions.json)