### PR TITLE
[openai-api-models] Set default stale release threshold to 3 years

### DIFF
--- a/products/openai-api-models.md
+++ b/products/openai-api-models.md
@@ -11,6 +11,7 @@ releasePolicyLink: https://developers.openai.com/api/docs/deprecations
 latestColumn: false
 eoasColumn: Active support
 eolColumn: Deprecated support
+staleReleaseThresholdDays: 1095 # llm may have longer support periods
 
 customFields:
   - name: aliases


### PR DESCRIPTION
LLM have no versions and may have longer support period.