### PR TITLE
drupal: 11.2 and 10.5 security support ended with the 11.4.0 release (2026-07-01)

### DIFF
--- a/products/drupal.md
+++ b/products/drupal.md
@@ -52,14 +52,14 @@ releases:
   - releaseCycle: "11.2"
     releaseDate: 2025-06-18
     eoas: 2025-12-10 # guessed, releaseDate(11.3) as planned on https://www.drupal.org/about/core/policies/core-release-cycles/schedule
-    eol: 2026-06-17
+    eol: 2026-07-01 # security support ended with the 11.4.0 release on 2026-07-01 (schedule: "Drupal 11.4.0 released. End of security support for 11.2.x and 10.5.x.")
     latest: "11.2.14"
     latestReleaseDate: 2026-06-17
 
   - releaseCycle: "10.5"
     releaseDate: 2025-06-18
     eoas: 2025-12-17
-    eol: 2026-06-17
+    eol: 2026-07-01 # security support ended with the 11.4.0 release on 2026-07-01 (schedule: "Drupal 11.4.0 released. End of security support for 11.2.x and 10.5.x.")
     latest: "10.5.12"
     latestReleaseDate: 2026-06-17
 


### PR DESCRIPTION
Drupal 11.2 and 10.5 are listed with `eol: 2026-06-17`, which is the day of their last patch releases (11.2.14 / 10.5.12). Drupal's own schedule ties the end of security support to the next-but-one minor release, and states it explicitly for these two branches:

- https://www.drupal.org/about/core/policies/core-release-cycles/schedule — schedule table row: "Week of Jun 29, 2026 (UTC) — Drupal 11.4.0 released. End of security support for 11.2.x and 10.5.x."
- https://www.drupal.org/project/drupal/releases/11.4.0 — 11.4.0 was released on 1 Jul 2026.
- https://www.drupal.org/project/drupal/releases/11.2.14 and https://www.drupal.org/project/drupal/releases/10.5.12 (both 17 Jun 2026): "This is likely the final release for 11.2.x. 11.2.x is expected to be end-of-life next week." (same wording for 10.5.x).

So both branches kept security coverage until 11.4.0 shipped; this sets `eol: 2026-07-01` for 11.2 and 10.5, with a comment quoting the schedule. Release dates are left untouched (they come from the git method).
