### PR TITLE
[jquery] Mark 3 as EOL

### DIFF
--- a/products/jquery.md
+++ b/products/jquery.md
@@ -23,6 +23,7 @@ auto:
   methods:
     - git: https://github.com/jquery/jquery.git
 
+# eol(x) = releaseDate(x+1)
 releases:
   - releaseCycle: "4"
     releaseDate: 2026-01-17
@@ -31,9 +32,8 @@ releases:
     latestReleaseDate: 2026-01-17
 
   - releaseCycle: "3"
-    staleReleaseThresholdDays: 1095 # see https://github.com/jquery/jquery?tab=security-ov-file#supported-versions
     releaseDate: 2016-06-09
-    eol: false
+    eol: 2026-01-17
     eoes: false
     latest: "3.7.1"
     latestReleaseDate: 2023-08-28


### PR DESCRIPTION
Only the latest release is supported, see https://github.com/jquery/jquery?tab=security-ov-file#supported-versions.