### PR TITLE
[rhel] Add lifecycle data for minor releases

### DIFF
--- a/products/rhel.md
+++ b/products/rhel.md
@@ -31,6 +31,9 @@ auto:
         eol: Maintenance support
         eoes: Extended life cycle support (ELS) add-on
 
+# Minor release rows are listed under their major version rather than in strict
+# release date order, so they are flagged as outOfOrder to opt out of the
+# chronological ordering check. Only the major version rows take part in it.
 releases:
   - releaseCycle: "10"
     releaseDate: 2025-05-20
@@ -39,7 +42,34 @@ releases:
     lts: 2035-05-31
     eoes: 2039-05-31
     latest: "10.2"
-    latestReleaseDate: 2026-05-20
+    latestReleaseDate: 2026-05-19
+
+  - releaseCycle: "10.2"
+    outOfOrder: true
+    releaseDate: 2026-05-19
+    eoas: false
+    eol: false
+    eoes: false
+    latest: "10.2"
+    latestReleaseDate: 2026-05-19
+
+  - releaseCycle: "10.1"
+    outOfOrder: true
+    releaseDate: 2025-11-11
+    eoas: 2026-05-19
+    eol: 2026-05-19
+    latest: "10.1"
+    latestReleaseDate: 2025-11-11
+
+  - releaseCycle: "10.0"
+    outOfOrder: true
+    releaseLabel: "10.0 (E4S)"
+    releaseDate: 2025-05-20
+    eoas: 2025-11-11
+    eol: 2025-11-11
+    eoes: 2029-05-31
+    latest: "10.0"
+    latestReleaseDate: 2025-05-20
 
   - releaseCycle: "9"
     releaseDate: 2022-05-18
@@ -48,7 +78,88 @@ releases:
     lts: 2032-05-31
     eoes: 2036-05-31
     latest: "9.8"
-    latestReleaseDate: 2026-05-20
+    latestReleaseDate: 2026-05-19
+
+  - releaseCycle: "9.8"
+    outOfOrder: true
+    releaseDate: 2026-05-19
+    eoas: false
+    eol: false
+    eoes: false
+    latest: "9.8"
+    latestReleaseDate: 2026-05-19
+
+  - releaseCycle: "9.7"
+    outOfOrder: true
+    releaseDate: 2025-11-11
+    eoas: 2026-05-19
+    eol: 2026-05-19
+    latest: "9.7"
+    latestReleaseDate: 2025-11-11
+
+  - releaseCycle: "9.6"
+    outOfOrder: true
+    releaseLabel: "9.6 (EUS, E4S)"
+    releaseDate: 2025-05-20
+    eoas: 2025-11-11
+    eol: 2027-05-31
+    eoes: 2029-05-31
+    latest: "9.6"
+    latestReleaseDate: 2025-05-20
+
+  - releaseCycle: "9.5"
+    outOfOrder: true
+    releaseDate: 2024-11-12
+    eoas: 2025-05-20
+    eol: 2025-05-20
+    latest: "9.5"
+    latestReleaseDate: 2024-11-12
+
+  - releaseCycle: "9.4"
+    outOfOrder: true
+    releaseLabel: "9.4 (EUS, E4S)"
+    releaseDate: 2024-04-30
+    eoas: 2024-11-12
+    eol: 2026-04-30
+    eoes: 2028-04-30
+    latest: "9.4"
+    latestReleaseDate: 2024-04-30
+
+  - releaseCycle: "9.3"
+    outOfOrder: true
+    releaseDate: 2023-11-07
+    eoas: 2024-04-30
+    eol: 2024-04-30
+    latest: "9.3"
+    latestReleaseDate: 2023-11-07
+
+  - releaseCycle: "9.2"
+    outOfOrder: true
+    releaseLabel: "9.2 (EUS, E4S)"
+    releaseDate: 2023-05-10
+    eoas: 2023-11-07
+    eol: 2025-05-31
+    eoes: 2027-05-31
+    latest: "9.2"
+    latestReleaseDate: 2023-05-10
+
+  - releaseCycle: "9.1"
+    outOfOrder: true
+    releaseDate: 2022-11-15
+    eoas: 2023-05-31
+    eol: 2023-05-31
+    latest: "9.1"
+    latestReleaseDate: 2022-11-15
+
+  - releaseCycle: "9.0"
+    outOfOrder: true
+    releaseLabel: "9.0 (EUS, E4S)"
+    releaseDate: 2022-05-17
+    eoas: 2022-11-15
+    eol: 2024-05-31
+    eoes: 2026-05-31
+    latest: "9.0"
+    latestReleaseDate: 2022-05-17
 
   - releaseCycle: "8"
     releaseDate: 2019-05-07
