### PR TITLE
[ubuntu] Correct future EOL/ESM dates, update Legacy add-on to 15 years, fix stale links

### DIFF
--- a/products/ubuntu.md
+++ b/products/ubuntu.md
@@ -8,7 +8,7 @@ permalink: /ubuntu
 alternate_urls:
   - /ubuntu-linux
 versionCommand: cat /etc/os-release
-releasePolicyLink: https://wiki.ubuntu.com/Releases
+releasePolicyLink: https://ubuntu.com/project/docs/release-team/list-of-releases/
 releaseLabel: "__RELEASE_CYCLE__ '__CODENAME__'"
 changelogTemplate: https://wiki.ubuntu.com/{{"__CODENAME__"|replace:' ',''}}/ReleaseNotes/
 eoasColumn: Hardware & Maintenance
@@ -28,7 +28,7 @@ identifiers:
   - cpe: cpe:2.3:o:canonical:ubuntu_linux
   - cpe: cpe:/o:canonical:ubuntu_linux
 
-# Support and EOL dates available on https://wiki.ubuntu.com/Releases.
+# Support and EOL dates available on https://ubuntu.com/project/docs/release-team/list-of-releases/.
 # Exact day for some dates is not available, in this case use the same day as the release date.
 releases:
   - releaseCycle: "26.04"
