### PR TITLE
[visual-studio] Add 18.9 cycle

### DIFF
--- a/products/visual-studio.md
+++ b/products/visual-studio.md
@@ -25,10 +25,18 @@ auto:
 # For LTSC, EOL dates can be found on https://learn.microsoft.com/visualstudio/productinfo/vs-servicing#long-term-servicing-channel-ltsc-support
 # When adding a new major version (codename changes), remember to update URLS at auto:methods above also check https://github.com/endoflife-date/release-data/blob/main/src/visual-studio.py
 releases:
+  - releaseCycle: "18.9"
+    codename: "2026"
+    releaseDate: 2026-08-11
+    eol: false # releaseDate(19.0 or 18.10)
+    latest: "18.9.0"
+    latestReleaseDate: 2026-08-11
+    link: https://learn.microsoft.com/visualstudio/releases/__CODENAME__/release-notes#__LATEST__
+
   - releaseCycle: "18.8"
     codename: "2026"
     releaseDate: 2026-07-14
-    eol: false # releaseDate(18.9)
+    eol: 2026-08-11
     latest: "18.8.3"
     latestReleaseDate: 2026-08-11
     link: https://learn.microsoft.com/visualstudio/releases/__CODENAME__/release-notes#__LATEST__


### PR DESCRIPTION
https://learn.microsoft.com/tr-tr/visualstudio/releases/2026/release-notes#august-update-1890

Note: I didn't added this url because probably they wil return back to classic syntax with .1 version
[ current url will still work / not properly but will]