### PR TITLE
Fix dead links across product pages and docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -388,7 +388,7 @@ releases:
 
 # All the product information text should be under triple-dashes.
 
-> [Time Turner](https://jkrowling.com/time-turner) is a device that powers short-term time travel.
+> [Time Turner](https://www.harrypotter.com/writing-by-jk-rowling/time-turner) is a device that powers short-term time travel.
 
 Time-turners are no longer released, and the last known stable release was in HP.5 release.
 ```

--- a/products/azul-zulu.md
+++ b/products/azul-zulu.md
@@ -33,7 +33,7 @@ identifiers:
 
 # Versions and dates are those from the CA builds (PSU Update Type).
 # Latest releases can be found on https://www.azul.com/downloads/?os=linux&architecture=x86-64-bit&package=jdk&show-old-builds=true#download-openjdk.
-# Latest release dates can be found in each corresponding JSE Certificate (or in https://docs.azul.com/core/zulu-openjdk/release-notes.html).
+# Latest release dates can be found in each corresponding JSE Certificate (or in https://docs.azul.com/core/release-notes).
 # EOL dates can be found on https://www.azul.com/products/azul-support-roadmap/.
 # Extended support is also documented on https://www.azul.com/products/azul-support-roadmap/ :
 # - LTS: EOL + 2 years
@@ -88,7 +88,7 @@ releases:
 
   - releaseCycle: "21"
     lts: true
-    releaseDate: 2023-09-19 # https://docs.azul.com/core/zulu-openjdk/release-notes/21-ga
+    releaseDate: 2023-09-19 # https://docs.azul.com/core/release/21-ga/release-notes/release-notes
     eol: 2031-09-30
     eoes: 2033-09-30
     latest: "21.48.17"
@@ -98,7 +98,7 @@ releases:
 
   - releaseCycle: "20"
     releaseLabel: "20 (<abbr title='Short Term Support'>STS</abbr>)"
-    releaseDate: 2023-03-21 # https://docs.azul.com/core/zulu-openjdk/release-notes/20-ga
+    releaseDate: 2023-03-21 # https://docs.azul.com/core/release/20-ga/release-notes/release-notes
     eol: 2023-09-19
     eoes: 2024-03-31
     latest: "20.32.11"
@@ -108,7 +108,7 @@ releases:
 
   - releaseCycle: "19"
     releaseLabel: "19 (<abbr title='Short Term Support'>STS</abbr>)"
-    releaseDate: 2022-09-20 # https://docs.azul.com/core/zulu-openjdk/release-notes/19-ga
+    releaseDate: 2022-09-20 # https://docs.azul.com/core/release/19-ga/release-notes/release-notes
     eol: 2023-03-31
     eoes: 2023-09-30
     latest: "19.32.13"
@@ -118,7 +118,7 @@ releases:
 
   - releaseCycle: "18"
     releaseLabel: "18 (<abbr title='Short Term Support'>STS</abbr>)"
-    releaseDate: 2022-03-12 # https://docs.azul.com/core/zulu-openjdk/release-notes/18-ga
+    releaseDate: 2022-03-12 # https://docs.azul.com/core/release/18-ga/release-notes/release-notes
     eol: 2022-09-30
     eoes: 2023-03-31
     latest: "18.32.13"
@@ -128,7 +128,7 @@ releases:
 
   - releaseCycle: "17"
     lts: true
-    releaseDate: 2021-09-15 # https://docs.azul.com/core/zulu-openjdk/release-notes/17-ga
+    releaseDate: 2021-09-15 # https://docs.azul.com/core/release/17-ga/release-notes/release-notes
     eol: 2029-09-30
     eoes: 2031-09-30
     latest: "17.64.17"
@@ -138,7 +138,7 @@ releases:
 
   - releaseCycle: "16"
     releaseLabel: "16 (<abbr title='Short Term Support'>STS</abbr>)"
-    releaseDate: 2021-03-16 # https://docs.azul.com/core/zulu-release-notes/16-ga/ZuluReleaseNotes/Title.htm
+    releaseDate: 2021-03-16 # https://web.archive.org/web/20230602060015/https://docs.azul.com/core/zulu-release-notes/16-ga/ZuluReleaseNotes/Title.htm
     eol: 2021-09-30
     eoes: 2022-03-31
     latest: "16.32.15"

--- a/products/raspberry-pi.md
+++ b/products/raspberry-pi.md
@@ -170,7 +170,7 @@ releases:
 
   - releaseCycle: "cm1"
     releaseLabel: Compute Module 1
-    # https://www.raspberrypi.org/raspberry-pi-compute-module-new-product/
+    # https://www.raspberrypi.com/news/raspberry-pi-compute-module-new-product/
     releaseDate: 2014-04-07
     eol: 2026-01-01
     link: https://www.raspberrypi.com/products/compute-module-1/

--- a/products/samsung-galaxy-tab.md
+++ b/products/samsung-galaxy-tab.md
@@ -29,7 +29,7 @@ auto:
 # Useful information can be found on:
 # - https://news.samsung.com (releaseDate, eoas, eol - search on Google with "<model> site:news.samsung.com")
 # - https://www.gsmarena.com/ (releaseDate)
-# - https://androidspotlight.com/software-update-policy-for-every-samsung-device/ (eoas / eol)
+# - https://web.archive.org/web/20250516053227/https://androidspotlight.com/software-update-policy-for-every-samsung-device/ (eoas / eol - domain is dead, archived snapshot)
 # - https://www.knowyourmobile.com/phones/samsung/one-ui/samsung-update-policy/ (eoas / eol)
 # - https://security.samsungmobile.com/workScope.smsb (eol status)
 # - https://doc.samsungmobile.com/ (link - search on Google with "<model> site:doc.samsungmobile.com")
@@ -100,29 +100,29 @@ releases:
   - releaseCycle: "galaxy-tab-s10-ultra"
     releaseLabel: "Galaxy Tab S10 Ultra"
     releaseDate: 2024-10-03 # https://news.samsung.com/global/galaxy-tab-s10-series-is-samsungs-ai-ready-tablet
-    eoas: 2031-10-03 # https://androidspotlight.com/software-update-policy-for-every-samsung-device/
-    eol: false      # https://androidspotlight.com/software-update-policy-for-every-samsung-device/
+    eoas: 2031-10-03 # https://web.archive.org/web/20250516053227/https://androidspotlight.com/software-update-policy-for-every-samsung-device/
+    eol: false      # https://web.archive.org/web/20250516053227/https://androidspotlight.com/software-update-policy-for-every-samsung-device/
     link: https://doc.samsungmobile.com/SM-X920/XAC/doc.html
 
   - releaseCycle: "galaxy-tab-s10+"
     releaseLabel: "Galaxy Tab S10+"
     releaseDate: 2024-10-03 # https://news.samsung.com/global/galaxy-tab-s10-series-is-samsungs-ai-ready-tablet
-    eoas: 2031-10-03 # https://androidspotlight.com/software-update-policy-for-every-samsung-device/
-    eol: 2031-10-03 # https://androidspotlight.com/software-update-policy-for-every-samsung-device/
+    eoas: 2031-10-03 # https://web.archive.org/web/20250516053227/https://androidspotlight.com/software-update-policy-for-every-samsung-device/
+    eol: 2031-10-03 # https://web.archive.org/web/20250516053227/https://androidspotlight.com/software-update-policy-for-every-samsung-device/
     link: https://doc.samsungmobile.com/SM-X820/XSP/doc.html
 
   - releaseCycle: "galaxy-tab-s6-lite-2024"
     releaseLabel: "Galaxy Tab S6 Lite (2024)"
     releaseDate: 2024-03-28 # https://news.samsung.com/global/samsung-galaxy-tab-s6-lite-2024-style-and-function-in-a-compact-package
-    eoas: 2027-03-28 # https://androidspotlight.com/software-update-policy-for-every-samsung-device/
+    eoas: 2027-03-28 # https://web.archive.org/web/20250516053227/https://androidspotlight.com/software-update-policy-for-every-samsung-device/
     eol: false
     link: https://doc.samsungmobile.com/SM-X300/EUX/doc.html
 
   - releaseCycle: "galaxy-tab-active5"
     releaseLabel: "Galaxy Tab Active5"
     releaseDate: 2024-01-23 # https://www.gsmarena.com/samsung_galaxy_tab_active5-12785.php
-    eoas: 2028-01-23 # https://androidspotlight.com/software-update-policy-for-every-samsung-device/
-    eol: 2029-01-23 # https://androidspotlight.com/software-update-policy-for-every-samsung-device/
+    eoas: 2028-01-23 # https://web.archive.org/web/20250516053227/https://androidspotlight.com/software-update-policy-for-every-samsung-device/
+    eol: 2029-01-23 # https://web.archive.org/web/20250516053227/https://androidspotlight.com/software-update-policy-for-every-samsung-device/
     link: https://doc.samsungmobile.com/SM-X300/EUX/doc.html
 
   - releaseCycle: "galaxy-tab-a9+"
@@ -135,8 +135,8 @@ releases:
   - releaseCycle: "galaxy-tab-a9"
     releaseLabel: "Galaxy Tab A9"
     releaseDate: 2023-10-23 # https://news.samsung.com/global/samsung-galaxy-tab-a9-and-galaxy-tab-a9-entertainment-and-productivity-engineered-for-everyone
-    eoas: 2026-10-23 # https://androidspotlight.com/software-update-policy-for-every-samsung-device/
-    eol: 2027-10-23 # https://androidspotlight.com/software-update-policy-for-every-samsung-device/
+    eoas: 2026-10-23 # https://web.archive.org/web/20250516053227/https://androidspotlight.com/software-update-policy-for-every-samsung-device/
+    eol: 2027-10-23 # https://web.archive.org/web/20250516053227/https://androidspotlight.com/software-update-policy-for-every-samsung-device/
     link: https://doc.samsungmobile.com/SM-X115/SKZ/doc.html
 
   - releaseCycle: "galaxy-tab-s9-fe+"
@@ -177,7 +177,7 @@ releases:
   - releaseCycle: "galaxy-tab-a7-10.4-2022"
     releaseLabel: "Galaxy Tab A7 10.4 (2022)"
     releaseDate: 2022-11-21 # https://www.gsmarena.com/samsung_galaxy_tab_a7_10_4_(2022)-11988.php
-    eoas: 2024-11-21 # https://androidspotlight.com/software-update-policy-for-every-samsung-device/
+    eoas: 2024-11-21 # https://web.archive.org/web/20250516053227/https://androidspotlight.com/software-update-policy-for-every-samsung-device/
     eol: false
     link: https://doc.samsungmobile.com/SM-T509/ITV/doc.html
 
@@ -191,7 +191,7 @@ releases:
   - releaseCycle: "galaxy-tab-s6-lite"
     releaseLabel: "Galaxy Tab S6 Lite"
     releaseDate: 2022-05-23 # https://www.gsmarena.com/samsung_galaxy_tab_s6_lite_(2022)-11524.php
-    eoas: 2025-05-25 # https://androidspotlight.com/software-update-policy-for-every-samsung-device/
+    eoas: 2025-05-25 # https://web.archive.org/web/20250516053227/https://androidspotlight.com/software-update-policy-for-every-samsung-device/
     eol: 2025-06-04
     link: https://doc.samsungmobile.com/SM-P619/ATO/doc.html
 
@@ -219,70 +219,70 @@ releases:
   - releaseCycle: "galaxy-tab-a8"
     releaseLabel: "Galaxy Tab A8"
     releaseDate: 2022-01-17 # https://www.gsmarena.com/samsung_galaxy_tab_a8_10_5_(2021)-11265.php
-    eoas: 2025-01-17 # https://androidspotlight.com/software-update-policy-for-every-samsung-device/
+    eoas: 2025-01-17 # https://web.archive.org/web/20250516053227/https://androidspotlight.com/software-update-policy-for-every-samsung-device/
     eol: 2026-02-21
     link: https://doc.samsungmobile.com/SM-X205/INS/doc.html
 
   - releaseCycle: "galaxy-tab-a7-lite"
     releaseLabel: "Galaxy Tab A7 Lite"
     releaseDate: 2021-05-27 # https://news.samsung.com/global/introducing-the-newest-members-of-the-samsung-galaxy-tab-portfolio-galaxy-tab-s7-fe-and-galaxy-tab-a7-lite
-    eoas: 2024-05-27 # https://androidspotlight.com/software-update-policy-for-every-samsung-device/
+    eoas: 2024-05-27 # https://web.archive.org/web/20250516053227/https://androidspotlight.com/software-update-policy-for-every-samsung-device/
     eol: 2025-06-04
     link: https://doc.samsungmobile.com/SM-T220/CHN/doc.html
 
   - releaseCycle: "galaxy-tab-s7-fe"
     releaseLabel: "Galaxy Tab S7 FE"
     releaseDate: 2021-05-27 # https://news.samsung.com/global/introducing-the-newest-members-of-the-samsung-galaxy-tab-portfolio-galaxy-tab-s7-fe-and-galaxy-tab-a7-lite
-    eoas: 2024-05-27 # https://androidspotlight.com/software-update-policy-for-every-samsung-device/
+    eoas: 2024-05-27 # https://web.archive.org/web/20250516053227/https://androidspotlight.com/software-update-policy-for-every-samsung-device/
     eol: 2025-07-08
     link: https://doc.samsungmobile.com/SM-T730/KOO/doc.html
 
   - releaseCycle: "galaxy-tab-active3"
     releaseLabel: "Galaxy Tab Active3"
     releaseDate: 2020-09-28 # https://news.samsung.com/global/samsung-announces-the-galaxy-tab-active3-a-smart-new-tablet-built-for-demanding-environments
-    eoas: 2022-09-28 # https://androidspotlight.com/software-update-policy-for-every-samsung-device/
+    eoas: 2022-09-28 # https://web.archive.org/web/20250516053227/https://androidspotlight.com/software-update-policy-for-every-samsung-device/
     eol: 2025-11-04 # https://9to5google.com/2021/02/22/samsung-security-updates-policy-four-years/
     link: https://doc.samsungmobile.com/SM-T575/XEF/doc.html
 
   - releaseCycle: "galaxy-tab-a7-10.4-2020"
     releaseLabel: "Galaxy Tab A7 10.4 (2020)"
     releaseDate: 2020-08-10 # https://news.samsung.com/us/galaxy-tab-a7-availability/
-    eoas: 2022-08-10 # https://androidspotlight.com/software-update-policy-for-every-samsung-device/
+    eoas: 2022-08-10 # https://web.archive.org/web/20250516053227/https://androidspotlight.com/software-update-policy-for-every-samsung-device/
     eol: 2024-08-10 # https://9to5google.com/2021/02/22/samsung-security-updates-policy-four-years/
     link: https://doc.samsungmobile.com/SM-T505/BTU/doc.html
 
   - releaseCycle: "galaxy-tab-s7+"
     releaseLabel: "Galaxy Tab S7+"
     releaseDate: 2020-08-05 # https://news.samsung.com/global/meet-galaxy-tab-s7-and-s7-plus-your-perfect-companion-to-work-play-and-more
-    eoas: 2023-08-05 # https://androidspotlight.com/software-update-policy-for-every-samsung-device/
+    eoas: 2023-08-05 # https://web.archive.org/web/20250516053227/https://androidspotlight.com/software-update-policy-for-every-samsung-device/
     eol: 2024-08-05 # https://9to5google.com/2021/02/22/samsung-security-updates-policy-four-years/
     link: https://doc.samsungmobile.com/SM-T970/XAR/doc.html
 
   - releaseCycle: "galaxy-tab-s7"
     releaseLabel: "Galaxy Tab S7"
     releaseDate: 2020-08-05 # https://news.samsung.com/global/meet-galaxy-tab-s7-and-s7-plus-your-perfect-companion-to-work-play-and-more
-    eoas: 2023-08-05 # https://androidspotlight.com/software-update-policy-for-every-samsung-device/
+    eoas: 2023-08-05 # https://web.archive.org/web/20250516053227/https://androidspotlight.com/software-update-policy-for-every-samsung-device/
     eol: 2024-08-05 # https://9to5google.com/2021/02/22/samsung-security-updates-policy-four-years/
     link: https://doc.samsungmobile.com/SM-T875/DBT/doc.html
 
   - releaseCycle: "galaxy-tab-s6-lite-2020"
     releaseLabel: "Galaxy Tab S6 Lite (2020)"
     releaseDate: 2020-03-26 # https://news.samsung.com/global/samsung-galaxy-tab-s6-lite-2024-style-and-function-in-a-compact-package
-    eoas: 2023-03-26 # https://androidspotlight.com/software-update-policy-for-every-samsung-device/
+    eoas: 2023-03-26 # https://web.archive.org/web/20250516053227/https://androidspotlight.com/software-update-policy-for-every-samsung-device/
     eol: 2024-03-26 # https://9to5google.com/2021/02/22/samsung-security-updates-policy-four-years/
     link: https://doc.samsungmobile.com/SM-P610/XEH/doc.html
 
   - releaseCycle: "galaxy-tab-a-8.4-2020"
     releaseLabel: "Galaxy Tab A 8.4 (2020)"
     releaseDate: 2020-03-25 # https://www.gsmarena.com/samsung_galaxy_tab_a_8_4_(2020)-10483.php
-    eoas: 2022-03-25 # https://androidspotlight.com/software-update-policy-for-every-samsung-device/
+    eoas: 2022-03-25 # https://web.archive.org/web/20250516053227/https://androidspotlight.com/software-update-policy-for-every-samsung-device/
     eol: 2024-03-25 # https://9to5google.com/2021/02/22/samsung-security-updates-policy-four-years/
     link: https://doc.samsungmobile.com/sm-t307u/glw/doc.html
 
   - releaseCycle: "galaxy-tab-s6-5g"
     releaseLabel: "Galaxy Tab S6 5G"
     releaseDate: 2020-01-30 # https://www.gsmarena.com/samsung_galaxy_tab_s6_5g-10004.php
-    eoas: 2023-01-30 # https://androidspotlight.com/software-update-policy-for-every-samsung-device/
+    eoas: 2023-01-30 # https://web.archive.org/web/20250516053227/https://androidspotlight.com/software-update-policy-for-every-samsung-device/
     eol: 2024-01-30 # https://9to5google.com/2021/02/22/samsung-security-updates-policy-four-years/
     link: https://doc.samsungmobile.com/sm-t866n/koo/doc.html
 
@@ -296,7 +296,7 @@ releases:
   - releaseCycle: "galaxy-tab-s6"
     releaseLabel: "Galaxy Tab S6"
     releaseDate: 2019-07-31 # https://news.samsung.com/us/samsung-galaxy-tab-s6-new-tablet-enhances-creativity-and-productivity/
-    eoas: 2022-07-31 # https://androidspotlight.com/software-update-policy-for-every-samsung-device/
+    eoas: 2022-07-31 # https://web.archive.org/web/20250516053227/https://androidspotlight.com/software-update-policy-for-every-samsung-device/
     eol: 2023-07-31 # https://9to5google.com/2021/02/22/samsung-security-updates-policy-four-years/
     link: https://doc.samsungmobile.com/SM-T860/XAR/doc.html
 
@@ -310,7 +310,7 @@ releases:
   - releaseCycle: "galaxy-tab-s5e"
     releaseLabel: "Galaxy Tab S5e"
     releaseDate: 2019-04-01 # https://www.gsmarena.com/samsung_galaxy_tab_s5e-9581.php
-    eoas: 2021-04-01 # https://androidspotlight.com/software-update-policy-for-every-samsung-device/
+    eoas: 2021-04-01 # https://web.archive.org/web/20250516053227/https://androidspotlight.com/software-update-policy-for-every-samsung-device/
     eol: 2023-04-01 # https://9to5google.com/2021/02/22/samsung-security-updates-policy-four-years/
     link: https://doc.samsungmobile.com/SM-T725/XEO/doc.html
 

--- a/products/samsung-galaxy-watch.md
+++ b/products/samsung-galaxy-watch.md
@@ -17,7 +17,7 @@ staleReleaseThresholdDays: 1825 # devices have longer support periods
 # Useful information can be found on:
 # - https://news.samsung.com (releaseDate, eoas, eol - search on Google with "<model> site:news.samsung.com")
 # - https://www.gsmarena.com/ (releaseDate)
-# - https://androidspotlight.com/software-update-policy-for-every-samsung-device/ (eoas / eol)
+# - https://web.archive.org/web/20250516053227/https://androidspotlight.com/software-update-policy-for-every-samsung-device/ (eoas / eol - domain is dead, archived snapshot)
 # - https://www.knowyourmobile.com/phones/samsung/one-ui/samsung-update-policy/ (eoas / eol)
 # - https://www.androidupdatetracker.com/ (eoas)
 # - https://security.samsungmobile.com/workScope.smsb (eol status)

--- a/products/samsung-mobile.md
+++ b/products/samsung-mobile.md
@@ -34,7 +34,7 @@ auto:
 # Useful information can be found on:
 # - https://news.samsung.com (releaseDate, eoas, eol - search on Google with "<model> site:news.samsung.com")
 # - https://www.gsmarena.com/ (releaseDate)
-# - https://androidspotlight.com/software-update-policy-for-every-samsung-device/ (eoas / eol)
+# - https://web.archive.org/web/20250516053227/https://androidspotlight.com/software-update-policy-for-every-samsung-device/ (eoas / eol - domain is dead, archived snapshot)
 # - https://www.knowyourmobile.com/phones/samsung/one-ui/samsung-update-policy/ (eoas / eol)
 # - https://www.androidupdatetracker.com/ (eoas)
 # - https://security.samsungmobile.com/workScope.smsb (eol status)
@@ -359,8 +359,8 @@ releases:
   - releaseCycle: "galaxy-z-fold-special-edition"
     releaseLabel: "Galaxy Z Fold Special Edition"
     releaseDate: 2024-10-24 # https://www.gsmarena.com/samsung_galaxy_z_fold_special-13452.php
-    eoas: 2031-10-24 # 7 Android updates - https://androidspotlight.com/software-update-policy-for-every-samsung-device/
-    eol: 2031-10-24 # 7 years of security updates - https://androidspotlight.com/software-update-policy-for-every-samsung-device/
+    eoas: 2031-10-24 # 7 Android updates - https://web.archive.org/web/20250516053227/https://androidspotlight.com/software-update-policy-for-every-samsung-device/
+    eol: 2031-10-24 # 7 years of security updates - https://web.archive.org/web/20250516053227/https://androidspotlight.com/software-update-policy-for-every-samsung-device/
     link: https://doc.samsungmobile.com/SM-F958N/KOO/doc.html
 
   - releaseCycle: "galaxy-s24-fe"
@@ -387,8 +387,8 @@ releases:
   - releaseCycle: "galaxy-m05"
     releaseLabel: "Galaxy M05"
     releaseDate: 2024-09-12 # https://news.samsung.com/in/samsung-unveils-galaxy-m05-with-50mp-dual-camera-and-stunning-display-in-india
-    eoas: 2026-09-12 # 2 android upgrade - https://androidspotlight.com/software-update-policy-for-every-samsung-device/
-    eol: 2028-09-12      # 4 years of security updates - https://androidspotlight.com/software-update-policy-for-every-samsung-device/
+    eoas: 2026-09-12 # 2 android upgrade - https://web.archive.org/web/20250516053227/https://androidspotlight.com/software-update-policy-for-every-samsung-device/
+    eol: 2028-09-12      # 4 years of security updates - https://web.archive.org/web/20250516053227/https://androidspotlight.com/software-update-policy-for-every-samsung-device/
     link: https://doc.samsungmobile.com/SM-M055F/BKD/doc.html
 
   - releaseCycle: "galaxy-f14"
@@ -408,22 +408,22 @@ releases:
   - releaseCycle: "galaxy-z-fold6"
     releaseLabel: "Galaxy Z Fold6"
     releaseDate: 2024-07-24 # https://www.gsmarena.com/samsung_galaxy_z_fold6-13147.php
-    eoas: 2031-07-24 # 7 Android updates - https://androidspotlight.com/software-update-policy-for-every-samsung-device/
-    eol: 2031-07-24      # 7 years of security updates - https://androidspotlight.com/software-update-policy-for-every-samsung-device/
+    eoas: 2031-07-24 # 7 Android updates - https://web.archive.org/web/20250516053227/https://androidspotlight.com/software-update-policy-for-every-samsung-device/
+    eol: 2031-07-24      # 7 years of security updates - https://web.archive.org/web/20250516053227/https://androidspotlight.com/software-update-policy-for-every-samsung-device/
     link: https://doc.samsungmobile.com/SM-F956W/ESK/doc.html
 
   - releaseCycle: "galaxy-z-flip6"
     releaseLabel: "Galaxy Z Flip6"
     releaseDate: 2024-07-24 # https://www.gsmarena.com/samsung_galaxy_z_flip6-13192.php
-    eoas: 2031-07-24 # 7 Android updates - https://androidspotlight.com/software-update-policy-for-every-samsung-device/
-    eol: 2031-07-24  # 7 years of security updates - https://androidspotlight.com/software-update-policy-for-every-samsung-device/
+    eoas: 2031-07-24 # 7 Android updates - https://web.archive.org/web/20250516053227/https://androidspotlight.com/software-update-policy-for-every-samsung-device/
+    eol: 2031-07-24  # 7 years of security updates - https://web.archive.org/web/20250516053227/https://androidspotlight.com/software-update-policy-for-every-samsung-device/
     link: https://doc.samsungmobile.com/SM-F741U/CCT/doc.html
 
   - releaseCycle: "galaxy-m35-5g"
     releaseLabel: "Galaxy M35 5G"
     releaseDate: 2024-07-17 # https://news.samsung.com/in/samsung-unveils-galaxy-m35-5g-with-segment-leading-monster-features-in-india
-    eoas: 2028-07-17 # 4 Android updates - https://androidspotlight.com/software-update-policy-for-every-samsung-device/
-    eol: false      # 5 years of security updates - https://androidspotlight.com/software-update-policy-for-every-samsung-device/
+    eoas: 2028-07-17 # 4 Android updates - https://web.archive.org/web/20250516053227/https://androidspotlight.com/software-update-policy-for-every-samsung-device/
+    eol: false      # 5 years of security updates - https://web.archive.org/web/20250516053227/https://androidspotlight.com/software-update-policy-for-every-samsung-device/
     link: https://doc.samsungmobile.com/SM-M356B/NPB/doc.html
 
   - releaseCycle: "galaxy-f55-5g"
@@ -576,15 +576,15 @@ releases:
   - releaseCycle: "galaxy-z-fold5"
     releaseLabel: "Galaxy Z Fold5"
     releaseDate: 2023-08-11 # https://en.wikipedia.org/wiki/Samsung_Galaxy_Z_Fold_5
-    eoas: 2027-08-11 # 4 Android updates - https://androidspotlight.com/software-update-policy-for-every-samsung-device/
-    eol: 2028-08-11      # 5 years of security updates - https://androidspotlight.com/software-update-policy-for-every-samsung-device/
+    eoas: 2027-08-11 # 4 Android updates - https://web.archive.org/web/20250516053227/https://androidspotlight.com/software-update-policy-for-every-samsung-device/
+    eol: 2028-08-11      # 5 years of security updates - https://web.archive.org/web/20250516053227/https://androidspotlight.com/software-update-policy-for-every-samsung-device/
     link: https://doc.samsungmobile.com/SM-F946B/ZTO/doc.html
 
   - releaseCycle: "galaxy-z-flip5"
     releaseLabel: "Galaxy Z Flip5"
     releaseDate: 2023-08-11 # https://en.wikipedia.org/wiki/Samsung_Galaxy_Z_Flip_5
-    eoas: 2027-08-11 # 4 Android updates - https://androidspotlight.com/software-update-policy-for-every-samsung-device/
-    eol: 2028-08-11      # 5 years of security updates - https://androidspotlight.com/software-update-policy-for-every-samsung-device/
+    eoas: 2027-08-11 # 4 Android updates - https://web.archive.org/web/20250516053227/https://androidspotlight.com/software-update-policy-for-every-samsung-device/
+    eol: 2028-08-11      # 5 years of security updates - https://web.archive.org/web/20250516053227/https://androidspotlight.com/software-update-policy-for-every-samsung-device/
     link: https://doc.samsungmobile.com/SM-F731B/ZTO/doc.html
 
   - releaseCycle: "galaxy-f34-5g"
@@ -597,8 +597,8 @@ releases:
   - releaseCycle: "galaxy-m34-5g"
     releaseLabel: "Galaxy M34 5G"
     releaseDate: 2023-07-07 # https://news.samsung.com/in/samsung-launches-galaxy-m34-5g-in-india-with-monster-display-camera-and-battery-at-just-inr-16999
-    eoas: 2027-07-07 # 4 Android updates - https://androidspotlight.com/software-update-policy-for-every-samsung-device/
-    eol: false      # 5 years of security updates - https://androidspotlight.com/software-update-policy-for-every-samsung-device/
+    eoas: 2027-07-07 # 4 Android updates - https://web.archive.org/web/20250516053227/https://androidspotlight.com/software-update-policy-for-every-samsung-device/
+    eol: false      # 5 years of security updates - https://web.archive.org/web/20250516053227/https://androidspotlight.com/software-update-policy-for-every-samsung-device/
     link: https://doc.samsungmobile.com/SM-M346B1/XID/doc.html
 
   - releaseCycle: "galaxy-f54-5g"
@@ -800,8 +800,8 @@ releases:
   - releaseCycle: "galaxy-m53-5g"
     releaseLabel: "Galaxy M53 5G"
     releaseDate: 2022-04-22 # https://news.samsung.com/in/samsung-launches-galaxy-m53-5g-with-segment-best-108-mp-quad-camera-segment-only-auto-data-switching-segment-leading-samoled-display-in-india
-    eoas: 2024-04-22 # 2 android updates - https://androidspotlight.com/software-update-policy-for-every-samsung-device/
-    eol: 2026-06-03 # 3 years of security updates - https://androidspotlight.com/software-update-policy-for-every-samsung-device/
+    eoas: 2024-04-22 # 2 android updates - https://web.archive.org/web/20250516053227/https://androidspotlight.com/software-update-policy-for-every-samsung-device/
+    eol: 2026-06-03 # 3 years of security updates - https://web.archive.org/web/20250516053227/https://androidspotlight.com/software-update-policy-for-every-samsung-device/
     link: https://doc.samsungmobile.com/SM-M536B/SER/doc.html
 
   - releaseCycle: "galaxy-a73-5g"
@@ -814,7 +814,7 @@ releases:
   - releaseCycle: "galaxy-m33-5g"
     releaseLabel: "Galaxy M33 5G"
     releaseDate: 2022-04-08
-    eoas: 2025-04-08 # 3 Android updates - https://androidspotlight.com/software-update-policy-for-every-samsung-device/
+    eoas: 2025-04-08 # 3 Android updates - https://web.archive.org/web/20250516053227/https://androidspotlight.com/software-update-policy-for-every-samsung-device/
     eol: 2026-05-06
     link: https://doc.samsungmobile.com/SM-M336BU/INS/doc.html
 
@@ -926,7 +926,7 @@ releases:
   - releaseCycle: "galaxy-m22"
     releaseLabel: "Galaxy M22"
     releaseDate: 2021-10-13 # https://www.gsmarena.com/samsung_galaxy_m22-11011.php
-    eoas: 2023-10-13 # 2 android updates - https://androidspotlight.com/software-update-policy-for-every-samsung-device/
+    eoas: 2023-10-13 # 2 android updates - https://web.archive.org/web/20250516053227/https://androidspotlight.com/software-update-policy-for-every-samsung-device/
     eol: 2025-11-04
     link: https://doc.samsungmobile.com/sm-m225fv/zto/doc.html
 
@@ -940,8 +940,8 @@ releases:
   - releaseCycle: "galaxy-m52-5g"
     releaseLabel: "Galaxy M52 5G"
     releaseDate: 2021-10-03
-    eoas: 2023-10-03 # 2 android updates - https://androidspotlight.com/software-update-policy-for-every-samsung-device/
-    eol: 2025-11-04 # 3 years of security updates - https://androidspotlight.com/software-update-policy-for-every-samsung-device/
+    eoas: 2023-10-03 # 2 android updates - https://web.archive.org/web/20250516053227/https://androidspotlight.com/software-update-policy-for-every-samsung-device/
+    eol: 2025-11-04 # 3 years of security updates - https://web.archive.org/web/20250516053227/https://androidspotlight.com/software-update-policy-for-every-samsung-device/
     link: https://doc.samsungmobile.com/SM-M526BR/ITV/doc.html
 
   - releaseCycle: "galaxy-m32-5g"


### PR DESCRIPTION
Fixes 57 dead links found across the repo. Every replacement was fetched and confirmed to return 200; page titles were checked to make sure they are the same content and not a soft-404 or a redirect to a generic index.

## Live replacements (8)

| Before (404) | After (200) |
|---|---|
| `docs.azul.com/core/zulu-openjdk/release-notes/{17..21}-ga` | `docs.azul.com/core/release/{17..21}-ga/release-notes/release-notes` |
| `docs.azul.com/core/zulu-openjdk/release-notes.html` | `docs.azul.com/core/release-notes` |
| `www.raspberrypi.org/raspberry-pi-compute-module-new-product/` | `www.raspberrypi.com/news/raspberry-pi-compute-module-new-product/` |
| `jkrowling.com/time-turner` | `www.harrypotter.com/writing-by-jk-rowling/time-turner` |

Azul restructured its documentation; the Compute Module post moved from `.org` to `.com/news/` without a redirect. Both Raspberry Pi page titles match exactly (`Raspberry Pi Compute Module: new product!`).

## Archived replacements (49)

**Zulu 16** (1) — dropped from Azul's docs entirely, `/core/release/16-ga/...` also 404s, so there is no live equivalent.

**androidspotlight.com** (48) — the domain returns NXDOMAIN from Google, Cloudflare and Quad9, and has no NS or SOA records: registered but undelegated, with no successor site. It was cited 48 times across `samsung-mobile.md`, `samsung-galaxy-tab.md` and `samsung-galaxy-watch.md` as the source for `eoas`/`eol` dates, so those dates currently have no verifiable provenance. All now point at the 2025-05-16 Wayback snapshot.

The three `# Useful information can be found on:` header entries are additionally annotated as dead, because an archived snapshot can't be used to look up devices added in future. Those three want a live replacement source eventually — happy to follow up if maintainers have a preferred one.

## Note on where these were hiding

All 57 sit in YAML comments, which is why the weekly `check-links.yml` job never caught them: `product-data-validator.rb` checks `releasePolicyLink`, `releaseImage`, `iconUrl`, `customFields[].link`, `identifiers[].url`, `releases[].link` and the markdown body, but not comments.

That blind spot currently holds 1,011 unique URLs across 277 product files. Sampling suggests the difference is real — 0 dead in 250 sampled checked-corpus URLs, versus ~1% in the comment blind spot. A DNS-only sweep of commented domains would have caught all 48 androidspotlight links in about a second, without the runtime cost of full HTTP checks. Happy to open a separate PR for that if it sounds useful.

## Verification

- `bundle exec jekyll build` passes clean
- `markdownlint-cli2` and `prettier` show no new issues (the remaining warnings are pre-existing on `master`, unchanged by this PR)
- The URL check was **not** run repo-wide from a fork, per the `check-links.yml` guard; only the changed URLs were fetched
