### PR TITLE
Add timeline pages for lifecycle events

### DIFF
--- a/_layouts/timeline-overview.html
+++ b/_layouts/timeline-overview.html
@@ -1,0 +1,24 @@
+---
+layout: default
+---
+<div class="timeline-overview">
+  <h1>{{ page.title }}</h1>
+  <p>Browse release and support lifecycle events by month.</p>
+
+  <div class="timeline-years">
+    {% for year in page.years %}
+      <section class="timeline-year" aria-labelledby="timeline-year-{{ year.year }}"{% if year.current %} data-current-year{% endif %}>
+        <h2 id="timeline-year-{{ year.year }}">{{ year.year }}</h2>
+        <div class="timeline-year-months">
+          {% for month in year.months %}
+            {% if month.available %}<a{% else %}<span{% endif %} class="timeline-overview-month timeline-month-{{ month.state }}{% if month.state == 'current' %} timeline-nav-current{% endif %}"{% if month.available %} href="{{ month.url | relative_url }}"{% endif %}>
+              <span class="timeline-overview-month-name">{{ month.title }}</span>
+              <span class="timeline-overview-month-count">{{ month.event_count }}</span>
+            {% if month.available %}</a>{% else %}</span>{% endif %}
+          {% endfor %}
+        </div>
+      </section>
+    {% endfor %}
+  </div>
+</div>
+<script src="{{ '/assets/timeline-overview.js' | relative_url }}" defer></script>

--- a/_layouts/timeline.html
+++ b/_layouts/timeline.html
@@ -1,0 +1,40 @@
+---
+layout: default
+---
+<div class="timeline-page">
+  <h1>{{ page.title }}</h1>
+
+  <nav class="timeline-nav" aria-label="Timeline months">
+    {% if page.more_months_before %}<span class="timeline-nav-more" aria-label="More months before" title="More months before">&hellip;</span>{% endif %}
+    {% for month in page.months %}
+      <a class="timeline-month timeline-month-{{ month.state }}{% if month.current %} timeline-nav-current{% endif %}" href="{{ month.url | relative_url }}"{% if month.current %} aria-current="page"{% endif %}>
+        <span class="timeline-month-year">{{ month.year }}</span>
+        <span class="timeline-month-name">{{ month.title }}</span>
+        <span class="timeline-month-count" aria-label="{{ month.event_count }} events this month" title="{{ month.event_count }} events this month"><strong>{{ month.event_count }}</strong><span class="sr-only"> events</span></span>
+      </a>
+    {% endfor %}
+    {% if page.more_months_after %}<span class="timeline-nav-more" aria-label="More months after" title="More months after">&hellip;</span>{% endif %}
+  </nav>
+
+  <p class="timeline-introduction"><strong>{{ page.title }}</strong> has <strong>{{ page.events.size }}</strong> events:{% for summary in page.event_summaries %} <strong>{{ summary.count }}</strong> {{ summary.label }}{% unless forloop.last %},{% endunless %}{% endfor %}.</p>
+
+  {% if page.events.size > 0 %}
+    <div class="timeline-events">
+      {% for event in page.events %}
+        <a class="timeline-event timeline-event-{{ event.field }}" href="{{ event.product.url | relative_url }}" title="View details for {{ event.product.title }}" aria-label="View details for {{ event.product.title }}">
+          <div class="timeline-event-date">
+            <time datetime="{{ event.date | date_to_xmlschema }}">{{ event.date | date: "%b %-d" }}</time>
+            {% if event.days < 0 %}<span>{{ event.days | abs }} days ago</span>{% elsif event.days == 0 %}<span>Today</span>{% else %}<span>{{ event.days }} days left</span>{% endif %}
+          </div>
+          <div class="timeline-event-product">
+            {% include product-icon.html product=event.product size=40 %}
+            <p>{{ event.description }}</p>
+          </div>
+          <span class="timeline-event-link-icon" aria-hidden="true">&#8599;</span>
+        </a>
+      {% endfor %}
+    </div>
+  {% else %}
+    <p>No release or support lifecycle events are recorded for this month.</p>
+  {% endif %}
+</div>

