### PR TITLE
[oracle-jdk] Update auto-configuration

### DIFF
--- a/products/oracle-jdk.md
+++ b/products/oracle-jdk.md
@@ -46,7 +46,7 @@ auto:
       fields:
         releaseCycle:
           column: "Version"
-          regex: '^(?P<value>\d+)(\s+LTS)?$'
+          regex: '^(?:JDK\s+)?(?P<value>\d+)(?:\s+LTS(?:\s+.*)?)?$'
         releaseDate: "Date"
 
 # Release dates, including future release dates, can be found on https://www.java.com/releases/.


### PR DESCRIPTION
The addition of the "JDK" prefix for new releases on https://ops.java/releases/ broke the auto-update.