### PR TITLE
[postmarketos] Update auto configuration

### DIFF
--- a/products/postmarketos.md
+++ b/products/postmarketos.md
@@ -10,90 +10,83 @@ latestColumn: false
 
 auto:
   methods:
-    # Cross check with the channels.cfg
-    # https://gitlab.postmarketos.org/postmarketOS/pmaports/-/blob/master/channels.cfg?ref_type=heads
-    - distrowatch: postmarketos
-      regex: 'Distribution Release: postmarketOS (?P<version>\d{2}[.]\d{2})'
-      template: "{{version}}"
+    - release_table: https://docs.postmarketos.org/pmaports/main/releases.html#active-and-planned table
+      remove_if_undefined: releaseDate
+      fields:
+        releaseCycle: "Release"
+        releaseDate: "Announcement"
+        eol: "EOL"
+    - release_table: https://docs.postmarketos.org/pmaports/main/releases.html#end-of-life
+      fields:
+        releaseCycle: "Release"
+        releaseDate: "Announcement"
 
 # eol(x) = releaseDate(x+1) + 1 month
 releases:
   - releaseCycle: "26.06"
     releaseDate: 2026-06-21
     eol: 2027-01-31
-    latest: "26.06"
-    latestReleaseDate: 2026-06-21
     link: https://postmarketos.org/blog/2026/06/21/v26.06-release/
 
   - releaseCycle: "25.12"
     releaseDate: 2025-12-23
     eol: 2026-07-31
-    latest: "25.12"
-    latestReleaseDate: 2025-12-23
     link: https://postmarketos.org/blog/2025/12/23/v25.12-release/
 
   - releaseCycle: "25.06"
-    releaseDate: 2025-06-23
+    releaseDate: 2025-06-22
     eol: 2026-01-23
-    latest: "25.06"
-    latestReleaseDate: 2025-06-23
     link: https://postmarketos.org/blog/2025/06/22/v25.06-release/
 
   - releaseCycle: "24.12"
     releaseDate: 2024-12-23
     eol: 2025-07-23
-    latest: "24.12"
-    latestReleaseDate: 2024-12-23
     link: https://postmarketos.org/blog/2024/12/23/v24.12-release/
 
   - releaseCycle: "24.06"
     releaseDate: 2024-06-16
     eol: 2025-01-23
-    latest: "24.06"
-    latestReleaseDate: 2024-06-16
     link: https://postmarketos.org/blog/2024/06/16/v24.06-release/
 
   - releaseCycle: "23.12"
     releaseDate: 2023-12-18
     eol: 2024-07-16
-    latest: "23.12"
-    latestReleaseDate: 2023-12-19
     link: https://postmarketos.org/blog/2023/12/18/v23.12-release/
 
   - releaseCycle: "23.06"
     releaseDate: 2023-06-07
     eol: 2024-01-18
-    latest: "23.06"
-    latestReleaseDate: 2023-06-07
     link: https://postmarketos.org/blog/2023/06/07/v23.06-release/
 
   - releaseCycle: "22.12"
     releaseDate: 2022-12-18
     eol: 2023-07-07
-    latest: "22.12"
-    latestReleaseDate: 2022-12-18
     link: https://postmarketos.org/blog/2022/12/18/v22.12-release/
 
   - releaseCycle: "22.06"
     releaseDate: 2022-06-12
     eol: 2023-01-18
-    latest: "22.06"
-    latestReleaseDate: 2022-06-12
     link: https://postmarketos.org/blog/2022/06/12/v22.06-release/
 
   - releaseCycle: "21.12"
     releaseDate: 2021-12-29
     eol: 2022-07-12
-    latest: "21.12"
-    latestReleaseDate: 2021-12-29
     link: https://postmarketos.org/blog/2021/12/29/v21.12-release/
 
   - releaseCycle: "21.06"
     releaseDate: 2021-07-04
     eol: 2022-01-29
-    latest: "21.06"
-    latestReleaseDate: 2021-07-04
     link: https://postmarketos.org/blog/2021/07/04/v21.06-release/
+
+  - releaseCycle: "21.03"
+    releaseDate: 2021-03-31
+    eol: 2021-08-04
+    link: https://postmarketos.org/blog/2021/03/31/v21.03-release/
+
+  - releaseCycle: "20.05"
+    releaseDate: 2020-05-31
+    eol: 2021-04-30
+    link: https://postmarketos.org/blog/2020/05/31/three-years/#stable-release-channel
 ---
 
 > [postmarketOS](https://postmarketos.org/) extends Alpine Linux


### PR DESCRIPTION
Switch from `distrowatch` to `release_table` : https://docs.postmarketos.org/pmaports/main/releases.html is more accurate and up-to-date.

Because of this change, also add a few historic releases and drop the latest fields (they were only necessary because `distrowatch` was used - the column what not displayed on https://endoflife.date/postmarketos).