### PR TITLE
Validate support phase status consistency

### DIFF
--- a/_plugins/product-data-validator.rb
+++ b/_plugins/product-data-validator.rb
@@ -234,6 +234,9 @@ module EndOfLifeHooks
       error_if.is_not_before('eoas', 'eol') if product.data['eoasColumn']
       error_if.is_not_before('eoas', 'eoes') if product.data['eoasColumn'] and product.data['eoesColumn']
       error_if.is_not_before('eol', 'eoes') if product.data['eoesColumn']
+      error_if.inconsistent_support_status('eoas', 'eol') if product.data['eoasColumn']
+      error_if.inconsistent_support_status('eol', 'eoes') if product.data['eoesColumn']
+      error_if.inconsistent_support_status('eoas', 'eoes') if product.data['eoasColumn'] and product.data['eoesColumn']
     }
 
     Jekyll.logger.debug TOPIC, "Product '#{product.name}' successfully validated in #{(Time.now - start).round(3)} seconds."
@@ -368,6 +371,17 @@ module EndOfLifeHooks
 
       if value1.respond_to?(:strftime) and value2.respond_to?(:strftime) and value1 > value2
         declare_error(property1, value1, "expecting a value before #{property2} (#{value2})")
+      end
+    end
+
+    def inconsistent_support_status(earlier_support_phase, later_support_phase)
+      earlier_support_phase_value = @data[earlier_support_phase]
+      later_support_phase_value = @data[later_support_phase]
+      later_support_phase_reached = later_support_phase_value == true or (later_support_phase_value.respond_to?(:strftime) and later_support_phase_value < Date.today)
+      earlier_support_phase_pending = earlier_support_phase_value == false or (earlier_support_phase_value.respond_to?(:strftime) and earlier_support_phase_value > Date.today)
+
+      if later_support_phase_reached and earlier_support_phase_pending
+        declare_error(earlier_support_phase, earlier_support_phase_value, "expecting #{earlier_support_phase} to have been reached when #{later_support_phase} has been reached")
       end
     end
 

--- a/products/apache-struts.md
+++ b/products/apache-struts.md
@@ -27,14 +27,12 @@ releases:
   - releaseCycle: "7"
     releaseDate: 2024-12-11
     eol: false
-    eoes: true
     latest: "7.3.0"
     latestReleaseDate: 2026-08-01
 
   - releaseCycle: "6"
     releaseDate: 2022-06-02
     eol: false
-    eoes: true
     latest: "6.11.0"
     latestReleaseDate: 2026-08-01
 


### PR DESCRIPTION
Reject releases that reach a later support phase while an earlier phase remains pending.

Also fix Apache Struts 6 and 7 releases that had this issue.