### PR TITLE
[istio] Add 1.31

### DIFF
--- a/products/istio.md
+++ b/products/istio.md
@@ -47,6 +47,13 @@ auto:
 # Effective and approximate EOL dates as well as Supported Kubernetes Versions can be found on
 # https://istio.io/latest/docs/releases/supported-releases/#support-status-of-istio-releases.
 releases:
+  - releaseCycle: "1.31"
+    releaseDate: 2026-08-31
+    eol: 2027-02-28
+    supportedKubernetesVersions: "1.32 - 1.36"
+    latest: "1.31.0"
+    latestReleaseDate: 2026-08-31
+
   - releaseCycle: "1.30"
     releaseDate: 2026-05-18
     eol: 2026-12-31


### PR DESCRIPTION
https://istio.io/latest/news/releases/1.31.x/announcing-1.31/change-notes/

In its Support status of Istio releases page it mentioned as release date as 	Aug 27, 2026 on the other hand announcement date was Aug 31, 2026 . So i have accepted its releaseDate as its announcement date