### PR TITLE
Fix typos across docs and product pages

### DIFF
--- a/CHANGELOG_API.md
+++ b/CHANGELOG_API.md
@@ -24,8 +24,8 @@ API v1 is a major rework of the API v0 with a lot of breaking changes. Compared 
 v1:
 
 - feels more _Restful_ (#2431),
-- expose almost all products' data (#394, #759, #2062, #2595),
-- expose new metadata such as `schema version` (#2331), `total` (for lists), `generated_at` or
+- exposes almost all products' data (#394, #759, #2062, #2595),
+- exposes new metadata such as `schema version` (#2331), `total` (for lists), `generated_at` or
   `last modified` date,
 - is easier to consume thanks to:
   - new computed fields such as `is_maintained`,

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -159,7 +159,7 @@ eoesColumn: Extended Support
 # - displayed in the release table,
 # - made available in API responses,
 # - used in table includes, such as in https://github.com/endoflife-date/endoflife.date/blob/master/products/ansible.md
-#   (preferred this over release table when there are more than 2 or 3 custom fields),
+#   (prefer this over the release table when there are more than 2 or 3 custom fields),
 # - or even just used for internal documentation.
 # Search in the existing products source file to see how they are used.
 customFields:
@@ -213,7 +213,7 @@ auto:
 
       # Python-compatible regex that defines how the tags above should translate to versions (optional).
       # The default regex can handle versions having at least 2 digits (ex. 1.2) and at most 4 digits (ex. 1.2.3.4),
-      # with an optional leading "v"). Use named capturing groups to capture the version or version's parts.
+      # with an optional leading "v". Use named capturing groups to capture the version or version's parts.
       # Default value should work for most releases of the form a.b, a.b.c or 'v'a.b.c.
       # It should also skip over any special releases (such as nightly, beta, pre, rc...).
       regex: ^v(?P<major>\d+)_(?P<minor>\d+)_(?P<patch>\d{1,3})_?(?P<tiny>\d+)?$
@@ -258,7 +258,7 @@ auto:
     - maven: org.apache.tomcat/tomcat
 
     # Configuration for auto-update based on a custom script in the release-data repository.
-    # The value must be the script name in the release-data repository, without it's '.py' extension.
+    # The value must be the script name in the release-data repository, without its '.py' extension.
     - custom: script-name
 
 # A list of identifiers that can be used to detect this product as being used,
@@ -436,7 +436,7 @@ Click all the links on the page you've changed and make sure they're not broken.
 ### Run endoflife.date locally
 
 Please read the [HACKING documentation](https://github.com/endoflife-date/endoflife.date/blob/master/HACKING.md)
-for instructions on how to run the endoflife.date locally.
+for instructions on how to run endoflife.date locally.
 
 ### Testing API payload
 

--- a/assets/openapi.yml
+++ b/assets/openapi.yml
@@ -65,7 +65,7 @@ paths:
           name: product
           in: path
           required: true
-          description: Product URL as per the canonical URL on the endofife.date website.
+          description: Product URL as per the canonical URL on the endoflife.date website.
   "/api/{product}/{cycle}.json":
     get:
       summary: Single cycle details
@@ -100,7 +100,7 @@ paths:
           name: product
           in: path
           required: true
-          description: Product URL as per the canonical URL on the endofife.date website.
+          description: Product URL as per the canonical URL on the endoflife.date website.
         - schema:
             type: string
           name: cycle

--- a/products/anthropic-claude.md
+++ b/products/anthropic-claude.md
@@ -294,6 +294,6 @@ Anthropic recommends moving workloads to active models to maintain the highest l
 
 Customers with active deployments receive at least 60 days notice before retirement for publicly released models.
 Anthropic recommends auditing API usage to discover model usage and testing replacement models before retirement.
-Claude Mythos 5 is is offered in limited availability to approved customers and does not have a published retirement date.
+Claude Mythos 5 is offered in limited availability to approved customers and does not have a published retirement date.
 
 Anthropic has committed to preserve the weights of publicly released models and may make past models available again in the future.

--- a/products/netbackup-appliance-os.md
+++ b/products/netbackup-appliance-os.md
@@ -97,4 +97,4 @@ The Extended Phase starts after the Primary Phase and lasts for 1 to 2 years.
 During this phase no new bug fixes are provided, but customers can still access existing patches and receive technical support.
 
 The Sustaining Phase follows the Extended Phase and can last from 1 to 6 years.
-It is similar to the Extended Phase, but with a focus on on addressing severe service restoration or data retrieval issues.
+It is similar to the Extended Phase, but with a focus on addressing severe service restoration or data retrieval issues.

--- a/products/quarkus-framework.md
+++ b/products/quarkus-framework.md
@@ -434,7 +434,7 @@ releases:
 
 The Quarkus team releases a `major.minor` version every 4 to 6 weeks, and a fix version targeting the latest version every week in between.
 [Beginning with Quarkus 3.2](https://quarkus.io/blog/lts-releases/), a new LTS version is also published every 6 months.
-For up-to-date release planning informations, see [dedicated page](https://github.com/quarkusio/quarkus/wiki/Release-Planning).
+For up-to-date release planning information, see [dedicated page](https://github.com/quarkusio/quarkus/wiki/Release-Planning).
 
 Quarkus releases an LTS (Long-Term Support) version every six months.
 LTS is designed for users who prioritize stability over new features.

--- a/products/sns-firmware.md
+++ b/products/sns-firmware.md
@@ -110,6 +110,6 @@ releases:
 > are certified (ANSSI, CCN) firmwares that run
 > on [Stormshield firewalls](https://www.stormshield.com/products-services/products/network-security/product-range-sns/).
 
-Maintenance is guaranteed on release branches with an LTSB label for at least 12 months after they are designated as such. LTSB branches receieve
-only only functional or security patches. A minimum 6-month overlap is expected between each LTSB release branch,
+Maintenance is guaranteed on release branches with an LTSB label for at least 12 months after they are designated as such. LTSB branches receive
+only functional or security patches. A minimum 6-month overlap is expected between each LTSB release branch,
 to allow clients to migrate their installations to the next LTSB branch.

--- a/products/suse-manager.md
+++ b/products/suse-manager.md
@@ -109,7 +109,7 @@ SUSE Multi-Linux Manager Proxy follows the same lifecycle as SUSE Multi-Linux Ma
 
 ## [Long Term Support](https://www.suse.com/releasenotes/x86_64/SUSE-MANAGER/4.3/index.html#_suse_manager_4_3_lts)
 
-There is no additional LTS offering available, as Multi-Linux Manager can be seamingless upgraded.
+There is no additional LTS offering available, as Multi-Linux Manager can be seamlessly upgraded.
 
 An exception is in place for SUSE Multi-Linux Manager version 4.3 (formerly named SUSE Manager 4.3), 
 which continued to receive critical bug fixes and security fixes for an additional year for customers with an active LTS subscription. 

--- a/recommendations.md
+++ b/recommendations.md
@@ -162,10 +162,10 @@ If you think they are important to your users, mark them extremely well in the t
 Many times, your support/EoL policies are relative. Common examples:
 
 1. The last major release becomes unsupported 90 days after a new major release.
-2. Bug fixes on previous releases will be made till the latest releases gets the first point release.
+2. Bug fixes on previous releases will be made till the latest release gets the first point release.
 
 However, your end-users shouldn't have to do the math.
-Make sure that all your releases always have a clear dates (I suggest `YYYY-MM-DD`) irrespective of how these dates are decided.
+Make sure that all your releases always have a clear date (I suggest `YYYY-MM-DD`) irrespective of how these dates are decided.
 You doing the math once will save your users much more time.
 
 ### Bad - no clear dates
@@ -186,7 +186,7 @@ Some projects will often put a note instead of documenting absolute dates:
 | 2.1     | 3rd March 2021 |
 | 2.0     | 1st March 2020 |
 
-Release are supported for 2 years from the release date.
+Releases are supported for 2 years from the release date.
 
 ### Good
 


### PR DESCRIPTION
A batch of typo fixes: misspellings, doubled words, and a few grammar errors.

Misspellings:

- `assets/openapi.yml` - `endofife.date` -> `endoflife.date` (x2, appears in the published v0 API docs)
- `products/sns-firmware.md` - `receieve` -> `receive`
- `products/suse-manager.md` - `seamingless` -> `seamlessly`
- `products/quarkus-framework.md` - `informations` -> `information`

Doubled words:

- `products/anthropic-claude.md` - "is is offered"
- `products/netbackup-appliance-os.md` - "focus on on addressing"
- `products/sns-firmware.md` - "only only functional"

Grammar:

- `CONTRIBUTING.md` - `it's` -> `its`; "preferred this over release table" -> "prefer this over the release table"; stray `)` after `"v"`; "run the endoflife.date locally" -> "run endoflife.date locally"
- `recommendations.md` - "the latest releases gets" -> "release gets"; "a clear dates" -> "a clear date"; "Release are supported" -> "Releases are supported"
- `CHANGELOG_API.md` - "expose" -> "exposes" (x2, list parallelism)

No content or data changes.