### PR TITLE
[magento] Update livecycle policy link

### DIFF
--- a/products/magento.md
+++ b/products/magento.md
@@ -8,7 +8,7 @@ permalink: /magento
 alternate_urls:
   - /adobe-commerce
 versionCommand: php bin/magento --version
-releasePolicyLink: https://www.adobe.com/content/dam/cc/en/legal/terms/enterprise/pdfs/Magento-Open-Source-Software-Maintenance-Policy.pdf
+releasePolicyLink: https://experienceleague.adobe.com/en/docs/commerce-operations/release/planning/lifecycle-policy
 changelogTemplate: "https://experienceleague.adobe.com/docs/commerce-operations/release/notes/magento-open-source/{{'__LATEST__'|replace:'.','-'}}.html"
 eoasColumn: Bug fix maintenance
 eolColumn: Security maintenance


### PR DESCRIPTION
The current PDF is from 2022