### PR TITLE
[Apple MacOS] Added MacOS 27

### DIFF
--- a/products/macos.md
+++ b/products/macos.md
@@ -25,6 +25,13 @@ auto:
         - '^Mac\s+OS\s+X\s[\w\s]+\sv?(?P<version>\d{2}(?:\.\d+)+)'
 
 releases:
+  - releaseCycle: "27"
+    codename: "Golden Gate"
+    releaseDate: 2026-09-14
+    eol: false
+    latest: "27"
+    latestReleaseDate: 2026-09-14
+
   - releaseCycle: "26"
     codename: "Tahoe"
     releaseDate: 2025-09-15


### PR DESCRIPTION
MacOS 27 Golden Gate was released on Monday, September 14th.

https://www.apple.com/os/macos/

