### PR TITLE
Add filters to timeline pages

### DIFF
--- a/_layouts/timeline-overview.html
+++ b/_layouts/timeline-overview.html
@@ -21,4 +21,4 @@ layout: default
     {% endfor %}
   </div>
 </div>
-<script src="{{ '/assets/timeline-overview.js' | relative_url }}" defer></script>
+<script src="{{ '/assets/timeline.js' | relative_url }}" defer></script>

--- a/_layouts/timeline.html
+++ b/_layouts/timeline.html
@@ -18,10 +18,39 @@ layout: default
 
   <p class="timeline-introduction"><strong>{{ page.title }}</strong> has <strong>{{ page.events.size }}</strong> events:{% for summary in page.event_summaries %} <strong>{{ summary.count }}</strong> {{ summary.label }}{% unless forloop.last %},{% endunless %}{% endfor %}.</p>
 
+  <fieldset class="timeline-filter-box">
+    <legend>Filters</legend>
+    <form class="timeline-filters" data-timeline-filters>
+    <div class="timeline-filter" data-timeline-filter="product">
+      <span class="sr-only" id="timeline-product-filter">Products</span>
+      <div class="timeline-filter-toggle" role="button" tabindex="0" aria-expanded="false" aria-controls="timeline-product-options" aria-labelledby="timeline-product-filter" data-timeline-filter-toggle>All products</div>
+      <div class="timeline-filter-menu" id="timeline-product-options" hidden data-timeline-filter-menu>
+        <input class="timeline-filter-search" type="search" placeholder="Search products" aria-label="Search products" data-timeline-filter-search>
+        <div class="timeline-filter-options" role="group" aria-labelledby="timeline-product-filter">
+          {% for product in page.products %}<label class="timeline-filter-option" data-label="{{ product.title | downcase }}"><input type="checkbox" value="{{ product.url | relative_url | remove_first: '/' }}"> {{ product.title }}</label>{% endfor %}
+        </div>
+      </div>
+    </div>
+    <div class="timeline-filter" data-timeline-filter="event">
+      <span class="sr-only" id="timeline-event-filter">Event types</span>
+      <div class="timeline-filter-toggle" role="button" tabindex="0" aria-expanded="false" aria-controls="timeline-event-options" aria-labelledby="timeline-event-filter" data-timeline-filter-toggle>All event types</div>
+      <div class="timeline-filter-menu" id="timeline-event-options" hidden data-timeline-filter-menu>
+        <input class="timeline-filter-search" type="search" placeholder="Search event types" aria-label="Search event types" data-timeline-filter-search>
+        <div class="timeline-filter-options" role="group" aria-labelledby="timeline-event-filter">
+          <label class="timeline-filter-option" data-label="releases"><input type="checkbox" value="releaseDate"> Releases</label>
+          <label class="timeline-filter-option" data-label="ends of active support"><input type="checkbox" value="eoas"> Ends of active support</label>
+          <label class="timeline-filter-option" data-label="ends of life"><input type="checkbox" value="eol"> Ends of life</label>
+          <label class="timeline-filter-option" data-label="ends of extended support"><input type="checkbox" value="eoes"> Ends of extended support</label>
+        </div>
+      </div>
+    </div>
+    </form>
+  </fieldset>
+
   {% if page.events.size > 0 %}
     <div class="timeline-events">
       {% for event in page.events %}
-        <a class="timeline-event timeline-event-{{ event.field }}" href="{{ event.product.url | relative_url }}" title="View details for {{ event.product.title }}" aria-label="View details for {{ event.product.title }}">
+        <a class="timeline-event timeline-event-{{ event.field }}" data-product="{{ event.product.url | relative_url | remove_first: '/' }}" data-event="{{ event.field }}" href="{{ event.product.url | relative_url }}" title="View details for {{ event.product.title }}" aria-label="View details for {{ event.product.title }}">
           <div class="timeline-event-date">
             <time datetime="{{ event.date | date_to_xmlschema }}">{{ event.date | date: "%b %-d" }}</time>
             {% if event.days < 0 %}<span>{{ event.days | abs }} days ago</span>{% elsif event.days == 0 %}<span>Today</span>{% else %}<span>{{ event.days }} days left</span>{% endif %}
@@ -34,7 +63,9 @@ layout: default
         </a>
       {% endfor %}
     </div>
+    <p class="timeline-no-results" data-timeline-no-results hidden>No events match the selected filters.</p>
   {% else %}
     <p>No release or support lifecycle events are recorded for this month.</p>
   {% endif %}
 </div>
+<script src="{{ '/assets/timeline.js' | relative_url }}" defer></script>

--- a/_plugins/generate-timeline-pages.rb
+++ b/_plugins/generate-timeline-pages.rb
@@ -57,6 +57,7 @@ module EndOfLife
           month_events,
           navigation_months,
           event_summaries,