@@ -59,6 +170,104 @@ releases:
     latest: "8.10"
     latestReleaseDate: 2024-05-22
 
+  - releaseCycle: "8.10"
+    outOfOrder: true
+    releaseDate: 2024-05-22
+    eoas: 2024-05-31
+    eol: 2029-05-31
+    eoes: 2033-05-31
+    latest: "8.10"
+    latestReleaseDate: 2024-05-22
+
+  - releaseCycle: "8.9"
+    outOfOrder: true
+    releaseDate: 2023-11-14
+    eoas: 2024-05-31
+    eol: 2024-05-31
+    latest: "8.9"
+    latestReleaseDate: 2023-11-14
+
+  - releaseCycle: "8.8"
+    outOfOrder: true
+    releaseLabel: "8.8 (EUS, E4S)"
+    releaseDate: 2023-05-16
+    eoas: 2023-11-14
+    eol: 2025-05-31
+    eoes: 2027-05-31
+    latest: "8.8"
+    latestReleaseDate: 2023-05-16
+
+  - releaseCycle: "8.7"
+    outOfOrder: true
+    releaseDate: 2022-11-09
+    eoas: 2023-05-31
+    eol: 2023-05-31
+    latest: "8.7"
+    latestReleaseDate: 2022-11-09
+
+  - releaseCycle: "8.6"
+    outOfOrder: true
+    releaseLabel: "8.6 (EUS, E4S)"
+    releaseDate: 2022-05-10
+    eoas: 2022-11-09
+    eol: 2024-05-31
+    eoes: 2026-05-31
+    latest: "8.6"
+    latestReleaseDate: 2022-05-10
+
+  - releaseCycle: "8.5"
+    outOfOrder: true
+    releaseDate: 2021-11-09
+    eoas: 2022-05-31
+    eol: 2022-05-31
+    latest: "8.5"
+    latestReleaseDate: 2021-11-09
+
+  - releaseCycle: "8.4"
+    outOfOrder: true
+    releaseLabel: "8.4 (EUS)"
+    releaseDate: 2021-05-18
+    eoas: 2021-11-09
+    eol: 2023-05-31
+    latest: "8.4"
+    latestReleaseDate: 2021-05-18
+
+  - releaseCycle: "8.3"
+    outOfOrder: true
+    releaseDate: 2020-11-03
+    eoas: 2021-05-31
+    eol: 2021-05-31
+    latest: "8.3"
+    latestReleaseDate: 2020-11-03
+
+  - releaseCycle: "8.2"
+    outOfOrder: true
+    releaseLabel: "8.2 (EUS, E4S)"
+    releaseDate: 2020-04-28
+    eoas: 2020-11-03
+    eol: 2022-04-30
+    eoes: 2024-04-30
+    latest: "8.2"
+    latestReleaseDate: 2020-04-28
+
+  - releaseCycle: "8.1"
+    outOfOrder: true
+    releaseLabel: "8.1 (EUS, E4S)"
+    releaseDate: 2019-11-05
+    eoas: 2020-04-28
+    eol: 2021-11-30
+    eoes: 2023-11-30
+    latest: "8.1"
+    latestReleaseDate: 2019-11-05
+
+  - releaseCycle: "8.0"
+    outOfOrder: true
+    releaseDate: 2019-05-07
+    eoas: 2019-11-05
+    eol: 2019-11-05
+    latest: "8.0"
+    latestReleaseDate: 2019-05-07
+
   - releaseCycle: "7"
     releaseDate: 2014-06-10
     eoas: 2019-08-06
@@ -67,6 +276,98 @@ releases:
     eoes: 2029-05-31
     latest: "7.9"
     latestReleaseDate: 2020-09-29
