### PR TITLE
[visual-studio] Replace visual-studio auto method by version_table

### DIFF
--- a/products/visual-studio.md
+++ b/products/visual-studio.md
@@ -16,14 +16,22 @@ auto:
   methods:
     # There is no build history for versions 2015 and below.
     # This is not a big deal because there was no version for those releases in a very long time.
-    - visual-studio: https://learn.microsoft.com/en-us/visualstudio/releasenotes/vs2017-relnotes-history
-    - visual-studio: https://learn.microsoft.com/en-us/visualstudio/releases/2019/history
-    - visual-studio: https://learn.microsoft.com/en-us/visualstudio/releases/2022/release-history
-    - visual-studio: https://learn.microsoft.com/en-us/visualstudio/releases/2026/release-history
+    - version_table: https://learn.microsoft.com/en-us/visualstudio/releasenotes/vs2017-relnotes-history
+      name_column: "Version"
+      date_column: "Release Date"
+    - version_table: https://learn.microsoft.com/en-us/visualstudio/releases/2019/history
+      name_column: "Version"
+      date_column: "Release Date"
+    - version_table: https://learn.microsoft.com/en-us/visualstudio/releases/2022/release-history
+      name_column: "Version"
+      date_column: "Release Date"
+    - version_table: https://learn.microsoft.com/en-us/visualstudio/releases/2026/release-history
+      name_column: "Version"
+      date_column: "Release Date"
 
 # For non-LTSC, eol(x) = releaseDate(x+1)
 # For LTSC, EOL dates can be found on https://learn.microsoft.com/visualstudio/productinfo/vs-servicing#long-term-servicing-channel-ltsc-support
-# When adding a new major version (codename changes), remember to update URLS at auto:methods above also check https://github.com/endoflife-date/release-data/blob/main/src/visual-studio.py
+# When adding a new major version (codename changes), remember to update URLs at auto:methods above.
 releases:
   - releaseCycle: "18.9"
     codename: "2026"


### PR DESCRIPTION
Replace the use of the custom visual-studio auto method by the generic version_table one.