--- a/_plugins/generate-timeline-pages.rb
+++ b/_plugins/generate-timeline-pages.rb
@@ -1,0 +1,203 @@
+# Generate one timeline page for each month covered by the recorded events.
+
+require 'date'
+require 'jekyll'
+
+module EndOfLife
+  class TimelinePagesGenerator < Jekyll::Generator
+    safe true
+    priority :lowest
+
+    TOPIC = "Timeline pages:"
+    NAV_MONTHS_EITHER_SIDE = 3
+    EVENT_FIELDS = {
+      'releaseDate' => { past: 'was released', future: 'will be released', label: 'releases' },
+      'eoas' => { past: 'reached its end of active support', future: 'will reach its end of active support', label: 'ends of active support' },
+      'eol' => { past: 'reached its end of life', future: 'will reach its end of life', label: 'ends of life' },
+      'eoes' => { past: 'reached its end of extended support', future: 'will reach its end of extended support', label: 'ends of extended support' }
+    }.freeze
+    EMPTY_EVENT_COUNTS = EVENT_FIELDS.keys.to_h { |field| [field, 0] }.freeze
+
+    def generate(site)
+      start = Time.now
+      Jekyll.logger.info TOPIC, "Generating..."
+
+      products = site.pages.select { |page| page.data['layout'] == 'product' }
+      today = Date.today
+      events = all_events(products, today)
+      events_by_month = events.group_by { |event| month_key(event['date']) }
+      event_counts_by_month = events_by_month.transform_values do |month_events|
+        month_events.each_with_object(EMPTY_EVENT_COUNTS.dup) do |event, counts|
+          counts[event['field']] += 1
+        end
+      end
+      current_month = Date.new(today.year, today.month, 1)
+      first_month = Date.new([events.first&.dig('date')&.year || today.year, today.year].min, 1, 1)
+      last_month = Date.new([events.last&.dig('date')&.year || today.year, today.year].max, 12, 1)
+      page_count = months_count(first_month, last_month)
+      overview_years = years_between(first_month, last_month, event_counts_by_month, current_month)
+
+      site.pages << TimelineOverviewPage.new(site, overview_years)
+
+      page_count.times do |offset|
+        month = first_month >> offset
+        key = month_key(month)
+        month_events = events_by_month.fetch(key, [])
+        event_summaries = build_event_summaries(event_counts_by_month.fetch(key, EMPTY_EVENT_COUNTS))
+        navigation_first = [month << NAV_MONTHS_EITHER_SIDE, first_month].max
+        navigation_last = [month >> NAV_MONTHS_EITHER_SIDE, last_month].min
+        navigation_months = mark_current_month(
+          months_between(navigation_first, navigation_last, event_counts_by_month, current_month),
+          month
+        )
+
+        site.pages << TimelinePage.new(
+          site,
+          month,
+          month_events,
+          navigation_months,
+          event_summaries,
+          navigation_first > first_month,
+          navigation_last < last_month
+        )
+      end
+
+      elapsed = (Time.now - start).round(3)
+      Jekyll.logger.info TOPIC, "Generated #{page_count} pages for #{events.length} events in #{elapsed} seconds."
+    end
+
+    private
+
+    def all_events(products, today)
+      products.flat_map do |product|
+        product.data['releases'].flat_map do |release|
+          EVENT_FIELDS.filter_map do |field, descriptions|
+            date = release[field]
+            next unless date.is_a?(Date)
+
+            past = date < today
+            {
+              'date' => date,
+              'days' => (date - today).to_i,
+              'description' => "#{product.data['title']} #{release['releaseCycle']} #{past ? descriptions[:past] : descriptions[:future]}.",
+              'product' => product,
+              'release' => release,
+              'field' => field
+            }
+          end
+        end
+      end.sort_by { |event| [event['date'], event['product'].data['title'], event['release']['releaseCycle'], event['field']] }
+    end
+
+    def month_key(date)
+      [date.year, date.month]
+    end
+
+    def months_between(first_month, last_month, event_counts, current_month)
+      Array.new(months_count(first_month, last_month)) do |offset|
+        month = first_month >> offset
+        month_data(month, event_counts, current_month)
+      end
+    end
+
+    def months_count(first_month, last_month)
+      (last_month.year * 12 + last_month.month) - (first_month.year * 12 + first_month.month) + 1
+    end
+
+    def years_between(first_month, last_month, event_counts, current_month)
+      (first_month.year..last_month.year).map do |year|
+        {
+          'year' => year,
+          'current' => year == current_month.year,
+          'months' => (1..12).map do |month_number|
+            month = Date.new(year, month_number, 1)
+            in_timeline = month >= first_month && month <= last_month
+            month_data(month, event_counts, current_month).merge('available' => in_timeline)
+          end
+        }
+      end
+    end
+
+    def month_data(month, event_counts, current_month)
+      month_counts = event_counts.fetch(month_key(month), EMPTY_EVENT_COUNTS)
+      {
+        'year' => month.year,
+        'title' => month.strftime('%b'),
+        'url' => self.class.timeline_url(month),
+        'event_count' => month_counts.values.sum,
+        'state' => if month < current_month
+                     'past'
+                   elsif month > current_month
+                     'future'
+                   else
+                     'current'
+                   end
+      }
+    end
+
+    def build_event_summaries(event_counts)
+      EVENT_FIELDS.map { |field, details|
+        { 'count' => event_counts.fetch(field, 0), 'label' => details[:label] }
+      }
+    end
+
+    def mark_current_month(months, viewed_month)
+      months.map { |month| month.merge('current' => month['url'] == self.class.timeline_url(viewed_month)) }
+    end
+
+    def self.timeline_url(month)
+      "/#{timeline_path(month)}/"
+    end
+
+    def self.timeline_path(month)
+      "timeline/#{month.year}/#{month.month}"
+    end
+  end
+
+  class TimelineOverviewPage < Jekyll::Page
+    def initialize(site, years)
+      @site = site
+      @base = site.source
+      @dir = 'timeline'
+      @name = 'index.html'
+      @data = {
+        'title' => 'Timeline',
+        'description' => 'Explore product release and end-of-life events across the timeline.',
+        'layout' => 'timeline-overview',
+        'permalink' => '/timeline/',
+        'years' => years,
+        'nav_order' => 9999,
+        'nav_title' => 'Timeline',
+        'search_exclude' => true,
+        'has_toc' => false
+      }
+
+      process(@name)
+    end
+  end
+
+  class TimelinePage < Jekyll::Page
+    def initialize(site, month, events, months, event_summaries, more_before, more_after)
+      @site = site
+      @base = site.source
+      @dir = TimelinePagesGenerator.timeline_path(month)
+      @name = 'index.html'
+      @data = {
+        'title' => "#{month.strftime('%B %Y')} timeline",
+        'description' => "Product release and end-of-life events for #{month.strftime('%B %Y')}.",
+        'layout' => 'timeline',
+        'permalink' => TimelinePagesGenerator.timeline_url(month),
+        'events' => events,
+        'event_summaries' => event_summaries,
+        'more_months_before' => more_before,
+        'more_months_after' => more_after,
+        'months' => months,
+        'nav_exclude' => true,
+        'search_exclude' => true,
+        'has_toc' => false
+      }
+
+      process(@name)
+    end
+  end
+end

