### PR TITLE
[ibm-aix] Replace ibm-aix auto method by version_table

### DIFF
--- a/products/ibm-aix.md
+++ b/products/ibm-aix.md
@@ -19,7 +19,14 @@ identifiers:
 
 auto:
   methods:
-    - ibm-aix: https://www.ibm.com/support/pages/aix-support-lifecycle-information
+    - version_table: https://www.ibm.com/support/pages/aix-support-lifecycle-information
+      header_selector: "tbody tr:nth-of-type(1)"
+      name_column: "TL"
+      date_column: "Release date"
+      render_javascript: true
+      render_javascript_wait_for: "table"
+      regex: 'AIX (?P<major>\d+)\.(?P<minor>\d+) TL(?P<patch>\d+)'
+      template: "{{major}}.{{minor}}.{{patch}}"
     - release_table: https://www.ibm.com/support/pages/aix-support-lifecycle-information
       header_selector: "tbody tr:nth-of-type(1)"
       fields:


### PR DESCRIPTION
Replace the use of the custom `ibm-aix` auto method by the generic `version_table` one.