### PR TITLE
[zabbix] Update eol date for 7.4 cycle

### DIFF
--- a/products/zabbix.md
+++ b/products/zabbix.md
@@ -26,7 +26,7 @@ releases:
   - releaseCycle: "7.4"
     releaseDate: 2025-06-30
     eoas: false # until 8.0 LTS
-    eol: 2026-12-31 # Q4 2026, per the vendor lifecycle page
+    eol: 2026-12-31 # Q4 2026, https://www.zabbix.com/life_cycle_and_release_policy#:~:text=Currently%20Supported%20Zabbix%20Releases
     latest: "7.4.13"
     latestReleaseDate: 2026-07-29
 

--- a/products/zabbix.md
+++ b/products/zabbix.md
@@ -26,7 +26,7 @@ releases:
   - releaseCycle: "7.4"
     releaseDate: 2025-06-30
     eoas: false # until 8.0 LTS
-    eol: 2026-09-30 # Q3 2026
+    eol: 2026-12-31 # Q4 2026, per the vendor lifecycle page
     latest: "7.4.13"
     latestReleaseDate: 2026-07-29
 


### PR DESCRIPTION
Zabbix's lifecycle page (https://www.zabbix.com/life_cycle_and_release_policy) currently lists **Zabbix 7.4** as:

| | |
|---|---|
| Release date | July 1, 2025 |
| Full support | until 8.0 LTS |
| Limited support | **Q4 2026** |

The file has `eol: 2026-09-30 # Q3 2026`, which no longer matches the vendor table. 8.0 LTS is scheduled for Q3 2026 on the same page, and 7.4's limited-support window runs one further quarter — consistent with the standard-release policy stated there: *"Limited Support: Minimum 6 months (until next Standard Release)."*

Encoded as the last day of the quarter (`2026-12-31`), matching how the previous Q3 value was expressed. `eoas: false # until 8.0 LTS` is left as-is since full support genuinely ends on 8.0's release rather than a fixed date.

Verified against the live vendor page on 2026-08-17.