### PR TITLE
[Apple iPadOS] Added iPadOS 27

### DIFF
--- a/products/ipados.md
+++ b/products/ipados.md
@@ -18,6 +18,13 @@ auto:
         - 'iPadOS\s+(?P<version>\d+(?:\.\d+)+)'
 
 releases:
+  - releaseCycle: "27"
+    releaseDate: 2026-09-14
+    eoas: false
+    eol: false
+    latest: "27"
+    latestReleaseDate: 2026-09-14
+
   - releaseCycle: "26"
     releaseDate: 2025-09-15
     eoas: false


### PR DESCRIPTION
iPadOS 27 was released on Monday, September 14th.

https://www.apple.com/os/ipados/

