### PR TITLE
Fix EOL date for Rocket.Chat version 8.5 LTS

### DIFF
--- a/products/rocket-chat.md
+++ b/products/rocket-chat.md
@@ -43,7 +43,7 @@ releases:
     lts: true
     releaseDate: 2026-06-10
     eoas: 2026-06-10
-    eol: 2026-07-10
+    eol: 2027-07-31
     latest: "8.5.2"
     latestReleaseDate: 2026-07-10
 


### PR DESCRIPTION
Correct the 8.5 LTS EOL date to match information here: https://docs.rocket.chat/docs/version-durability