+
+  - releaseCycle: "7.9"
+    outOfOrder: true
+    releaseDate: 2020-09-29
+    eoas: 2024-06-30
+    eol: 2024-06-30
+    eoes: 2029-05-31
+    latest: "7.9"
+    latestReleaseDate: 2020-09-29
+
+  - releaseCycle: "7.8"
+    outOfOrder: true
+    releaseDate: 2020-03-31
+    eoas: 2020-09-30
+    eol: 2020-09-30
+    latest: "7.8"
+    latestReleaseDate: 2020-03-31
+
+  - releaseCycle: "7.7"
+    outOfOrder: true
+    releaseLabel: "7.7 (EUS)"
+    releaseDate: 2019-08-06
+    eoas: 2020-03-31
+    eol: 2021-08-30
+    latest: "7.7"
+    latestReleaseDate: 2019-08-06
+
+  - releaseCycle: "7.6"
+    outOfOrder: true
+    releaseLabel: "7.6 (EUS, E4S)"
+    releaseDate: 2018-10-30
+    eoas: 2019-08-06
+    eol: 2021-05-31
+    eoes: 2022-10-31
+    latest: "7.6"
+    latestReleaseDate: 2018-10-30
+
+  - releaseCycle: "7.5"
+    outOfOrder: true
+    releaseLabel: "7.5 (EUS)"
+    releaseDate: 2018-04-10
+    eoas: 2018-10-30
+    eol: 2020-04-30
+    latest: "7.5"
+    latestReleaseDate: 2018-04-10
+
+  - releaseCycle: "7.4"
+    outOfOrder: true
+    releaseLabel: "7.4 (EUS, E4S)"
+    releaseDate: 2017-07-31
+    eoas: 2018-04-10
+    eol: 2019-08-31
+    eoes: 2021-08-31
+    latest: "7.4"
+    latestReleaseDate: 2017-07-31
+
+  - releaseCycle: "7.3"
+    outOfOrder: true
+    releaseLabel: "7.3 (EUS, E4S)"
+    releaseDate: 2016-11-03
+    eoas: 2017-07-31
+    eol: 2018-11-30
+    eoes: 2020-11-30
+    latest: "7.3"
+    latestReleaseDate: 2016-11-03
+
+  - releaseCycle: "7.2"
+    outOfOrder: true
+    releaseLabel: "7.2 (EUS, E4S)"
+    releaseDate: 2015-11-19
+    eoas: 2016-11-03
+    eol: 2017-11-30
+    eoes: 2019-11-30
+    latest: "7.2"
+    latestReleaseDate: 2015-11-19
+
+  - releaseCycle: "7.1"
+    outOfOrder: true
+    releaseLabel: "7.1 (EUS)"
+    releaseDate: 2015-03-05
+    eoas: 2015-11-19
+    eol: 2017-03-31
+    latest: "7.1"
+    latestReleaseDate: 2015-03-05
+
+  - releaseCycle: "7.0"
+    outOfOrder: true
+    releaseDate: 2014-06-09
+    eoas: 2015-03-05
+    eol: 2015-03-05
+    latest: "7.0"
+    latestReleaseDate: 2014-06-09
 
   - releaseCycle: "6"
     releaseDate: 2010-11-10
@@ -77,6 +378,103 @@ releases:
     latest: "6.10"
     latestReleaseDate: 2018-06-19
 
