### PR TITLE
[Apple Watch] Added Series 12 and Ultra 4, Updated Devices that Support WatchOS 27

### DIFF
--- a/products/apple-watch.md
+++ b/products/apple-watch.md
@@ -24,7 +24,7 @@ customFields:
 releases:
   - releaseCycle: "series-12"
     releaseLabel: "Series 12"
-    releaseDate: 2026-09-19
+    releaseDate: 2026-09-18
     discontinued: false
     eol: false
     link:
@@ -32,16 +32,16 @@ releases:
 
   - releaseCycle: "ultra-4"
     releaseLabel: "Ultra 4"
-    releaseDate: 2026-09-19
+    releaseDate: 2026-09-18
     discontinued: false
     eol: false
-    link: https://support.apple.com/en-us/125095
+    link:
     supportedWatchOsVersions: "27"
 
   - releaseCycle: "series-11"
     releaseLabel: "Series 11"
     releaseDate: 2025-09-19
-    discontinued: false
+    discontinued: 2026-09-18
     eol: false
     link: https://support.apple.com/en-us/125093
     supportedWatchOsVersions: "26 - 27"
@@ -57,7 +57,7 @@ releases:
   - releaseCycle: "ultra-3"
     releaseLabel: "Ultra 3"
     releaseDate: 2025-09-19
-    discontinued: false
+    discontinued: 2026-09-18
     eol: false
     link: https://support.apple.com/en-us/125095
     supportedWatchOsVersions: "26 - 27"

--- a/products/apple-watch.md
+++ b/products/apple-watch.md
@@ -27,7 +27,7 @@ releases:
     releaseDate: 2026-09-18
     discontinued: false
     eol: false
-    link:
+    link: https://www.apple.com/apple-watch-series-12/specs/
     supportedWatchOsVersions: "27"
 
   - releaseCycle: "ultra-4"
@@ -35,13 +35,13 @@ releases:
     releaseDate: 2026-09-18
     discontinued: false
     eol: false
-    link:
+    link: https://www.apple.com/apple-watch-ultra-4/specs/
     supportedWatchOsVersions: "27"
 
   - releaseCycle: "series-11"
     releaseLabel: "Series 11"
     releaseDate: 2025-09-19
-    discontinued: 2026-09-18
+    discontinued: 2026-09-09
     eol: false
     link: https://support.apple.com/en-us/125093
     supportedWatchOsVersions: "26 - 27"
@@ -57,7 +57,7 @@ releases:
   - releaseCycle: "ultra-3"
     releaseLabel: "Ultra 3"
     releaseDate: 2025-09-19
-    discontinued: 2026-09-18
+    discontinued: 2026-09-09
     eol: false
     link: https://support.apple.com/en-us/125095
     supportedWatchOsVersions: "26 - 27"

--- a/products/apple-watch.md
+++ b/products/apple-watch.md
@@ -22,13 +22,29 @@ customFields:
 # All links can be found on https://support.apple.com/en_US/specs/applewatch.
 # All supported watchOS versions can be found on https://en.wikipedia.org/wiki/Apple_Watch#Support.
 releases:
+  - releaseCycle: "series-12"
+    releaseLabel: "Series 12"
+    releaseDate: 2026-09-19
+    discontinued: false
+    eol: false
+    link:
+    supportedWatchOsVersions: "27"
+
+  - releaseCycle: "ultra-4"
+    releaseLabel: "Ultra 4"
+    releaseDate: 2026-09-19
+    discontinued: false
+    eol: false
+    link: https://support.apple.com/en-us/125095
+    supportedWatchOsVersions: "27"
+
   - releaseCycle: "series-11"
     releaseLabel: "Series 11"
     releaseDate: 2025-09-19
     discontinued: false
     eol: false
     link: https://support.apple.com/en-us/125093
-    supportedWatchOsVersions: "26"
+    supportedWatchOsVersions: "26 - 27"
 
   - releaseCycle: "se-3"
     releaseLabel: "SE (3rd generation)"
@@ -36,7 +52,7 @@ releases:
     discontinued: false
     eol: false
     link: https://support.apple.com/en-us/125094
-    supportedWatchOsVersions: "26"
+    supportedWatchOsVersions: "26 - 27"
 
   - releaseCycle: "ultra-3"
     releaseLabel: "Ultra 3"
@@ -44,7 +60,7 @@ releases:
     discontinued: false
     eol: false
     link: https://support.apple.com/en-us/125095
-    supportedWatchOsVersions: "26"
+    supportedWatchOsVersions: "26 - 27"
 
   - releaseCycle: "series-10"
     releaseLabel: "Series 10"
@@ -52,7 +68,7 @@ releases:
     discontinued: 2025-09-19
     eol: false
     link: https://support.apple.com/en-us/121202
-    supportedWatchOsVersions: "11 - 26"
+    supportedWatchOsVersions: "11 - 27"
 
   - releaseCycle: "ultra-2"
     releaseLabel: "Ultra 2"
@@ -60,7 +76,7 @@ releases:
     discontinued: 2025-09-19
     eol: false
     link: https://support.apple.com/kb/SP906
-    supportedWatchOsVersions: "10 - 26"
+    supportedWatchOsVersions: "10 - 27"
 
   - releaseCycle: "series-9"
     releaseLabel: "Series 9"
@@ -68,7 +84,7 @@ releases:
     discontinued: 2024-09-12
     eol: false
     link: https://support.apple.com/kb/SP905
-    supportedWatchOsVersions: "10 - 26"
+    supportedWatchOsVersions: "10 - 27"
 
   - releaseCycle: "ultra-1"
     releaseLabel: "Ultra"


### PR DESCRIPTION
This pull request updates the Apple Watch product data to add new models and update support information for existing models. The most important changes are the addition of the Series 12 and Ultra 4 releases, and updating supported watchOS versions for several existing models.

New model additions:

* Added entries for `Series 12` and `Ultra 4` with release dates of 2026-09-18, both supporting watchOS 27.

Updates to existing releases:

* Updated the `discontinued` date for `Series 11` and `Ultra 3` to 2026-09-09.
* Updated the `supportedWatchOsVersions` for `Series 11`, `SE (3rd generation)`, and `Ultra 3` to "26 - 27".
* Updated the `supportedWatchOsVersions` for `Series 10`, `Ultra 2`, and `Series 9` to include watchOS 27.

Compatibility list found here: [https://www.apple.com/os/watchos/](https://www.apple.com/os/watchos/?version=no-hero#:~:text=safe%2E-,watchOS,devices)