@@ -445,21 +445,21 @@ or a [Free subscription for personal use](https://ubuntu.com/blog/ubuntu-pro-bet
 Ubuntu Pro offers security fixes for critical, high, and selected medium CVEs in the `main` and `universe` repositories.
 Ubuntu Pro (Infra-only)[^1] only guarantees security fixes for packages in the `main` repository.
 
-Canonical also offers [Ubuntu Legacy Support](https://ubuntu.com//blog/canonical-expands-long-term-support-to-12-years-starting-with-ubuntu-14-04-lts),
+Canonical also offers [Ubuntu Legacy Support](https://ubuntu.com/blog/canonical-expands-long-term-support-to-12-years-starting-with-ubuntu-14-04-lts),
 to extend the support of Ubuntu LTS releases from 14.04 by another 2 years beyond Expanded Security Maintenance (ESM).
 This offer is only available for Ubuntu Pro paying customers.
 
 ## Support Comparison
 
-| Feature/Plan                                                                            | Ubuntu LTS      | Ubuntu Pro (Infra-Only) [^1] | Ubuntu Pro    | Legacy Support |
-| --------------------------------------------------------------------------------------- | --------------- | ---------------------------- | ------------- | -------------- |
-| Main repository                                                                         | 5 years         | 10 years                     | 10 years      | 12 years       |
-| Restricted repository                                                                   | 5 years         | 10 years[^2]                 | 10 years [^2] | 12 years[^7]   |
-| Universe repository                                                                     | Best Effort[^6] | Best Effort                  | 10 years      | 12 years[^7]   |
-| Phone/Ticket Support                                                                    | No              | Yes                          | Yes           | Yes            |
-| Kernel Live Patching                                                                    | No              | Yes                          | Yes           | Yes            |
-| [Security Certifications and Hardening](https://ubuntu.com/security/certifications)[^3] | No              | Yes                          | Yes           | Yes            |
-| [Ubuntu Landscape](https://ubuntu.com/landscape)                                        | No              | Yes                          | Yes           | No[^8]         |
+| Feature/Plan                                                                                | Ubuntu LTS      | Ubuntu Pro (Infra-Only) [^1] | Ubuntu Pro    | Legacy Support |
+| ------------------------------------------------------------------------------------------- | --------------- | ---------------------------- | ------------- | -------------- |
+| Main repository                                                                             | 5 years         | 10 years                     | 10 years      | 12 years       |
+| Restricted repository                                                                       | 5 years         | 10 years[^2]                 | 10 years [^2] | 12 years[^7]   |
+| Universe repository                                                                         | Best Effort[^6] | Best Effort                  | 10 years      | 12 years[^7]   |
+| Phone/Ticket Support                                                                        | No              | Yes                          | Yes           | Yes            |
+| Kernel Live Patching                                                                        | No              | Yes                          | Yes           | Yes            |
+| [Security Certifications and Hardening](https://ubuntu.com/security/security-standards)[^3] | No              | Yes                          | Yes           | Yes            |
+| [Ubuntu Landscape](https://ubuntu.com/landscape)                                            | No              | Yes                          | Yes           | No[^8]         |
 
 For package-specific support details, the following commands are available:
 
@@ -482,4 +482,4 @@ For package-specific support details, the following commands are available:
 
 [^7]: The announcement for Legacy Support does not clarify which repositories are supported, so this is an estimate.
 
-[^8]: [Ubuntu Landscape](https://ubuntu.com/landscape/docs/self-hosted-landscape) can manage all versions of Ubuntu above 16.04, and Legacy Support is limited to 14.04 for now.
+[^8]: [Ubuntu Landscape](https://ubuntu.com/landscape/docs/explanation/landscape/self-hosted-landscape/) can manage all versions of Ubuntu above 16.04, and Legacy Support is limited to 14.04 for now.

--- a/products/ubuntu.md
+++ b/products/ubuntu.md
@@ -105,7 +105,7 @@ releases:
     releaseDate: 2022-04-21
     eoas: 2024-09-30
     eol: 2027-06-01
-    eoes: 2032-04-09
+    eoes: 2032-04-21
     latest: "22.04.5"
     latestReleaseDate: 2024-09-12
 
@@ -445,17 +445,18 @@ or a [Free subscription for personal use](https://ubuntu.com/blog/ubuntu-pro-bet
 Ubuntu Pro offers security fixes for critical, high, and selected medium CVEs in the `main` and `universe` repositories.
 Ubuntu Pro (Infra-only)[^1] only guarantees security fixes for packages in the `main` repository.
 
-Canonical also offers [Ubuntu Legacy Support](https://ubuntu.com/blog/canonical-expands-long-term-support-to-12-years-starting-with-ubuntu-14-04-lts),
-to extend the support of Ubuntu LTS releases from 14.04 by another 2 years beyond Expanded Security Maintenance (ESM).
+Canonical also offers [Ubuntu Legacy Support](https://ubuntu.com/blog/canonical-expands-total-coverage-for-ubuntu-lts-releases-to-15-years-with-legacy-add-on),
+to extend the support of Ubuntu LTS releases from 14.04 by another 5 years beyond Expanded Security Maintenance (ESM),
+for a total of 15 years.
 This offer is only available for Ubuntu Pro paying customers.
 
 ## Support Comparison
 
 | Feature/Plan                                                                                | Ubuntu LTS      | Ubuntu Pro (Infra-Only) [^1] | Ubuntu Pro    | Legacy Support |
 | ------------------------------------------------------------------------------------------- | --------------- | ---------------------------- | ------------- | -------------- |
-| Main repository                                                                             | 5 years         | 10 years                     | 10 years      | 12 years       |
-| Restricted repository                                                                       | 5 years         | 10 years[^2]                 | 10 years [^2] | 12 years[^7]   |
-| Universe repository                                                                         | Best Effort[^6] | Best Effort                  | 10 years      | 12 years[^7]   |
+| Main repository                                                                             | 5 years         | 10 years                     | 10 years      | 15 years       |
+| Restricted repository                                                                       | 5 years         | 10 years[^2]                 | 10 years [^2] | 15 years[^7]   |
+| Universe repository                                                                         | Best Effort[^6] | Best Effort                  | 10 years      | 15 years[^7]   |
 | Phone/Ticket Support                                                                        | No              | Yes                          | Yes           | Yes            |
 | Kernel Live Patching                                                                        | No              | Yes                          | Yes           | Yes            |
 | [Security Certifications and Hardening](https://ubuntu.com/security/security-standards)[^3] | No              | Yes                          | Yes           | Yes            |
@@ -482,4 +483,4 @@ For package-specific support details, the following commands are available:
 
 [^7]: The announcement for Legacy Support does not clarify which repositories are supported, so this is an estimate.
 
-[^8]: [Ubuntu Landscape](https://ubuntu.com/landscape/docs/explanation/landscape/self-hosted-landscape/) can manage all versions of Ubuntu above 16.04, and Legacy Support is limited to 14.04 for now.
+[^8]: [Ubuntu Landscape](https://ubuntu.com/landscape/docs/explanation/landscape/self-hosted-landscape/) can manage all versions of Ubuntu above 16.04, and Legacy Support currently covers 14.04 and 16.04.

--- a/products/ubuntu.md
+++ b/products/ubuntu.md
@@ -35,9 +35,9 @@ releases:
     codename: "Resolute Raccoon"
     lts: true
     releaseDate: 2026-04-23
-    eoas: 2031-04-30
-    eol: 2031-04-30
-    eoes: 2036-04-30
+    eoas: 2031-05-29
+    eol: 2031-05-29
+    eoes: 2036-04-23
     latest: "26.04"
     latestReleaseDate: 2026-04-23
     
@@ -71,7 +71,7 @@ releases:
     releaseDate: 2024-04-25
     eoas: 2029-05-31
     eol: 2029-05-31
-    eoes: 2036-05-31
+    eoes: 2034-04-25
     latest: "24.04.4"
     latestReleaseDate: 2026-02-12
 
@@ -104,7 +104,7 @@ releases:
     lts: true
     releaseDate: 2022-04-21
     eoas: 2024-09-30
-    eol: 2027-04-01
+    eol: 2027-06-01
     eoes: 2032-04-09
     latest: "22.04.5"
     latestReleaseDate: 2024-09-12
@@ -139,7 +139,7 @@ releases:
     releaseDate: 2020-04-23
     eoas: 2022-10-01
     eol: 2025-05-31
-    eoes: 2030-04-02
+    eoes: 2030-04-23
     latest: "20.04.6"
     latestReleaseDate: 2023-03-23
 
@@ -173,7 +173,7 @@ releases:
     releaseDate: 2018-04-26
     eoas: 2023-05-31
     eol: 2023-05-31
-    eoes: 2028-04-01
+    eoes: 2028-04-26
     latest: "18.04.6"
     latestReleaseDate: 2021-09-17
 


### PR DESCRIPTION
Verified `products/ubuntu.md` against Canonical sources:

- <https://ubuntu.com/about/release-cycle>
- <https://ubuntu.com/project/docs/release-team/list-of-releases/>
- <https://ubuntu.com/security/esm>
- <https://ubuntu.com/blog/canonical-expands-total-coverage-for-ubuntu-lts-releases-to-15-years-with-legacy-add-on>
- `distro-info-data/ubuntu.csv` — the only source with exact days; the web pages round to months

## 1. Date corrections

Only dates **still in the future** were changed. Past dates are deliberately left alone, even where they drift by a few days, to keep the diff reviewable.

| cycle | field | before | after |
| ----- | ----- | ------ | ----- |
| 24.04 | `eoes` | 2036-05-31 | **2034-04-25** |
| 22.04 | `eol` | 2027-04-01 | **2027-06-01** |
| 22.04 | `eoes` | 2032-04-09 | **2032-04-21** |
| 26.04 | `eoas`, `eol` | 2031-04-30 | **2031-05-29** |
| 26.04 | `eoes` | 2036-04-30 | **2036-04-23** |
| 20.04 | `eoes` | 2030-04-02 | **2030-04-23** |
| 18.04 | `eoes` | 2028-04-01 | **2028-04-26** |

The **24.04 `eoes`** entry was the significant one — off by nearly two years. `ubuntu.com/security/esm` gives "End of Ubuntu Pro Support: May 2034" for 24.04, and the rule below puts it at 2034-04-25.

Every LTS release satisfies **`eoes = releaseDate + 10 years`**. After this PR, all entries with a future `eoes` match that rule *and* `distro-info-data` exactly. The two that still don't (14.04, 16.04) are in the past and were left alone.

26.04's `eoas` moved with its `eol` to preserve this file's convention that `eoas == eol` for LTS releases with no separately-known hardware-enablement date (as in 14.04, 16.04, 18.04, 24.04).

<details>
<summary>Why 22.04 <code>eol</code> is 2027-06-01 and not "May 2027"</summary>

`ubuntu.com` renders this as *May 2027*, while the release-team page and `distro-info-data` say June. They describe the same thing — per `distro-info-data` commit `cb709633` ("Document Ubuntu ESM overlap period", LP: #2003949): standard updates keep flowing into the **public** security pocket through May, *"with ESM-only updates starting on 1st of June."* So the last day of support-without-Pro is June 1.
</details>

## 2. Legacy add-on: 12 → 15 years

Canonical [extended the Legacy add-on from 2 to 5 years](https://ubuntu.com/blog/canonical-expands-total-coverage-for-ubuntu-lts-releases-to-15-years-with-legacy-add-on), taking total coverage from 12 to 15 years, applying from 14.04 onward (also in `distro-info-data`, LP: #2131678). The file still documented the old 12-year figure and linked the superseded announcement. Updated the prose, the support comparison table, and the link.

Footnote 8 also claimed Legacy Support was "limited to 14.04 for now" — 16.04 entered Legacy in April 2026, so it now covers both.

Note that Legacy dates are **not** recorded as structured data: `product-schema.json` provides only `eoas`/`eol`/`eoes`, with no field for a fourth support tier. Happy to follow up if you'd want that modelled.

## 3. Link fixes

All 55 URLs referenced by the file were checked, including `changelogTemplate` expanded for every codename.

- `releasePolicyLink` and the header comment pointed at `wiki.ubuntu.com/Releases`, which now serves a `<meta http-equiv="refresh">` to the release-team docs. Since it still returns **HTTP 200**, curl-based checkers — including `check-links.yml` — cannot detect this, so it would have rotted silently.
- Stray double slash in the Legacy Support blog URL (`ubuntu.com//blog/...`).
- `/landscape/docs/self-hosted-landscape` → 301 → `/landscape/docs/explanation/landscape/self-hosted-landscape/`
- `/security/certifications` → 302 → `/security/security-standards`

The support comparison table was re-padded, as the longer security URL widened its first column.

**No changelog links were touched.** The 8 codenames whose wiki ReleaseNotes pages are dead (Warty, Hoary, Breezy, Dapper, Edgy, Feisty, Hardy, Intrepid) turn out to be exactly the 8 entries already carrying `link: null` — no gaps, no redundant entries.

## Not included

- **26.10 "Stonking Stingray"** is absent (due 2026-10-15).
- **`eoas` is applied inconsistently.** Only 20.04 and 22.04 carry a distinct "Hardware & Maintenance" date; other LTS releases set `eoas == eol`. 24.04's HWE phase actually ends with 24.04.5 (due Sep 2026), so it arguably warrants its own date rather than 2029-05-31. Happy to follow up if you have a preferred convention.
- Past-dated drift: ESM on 14.04/16.04 sits ~3 weeks early, and several interim releases are off by 1–11 days.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
