### PR TITLE
Fix Apache Kafka changelog links

### DIFF
--- a/products/apache-kafka.md
+++ b/products/apache-kafka.md
@@ -7,7 +7,7 @@ iconSlug: apachekafka
 permalink: /apache-kafka
 alternate_urls:
   - /kafka
-changelogTemplate: https://downloads.apache.org/kafka/__LATEST__/RELEASE_NOTES.html
+changelogTemplate: https://archive.apache.org/dist/kafka/__LATEST__/RELEASE_NOTES.html
 eolColumn: Support
 eoesColumn: Confluent Community software End of Support
 # https://stackoverflow.com/a/51782038/374236
@@ -73,7 +73,7 @@ releases:
     eoes: 2026-12-02
     latest: "3.8.1"
     latestReleaseDate: 2024-10-29
-    link: https://web.archive.org/web/20260216184820/https://downloads.apache.org/kafka/3.8.1/RELEASE_NOTES.html
+    link: https://archive.apache.org/dist/kafka/__LATEST__/RELEASE_NOTES.html
 
   - releaseCycle: "3.7"
     releaseDate: 2024-02-26
@@ -81,7 +81,7 @@ releases:
     eoes: 2026-07-26
     latest: "3.7.2"
     latestReleaseDate: 2024-12-04
-    link: https://web.archive.org/web/20260216184827/https://downloads.apache.org/kafka/3.7.2/RELEASE_NOTES.html
+    link: https://archive.apache.org/dist/kafka/__LATEST__/RELEASE_NOTES.html
 
   - releaseCycle: "3.6"
     releaseDate: 2023-10-03


### PR DESCRIPTION
Fixes every changelog link for Apache Kafka, and drops the two Wayback Machine snapshots.

## Why downloads.apache.org does not work

Apache only mirrors the newest patch of each actively maintained line on `downloads.apache.org`. Right now that directory holds exactly three releases:

```
$ curl -s https://downloads.apache.org/kafka/
4.1.2/  4.2.1/  4.3.1/  KEYS
```

Everything else has been rotated off to `archive.apache.org`. So a permanent link pointing at `downloads.apache.org` breaks as soon as the next patch ships. That is what the weekly Check URLs run is reporting:

```
Invalid link ".../kafka/4.0.2/RELEASE_NOTES.html" for apache-kafka.md#releases#4.0, got an error : "404 Not Found"
Invalid link ".../kafka/3.9.2/RELEASE_NOTES.html" for apache-kafka.md#releases#3.9, got an error : "404 Not Found"
```

`archive.apache.org` carries every release, including the three current ones, so it is stable for all cycles.

## Changes

- `changelogTemplate` now points at `archive.apache.org/dist/kafka/__LATEST__/RELEASE_NOTES.html` (was `downloads.apache.org`). This covers cycles 4.3, 4.2, 4.1, 4.0 and 3.9.
- Cycles 3.8 and 3.7 used `web.archive.org` snapshots wrapping the dead `downloads.apache.org` URLs. They now use the same direct `archive.apache.org` pattern as the other 25 release entries, so there is no longer any Wayback Machine dependency in this file.

Note `archive.apache.org` is the ASF-run permanent archive on `apache.org`, not the Internet Archive.

## Verification

Resolved the effective URL for every release entry (per-release `link:` where present, otherwise the template) and fetched all of them. 30/30 return 200:

```
4.3 200   4.2 200   4.1 200   4.0 200   3.9 200   3.8 200
3.7 200   3.6 200   3.5 200   3.4 200   3.3 200   3.2 200
3.1 200   3.0 200   2.8 200   2.7 200   2.6 200   2.5 200
2.4 200   2.3 200   2.2 200   2.1 200   2.0 200   1.1 200
1.0 200   0.11 200  0.10 200  0.9 200   0.8 200   0.7 200
```

## Possible follow-up

With the template now on `archive.apache.org`, the 27 per-release `link:` overrides that spell out that exact same URL are redundant and could be deleted. Left alone here to keep this diff focused - happy to do it in a separate PR if wanted.