### PR TITLE
[ipados] Set active support end for 18

### DIFF
--- a/products/ipados.md
+++ b/products/ipados.md
@@ -27,7 +27,7 @@ releases:
 
   - releaseCycle: "18"
     releaseDate: 2024-09-16
-    eoas: false
+    eoas: 2025-09-15
     eol: false
     latest: "18.7.10"
     latestReleaseDate: 2026-08-17
@@ -76,7 +76,6 @@ releases:
     latest: "12.5.8"
     latestReleaseDate: 2026-01-26
     link: https://developer.apple.com/documentation/ios-ipados-release-notes/ios-12-release-notes
-
 ---
 
 > [iPadOS](https://www.apple.com/ipados/) is a mobile operating system created by Apple for its iPad line of devices.


### PR DESCRIPTION
Fixes #10721

## Summary
Set iPadOS 18 end of active support to 2025-09-15, matching the iOS lifecycle and the release date of iPadOS 26. iPadOS 18 remains under security support.

## Tests
- bin/lint-product.sh products/ipados.md: 0 issues
- bundle exec jekyll build: passed