### PR TITLE
[dovecot] Update stale release threshold for 2.3

### DIFF
--- a/products/dovecot.md
+++ b/products/dovecot.md
@@ -29,7 +29,7 @@ releases:
     latestReleaseDate: 2026-08-28
 
   - releaseCycle: "2.3"
-    staleReleaseThresholdDays: 730 # mentioned recently on https://dovecot.org/mailman3/archives/list/dovecot-news@dovecot.org/thread/3P45L76DOC3NKUNSSPIXQNKINGOCYH5K/
+    staleReleaseThresholdDays: 1095 # mentioned recently on https://dovecot.org/mailman3/archives/list/dovecot-news@dovecot.org/thread/3P45L76DOC3NKUNSSPIXQNKINGOCYH5K/, still listed on https://repo.dovecot.org/
     releaseDate: 2017-12-22
     eoas: 2025-01-24
     eol: false


### PR DESCRIPTION
Release is still listed on https://repo.dovecot.org/.