### PR TITLE
splunk: 8.2 EOL extended to 2023-09-30, 8.1 release date 2020-10-19 (vendor support policy)

### DIFF
--- a/products/splunk.md
+++ b/products/splunk.md
@@ -70,13 +70,13 @@ releases:
 
   - releaseCycle: "8.2"
     releaseDate: 2021-05-12
-    eol: 2023-05-12
+    eol: 2023-09-30
     latest: "8.2.12"
     latestReleaseDate: 2023-08-30
     link: https://docs.splunk.com/Documentation/Splunk/__LATEST__/ReleaseNotes/MeetSplunk
 
   - releaseCycle: "8.1"
-    releaseDate: 2020-10-20
+    releaseDate: 2020-10-19
     eol: 2023-04-19
     latest: "8.1.14"
     latestReleaseDate: 2023-06-01


### PR DESCRIPTION
Two corrections from Splunk's Software Support Policy table (https://www.splunk.com/en_us/legal/splunk-software-support-policy.html):

- **8.2 `eol`: 2023-05-12 -> 2023-09-30.** The table shows 8.2 with End of Splunk Enterprise Support Date "Sep 30 2023", and the footnote reads: "The End of Support Date for Splunk Enterprise 8.2 has been extended to September 30, 2023." The current value is the original 24-month date before the extension.
- **8.1 `releaseDate`: 2020-10-20 -> 2020-10-19.** The table's Release Date for 8.1 is "Oct 19 2020".

Both values were read twice from the vendor page by our adapter on 2026-09-07 before this PR. No other fields changed.