### PR TITLE
[samsung-mobile] Update Galaxy A56 5G EOL to 2032-03-31

### DIFF
--- a/products/samsung-mobile.md
+++ b/products/samsung-mobile.md
@@ -255,7 +255,7 @@ releases:
     releaseLabel: "Galaxy A56 5G"
     releaseDate: 2025-03-28 # https://news.samsung.com/global/samsung-galaxy-a56-5g-galaxy-a36-5g-and-galaxy-a26-5g-are-now-available-worldwide
     eoas: 2031-03-28 # 6 android upgrade - https://news.samsung.com/global/samsung-galaxy-a56-5g-galaxy-a36-5g-and-galaxy-a26-5g-are-now-available-worldwide
-    eol: 2031-03-28 # 6 years of security updates - https://news.samsung.com/global/samsung-galaxy-a56-5g-galaxy-a36-5g-and-galaxy-a26-5g-are-now-available-worldwide
+    eol: 2032-03-31 # 7 years of security updates - https://news.samsung.com/global/samsung-galaxy-a56-5g-galaxy-a36-5g-and-galaxy-a26-5g-are-now-available-worldwide
     link: https://doc.samsungmobile.com/SM-A5660/TGY/doc.html
 
   - releaseCycle: "galaxy-a36-5g"


### PR DESCRIPTION
Samsung's official product specifications state that the security update period for the Galaxy A56 5G is valid until 31 March 2032.

This updates the `eol` value from `2031-03-28` to `2032-03-31`.

Source: https://www.samsung.com/fr/smartphones/galaxy-a/galaxy-a56-5g-awesome-lightgray-256gb-sm-a566bzaceub/#specs