+  - releaseCycle: "6.10"
+    outOfOrder: true
+    releaseDate: 2018-06-19
+    eoas: 2020-11-30
+    eol: 2020-11-30
+    eoes: 2024-06-30
+    latest: "6.10"
+    latestReleaseDate: 2018-06-19
+
+  - releaseCycle: "6.9"
+    outOfOrder: true
+    releaseDate: 2017-03-21
+    eoas: 2018-06-19
+    eol: 2018-06-19
+    latest: "6.9"
+    latestReleaseDate: 2017-03-21
+
+  - releaseCycle: "6.8"
+    outOfOrder: true
+    releaseDate: 2016-05-10
+    eoas: 2017-03-21
+    eol: 2017-03-21
+    latest: "6.8"
+    latestReleaseDate: 2016-05-10
+
+  - releaseCycle: "6.7"
+    outOfOrder: true
+    releaseLabel: "6.7 (EUS)"
+    releaseDate: 2015-07-22
+    eoas: 2016-05-10
+    eol: 2018-12-31
+    latest: "6.7"
+    latestReleaseDate: 2015-07-22
+
+  - releaseCycle: "6.6"
+    outOfOrder: true
+    releaseLabel: "6.6 (EUS)"
+    releaseDate: 2014-10-14
+    eoas: 2015-07-22
+    eol: 2016-10-31
+    latest: "6.6"
+    latestReleaseDate: 2014-10-14
+
+  - releaseCycle: "6.5"
+    outOfOrder: true
+    releaseLabel: "6.5 (EUS)"
+    releaseDate: 2013-11-21
+    eoas: 2014-10-14
+    eol: 2015-11-30
+    latest: "6.5"
+    latestReleaseDate: 2013-11-21
+
+  - releaseCycle: "6.4"
+    outOfOrder: true
+    releaseLabel: "6.4 (EUS)"
+    releaseDate: 2013-02-21
+    eoas: 2013-11-21
+    eol: 2015-03-03
+    latest: "6.4"
+    latestReleaseDate: 2013-02-21
+
+  - releaseCycle: "6.3"
+    outOfOrder: true
+    releaseLabel: "6.3 (EUS)"
+    releaseDate: 2012-06-20
+    eoas: 2013-02-21
+    eol: 2014-06-30
+    latest: "6.3"
+    latestReleaseDate: 2012-06-20
+
+  - releaseCycle: "6.2"
+    outOfOrder: true
+    releaseLabel: "6.2 (EUS)"
+    releaseDate: 2011-12-06
+    eoas: 2012-06-20
+    eol: 2014-01-07
+    latest: "6.2"
+    latestReleaseDate: 2011-12-06
+
+  - releaseCycle: "6.1"
+    outOfOrder: true
+    releaseLabel: "6.1 (EUS)"
+    releaseDate: 2011-05-19
+    eoas: 2011-12-06
+    eol: 2013-05-31
+    latest: "6.1"
+    latestReleaseDate: 2011-05-19
+
+  - releaseCycle: "6.0"
+    outOfOrder: true
+    releaseLabel: "6.0 (EUS)"
+    releaseDate: 2010-11-09
+    eoas: 2011-05-19
+    eol: 2012-11-30
+    latest: "6.0"
+    latestReleaseDate: 2010-11-09
+
   - releaseCycle: "5"
     releaseDate: 2007-03-15
     eoas: 2013-01-08
@@ -86,6 +484,108 @@ releases:
     latest: "5.11"
     latestReleaseDate: 2014-09-16
 
+  - releaseCycle: "5.11"
+    outOfOrder: true
+    releaseDate: 2014-09-16
+    eoas: 2017-03-31
+    eol: 2017-03-31
+    eoes: 2020-11-30
+    latest: "5.11"
+    latestReleaseDate: 2014-09-16
+
+  - releaseCycle: "5.10"
+    outOfOrder: true
+    releaseDate: 2013-10-01
+    eoas: 2014-09-16
+    eol: 2014-09-16
+    latest: "5.10"
+    latestReleaseDate: 2013-10-01
+
+  - releaseCycle: "5.9"
+    outOfOrder: true
+    releaseLabel: "5.9 (EUS)"
+    releaseDate: 2013-01-07
+    eoas: 2013-10-01
+    eol: 2015-03-31
+    latest: "5.9"
+    latestReleaseDate: 2013-01-07
+
+  - releaseCycle: "5.8"
+    outOfOrder: true
+    releaseDate: 2012-02-20
+    eoas: 2013-01-07
+    eol: 2013-01-07
+    latest: "5.8"
+    latestReleaseDate: 2012-02-20
+
+  - releaseCycle: "5.7"
+    outOfOrder: true
+    releaseDate: 2011-07-21
+    eoas: 2012-02-20
+    eol: 2012-02-20
+    latest: "5.7"
+    latestReleaseDate: 2011-07-21
+
+  - releaseCycle: "5.6"
+    outOfOrder: true
+    releaseLabel: "5.6 (EUS)"
+    releaseDate: 2011-01-13
+    eoas: 2011-07-21
+    eol: 2013-07-31
+    latest: "5.6"
+    latestReleaseDate: 2011-01-13
+
+  - releaseCycle: "5.5"
+    outOfOrder: true
+    releaseDate: 2010-03-30
+    eoas: 2011-01-13
+    eol: 2011-01-13
+    latest: "5.5"
+    latestReleaseDate: 2010-03-30
+
+  - releaseCycle: "5.4"
+    outOfOrder: true
+    releaseLabel: "5.4 (EUS)"
+    releaseDate: 2009-09-02
+    eoas: 2010-03-30
+    eol: 2011-07-31
+    latest: "5.4"
+    latestReleaseDate: 2009-09-02
+
+  - releaseCycle: "5.3"
+    outOfOrder: true
+    releaseLabel: "5.3 (EUS)"
+    releaseDate: 2009-01-20
+    eoas: 2009-09-02
+    eol: 2010-11-30
+    latest: "5.3"
+    latestReleaseDate: 2009-01-20
+
+  - releaseCycle: "5.2"
+    outOfOrder: true
+    releaseLabel: "5.2 (EUS)"
+    releaseDate: 2008-05-21
+    eoas: 2009-01-20
+    eol: 2010-03-31
+    latest: "5.2"
+    latestReleaseDate: 2008-05-21
+
+  - releaseCycle: "5.1"
+    outOfOrder: true
+    releaseDate: 2007-11-07
+    eoas: 2008-05-21
+    eol: 2008-05-21
+    latest: "5.1"
+    latestReleaseDate: 2007-11-07
+
+  - releaseCycle: "5.0"
+    outOfOrder: true
+    releaseDate: 2007-03-15
+    eoas: 2007-11-07
+    eol: 2007-11-07
+    latest: "5.0"
+    latestReleaseDate: 2007-03-15
+
   - releaseCycle: "4"
     releaseDate: 2005-02-15
     eoas: 2009-03-31
