### PR TITLE
[amazon-mq-rabbitmq] Set staleReleaseThreshold to 3 years

### DIFF
--- a/products/amazon-mq-rabbitmq.md
+++ b/products/amazon-mq-rabbitmq.md
@@ -6,6 +6,7 @@ tags: amazon
 permalink: /amazon-mq-rabbitmq
 releasePolicyLink: https://docs.aws.amazon.com/amazon-mq/latest/developer-guide/rabbitmq-version-support.html
 latestColumn: false
+staleReleaseThresholdDays: 1095 # 3 years
 
 releases:
   - releaseCycle: "4.2"


### PR DESCRIPTION
So that the product is not mentioned in reports such as https://github.com/endoflife-date/endoflife.date/pull/10794.