### PR TITLE
[New Product] perforce - Helix Core Server, Helix Proxy, Helix Broker and Helix Swarm

### DIFF
--- a/products/helix-broker.md
+++ b/products/helix-broker.md
@@ -1,0 +1,116 @@
+---
+title: Helix Broker
+addedAt: 2026-09-10
+category: server-app
+tags: perforce
+permalink: /helix-broker
+alternate_urls:
+  - /p4broker
+  - /p4-broker
+releasePolicyLink: https://portal.perforce.com/s/article/Helix-Core-Maintenance-Lifecycle-Helix-Core-Server-P4D
+eoasColumn: End of Maintenance
+
+# General availability, End of Maintenance and End of Maintenance and Support come from
+# https://portal.perforce.com/s/article/Helix-Core-Maintenance-Lifecycle-Helix-Core-Server-P4D :
+# EOM is two years after GA and EOMS is four years after GA.
+# eoas is mapped to EOM, when bug fixes and security updates stop, and eol to EOMS, when technical
+# support is reduced to basic troubleshooting.
+#
+# Patch versions come from https://help.perforce.com/helix-core/release-notes/current/relnotes.txt ,
+# which covers p4d, p4, p4p and p4broker together as they are released as one train.
+releases:
+  - releaseCycle: "2026.1"
+    # Perforce has not published EOM/EOMS for this release yet.
+    releaseDate: 2026-05-19
+    eoas: false
+    eol: false
+    latest: "2026.1/2972966"
+    latestReleaseDate: 2026-06-10
+
+  - releaseCycle: "2025.2"
+    releaseDate: 2025-11-18
+    eoas: 2027-11-18
+    eol: 2029-11-18
+    latest: "2025.2/2907753"
+    latestReleaseDate: 2026-03-09
+
+  - releaseCycle: "2025.1"
+    releaseDate: 2025-05-16
+    eoas: 2027-05-16
+    eol: 2029-05-16
+    latest: "2025.1/2907437"
+    latestReleaseDate: 2026-03-09
+
+  - releaseCycle: "2024.2"
+    releaseDate: 2024-11-07
+    eoas: 2026-11-07
+    eol: 2028-11-07
+    latest: "2024.2/2877946"
+    latestReleaseDate: 2026-01-14
+
+  - releaseCycle: "2024.1"
+    releaseDate: 2024-05-15
+    eoas: 2026-05-15
+    eol: 2028-05-15
+    latest: "2024.1/2876055"
+    latestReleaseDate: 2026-01-09
+
+  - releaseCycle: "2023.2"
+    releaseDate: 2023-11-16
+    eoas: 2025-11-16
+    eol: 2027-11-16
+    latest: "2023.2/2873834"
+    latestReleaseDate: 2026-01-05
+
+  - releaseCycle: "2023.1"
+    releaseDate: 2023-05-18
+    eoas: 2025-05-18
+    eol: 2027-05-18
+    latest: "2023.1/2797325"
+    latestReleaseDate: 2025-07-11
+
+  - releaseCycle: "2022.2"
+    releaseDate: 2022-11-16
+    eoas: 2024-11-16
+    eol: 2026-11-16
+    latest: "2022.2/2693782"
+    latestReleaseDate: 2024-12-10
+
+  - releaseCycle: "2022.1"
+    releaseDate: 2022-05-17
+    eoas: 2024-05-17
+    eol: 2026-05-17
+    latest: "2022.1/2617865"
+    latestReleaseDate: 2024-06-28
+
+  - releaseCycle: "2021.2"
+    releaseDate: 2021-11-10
+    eoas: 2023-11-10
+    eol: 2025-11-10
+    latest: "2021.2/2536545"
+    latestReleaseDate: 2023-12-20
+
+  - releaseCycle: "2021.1"
+    releaseDate: 2021-05-14
+    eoas: 2023-05-14
+    eol: 2025-05-14
+    latest: "2021.1/2452965"
+    latestReleaseDate: 2023-06-14
+---
+
+> [Helix Broker](https://www.perforce.com/manuals/p4dist/Content/P4Dist/chapter.broker.html), also
+> known as P4Broker and now branded P4 Broker, sits between Helix Core clients and the server to
+> filter and redirect commands.
+
+Helix Broker is built and released from the same source train as Helix Core Server, so it shares its
+version numbers, release dates and lifecycle dates.
+
+Every release moves through three phases. From general availability to **End of Maintenance** it
+receives bug fixes and security updates. Between End of Maintenance and **End of Maintenance and
+Support** those fixes are available only for an additional fee, while technical support continues
+normally. After End of Maintenance and Support, technical support is reduced to basic troubleshooting
+and product usage questions.
+
+Perforce publishes end-of-life dates going back to 2021.1 only, so earlier releases are not listed
+here. The lifecycle table also lags new releases by a few months, which is why 2026.1 has no dates
+yet.

--- a/products/helix-broker.md
+++ b/products/helix-broker.md
@@ -3,6 +3,7 @@ title: Helix Broker
 addedAt: 2026-09-10
 category: server-app
 tags: perforce
+iconSlug: perforce
 permalink: /helix-broker
 alternate_urls:
   - /p4broker

--- a/products/helix-core.md
+++ b/products/helix-core.md
@@ -23,6 +23,18 @@ identifiers:
 #
 # Patch versions come from https://help.perforce.com/helix-core/release-notes/current/relnotes.txt ,
 # which covers p4d, p4, p4p and p4broker together as they are released as one train.
+#
+# Perforce publishes no lifecycle data before 2021.1, and no release date either: the release notes
+# carry dates only from 2020.2 and only for patches, archived copies of them carry none at all, and
+# every timestamp on the distribution host was reset by a bulk migration. Releases before 2021.1 are
+# therefore listed with eoas and eol as booleans, and with an approximate release date placed inside
+# the year the version number names, following the cadence the documented years show. The one
+# exception is 2007.2, capped by an archived copy of the release notes that names it as current on
+# 2007-06-13.
+#
+# The release list itself is exact: it is the union of the releases named in
+# https://filehost.perforce.com/perforce/r20.2/doc/user/relnotes.txt and the release directories on
+# https://filehost.perforce.com/perforce/ .
 releases:
   - releaseCycle: "2026.1"
     # Perforce has not published EOM/EOMS for this release yet.
@@ -101,6 +113,331 @@ releases:
     eol: 2025-05-14
     latest: "2021.1/2452965"
     latestReleaseDate: 2023-06-14
+
+  - releaseCycle: "2020.2"
+    releaseDate: 2020-11-01
+    eoas: true
+    eol: true
+    latest: "2020.2/2387343"
+    latestReleaseDate: 2022-12-19
+
+  - releaseCycle: "2020.1"
+    releaseDate: 2020-05-01
+    eoas: true
+    eol: true
+    latest: "2020.1/2298664"
+
+  - releaseCycle: "2019.2"
+    releaseDate: 2019-11-01
+    eoas: true
+    eol: true
+    latest: "2019.2/2224541"
+
+  - releaseCycle: "2019.1"
+    releaseDate: 2019-05-01
+    eoas: true
+    eol: true
+    latest: "2019.1/2135798"
+
+  - releaseCycle: "2018.2"
+    releaseDate: 2018-11-01
+    eoas: true
+    eol: true
+    latest: "2018.2"
+
+  - releaseCycle: "2018.1"
+    releaseDate: 2018-05-01
+    eoas: true
+    eol: true
+    latest: "2018.1"
+
+  - releaseCycle: "2017.2"
+    releaseDate: 2017-11-01
+    eoas: true
+    eol: true
+    latest: "2017.2"
+
+  - releaseCycle: "2017.1"
+    releaseDate: 2017-05-01
+    eoas: true
+    eol: true
+    latest: "2017.1"
+
+  - releaseCycle: "2016.2"
+    releaseDate: 2016-11-01
+    eoas: true
+    eol: true
+    latest: "2016.2"
+
+  - releaseCycle: "2016.1"
+    releaseDate: 2016-05-01
+    eoas: true
+    eol: true
+    latest: "2016.1"
+
+  - releaseCycle: "2015.2"
+    releaseDate: 2015-11-01
+    eoas: true
+    eol: true
+    latest: "2015.2"
+
+  - releaseCycle: "2015.1"
+    releaseDate: 2015-05-01
+    eoas: true
+    eol: true
+    latest: "2015.1"
+
+  - releaseCycle: "2014.2"
+    releaseDate: 2014-11-01
+    eoas: true
+    eol: true
+    latest: "2014.2"
+
+  - releaseCycle: "2014.1"
+    releaseDate: 2014-05-01
+    eoas: true
+    eol: true
+    latest: "2014.1"
+
+  - releaseCycle: "2013.4"
+    releaseDate: 2013-12-01
+    eoas: true
+    eol: true
+    latest: "2013.4"
+
+  - releaseCycle: "2013.3"
+    releaseDate: 2013-09-01
+    eoas: true
+    eol: true
+    latest: "2013.3"
+
+  - releaseCycle: "2013.2"
+    releaseDate: 2013-06-01
+    eoas: true
+    eol: true
+    latest: "2013.2"
+
+  - releaseCycle: "2013.1"
+    releaseDate: 2013-03-01
+    eoas: true
+    eol: true
+    latest: "2013.1"
+
+  - releaseCycle: "2012.3"
+    releaseDate: 2012-11-01
+    eoas: true
+    eol: true
+    latest: "2012.3"
+
+  - releaseCycle: "2012.2"
+    releaseDate: 2012-07-01
+    eoas: true
+    eol: true
+    latest: "2012.2"
+
+  - releaseCycle: "2012.1"
+    releaseDate: 2012-03-01
+    eoas: true
+    eol: true
+    latest: "2012.1"
+
+  - releaseCycle: "2011.2"
+    releaseDate: 2011-11-01
+    eoas: true
+    eol: true
+    latest: "2011.2"
+
+  - releaseCycle: "2011.1"
+    releaseDate: 2011-05-01
+    eoas: true
+    eol: true
+    latest: "2011.1"
+
+  - releaseCycle: "2010.2"
+    releaseDate: 2010-11-01
+    eoas: true
+    eol: true
+    latest: "2010.2"
+
+  - releaseCycle: "2010.1"
+    releaseDate: 2010-05-01
+    eoas: true
+    eol: true
+    latest: "2010.1"
+
+  - releaseCycle: "2009.3"
+    releaseDate: 2009-11-01
+    eoas: true
+    eol: true
+    latest: "2009.3"
+
+  - releaseCycle: "2009.2"
+    releaseDate: 2009-07-01
+    eoas: true
+    eol: true
+    latest: "2009.2"
+
+  - releaseCycle: "2009.1"
+    releaseDate: 2009-03-01
+    eoas: true
+    eol: true
+    latest: "2009.1"
+
+  - releaseCycle: "2008.2"
+    releaseDate: 2008-11-01
+    eoas: true
+    eol: true
+    latest: "2008.2"
+
+  - releaseCycle: "2008.1"
+    releaseDate: 2008-05-01
+    eoas: true
+    eol: true
+    latest: "2008.1"
+
+  - releaseCycle: "2007.3"
+    releaseDate: 2007-11-01
+    eoas: true
+    eol: true
+    latest: "2007.3"
+
+  - releaseCycle: "2007.2"
+    releaseDate: 2007-06-01
+    eoas: true
+    eol: true
+    latest: "2007.2"
+
+  - releaseCycle: "2007.1"
+    releaseDate: 2007-03-01
+    eoas: true
+    eol: true
+    latest: "2007.1"
+
+  - releaseCycle: "2006.2"
+    releaseDate: 2006-11-01
+    eoas: true
+    eol: true
+    latest: "2006.2"
+
+  - releaseCycle: "2006.1"
+    releaseDate: 2006-05-01
+    eoas: true
+    eol: true
+    latest: "2006.1"
+
+  - releaseCycle: "2005.2"
+    releaseDate: 2005-11-01
+    eoas: true
+    eol: true
+    latest: "2005.2"
+
+  - releaseCycle: "2005.1"
+    releaseDate: 2005-05-01
+    eoas: true
+    eol: true
+    latest: "2005.1"
+
+  - releaseCycle: "2004.2"
+    releaseDate: 2004-11-01
+    eoas: true
+    eol: true
+    latest: "2004.2"
+
+  - releaseCycle: "2004.1"
+    releaseDate: 2004-05-01
+    eoas: true
+    eol: true
+    latest: "2004.1"
+
+  - releaseCycle: "2003.2"
+    releaseDate: 2003-11-01
+    eoas: true
+    eol: true
+    latest: "2003.2"
+
+  - releaseCycle: "2003.1"
+    releaseDate: 2003-05-01
+    eoas: true
+    eol: true
+    latest: "2003.1"
+
+  - releaseCycle: "2002.2"
+    releaseDate: 2002-11-01
+    eoas: true
+    eol: true
+    latest: "2002.2"
+
+  - releaseCycle: "2002.1"
+    releaseDate: 2002-05-01
+    eoas: true
+    eol: true
+    latest: "2002.1"
+
+  - releaseCycle: "2001.2"
+    releaseDate: 2001-11-01
+    eoas: true
+    eol: true
+    latest: "2001.2"
+
+  - releaseCycle: "2001.1"
+    releaseDate: 2001-05-01
+    eoas: true
+    eol: true
+    latest: "2001.1"
+
+  - releaseCycle: "2000.2"
+    releaseDate: 2000-11-01
+    eoas: true
+    eol: true
+    latest: "2000.2"
+
+  - releaseCycle: "2000.1"
+    releaseDate: 2000-05-01
+    eoas: true
+    eol: true
+    latest: "2000.1"
+
+  - releaseCycle: "99.2"
+    releaseDate: 1999-11-01
+    eoas: true
+    eol: true
+    latest: "99.2"
+
+  - releaseCycle: "99.1"
+    releaseDate: 1999-05-01
+    eoas: true
+    eol: true
+    latest: "99.1"
+
+  - releaseCycle: "98.2"
+    releaseDate: 1998-11-01
+    eoas: true
+    eol: true
+    latest: "98.2"
+
+  - releaseCycle: "98.1"
+    releaseDate: 1998-05-01
+    eoas: true
+    eol: true
+    latest: "98.1"
+
+  - releaseCycle: "97.3"
+    releaseDate: 1997-11-01
+    eoas: true
+    eol: true
+    latest: "97.3"
+
+  - releaseCycle: "97.2"
+    releaseDate: 1997-07-01
+    eoas: true
+    eol: true
+    latest: "97.2"
+
+  - releaseCycle: "97.1"
+    releaseDate: 1997-03-01
+    eoas: true
+    eol: true
+    latest: "97.1"
 ---
 
 > [Helix Core Server](https://www.perforce.com/products/helix-core), also known as P4D and now branded
@@ -115,9 +452,12 @@ Support, technical support is reduced to basic troubleshooting and product usage
 Because fixes remain purchasable after End of Maintenance, patch releases occasionally appear for a
 version whose End of Maintenance has already passed.
 
-Perforce publishes end-of-life dates going back to 2021.1 only, so earlier releases are not listed
-here. The lifecycle table also lags new releases by a few months, which is why 2026.1 has no dates
-yet.
+Perforce publishes lifecycle dates going back to 2021.1 only. Earlier releases are still listed, so
+that any officially released version can be looked up, but they carry no dates beyond an approximate
+release date: Perforce does not publish when they shipped, and the archived release notes and the
+distribution host no longer say either. Treat those dates as the year and rough part of year the
+version number implies, nothing finer. The lifecycle table also lags new releases by a few months,
+which is why 2026.1 has no dates yet.
 
 Perforce renamed the product as part of a wider rebrand: Helix Core is now P4, and the server itself
 is P4 Server. The binary is still `p4d` and the version scheme is unchanged.

--- a/products/helix-core.md
+++ b/products/helix-core.md
@@ -3,6 +3,7 @@ title: Helix Core Server
 addedAt: 2026-09-10
 category: server-app
 tags: perforce
+iconSlug: perforce
 permalink: /helix-core
 alternate_urls:
   - /p4d

--- a/products/helix-core.md
+++ b/products/helix-core.md
@@ -1,0 +1,123 @@
+---
+title: Helix Core Server
+addedAt: 2026-09-10
+category: server-app
+tags: perforce
+permalink: /helix-core
+alternate_urls:
+  - /p4d
+  - /perforce
+  - /p4-server
+releasePolicyLink: https://portal.perforce.com/s/article/Helix-Core-Maintenance-Lifecycle-Helix-Core-Server-P4D
+eoasColumn: End of Maintenance
+
+identifiers:
+  - cpe: cpe:/a:perforce:helix_core
+  - cpe: cpe:2.3:a:perforce:helix_core
+
+# General availability, End of Maintenance and End of Maintenance and Support come from
+# https://portal.perforce.com/s/article/Helix-Core-Maintenance-Lifecycle-Helix-Core-Server-P4D :
+# EOM is two years after GA and EOMS is four years after GA.
+# eoas is mapped to EOM, when bug fixes and security updates stop, and eol to EOMS, when technical
+# support is reduced to basic troubleshooting.
+#
+# Patch versions come from https://help.perforce.com/helix-core/release-notes/current/relnotes.txt ,
+# which covers p4d, p4, p4p and p4broker together as they are released as one train.
+releases:
+  - releaseCycle: "2026.1"
+    # Perforce has not published EOM/EOMS for this release yet.
+    releaseDate: 2026-05-19
+    eoas: false
+    eol: false
+    latest: "2026.1/2972966"
+    latestReleaseDate: 2026-06-10
+
+  - releaseCycle: "2025.2"
+    releaseDate: 2025-11-18
+    eoas: 2027-11-18
+    eol: 2029-11-18
+    latest: "2025.2/2907753"
+    latestReleaseDate: 2026-03-09
+
+  - releaseCycle: "2025.1"
+    releaseDate: 2025-05-16
+    eoas: 2027-05-16
+    eol: 2029-05-16
+    latest: "2025.1/2907437"
+    latestReleaseDate: 2026-03-09
+
+  - releaseCycle: "2024.2"
+    releaseDate: 2024-11-07
+    eoas: 2026-11-07
+    eol: 2028-11-07
+    latest: "2024.2/2877946"
+    latestReleaseDate: 2026-01-14
+
+  - releaseCycle: "2024.1"
+    releaseDate: 2024-05-15
+    eoas: 2026-05-15
+    eol: 2028-05-15
+    latest: "2024.1/2876055"
+    latestReleaseDate: 2026-01-09
+
+  - releaseCycle: "2023.2"
+    releaseDate: 2023-11-16
+    eoas: 2025-11-16
+    eol: 2027-11-16
+    latest: "2023.2/2873834"
+    latestReleaseDate: 2026-01-05
+
+  - releaseCycle: "2023.1"
+    releaseDate: 2023-05-18
+    eoas: 2025-05-18
+    eol: 2027-05-18
+    latest: "2023.1/2797325"
+    latestReleaseDate: 2025-07-11
+
+  - releaseCycle: "2022.2"
+    releaseDate: 2022-11-16
+    eoas: 2024-11-16
+    eol: 2026-11-16
+    latest: "2022.2/2693782"
+    latestReleaseDate: 2024-12-10
+
+  - releaseCycle: "2022.1"
+    releaseDate: 2022-05-17
+    eoas: 2024-05-17
+    eol: 2026-05-17
+    latest: "2022.1/2617865"
+    latestReleaseDate: 2024-06-28
+
+  - releaseCycle: "2021.2"
+    releaseDate: 2021-11-10
+    eoas: 2023-11-10
+    eol: 2025-11-10
+    latest: "2021.2/2536545"
+    latestReleaseDate: 2023-12-20
+
+  - releaseCycle: "2021.1"
+    releaseDate: 2021-05-14
+    eoas: 2023-05-14
+    eol: 2025-05-14
+    latest: "2021.1/2452965"
+    latestReleaseDate: 2023-06-14
+---
+
+> [Helix Core Server](https://www.perforce.com/products/helix-core), also known as P4D and now branded
+> P4 Server, is the proprietary version control server developed by Perforce.
+
+Perforce ships two releases a year, numbered by year and release number. Every release moves through
+three phases. From general availability to **End of Maintenance** it receives bug fixes and security
+updates. Between End of Maintenance and **End of Maintenance and Support** those fixes are available
+only for an additional fee, while technical support continues normally. After End of Maintenance and
+Support, technical support is reduced to basic troubleshooting and product usage questions.
+
+Because fixes remain purchasable after End of Maintenance, patch releases occasionally appear for a
+version whose End of Maintenance has already passed.
+
+Perforce publishes end-of-life dates going back to 2021.1 only, so earlier releases are not listed
+here. The lifecycle table also lags new releases by a few months, which is why 2026.1 has no dates
+yet.
+
+Perforce renamed the product as part of a wider rebrand: Helix Core is now P4, and the server itself
+is P4 Server. The binary is still `p4d` and the version scheme is unchanged.

--- a/products/helix-proxy.md
+++ b/products/helix-proxy.md
@@ -3,6 +3,7 @@ title: Helix Proxy
 addedAt: 2026-09-10
 category: server-app
 tags: perforce
+iconSlug: perforce
 permalink: /helix-proxy
 alternate_urls:
   - /p4p

--- a/products/helix-proxy.md
+++ b/products/helix-proxy.md
@@ -1,0 +1,115 @@
+---
+title: Helix Proxy
+addedAt: 2026-09-10
+category: server-app
+tags: perforce
+permalink: /helix-proxy
+alternate_urls:
+  - /p4p
+  - /p4-proxy
+releasePolicyLink: https://portal.perforce.com/s/article/Helix-Core-Maintenance-Lifecycle-Helix-Core-Server-P4D
+eoasColumn: End of Maintenance
+
+# General availability, End of Maintenance and End of Maintenance and Support come from
+# https://portal.perforce.com/s/article/Helix-Core-Maintenance-Lifecycle-Helix-Core-Server-P4D :
+# EOM is two years after GA and EOMS is four years after GA.
+# eoas is mapped to EOM, when bug fixes and security updates stop, and eol to EOMS, when technical
+# support is reduced to basic troubleshooting.
+#
+# Patch versions come from https://help.perforce.com/helix-core/release-notes/current/relnotes.txt ,
+# which covers p4d, p4, p4p and p4broker together as they are released as one train.
+releases:
+  - releaseCycle: "2026.1"
+    # Perforce has not published EOM/EOMS for this release yet.
+    releaseDate: 2026-05-19
+    eoas: false
+    eol: false
+    latest: "2026.1/2972966"
+    latestReleaseDate: 2026-06-10
+
+  - releaseCycle: "2025.2"
+    releaseDate: 2025-11-18
+    eoas: 2027-11-18
+    eol: 2029-11-18
+    latest: "2025.2/2907753"
+    latestReleaseDate: 2026-03-09
+
+  - releaseCycle: "2025.1"
+    releaseDate: 2025-05-16
+    eoas: 2027-05-16
+    eol: 2029-05-16
+    latest: "2025.1/2907437"
+    latestReleaseDate: 2026-03-09
+
+  - releaseCycle: "2024.2"
+    releaseDate: 2024-11-07
+    eoas: 2026-11-07
+    eol: 2028-11-07
+    latest: "2024.2/2877946"
+    latestReleaseDate: 2026-01-14
+
+  - releaseCycle: "2024.1"
+    releaseDate: 2024-05-15
+    eoas: 2026-05-15
+    eol: 2028-05-15
+    latest: "2024.1/2876055"
+    latestReleaseDate: 2026-01-09
+
+  - releaseCycle: "2023.2"
+    releaseDate: 2023-11-16
+    eoas: 2025-11-16
+    eol: 2027-11-16
+    latest: "2023.2/2873834"
+    latestReleaseDate: 2026-01-05
+
+  - releaseCycle: "2023.1"
+    releaseDate: 2023-05-18
+    eoas: 2025-05-18
+    eol: 2027-05-18
+    latest: "2023.1/2797325"
+    latestReleaseDate: 2025-07-11
+
+  - releaseCycle: "2022.2"
+    releaseDate: 2022-11-16
+    eoas: 2024-11-16
+    eol: 2026-11-16
+    latest: "2022.2/2693782"
+    latestReleaseDate: 2024-12-10
+
+  - releaseCycle: "2022.1"
+    releaseDate: 2022-05-17
+    eoas: 2024-05-17
+    eol: 2026-05-17
+    latest: "2022.1/2617865"
+    latestReleaseDate: 2024-06-28
+
+  - releaseCycle: "2021.2"
+    releaseDate: 2021-11-10
+    eoas: 2023-11-10
+    eol: 2025-11-10
+    latest: "2021.2/2536545"
+    latestReleaseDate: 2023-12-20
+
+  - releaseCycle: "2021.1"
+    releaseDate: 2021-05-14
+    eoas: 2023-05-14
+    eol: 2025-05-14
+    latest: "2021.1/2452965"
+    latestReleaseDate: 2023-06-14
+---
+
+> [Helix Proxy](https://www.perforce.com/manuals/p4dist/Content/P4Dist/chapter.proxy.html), also known
+> as P4P and now branded P4 Proxy, is a caching proxy for Helix Core Server developed by Perforce.
+
+Helix Proxy is built and released from the same source train as Helix Core Server, so it shares its
+version numbers, release dates and lifecycle dates.
+
+Every release moves through three phases. From general availability to **End of Maintenance** it
+receives bug fixes and security updates. Between End of Maintenance and **End of Maintenance and
+Support** those fixes are available only for an additional fee, while technical support continues
+normally. After End of Maintenance and Support, technical support is reduced to basic troubleshooting
+and product usage questions.
+
+Perforce publishes end-of-life dates going back to 2021.1 only, so earlier releases are not listed
+here. The lifecycle table also lags new releases by a few months, which is why 2026.1 has no dates
+yet.

--- a/products/helix-swarm.md
+++ b/products/helix-swarm.md
@@ -3,6 +3,7 @@ title: Helix Swarm
 addedAt: 2026-09-10
 category: server-app
 tags: perforce
+iconSlug: perforce
 permalink: /helix-swarm
 alternate_urls:
   - /swarm

--- a/products/helix-swarm.md
+++ b/products/helix-swarm.md
@@ -1,0 +1,172 @@
+---
+title: Helix Swarm
+addedAt: 2026-09-10
+category: server-app
+tags: perforce
+permalink: /helix-swarm
+alternate_urls:
+  - /swarm
+  - /p4-code-review
+releasePolicyLink: https://portal.perforce.com/s/article/Helix-Swarm-Maintenance-Lifecycle
+eoasColumn: End of Maintenance
+
+# General availability, End of Maintenance and End of Maintenance and Support come from
+# https://portal.perforce.com/s/article/Helix-Swarm-Maintenance-Lifecycle :
+# EOM is one year after GA and EOMS is two years after GA, a shorter window than the one used for
+# Helix Core Server.
+# eoas is mapped to EOM, when bug fixes and security updates stop, and eol to EOMS, when technical
+# support is reduced to basic troubleshooting.
+#
+# https://help.perforce.com/helix-core/release-notes/current/swarm_relnotes.txt documents patch
+# releases but carries no dates or build numbers for them, so latest is the release itself, which is
+# also how the images on https://hub.docker.com/r/perforce/helix-swarm are tagged.
+releases:
+  - releaseCycle: "2026.3"
+    releaseDate: 2026-08-07
+    eoas: 2027-08-07
+    eol: 2028-08-07
+    latest: "2026.3"
+    latestReleaseDate: 2026-08-07
+
+  - releaseCycle: "2026.2"
+    releaseDate: 2026-06-05
+    eoas: 2027-06-05
+    eol: 2028-06-05
+    latest: "2026.2"
+    latestReleaseDate: 2026-06-05
+
+  - releaseCycle: "2026.1"
+    releaseDate: 2026-03-24
+    eoas: 2027-03-24
+    eol: 2028-03-24
+    latest: "2026.1"
+    latestReleaseDate: 2026-03-24
+
+  - releaseCycle: "2025.5"
+    releaseDate: 2025-12-16
+    eoas: 2026-12-16
+    eol: 2027-12-16
+    latest: "2025.5"
+    latestReleaseDate: 2025-12-16
+
+  - releaseCycle: "2025.4"
+    releaseDate: 2025-10-28
+    eoas: 2026-10-28
+    eol: 2027-10-28
+    latest: "2025.4"
+    latestReleaseDate: 2025-10-28
+
+  - releaseCycle: "2025.3"
+    releaseDate: 2025-09-25
+    eoas: 2026-09-25
+    eol: 2027-09-25
+    latest: "2025.3"
+    latestReleaseDate: 2025-09-25
+
+  - releaseCycle: "2025.2"
+    releaseDate: 2025-06-26
+    eoas: 2026-06-26
+    eol: 2027-06-26
+    latest: "2025.2"
+    latestReleaseDate: 2025-06-26
+
+  - releaseCycle: "2025.1"
+    releaseDate: 2025-04-10
+    eoas: 2026-04-10
+    eol: 2027-04-10
+    latest: "2025.1"
+    latestReleaseDate: 2025-04-10
+
+  - releaseCycle: "2024.6"
+    releaseDate: 2025-01-29
+    eoas: 2026-01-29
+    eol: 2027-01-29
+    latest: "2024.6"
+    latestReleaseDate: 2025-01-29
+
+  - releaseCycle: "2024.5"
+    releaseDate: 2024-10-15
+    eoas: 2025-10-15
+    eol: 2026-10-15
+    latest: "2024.5"
+    latestReleaseDate: 2024-10-15
+
+  - releaseCycle: "2024.4"
+    releaseDate: 2024-09-09
+    eoas: 2025-09-09
+    eol: 2026-09-09
+    latest: "2024.4"
+    latestReleaseDate: 2024-09-09
+
+  - releaseCycle: "2024.3"
+    releaseDate: 2024-06-24
+    eoas: 2025-06-24
+    eol: 2026-06-24
+    latest: "2024.3"
+    latestReleaseDate: 2024-06-24
+
+  - releaseCycle: "2024.2"
+    releaseDate: 2024-04-23
+    eoas: 2025-04-23
+    eol: 2026-04-23
+    latest: "2024.2"
+    latestReleaseDate: 2024-04-23
+
+  - releaseCycle: "2024.1"
+    releaseDate: 2024-03-25
+    eoas: 2025-03-25
+    eol: 2026-03-25
+    latest: "2024.1"
+    latestReleaseDate: 2024-03-25
+
+  - releaseCycle: "2023.4"
+    releaseDate: 2023-12-13
+    eoas: 2024-12-13
+    eol: 2025-12-13
+    latest: "2023.4"
+    latestReleaseDate: 2023-12-13
+
+  - releaseCycle: "2023.3"
+    releaseDate: 2023-09-21
+    eoas: 2024-09-21
+    eol: 2025-09-21
+    latest: "2023.3"
+    latestReleaseDate: 2023-09-21
+
+  - releaseCycle: "2023.2"
+    releaseDate: 2023-06-29
+    eoas: 2024-06-29
+    eol: 2025-06-29
+    latest: "2023.2"
+    latestReleaseDate: 2023-06-29
+
+  - releaseCycle: "2023.1"
+    releaseDate: 2023-03-16
+    eoas: 2024-03-16
+    eol: 2025-03-16
+    latest: "2023.1"
+    latestReleaseDate: 2023-03-16
+
+  - releaseCycle: "2022.3"
+    releaseDate: 2022-12-15
+    eoas: 2023-12-15
+    eol: 2024-12-15
+    latest: "2022.3"
+    latestReleaseDate: 2022-12-15
+---
+
+> [Helix Swarm](https://www.perforce.com/products/helix-swarm), now branded P4 Code Review, is the
+> proprietary code review and collaboration tool for Helix Core developed by Perforce.
+
+Swarm is released far more often than Helix Core Server, several times a year and on its own
+schedule, and it is supported for a shorter time. From general availability to **End of Maintenance**
+a release receives bug fixes and security updates, which is one year. Between End of Maintenance and
+**End of Maintenance and Support**, a further year, those fixes are available only for an additional
+fee while technical support continues normally. After that, technical support is reduced to basic
+troubleshooting and product usage questions.
+
+Swarm publishes patch releases, such as 2024.6 Patch 1, but its release notes give neither a date nor
+a build number for them, so only the release itself is listed here.
+
+Perforce renamed the product as part of a wider rebrand: Helix Swarm is now P4 Code Review, and Helix
+Core is now P4.


### PR DESCRIPTION
## Summary

Adds four Perforce products, none of which were on the site yet:

| Page | Product | Cycles |
| --- | --- | --- |
| `/helix-core` | Helix Core Server (p4d) | 65, 97.1 → 2026.1 |
| `/helix-proxy` | Helix Proxy (p4p) | 11, same train |
| `/helix-broker` | Helix Broker (p4broker) | 11, same train |
| `/helix-swarm` | Helix Swarm | 19, 2022.3 → 2026.3 |

Perforce has rebranded — Helix Core is now P4, Helix Swarm is now P4 Code Review — but the older names are still what the documentation, the binaries and search results use, so the pages keep them and mention the new names in the text. The new names are reachable through `alternate_urls` (`/p4d`, `/p4p`, `/p4broker`, `/swarm`, `/p4-server`, `/p4-proxy`, `/p4-broker`, `/p4-code-review`, `/perforce`).

## Support policy

Perforce documents three milestones:

- **GA** — the release becomes generally available.
- **EOM**, End of Maintenance — bug fixes and security updates stop.
- **EOMS**, End of Maintenance and Support — technical support drops to basic troubleshooting and product usage questions.

`eoas` is mapped to EOM and `eol` to EOMS. The [EOL Reference Table](https://portal.perforce.com/s/article/Perforce-End-of-Life-EOL-Reference-Table) is what settles that mapping: between EOM and EOMS, technical support is still full and only the fixes become a paid extra, so EOM is where bug fixes stop and EOMS is where support really ends. Mapping `eol` to EOM with `eoes` for EOMS was considered and rejected for that reason.

Helix Core Server, Helix Proxy and Helix Broker are built and shipped as one train, so they share version numbers and lifecycle dates; Perforce publishes them in a single table. EOM is two years after GA and EOMS is four. Helix Swarm is released several times a year on its own schedule, with one year to EOM and two to EOMS.

## Sources

Lifecycle dates come from the Perforce support portal. Those pages are a Salesforce Experience Cloud site that renders client-side, so they cannot be read with a plain request, but the public knowledge endpoint serves the article body unauthenticated:

```
https://portal.perforce.com/services/data/v59.0/support/knowledgeArticles/<urlName>
```

- [Helix Core Server (P4D)](https://portal.perforce.com/s/article/Helix-Core-Maintenance-Lifecycle-Helix-Core-Server-P4D) — GA, EOM and EOMS for P4D, P4Broker and P4Proxy
- [Helix Swarm](https://portal.perforce.com/s/article/Helix-Swarm-Maintenance-Lifecycle) — the same for Swarm
- [EOL Reference Table](https://portal.perforce.com/s/article/Perforce-End-of-Life-EOL-Reference-Table) — what each phase actually includes

Patch versions come from [the current release notes](https://help.perforce.com/helix-core/release-notes/current/relnotes.txt), which cover p4d, p4, p4p and p4broker in one file. `releaseDate` is taken from the lifecycle table rather than from the release notes, because the official GA runs about a week later than the build date and it is the GA that EOM and EOMS are anchored to.

## Notes for reviewers

- **This introduces the `perforce` vendor tag.** There was no Perforce product on the site before, and all four products that should carry it are in this PR, which is what CONTRIBUTING asks for when a new tag is added.
- **Helix Core Server lists every release back to 97.1; the other three start at 2021.1.** The release list is exact — the union of the releases named in [the full release notes](https://filehost.perforce.com/perforce/r20.2/doc/user/relnotes.txt) and the release directories on [the distribution host](https://filehost.perforce.com/perforce/). The dates before 2021.1 are not: Perforce publishes no release date for them, so those cycles carry `eoas` and `eol` as booleans and an approximate release date placed inside the year the version number names, following the cadence the documented years show. The page says so plainly. Happy to drop them if you would rather the page carried only dated releases.
- Helix Proxy and Helix Broker are **not** extended back, because the release notes covered p4 and p4d only until around 2020; the same list cannot be assumed for them.
- **The dates that could not be recovered** because that is where Perforce's published lifecycle data starts. Going further back was attempted through per-version release notes (dates appear only from 2020.2, and only on patches), archived copies of `relnotes.txt` (the older format has no dates at all, only `Bugs fixed in 2014.2 PATCH4`), the file host directory listings (a bulk migration reset every timestamp; even `r97.2` is dated 23-Dec-2014), and the embedded build date in the binaries (`r21.1/p4d` says 2023/06/12 against a GA of 2021-05-14). One real bound survives: an archived copy of the release notes names 2007.2 as current on 2007-06-13, and that caps its date.
- **2026.1 has no EOM or EOMS.** The lifecycle table was last updated in November 2025 and 2026.1 shipped in May 2026, so the dates are simply not published yet.
- **Some cycles have patches dated after their EOM**, such as 2023.2 getting a patch on 2026-01-05 against an EOM of 2025-11-16. That is not a data error: fixes stay purchasable until EOMS. The product text explains it.
- **Helix Swarm's `latest` is the release itself.** Its release notes list patches such as "2024.6 Patch 1" but give neither a date nor a build number for them. The container images on [Docker Hub](https://hub.docker.com/r/perforce/helix-swarm) are tagged the same way.
- **No `iconSlug`:** Simple Icons has no `perforce` or `helix` icon. `identifiers` are set on Helix Core Server only, as NVD has no CPE for the proxy, broker or Swarm.
- **No `auto` configuration** yet. `docker_hub: perforce/helix-swarm` would suit Swarm, and a small script over the knowledge endpoint plus `relnotes.txt` would cover the other three; both can follow separately.

## Test plan

- [x] `bundle exec jekyll build` passes, including `product-data-validator.rb`
- [x] All four frontmatters validate against `product-schema.json`
- [x] `markdownlint-cli2` reports no issues
- [x] `prettier --check` passes
- [x] All eight `alternate_urls` appear in the generated `_site/_redirects`
- [x] Netlify deploy preview renders the four pages correctly