@@ -93,7 +593,6 @@ releases:
     eoes: 2017-03-31
     latest: "4.9"
     latestReleaseDate: 2011-02-16
-
 ---
 
 > Red Hat Enterprise Linux is a Linux distribution developed by Red Hat for the commercial market.
@@ -127,3 +626,37 @@ selected urgent priority bug fixes, and troubleshooting for the last minor relea
 - On RHEL 7 ELS is not available for the architectures System z (Structure A), ARM, and POWER9.
 - On RHEL 6 ELS is only available for the IBM z Systems and the x86 architecture, both 32-bit and 64-bit variants.
 - On RHEL 6 a specific number of packages are supported under ELS, which is listed [here](https://access.redhat.com/articles/4997301).
+
+## Minor Releases
+
+In addition to major versions, this page lists individual minor releases (point releases).
+Under a standard Red Hat Enterprise Linux subscription, a minor release only receives
+errata until the next minor release becomes available, so most minor releases reach their
+end of life roughly six months after their general availability.
+
+For a minor release row:
+
+- **Full Support** is the date the next minor release became available, after which the
+  release no longer receives standard errata.
+- **Maintenance Support** is the end of the extended stream for that specific minor release
+  (Extended Update Support), or the same date as Full Support when no such stream exists.
+- **Extended Life Cycle Support** is the end of Enhanced EUS or Update Services for SAP
+  Solutions for that minor release.
+
+Minor releases covered by an extended stream are labelled accordingly (for example
+`9.4 (EUS, E4S)`). No minor release follows the last minor release of a major version,
+so that release keeps receiving errata until the end of the Maintenance Support phase of
+that major version, and it inherits the Maintenance Support and Extended Life Cycle
+Support dates of the major version. Its Full Support date is the one of the major version
+too, unless it was released after Full Support had already ended, in which case it never
+had a separate active support window and the date is the same as its Maintenance Support
+date.
+
+Starting with RHEL 9, Red Hat is consolidating EUS, Enhanced EUS and Update Services for
+SAP Solutions into a single [Extended Life Cycle (ELC)](https://access.redhat.com/support/policy/updates/errata)
+offering that provides six years of support from general availability for eligible
+even-numbered minor releases. Dates for minor releases are collected from
+[Red Hat Enterprise Linux Release Dates](https://access.redhat.com/articles/3078),
+[Red Hat Enterprise Linux Retired Life Cycle Dates](https://access.redhat.com/articles/4038291)
+and [Legacy Extended Support Offerings](https://access.redhat.com/support/policy/updates/errata_legacy),
+as the Red Hat Product Life Cycle Data API only exposes major version lifecycle data.


### PR DESCRIPTION
Refs #3318

## Summary

RHEL lifecycle data is currently tracked only at the major version level, so it is not
possible to tell whether a specific point release such as 9.4 is still supported. The
issue thread lists concrete consequences: users pinned to a minor release, SAP workloads
that are only supported on specific minor releases, compliance tooling that queries the
API, and at least one report of endoflife.date being cited to declare a still-supported
release EOL.

This PR adds a row for every minor release of RHEL 5 through 10 (56 rows), keeping the
seven major version rows. It follows the approach agreed in
[#3318](https://github.com/endoflife-date/endoflife.date/issues/3318#issuecomment-2841929886):
the major rows stay on the `redhat_lifecycles` automation, and the minor rows are filled
manually, because the Red Hat Product Life Cycle Data API only returns major versions.
I confirmed this by querying it directly — it returns exactly three versions (`8`, `9`,
`10`), so relaxing the `regex` in the frontmatter would not produce any minor release.

## Data model for a minor release row

| Column | Meaning for a minor release |
|---|---|
| Full Support (`eoas`) | The GA date of the next minor release, after which the release no longer receives standard errata |
| Maintenance Support (`eol`) | End of Extended Update Support, or the same date as Full Support when there is no such stream |
| Extended Life Cycle Support (`eoes`) | End of Enhanced EUS or Update Services for SAP Solutions |

Minor releases covered by an extended stream get a `releaseLabel` such as `9.4 (EUS, E4S)`.

Minor releases **without** any extended stream leave `eoes` unset rather than `false`, so
that the column renders `Unavailable` instead of `Yes`
([product.html#L127](https://github.com/endoflife-date/endoflife.date/blob/ca0c14146508a5348db564c3e46c3a062c4d10dc/_layouts/product.html#L127)).
`false` would claim these releases still have extended support. 37 rows are affected.

The last minor release of a major version (5.11, 6.10, 7.9, 8.10) has no successor, so it
keeps receiving errata until the end of Maintenance Support and inherits the dates of its
major version. 8.10 matches RHEL 8 on all three columns. For 5.11, 6.10 and 7.9 the major
version's Full Support had already ended before those releases shipped, so `eoas` is set
to the Maintenance Support date instead — the validator rejects an `eoas` earlier than
`releaseDate`.

`9.8` and `10.2` keep `eoas: false` / `eol: false` / `eoes: false`: no successor has
shipped and Red Hat lists their extended streams as *Planned*.

## Row ordering

Minor rows are listed under their major version rather than in strict release date order,
which is far more readable at 63 rows. They are flagged with `outOfOrder: true` so that
only the seven major rows take part in the ordering check
([product-data-validator.rb#L189](https://github.com/endoflife-date/endoflife.date/blob/ca0c14146508a5348db564c3e46c3a062c4d10dc/_plugins/product-data-validator.rb#L189),
[#L377](https://github.com/endoflife-date/endoflife.date/blob/ca0c14146508a5348db564c3e46c3a062c4d10dc/_plugins/product-data-validator.rb#L377)).

This also keeps `/api/v1/products/rhel/releases/latest` returning `10`, since that
endpoint serves `releases[0]`
([generate-api-v1.rb#L107](https://github.com/endoflife-date/endoflife.date/blob/ca0c14146508a5348db564c3e46c3a062c4d10dc/_plugins/generate-api-v1.rb#L107)).
Sorting all 63 rows by release date would have changed it to `10.2`.

`outOfOrder` is only read by the validator; no layout, the API serializer, nor
`update-product-data.py` looks at it.

## Correction to existing data

`latestReleaseDate` on the RHEL 9 and 10 rows is changed from `2026-05-20` to
`2026-05-19`. Both 9.8 and 10.2 shipped their `redhat-release` package on 2026-05-19
([RHBA-2026:18586](https://access.redhat.com/errata/RHBA-2026:18586),
[RHBA-2026:18131](https://access.redhat.com/errata/RHBA-2026:18131)), which is also the
GA date in Red Hat's release dates article. The other five major rows already match that
source. This field is not written by the automation, so it does not self-correct.

Happy to split this into a separate PR if preferred, but leaving it would mean `10` and
`10.2` showing different dates for the same release on the same page.

## Sources

- [Red Hat Enterprise Linux Release Dates](https://access.redhat.com/articles/3078) — GA dates for all minor releases
- [Red Hat Enterprise Linux Retired Life Cycle Dates](https://access.redhat.com/articles/4038291) — retired EUS / E4S / non-EUS end dates
- [Legacy Extended Support Offerings](https://access.redhat.com/support/policy/updates/errata_legacy) — active EUS / Enhanced EUS / E4S streams
- [Life Cycle policy](https://access.redhat.com/support/policy/updates/errata) — the new ELC model

<img width="879" height="967" alt="スクリーンショット 2026-08-21 15 50 51" src="https://github.com/user-attachments/assets/0c42337f-36f1-4c29-89e9-2a94092cfbd5" />