+          products,
           navigation_first > first_month,
           navigation_last < last_month
         )
@@ -177,7 +178,7 @@ module EndOfLife
   end
 
   class TimelinePage < Jekyll::Page
-    def initialize(site, month, events, months, event_summaries, more_before, more_after)
+    def initialize(site, month, events, months, event_summaries, products, more_before, more_after)
       @site = site
       @base = site.source
       @dir = TimelinePagesGenerator.timeline_path(month)
@@ -189,6 +190,7 @@ module EndOfLife
         'permalink' => TimelinePagesGenerator.timeline_url(month),
         'events' => events,
         'event_summaries' => event_summaries,
+        'products' => products.sort_by { |product| product.data['title'].to_s.downcase },
         'more_months_before' => more_before,
         'more_months_after' => more_after,
         'months' => months,

--- a/_sass/custom/custom.scss
+++ b/_sass/custom/custom.scss
@@ -181,7 +181,50 @@ a {
   border-color: #5890ff;
   font-weight: 400;
 }
+.timeline-filters { display: grid; gap: .6rem; grid-template-columns: 2fr 1fr; margin: .75rem 0; }
+.timeline-filter-box { border: 1px solid #d8dee9; border-radius: .35rem; margin: .75rem 0; padding: 0 .6rem .6rem; }
+.timeline-filter-box legend { color: #273142; font-size: .9rem; font-weight: 600; padding: 0 .35rem; }
+.timeline-filter { min-width: 0; position: relative; }
+.timeline-filter-toggle {
+  align-items: center;
+  background: #fff;
+  border: 1px solid #cbd5e1;
+  border-radius: .25rem;
+  color: #273142;
+  cursor: pointer;
+  display: flex;
+  flex-wrap: wrap;
+  gap: .35rem;
+  min-width: 12rem;
+  padding: .35rem .5rem;
+  text-align: left;
+}
+.timeline-filter-tag { align-items: center; background: #e8efff; border-radius: 999px; color: #273142; display: inline-flex; font-size: .8rem; gap: .2rem; padding: .15rem .3rem .15rem .45rem; }
+.timeline-filter-tag-remove { background: transparent; border: 0; border-radius: 50%; color: #3468e8; cursor: pointer; font-size: .9rem; line-height: 1; padding: .1rem .25rem; }
+.timeline-filter-tag-remove:hover, .timeline-filter-tag-remove:focus { background: #cbdcff; }
+.timeline-filter-toggle[aria-expanded="true"] { border-color: #5890ff; box-shadow: 0 0 0 2px rgba(88, 144, 255, .2); }
+.timeline-filter-menu {
+  background: #fff;
+  border: 1px solid #cbd5e1;
+  border-radius: .25rem;
+  box-shadow: 0 .35rem .8rem rgba(39, 49, 66, .16);
+  margin-top: .25rem;
+  min-width: 100%;
+  padding: .35rem;
+  position: absolute;
+  z-index: 2;
+}
+.timeline-filter-search { box-sizing: border-box; margin-bottom: .5rem; width: 100%; }
+.timeline-filter-options { max-height: 16rem; overflow-y: auto; }
+.timeline-filter-option { align-items: center; cursor: pointer; display: flex; font-weight: 400; gap: .4rem; padding: .25rem .2rem; }
+.timeline-filter-option[hidden] { display: none; }
+.timeline-filter-option:hover { background: #f1f5f9; }
+.timeline-no-results { margin-top: 1rem; }
 .timeline-events { display: grid; gap: 1rem; }
+.timeline-event[hidden] { display: none; }
+@media (max-width: 40em) {
+  .timeline-filters { grid-template-columns: 1fr; }
+}
 .timeline-event {
   align-items: center;
   border: 1px solid #d8dee9;

--- a/assets/timeline-overview.js
+++ b/assets/timeline-overview.js
@@ -1,3 +1,0 @@
-document.addEventListener('DOMContentLoaded', () => {
-  document.querySelector('[data-current-year]')?.scrollIntoView({ block: 'start', behavior: 'auto' });
-});

--- a/assets/timeline.js
+++ b/assets/timeline.js
@@ -1,0 +1,121 @@
+document.addEventListener('DOMContentLoaded', () => {
+  document.querySelector('[data-current-year]')?.scrollIntoView({ block: 'start', behavior: 'auto' });
+
+  const preserveFilters = (link) => {
+    const url = new URL(link.href, window.location.href);
+    url.search = window.location.search;
+    link.href = url.href;
+  };
+  document.querySelectorAll('.timeline-overview-month[href], .timeline-month[href]').forEach((link) => {
+    preserveFilters(link);
+    link.addEventListener('click', () => preserveFilters(link));
+  });
+
+  const filters = document.querySelector('[data-timeline-filters]');
+  if (!filters) return;
+
+  const events = [...document.querySelectorAll('.timeline-event[data-product][data-event]')];
+  const noResults = document.querySelector('[data-timeline-no-results]');
+  const filterElements = [...filters.querySelectorAll('[data-timeline-filter]')];
+  const selectedValues = (filter) => new Set(
+    [...filter.querySelectorAll('.timeline-filter-option input:checked')].map((checkbox) => checkbox.value)
+  );
+  const filterFor = (name) => filters.querySelector(`[data-timeline-filter="${name}"]`);
+  const productFilter = filterFor('product');
+  const eventFilter = filterFor('event');
+
+  const readFilters = () => {
+    const params = new URLSearchParams(window.location.search);
+    return {
+      product: new Set(params.getAll('product').map((value) => value.replace(/^\//, ''))),
+      event: new Set(params.getAll('event'))
+    };
+  };
+  const writeFilters = () => {
+    const params = new URLSearchParams(window.location.search);
+    ['product', 'event'].forEach((name) => {
+      params.delete(name);
+      selectedValues(filterFor(name)).forEach((value) => params.append(name, value));
+    });
+    const query = params.toString();
+    window.history.replaceState(null, '', `${window.location.pathname}${query ? `?${query}` : ''}${window.location.hash}`);
+  };
+  const updateTags = (filter, defaultLabel) => {
+    const selected = selectedValues(filter);
+    const toggle = filter.querySelector('[data-timeline-filter-toggle]');
+    toggle.textContent = selected.size === 0 ? defaultLabel : 'Edit selection';
+    selected.forEach((value) => {
+      const checkbox = [...filter.querySelectorAll('.timeline-filter-option input')].find((input) => input.value === value);
+      if (!checkbox) return;
+      const tag = document.createElement('span');
+      tag.className = 'timeline-filter-tag';
+      tag.append(document.createTextNode(checkbox.parentElement.textContent.trim()));
+      const remove = document.createElement('button');
+      remove.type = 'button';
+      remove.className = 'timeline-filter-tag-remove';
+      remove.setAttribute('aria-label', `Remove ${checkbox.parentElement.textContent.trim()}`);
+      remove.textContent = 'x';
+      remove.addEventListener('click', (event) => {
+        event.stopPropagation();
+        checkbox.checked = false;
+        filters.dispatchEvent(new Event('change'));
+      });
+      tag.append(remove);
+      toggle.append(tag);
+    });
+  };
+  const applyFilters = () => {
+    const products = selectedValues(productFilter);
+    const eventTypes = selectedValues(eventFilter);
+    const matches = (event) => (products.size === 0 || products.has(event.dataset.product)) &&
+      (eventTypes.size === 0 || eventTypes.has(event.dataset.event));
+    events.forEach((event) => { event.hidden = !matches(event); });
+    if (noResults) noResults.hidden = events.some(matches);
+  };
+  const update = () => {
+    writeFilters();
+    applyFilters();
+    updateTags(productFilter, 'All products');
+    updateTags(eventFilter, 'All event types');
+  };
+
+  const current = readFilters();
+  filterElements.forEach((filter) => {
+    const name = filter.dataset.timelineFilter;
+    filter.querySelectorAll('.timeline-filter-option input').forEach((checkbox) => {
+      checkbox.checked = current[name].has(checkbox.value);
+    });
+    const toggle = filter.querySelector('[data-timeline-filter-toggle]');
+    const menu = filter.querySelector('[data-timeline-filter-menu]');
+    toggle.addEventListener('click', () => {
+      const open = menu.hidden;
+      menu.hidden = !open;
+      toggle.setAttribute('aria-expanded', open);
+      if (open) menu.querySelector('input').focus();
+    });
+    toggle.addEventListener('keydown', (event) => {
+      if (event.key === 'Enter' || event.key === ' ') {
+        event.preventDefault();
+        toggle.click();
+      }
+    });
+    filter.querySelector('[data-timeline-filter-search]').addEventListener('input', (event) => {
+      const query = event.target.value.toLocaleLowerCase().trim();
+      filter.querySelectorAll('.timeline-filter-option').forEach((option) => {
+        option.hidden = Boolean(query) && !option.dataset.label.includes(query);
+      });
+    });
+  });
+  document.addEventListener('click', (event) => {
+    filterElements.forEach((filter) => {
+      if (!filter.contains(event.target)) {
+        filter.querySelector('[data-timeline-filter-menu]').hidden = true;
+        filter.querySelector('[data-timeline-filter-toggle]').setAttribute('aria-expanded', 'false');
+      }
+    });
+  });
+  filters.addEventListener('change', update);
+  applyFilters();
+  updateTags(productFilter, 'All products');
+  updateTags(eventFilter, 'All event types');
+});


### PR DESCRIPTION
Let visitors narrow a monthly timeline to selected products and lifecycle event types. The chosen filters are shown in the page URL, so they remain selected when moving between months and can be shared with others.