### PR TITLE
[tails] Update auto-configuration

### DIFF
--- a/products/tails.md
+++ b/products/tails.md
@@ -11,12 +11,16 @@ changelogTemplate: https://tails.net/news/version___LATEST__/
 identifiers:
   - cpe: cpe:2.3:o:tails_project:tails
 
-# We fetch dates from Git and then override a few
-# older releases with more accurate dates from distrowatch
-# pre-1.3 releases were tagged later, so git data isn't accurate for those.
+# Do not use distrowatch: it's slow and inaccurate.
+# Do not use git (https://gitlab.tails.boum.org/tails/tails.git): the source code is not publicly available anymore.
 auto:
   methods:
-    - git: https://gitlab.tails.boum.org/tails/tails.git
+    - xml_versions: https://tails.net/news/index.en.atom
+      selector: 'feed > entry'
+      name:
+        selector: 'title'
+        regex: '^Tails (?P<value>\d+\.\d+)$'
+      date: 'published'
 
 # eol(x) = releaseDate(x+1)
 releases:


### PR DESCRIPTION
Switch to using the ATOM feed (https://tails.net/news/index.en.atom) instead of the git repository (https://gitlab.tails.boum.org/tails/tails.git).

The git repository source code is not publicly available anymore: it now requires to authenticate.