### PR TITLE
[ansible-core] Update auto configuration

### DIFF
--- a/products/ansible-core.md
+++ b/products/ansible-core.md
@@ -37,7 +37,7 @@ identifiers:
 auto:
   methods:
     - git: https://github.com/ansible/ansible.git
-    - release_table: https://docs.ansible.com/ansible/devel/reference_appendices/release_and_maintenance.html
+    - release_table: https://github.com/ansible/ansible-documentation/blob/devel/docs/docsite/rst/reference_appendices/release_and_maintenance.rst
       fields:
         releaseCycle: "Version"
         releaseDate:
@@ -50,7 +50,6 @@ auto:
 # EOL dates as well as Python / PowerShell versions can be found on
 # https://docs.ansible.com/ansible/devel/reference_appendices/release_and_maintenance.html
 releases:
-
   - releaseCycle: "2.21"
     pythonVersionsControlNode: "3.12 - 3.14"
     pythonVersionsManagedNode: "3.9 - 3.14"


### PR DESCRIPTION
Switch from https://docs.ansible.com/ansible/devel/reference_appendices/release_and_maintenance.html to https://github.com/ansible/ansible-documentation/blob/devel/docs/docsite/rst/reference_appendices/release_and_maintenance.rst to get release information.

https://docs.ansible.com/ansible/devel/reference_appendices/release_and_maintenance.html is protected by anti-bot measures which [make the retrieval of those information fail](https://github.com/endoflife-date/release-data/actions/runs/33240122038) (and is very long).