### PR TITLE
[samsung-mobile] Increase stale release threshold

### DIFF
--- a/products/samsung-mobile.md
+++ b/products/samsung-mobile.md
@@ -11,7 +11,7 @@ releasePolicyLink: https://security.samsungmobile.com/workScope.smsb
 latestColumn: false
 eoasColumn: Android Upgrades
 eolColumn: Security Updates
-staleReleaseThresholdDays: 1825 # devices have longer support periods
+staleReleaseThresholdDays: 2190 # 6 years, devices have longer support periods
 
 auto:
   cumulative: true


### PR DESCRIPTION
Devices such as Galaxy Z Fold3 5G and Galaxy Z Flip3 5G are still listed on https://security.samsungmobile.com/workScope.smsb.