--- a/_sass/custom/custom.scss
+++ b/_sass/custom/custom.scss
@@ -29,6 +29,203 @@ a {
   margin-right: .5em;
 }
 
+.timeline-nav {
+  align-items: stretch;
+  box-sizing: border-box;
+  display: flex;
+  gap: .75rem;
+  margin: 1.5rem 0 2rem;
+  overflow-x: auto;
+  padding: .25rem 0;
+  white-space: nowrap;
+  width: 100%;
+}
+
+.timeline-introduction {
+  margin: 1rem 0 0;
+  padding-bottom: 1rem;
+}
+
+.timeline-nav-more {
+  align-items: center;
+  color: #64748b;
+  display: flex;
+  flex: 0 0 auto;
+  font-size: 1.25rem;
+  justify-content: center;
+  padding: 0 .15rem;
+}
+
+.timeline-years { display: grid; gap: 1.5rem; }
+.timeline-year {
+  border: 1px solid #d8dee9;
+  border-radius: .65rem;
+  padding: 1rem;
+  scroll-margin-top: 1rem;
+}
+.timeline-year h2 { margin: 0 0 1rem; }
+.timeline-year-months {
+  display: grid;
+  gap: .5rem;
+  grid-template-columns: repeat(12, minmax(0, 1fr));
+}
+.timeline-overview-month {
+  align-items: stretch;
+  border: 2px solid transparent;
+  border-radius: .45rem;
+  color: inherit;
+  display: flex;
+  flex-direction: column;
+  gap: .35rem;
+  min-width: 0;
+  padding: .5rem .25rem;
+  text-align: center;
+  text-decoration: none;
+}
+.timeline-overview-month:hover,
+.timeline-overview-month:focus,
+.timeline-month:hover,
+.timeline-month:focus {
+  border-color: #8ab4ff;
+}
+.timeline-overview-month-name { color: #64748b; font-size: .8rem; }
+.timeline-overview-month-count {
+  background: rgb(255 255 255 / .7);
+  border-radius: .25rem;
+  color: #475569;
+  font-size: .75rem;
+  padding: .15rem;
+}
+@media (max-width: 50em) {
+  .timeline-year-months { grid-template-columns: repeat(6, minmax(0, 1fr)); }
+}
+
+@media (max-width: 30em) {
+  .timeline-year-months { grid-template-columns: repeat(4, minmax(0, 1fr)); }
+}
+
+.timeline-month {
+  align-items: center;
+  border: 2px solid transparent;
+  border-radius: .65rem;
+  box-sizing: border-box;
+  display: flex;
+  flex: 1 1 0;
+  min-width: 0;
+  flex-direction: column;
+  justify-content: space-between;
+  min-height: 5.35rem;
+  padding: .7rem .4rem .55rem;
+  text-align: center;
+  text-decoration: none;
+}
+
+.timeline-month-past {
+  background-color: #f1f5f9;
+}
+
+.timeline-month-current {
+  background-color: #e0e7ff;
+}
+
+.timeline-month-future {
+  background-color: #ede9fe;
+}
+
+.timeline-month-year {
+  color: #818898;
+  font-size: .8rem;
+  line-height: 1;
+}
+
+.timeline-month-name {
+  color: #3468e8;
+  font-size: .95rem;
+  line-height: 1;
+}
+
+.timeline-month-count {
+  align-items: baseline;
+  background-color: #fff;
+  border: 1px solid #cbd5e1;
+  border-radius: 999px;
+  display: inline-flex;
+  justify-content: center;
+  line-height: 1;
+  margin-top: .35rem;
+  min-width: 1.5rem;
+  padding: .2rem .4rem;
+}
+
+.timeline-month-count strong {
+  color: #273142;
+  font-size: .6rem;
+}
+
+.timeline-event-releaseDate { background-color: #dbeafe; }
+.timeline-event-eoas { background-color: #fef3c7; }
+.timeline-event-eol { background-color: #fee2e2; }
+.timeline-event-eoes { background-color: #ede9fe; }
+
+.sr-only {
+  clip: rect(0, 0, 0, 0);
+  clip-path: inset(50%);
+  height: 1px;
+  overflow: hidden;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.timeline-nav-current {
+  border-color: #5890ff;
+  font-weight: 400;
+}
+.timeline-events { display: grid; gap: 1rem; }
+.timeline-event {
+  align-items: center;
+  border: 1px solid #d8dee9;
+  border-radius: 0.35rem;
+  color: inherit;
+  display: grid;
+  gap: 1.25rem;
+  grid-template-columns: 8rem 1fr auto;
+  padding: 1rem;
+  text-decoration: none;
+  transition: box-shadow .15s ease, transform .15s ease;
+}
+
+.timeline-event:hover,
+.timeline-event:focus {
+  box-shadow: 0 .2rem .6rem rgba(39, 49, 66, .16);
+  transform: translateY(-1px);
+}
+
+.timeline-event:focus {
+  outline: 2px solid #5890ff;
+  outline-offset: 2px;
+}
+
+.timeline-event-link-icon {
+  color: #3468e8;
+  font-size: 1.25rem;
+  line-height: 1;
+}
+
+.timeline-event-date { display: grid; gap: 0.25rem; }
+.timeline-event-date time { font-size: 1.1rem; font-weight: 600; }
+.timeline-event-date span { color: #5c596d; font-size: 0.85rem; }
+.timeline-event-product { align-items: center; display: flex; gap: 1rem; }
+.timeline-event-product p { margin: 0; }
+.timeline-event-product .product-logo { flex: 0 0 auto; max-height: 40px; max-width: 40px; }
+
+@media (max-width: 30em) {
+  .timeline-event { grid-template-columns: 1fr auto; gap: 0.75rem; }
+  .timeline-event-date { grid-column: 1 / -1; }
+  .timeline-event-product { grid-column: 1; }
+  .timeline-event-link-icon { grid-column: 2; grid-row: 2; }
+}
+
 .bg-light {
   background-color: #f8f9fa !important;
 }

--- a/assets/timeline-overview.js
+++ b/assets/timeline-overview.js
@@ -1,0 +1,3 @@
+document.addEventListener('DOMContentLoaded', () => {
+  document.querySelector('[data-current-year]')?.scrollIntoView({ block: 'start', behavior: 'auto' });
+});

--- a/test/timeline_pages_generator_test.rb
+++ b/test/timeline_pages_generator_test.rb
@@ -1,0 +1,143 @@
+require 'date'
+require 'minitest/autorun'
+
+require_relative '../_plugins/generate-timeline-pages'
+
+class TimelinePagesGeneratorTest < Minitest::Test
+  Product = Struct.new(:data)
+
+  def setup
+    @generator = EndOfLife::TimelinePagesGenerator.new
+    @today = Date.new(2026, 8, 24)
+  end
+
+  def test_all_events_includes_each_lifecycle_field_in_past_current_and_future
+    product = Product.new({
+      'title' => 'Example',
+      'releases' => [
+        {
+          'releaseCycle' => '1.0',
+          'releaseDate' => Date.new(2026, 8, 23),
+          'eoas' => Date.new(2026, 8, 24),
+          'eol' => Date.new(2026, 8, 25),
+          'eoes' => Date.new(2026, 8, 26)
+        }
+      ]
+    })
+
+    events = @generator.send(:all_events, [product], @today)
+
+    assert_equal %w[releaseDate eoas eol eoes], events.map { |event| event['field'] }
+    assert_equal [
+      'Example 1.0 was released.',
+      'Example 1.0 will reach its end of active support.',
+      'Example 1.0 will reach its end of life.',
+      'Example 1.0 will reach its end of extended support.'
+    ], events.map { |event| event['description'] }
+    assert_equal [-1, 0, 1, 2], events.map { |event| event['days'] }
+  end
+
+  def test_all_events_ignores_missing_and_non_date_values
+    product = Product.new({
+      'title' => 'Example',
+      'releases' => [
+        { 'releaseCycle' => '1.0', 'releaseDate' => 'unknown', 'eol' => nil },
+        { 'releaseCycle' => '2.0' }
+      ]
+    })
+
+    assert_empty @generator.send(:all_events, [product], @today)
+  end
+
+  def test_past_support_descriptions_use_its
+    product = Product.new({
+      'title' => 'Sony Xperia',
+      'releases' => [{
+        'releaseCycle' => '5-v',
+        'eoas' => Date.new(2026, 8, 23),
+        'eol' => Date.new(2026, 8, 23),
+        'eoes' => Date.new(2026, 8, 23)
+      }]
+    })
+
+    events = @generator.send(:all_events, [product], @today)
+
+    assert_equal 'Sony Xperia 5-v reached its end of active support.', events.find { |event| event['field'] == 'eoas' }['description']
+    assert_equal 'Sony Xperia 5-v reached its end of life.', events.find { |event| event['field'] == 'eol' }['description']
+    assert_equal 'Sony Xperia 5-v reached its end of extended support.', events.find { |event| event['field'] == 'eoes' }['description']
+  end
+
+  def test_month_data_includes_counts_and_state
+    counts = { [2026, 8] => { 'releaseDate' => 2, 'eol' => 1 } }
+
+    month = @generator.send(:month_data, Date.new(2026, 8, 1), counts, Date.new(2026, 8, 1))
+
+    assert_equal({
+      'year' => 2026,
+      'title' => 'Aug',
+      'url' => '/timeline/2026/8/',
+      'event_count' => 3,
+      'state' => 'current'
+    }, month)
+  end
+
+  def test_event_summaries_include_all_fields_and_zero_counts
+    summaries = @generator.send(:build_event_summaries, { 'eol' => 2 })
+
+    assert_equal [
+      { 'count' => 0, 'label' => 'releases' },
+      { 'count' => 0, 'label' => 'ends of active support' },
+      { 'count' => 2, 'label' => 'ends of life' },
+      { 'count' => 0, 'label' => 'ends of extended support' }
+    ], summaries
+  end
+
+  def test_month_data_classifies_past_and_future_months
+    current_month = Date.new(2026, 8, 1)
+
+    assert_equal 'past', @generator.send(:month_data, Date.new(2026, 7, 1), {}, current_month)['state']
+    assert_equal 'future', @generator.send(:month_data, Date.new(2026, 9, 1), {}, current_month)['state']
+  end
+
+  def test_months_between_includes_empty_months
+    months = @generator.send(
+      :months_between,
+      Date.new(2026, 8, 1),
+      Date.new(2026, 10, 1),
+      { [2026, 9] => { 'eol' => 2 } },
+      Date.new(2026, 9, 1)
+    )
+
+    assert_equal %w[Aug Sep Oct], months.map { |month| month['title'] }
+    assert_equal [0, 2, 0], months.map { |month| month['event_count'] }
+    assert_equal %w[past current future], months.map { |month| month['state'] }
+  end
+
+  def test_mark_current_month_marks_the_viewed_month
+    months = @generator.send(
+      :months_between,
+      Date.new(2026, 7, 1),
+      Date.new(2026, 9, 1),
+      {},
+      Date.new(2026, 8, 1)
+    )
+
+    marked = @generator.send(:mark_current_month, months, Date.new(2026, 7, 1))
+
+    assert_equal [true, false, false], marked.map { |month| month['current'] }
+    assert_equal %w[past current future], marked.map { |month| month['state'] }
+  end
+
+  def test_years_between_marks_only_timeline_months_available
+    years = @generator.send(
+      :years_between,
+      Date.new(2026, 8, 1),
+      Date.new(2026, 10, 1),
+      {},
+      Date.new(2026, 9, 1)
+    )
+
+    assert_equal [false, true, true, true, false], years[0]['months'].values_at(6, 7, 8, 9, 10).map { |month| month['available'] }
+    assert years[0]['current']
+  end
+end


### PR DESCRIPTION
Generate a timeline overview and one page for every month covered by recorded release and support dates.

- Collect releaseDate, eoas, eol, and eoes events from product pages.
- Group events by month and calculate monthly and yearly event counts.
- Add adjacent-month navigation with current, past, and future states.
- Render event descriptions, dates, relative day counts, product icons, and links.
- Add responsive styling for the overview grid, month navigation, and event cards.
- Exclude generated timeline pages from site navigation and search indexing.

Relates to #2148, #3285, #8051.