### PR TITLE
[mastodon] Add 4.7 Cycle and Update eol date for 4.5 cycle

### DIFF
--- a/products/mastodon.md
+++ b/products/mastodon.md
@@ -24,6 +24,12 @@ auto:
 # EOL dates are either false if no information could be found, or the date found in
 # https://github.com/mastodon/mastodon/blob/main/SECURITY.md history.
 releases:
+  - releaseCycle: "4.7"
+    releaseDate: 2026-08-20
+    eol: false
+    latest: "4.7.0"
+    latestReleaseDate: 2026-08-20
+
   - releaseCycle: "4.6"
     releaseDate: 2026-06-17
     eol: false
@@ -32,7 +38,7 @@ releases:
 
   - releaseCycle: "4.5"
     releaseDate: 2025-11-06
-    eol: false
+    eol: 2027-02-20
     latest: "4.5.16"
     latestReleaseDate: 2026-08-13
 


### PR DESCRIPTION
https://github.com/mastodon/mastodon/releases/tag/v4.7.0