### PR TITLE
[raspberry-pi] Update eol date for  2 model B

### DIFF
--- a/products/raspberry-pi.md
+++ b/products/raspberry-pi.md
@@ -151,7 +151,7 @@ releases:
     releaseLabel: "2 Model B"
     # https://www.raspberrypi.com/news/raspberry-pi-2-on-sale/
     releaseDate: 2015-02-02
-    eol: false # Due to revision 1.3 still supported ( 14/07/2026 )
+    eol: 2030-01-01
     link: https://www.raspberrypi.com/products/raspberry-pi-2-model-b/
 
   - releaseCycle: "1-a+"


### PR DESCRIPTION
Raspberry Pi 2 rev 1.3 will remain in production until at least January 2030. They confirmed to me in an email