### PR TITLE
[KDE] change plasma 6.6 to LTS

### DIFF
--- a/products/kde-plasma.md
+++ b/products/kde-plasma.md
@@ -37,7 +37,7 @@ releases:
     lts: true
     releaseDate: 2026-02-17
     eoas: 2026-06-16
-    eol: 2029-08-01
+    eol: 2029-08-31
     latest: "6.6.6"
     latestReleaseDate: 2026-07-07
 

--- a/products/kde-plasma.md
+++ b/products/kde-plasma.md
@@ -34,9 +34,10 @@ releases:
     latestReleaseDate: 2026-08-04
 
   - releaseCycle: "6.6"
+    lts: true
     releaseDate: 2026-02-17
     eoas: 2026-06-16
-    eol: 2026-06-16
+    eol: 2029-08-01
     latest: "6.6.6"
     latestReleaseDate: 2026-07-07
 


### PR DESCRIPTION
Plasma 6.6 is now LTS - https://community.kde.org/Schedules/Plasma_6#Long-term_support_releases