### PR TITLE
[pan-os] Update 10.2,11.1 11.2,12.1 (4 cycles)

### DIFF
--- a/products/pan-os.md
+++ b/products/pan-os.md
@@ -39,23 +39,23 @@ releases:
   - releaseCycle: "12.1"
     releaseDate: 2025-08-28
     eol: 2028-08-28
-    latest: "12.1.9"
-    latestReleaseDate: 2026-08-13
-    link: https://docs.paloaltonetworks.com/ngfw/release-notes/12-1/pan-os-12-1-9-known-and-addressed-issues/pan-os-12-1-9-addressed-issues
+    latest: "12.1.10"
+    latestReleaseDate: 2026-09-06
+    link: https://docs.paloaltonetworks.com/ngfw/release-notes/12-1/pan-os-12-1-10-known-and-addressed-issues/pan-os-12-1-10-addressed-issues
 
   - releaseCycle: "11.2"
     releaseDate: 2024-05-02
     eol: 2027-05-02
-    latest: "11.2.13-h1"
-    latestReleaseDate: 2026-08-12
-    link: https://docs.paloaltonetworks.com/pan-os/11-2/pan-os-release-notes/pan-os-11-2-13-known-and-addressed-issues/pan-os-11-2-13-h1-addressed-issues
+    latest: "11.2.15"
+    latestReleaseDate: 2026-09-08
+    link: https://docs.paloaltonetworks.com/pan-os/11-2/pan-os-release-notes/pan-os-11-2-15-known-and-addressed-issues/pan-os-11-2-15-addressed-issues
 
   - releaseCycle: "11.1"
     releaseDate: 2023-11-03
     eol: 2027-05-03
-    latest: "11.1.16-h1"
-    latestReleaseDate: 2026-08-10
-    link: https://docs.paloaltonetworks.com/pan-os/11-1/pan-os-release-notes/pan-os-11-1-16-known-and-addressed-issues/pan-os-11-1-16-h1-addressed-issues
+    latest: "11.1.16-h2"
+    latestReleaseDate: 2026-09-04
+    link: https://docs.paloaltonetworks.com/pan-os/11-1/pan-os-release-notes/pan-os-11-1-16-known-and-addressed-issues/pan-os-11-1-16-h2-addressed-issues
 
   - releaseCycle: "11.0"
     releaseDate: 2022-11-17
@@ -67,9 +67,9 @@ releases:
   - releaseCycle: "10.2"
     releaseDate: 2022-02-27
     eol: 2025-08-27
-    latest: "10.2.18-h9"
-    latestReleaseDate: 2026-07-21
-    link: https://docs.paloaltonetworks.com/pan-os/10-2/pan-os-release-notes/pan-os-10-2-18-known-and-addressed-issues/pan-os-10-2-18-h9-addressed-issues
+    latest: "10.2.18-h10"
+    latestReleaseDate: 2026-09-07
+    link: https://docs.paloaltonetworks.com/pan-os/10-2/pan-os-release-notes/pan-os-10-2-18-known-and-addressed-issues/pan-os-10-2-18-h10-addressed-issues
 
   - releaseCycle: "10.1"
     releaseDate: 2021-05-31


### PR DESCRIPTION
## Summary
Automated update of PAN-OS versions.

### Changes
10.2: 10.2.18-h9 -> 10.2.18-h10
11.1: 11.1.16-h1 -> 11.1.16-h2
11.2: 11.2.13-h1 -> 11.2.15
12.1: 12.1.9 -> 12.1.10

---
Data sourced from [PaloAltoVersions.json](https://github.com/mrjcap/panos-versions/blob/master/PaloAltoVersions.json)