### PR TITLE
[amazon-mq-activemq] Update releasePolicyLink

### DIFF
--- a/products/amazon-mq-activemq.md
+++ b/products/amazon-mq-activemq.md
@@ -4,8 +4,9 @@ addedAt: 2026-08-12
 category: service
 tags: amazon
 permalink: /amazon-mq-activemq
-releasePolicyLink: https://docs.aws.amazon.com/amazon-mq/latest/developer-guide/activemq-version-support.html
+releasePolicyLink: https://docs.aws.amazon.com/amazon-mq/latest/developer-guide/activemq-version-management.html
 latestColumn: false
+staleReleaseThresholdDays: 1460 # 4 years
 
 releases:
   - releaseCycle: "5.19"


### PR DESCRIPTION
Also set default staleReleaseThreshold for 4 years so that supported releases doesn't show up on reports such as https://github.com/endoflife-date/endoflife.date/pull/10794.