### PR TITLE
[azure-database-for-mysql] Increase staleReleaseThresholdDays to 2 years for 8.4

### DIFF
--- a/products/azure-database-for-mysql.md
+++ b/products/azure-database-for-mysql.md
@@ -24,6 +24,7 @@ auto:
 
 releases:
   - releaseCycle: "8.4"
+    staleReleaseThresholdDays: 730 # no eol documented on https://learn.microsoft.com/azure/mysql/concepts-version-policy
     releaseDate: 2025-09-01
     eol: false
 


### PR DESCRIPTION
To suppress warnings during auto updates such as https://github.com/endoflife-date/endoflife.date/pull/10894 anymore.