### PR TITLE
[joomla] Update auto-configuration

### DIFF
--- a/products/joomla.md
+++ b/products/joomla.md
@@ -15,7 +15,7 @@ identifiers:
 
 auto:
   methods:
-    - git: https://github.com/joomla/joomla-cms.git
+    - github_releases: joomla/joomla-cms
 
 # eol see https://developer.joomla.org/roadmap.html
 releases:
@@ -32,24 +32,22 @@ releases:
     releaseDate: 2023-10-14
     eoas: 2026-10-13
     eol: 2027-10-12
-    latest: "5.4.112"
-    latestReleaseDate: 2025-07-22
-    # check later for removal: the link with changelogTemplate does not work (yet)
-    link: https://www.joomla.org/announcements/release-news/5900-joomla-5-0-and-joomla-4-4-are-here
+    latest: "5.4.8"
+    latestReleaseDate: 2026-08-18
 
   - releaseCycle: "4"
     releaseDate: 2021-08-17
     eoas: 2024-10-15
     eol: 2025-10-14
     latest: "4.4.14"
-    latestReleaseDate: 2025-09-23
+    latestReleaseDate: 2025-09-30
 
   - releaseCycle: "3"
     releaseDate: 2012-09-27
     eoas: 2021-08-17
     eol: 2023-08-17
     latest: "3.10.12"
-    latestReleaseDate: 2023-07-08
+    latestReleaseDate: 2023-07-11
 
 ---
 


### PR DESCRIPTION
Switch from git to github_releases so that alpha/beta releases, which have odd tags such as x.y.112, are ignored. Updated release according to this change.

Closes #10831