### PR TITLE
Fix Spring Cloud changelog links (missing v prefix)

### DIFF
--- a/products/spring-cloud.md
+++ b/products/spring-cloud.md
@@ -6,7 +6,7 @@ tags: java-runtime vmware
 iconSlug: spring
 permalink: /spring-cloud
 releasePolicyLink: https://spring.io/projects/spring-cloud#support
-changelogTemplate: https://github.com/spring-cloud/spring-cloud-release/releases/tag/__LATEST__
+changelogTemplate: https://github.com/spring-cloud/spring-cloud-release/releases/tag/v__LATEST__
 eolColumn: OSS support
 eoesColumn: Commercial Support
 releaseLabel: "__RELEASE_CYCLE__ (__CODENAME__)"


### PR DESCRIPTION
The `changelogTemplate` for Spring Cloud generates changelog links that all 404:

```
https://github.com/spring-cloud/spring-cloud-release/releases/tag/2024.0.3   -> 404
https://github.com/spring-cloud/spring-cloud-release/releases/tag/v2024.0.3  -> 200
```

Upstream tags are `v`-prefixed. The auto-update regex `^v?(?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)$` matches the `v` but keeps it outside the capture groups, so `latest` is stored bare — the template needs to add it back.

This shows up in the weekly Check URLs run as 7 errors, one per release cycle:

```
Invalid link ".../releases/tag/2025.1.2" for spring-cloud.md#releases#2025.1, got an error : "404 Not Found"
Invalid link ".../releases/tag/2025.0.3" for spring-cloud.md#releases#2025.0, got an error : "404 Not Found"
... (2024.0, 2023.0, 2022.0, 2021.0, 2020.0)
```

Verified every cycle resolves after the change:

| latest | status |
| --- | --- |
| 2025.1.3 | 200 |
| 2025.0.3 | 200 |
| 2024.0.3 | 200 |
| 2023.0.6 | 200 |
| 2022.0.5 | 200 |
| 2021.0.9 | 200 |
| 2020.0.6 | 200 |

All release cycles in this product are numeric with no per-release `link:` overrides, so the template change covers all of them and nothing else.