### PR TITLE
[New Product] TRMNL Software

### DIFF
--- a/products/trmnl-software.md
+++ b/products/trmnl-software.md
@@ -1,0 +1,111 @@
+---
+title: TRMNL Software
+addedAt: 2026-08-14
+category: server-app
+tags: e-reader
+permalink: /trmnl-software
+alternate_urls:
+  - /trmnl-byos
+  - /trmnl-plugins
+eolColumn: true
+latestColumn: false
+discontinuedColumn: false
+
+releases:
+  - releaseCycle: "terminus"
+    releaseLabel: "Terminus (official BYOS)"
+    releaseDate: 2025-01-01
+    eol: false
+    link: https://github.com/usetrmnl/terminus
+
+  - releaseCycle: "larapaper"
+    releaseLabel: "LaraPaper (BYOS)"
+    releaseDate: 2025-01-01
+    eol: false
+    link: https://github.com/usetrmnl/larapaper
+
+  - releaseCycle: "inker"
+    releaseLabel: "Inker (BYOS)"
+    releaseDate: 2025-01-01
+    eol: false
+    link: https://github.com/usetrmnl/inker
+
+  - releaseCycle: "byos-next"
+    releaseLabel: "BYOS Next.js"
+    releaseDate: 2025-01-01
+    eol: false
+    link: https://github.com/usetrmnl/byos_next
+
+  - releaseCycle: "byos-fastapi"
+    releaseLabel: "BYOS FastAPI"
+    releaseDate: 2025-01-01
+    eol: false
+    link: https://github.com/usetrmnl/byos_fastapi
+
+  - releaseCycle: "byos-django"
+    releaseLabel: "BYOS Django"
+    releaseDate: 2025-01-01
+    eol: false
+    link: https://github.com/usetrmnl/byos_django
+
+  - releaseCycle: "byos-phoenix"
+    releaseLabel: "BYOS Phoenix"
+    releaseDate: 2025-01-01
+    eol: false
+    link: https://github.com/usetrmnl/byos_phoenix
+
+  - releaseCycle: "trmnlp"
+    releaseLabel: "trmnlp (plugin dev server)"
+    releaseDate: 2025-01-01
+    eol: false
+    link: https://github.com/usetrmnl/trmnlp
+
+---
+
+> [TRMNL Software](https://trmnl.com/) encompasses the open-source and community ecosystem that powers TRMNL ePaper devices: self-hosted servers (BYOS), the plugin/recipe marketplace, and developer tooling.
+
+TRMNL devices can run against the official hosted Core service or against any compatible self-hosted server. The open ecosystem ensures devices remain usable even if the commercial service changes.
+
+### BYOS (Build Your Own Server / Bring Your Own Server)
+
+BYOS implementations let you point official or DIY TRMNL-compatible hardware at a private server. Official documentation lists the following implementations:
+
+| Implementation | Language / Framework | Status | Repository |
+|----------------|----------------------|--------|------------|
+| **Terminus** | Ruby / Hanami | Official flagship, actively maintained | [usetrmnl/terminus](https://github.com/usetrmnl/terminus) |
+| **LaraPaper** | PHP / Laravel | Popular community/official, recipe support, Docker | [usetrmnl/larapaper](https://github.com/usetrmnl/larapaper) |
+| **Inker** | JavaScript / modern stack | Homelab-focused, drag-and-drop designer, Docker | [usetrmnl/inker](https://github.com/usetrmnl/inker) |
+| **BYOS Next.js** | TypeScript / Next.js | Official community, Postgres/Supabase, recipes gallery | [usetrmnl/byos_next](https://github.com/usetrmnl/byos_next) |
+| **BYOS FastAPI** | Python / FastAPI | Community | [usetrmnl/byos_fastapi](https://github.com/usetrmnl/byos_fastapi) |
+| **BYOS Django** | Python / Django | Community | [usetrmnl/byos_django](https://github.com/usetrmnl/byos_django) |
+| **BYOS Phoenix** | Elixir / Phoenix | Community | [usetrmnl/byos_phoenix](https://github.com/usetrmnl/byos_phoenix) |
+
+All implementations must support at least the core device endpoints (`/api/setup`, `/api/display`, `/api/log`). Feature completeness (playlists, recipes, sensors, auto-join, Docker, etc.) varies; Terminus and LaraPaper are the most feature-rich at present.
+
+### Plugins, Recipes & Native Integrations
+
+- **Native plugins** – maintained by the TRMNL team (calendar, weather, Notion, GitHub, Shopify, Home Assistant-related, etc.).
+- **Private plugins** – user-created for personal use (webhook or polling).
+- **Recipes** – private plugins that have been published to the public catalog for anyone to install. Hundreds exist; authors can earn from usage. Browse at [trmnl.com/recipes](https://trmnl.com/recipes).
+- **Community / third-party plugins** – additional open-source examples live in [usetrmnl/plugins](https://github.com/usetrmnl/plugins).
+
+### Developer tooling
+
+- **[trmnlp](https://github.com/usetrmnl/trmnlp)** – local development server and CLI for building, previewing (HTML/PNG), linting, and pushing TRMNL plugins. Uses the TRMNL Design System / Liquid templates. Installable as a Ruby gem or via Docker.
+- Related utilities include the Design Framework, plugin generators, and agent skills for AI-assisted template writing.
+
+### APIs
+
+TRMNL exposes three complementary API surfaces documented at [docs.trmnl.com](https://docs.trmnl.com/):
+
+| API | Audience | Auth | Purpose |
+|-----|----------|------|---------|
+| **[Public API](https://docs.trmnl.com/go/public-api/introduction)** | Anyone | None required | Open endpoints for community data: [Recipes API](https://docs.trmnl.com/go/public-api/recipes-api) (search/sort community plugins), Categories API, device models, color palettes, and related public metadata. |
+| **[Private API](https://docs.trmnl.com/go/private-api/introduction)** | Developer Edition / advanced users | Device Access-Token | Advanced features beyond the basic device `/api/display` endpoint. Includes Display API (retrieve images device-free), Plugin Data API (parsed JSON for custom templates), Account API, and additional customization endpoints. |
+| **[Partners API](https://docs.trmnl.com/go/partners-api/introduction)** | Approved partners / companies | Client-ID + Access-Token (issued by TRMNL) | Provision devices and pre-load plugins for customers. Generate discount/coupon codes, associate devices with partner accounts, and ship units that arrive pre-configured with the partner’s plugin. |
+
+The core device protocol (`GET /api/setup`, `GET /api/display`, `GET /api/log`) is implemented by both the hosted Core service and all BYOS servers. Full OpenAPI/Swagger documentation is also available at [trmnl.com/api-docs](https://trmnl.com/api-docs/index.html).
+
+No formal multi-year end-of-support schedule is published for these software components. Most projects are under active development with regular tagged releases (especially LaraPaper and the firmware that consumes the API). Support is community- and maintainer-driven; the Unbrickable Pledge and open-source nature of the stack further reduce lock-in risk.
+
+More information: [docs.trmnl.com](https://docs.trmnl.com/), [BYOS documentation](https://docs.trmnl.com/go/diy/byos), [GitHub organization](https://github.com/usetrmnl).


### PR DESCRIPTION
## Summary

Adds a new product page for **TRMNL Software** (category: `server-app`).

This page covers the open-source software ecosystem that powers TRMNL ePaper devices:

### BYOS (Build Your Own Server) implementations
- **Terminus** – official flagship (Ruby/Hanami)
- **LaraPaper** – popular Laravel implementation with strong recipe support
- **Inker** – modern JS/homelab-focused server with drag-and-drop designer
- **BYOS Next.js** – TypeScript/Next.js implementation
- **BYOS FastAPI** – Python/FastAPI (community)
- **BYOS Django** – Python/Django (community)
- **BYOS Phoenix** – Elixir/Phoenix (community)

### Plugins, Recipes & tooling
- Native plugins, private plugins, and the public **Recipes** marketplace (hundreds of community-shared plugins)
- **trmnlp** – local development server/CLI for scaffolding, previewing, linting, and publishing plugins

### APIs
Documents the three official API surfaces:

- **Public API** – unauthenticated endpoints (Recipes API, Categories, device models, colour palettes, etc.)
- **Private API** – Developer Edition / advanced features (Display API, Plugin Data API, Account API) authenticated via device Access-Token
- **Partners API** – for approved partners to provision devices, generate discount codes, and pre-load plugins for customers

Also note the core device protocol (`/api/setup`, `/api/display`, `/api/log`) used by both Core and all BYOS servers, plus the OpenAPI/Swagger docs.

## Rationale

- Complements the existing TRMNL hardware page.
- BYOS is a core part of the “Unbrickable” design; users and operators need a place to track the self-hosted options.
- The Public / Private / Partners APIs are first-class parts of the platform and should be visible alongside the server implementations and plugin ecosystem.
- Fits `server-app` (self-hosted servers) while documenting the broader plugin/recipe ecosystem, developer tooling, and APIs in the body.
- All listed projects are actively or recently maintained; no formal EOL dates exist, so every cycle uses `eol: false`.

## Sources

- https://docs.trmnl.com/ (Public, Private, and Partners API sections)
- https://docs.trmnl.com/go/diy/byos
- https://github.com/usetrmnl (terminus, larapaper, inker, byos_next, byos_fastapi, byos_django, byos_phoenix, trmnlp, plugins)
- https://trmnl.com/recipes
- https://trmnl.com/api-docs
- Official help centre articles on plugins & recipes

## Notes

- `releaseDate` values are approximate placeholders (early 2025) because exact first public release dates vary and are not always tagged; happy to refine with better data.
- `latestColumn` disabled (multiple independent projects with their own versioning).
- Alternate URLs: `/trmnl-byos`, `/trmnl-plugins`.
- Ready for review/lint. Feedback welcome on category, additional cycles, or more precise dates.