### PR TITLE
[debian] Update eol for 12 (bookworm)

### DIFF
--- a/products/debian.md
+++ b/products/debian.md
@@ -41,7 +41,7 @@ releases:
   - releaseCycle: "12"
     codename: "Bookworm"
     releaseDate: 2023-06-10
-    eol: 2026-07-11
+    eol: 2026-07-12
     eoes: 2028-06-30
     link: https://www.debian.org/News/2026/2026051602
     latest: "12.15"


### PR DESCRIPTION
Debian's dated end-of-support announcement and the DebianReleases wiki both give **12 July 2026** as the end of regular security support for bookworm; only debian.org/releases/ still shows 2026-07-11.

- https://www.debian.org/News/2026/20260712 — "regular security support … ended 12 July"
- https://wiki.debian.org/DebianReleases — "End of life: 2026-07-12"
- Dissenting: https://www.debian.org/releases/ (2026-07-11)

Following the majority of Debian's own sources, with the dated announcement as the strongest of them. One-day change; `eoes` (LTS to 2028-06-30) is undisputed and untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)