### PR TITLE
[New Product] BIND 9

### DIFF
--- a/products/bind-9.md
+++ b/products/bind-9.md
@@ -1,0 +1,70 @@
+---
+title: BIND 9
+addedAt: 2026-09-10
+category: server-app
+permalink: /bind-9
+releasePolicyLink: https://kb.isc.org/docs/aa-00896
+changelogTemplate: https://bind9.readthedocs.io/en/v__LATEST__/notes.html
+
+identifiers:
+  - repology: bind
+  - purl: pkg:docker/internetsystemsconsortium/bind9
+
+auto:
+  methods:
+    - git: https://gitlab.isc.org/isc-projects/bind9.git
+      regex: '^v(?<major>\d+)\.(?<minor>\d+)\.(?<patch>\d+)$'
+
+releases:
+  - releaseCycle: "9.21"
+    releaseLabel: "9.21 (Development)"
+    releaseDate: 2024-08-13
+    eol: false
+    latest: "9.21.25"
+    latestReleaseDate: 2026-08-05
+
+  - releaseCycle: "9.20"
+    releaseLabel: "9.20 (Stable)"
+    releaseDate: 2024-07-08
+    eol: 2028-07-08
+    latest: "9.20.27"
+    latestReleaseDate: 2026-08-05
+    lts: true
+
+  - releaseCycle: "9.18"
+    releaseLabel: "9.18 (ESV)"
+    releaseDate: 2022-01-24
+    eol: 2026-06-30
+    latest: "9.18.50"
+    latestReleaseDate: 2026-06-08
+    lts: true
+
+  - releaseCycle: "9.16"
+    releaseDate: 2020-02-12
+    eol: 2024-03-31
+    latest: "9.16.50"
+    latestReleaseDate: 2024-04-03
+    lts: true
+---
+
+> [BIND 9](https://www.isc.org/bind/) is an open source DNS server from
+> [ISC](https://www.isc.org/), and the most widely deployed one on Unix-like systems. It can act
+> as an authoritative name server, a recursive resolver, or both.
+
+ISC ships two kinds of major version:
+
+- **Even-numbered versions are Stable** (9.16, 9.18, 9.20) and are supported for a total of four
+  years. A branch receives feature updates and bug fixes for roughly twelve months, then moves to
+  Extended Support (ESV) where it gets critical fixes only, and finally security patches only.
+- **Odd-numbered versions are Development** (9.19, 9.21), released off the main branch and
+  maintained for 24 months. At the end of that period the stabilised development branch is
+  re-labelled and re-released as the next Stable version. They are **not intended for production**:
+  minor releases may break backward compatibility, and vulnerabilities are fixed as ordinary bugs,
+  without separate patches or CVE advisories.
+
+BIND 9.22 was expected in 2026 but ISC has
+[delayed it to at least Q4 2026](https://kb.isc.org/docs/aa-00896), so 9.21 remains the current
+development branch beyond the usual 24 months.
+
+There is also a Supported Preview ("Subscription", `-S`) edition available to ISC support
+customers, which is not tracked here.


### PR DESCRIPTION
Closes #4816.

BIND 9 is the most widely deployed DNS server on Unix-like systems, and it is the last major
piece of DNS infrastructure missing here — the catalogue currently tracks no DNS server at all
(no bind, knot, powerdns, unbound, coredns or nsd), even though `isc-dhcp` from the same vendor
is present.

## Release policy

ISC documents it at https://kb.isc.org/docs/aa-00896 (page updated 2026-05-11), the same article
`isc-dhcp` already links to:

- **Even-numbered majors are Stable** (9.16, 9.18, 9.20), supported for **four years in total**:
  roughly twelve months of feature and bug fixes, then Extended Support (ESV) with critical fixes
  only, then security patches only.
- **Odd-numbered majors are Development** (9.19, 9.21), maintained for 24 months, after which the
  stabilised branch is re-released as the next Stable version. They are explicitly not intended
  for production: minor releases may break backward compatibility, and vulnerabilities are fixed
  as ordinary bugs, without separate patches or CVE advisories.

I have flagged the development cycle with `releaseLabel` so this is visible at a glance. That
distinction is the practical value of the page: it is easy to end up on an odd branch believing
it is a normal release.

## Sources for the dates

Release dates and latest versions come from the tags on ISC's own GitLab
(https://gitlab.isc.org/isc-projects/bind9):

| Cycle | First release | Latest | Source of the EOL date |
|---|---|---|---|
| 9.21 | 2024-08-13 (`v9.21.0`) | 9.21.25 | no date announced |
| 9.20 | 2024-07-08 (`v9.20.0`) | 9.20.27 | **derived**, see below |
| 9.18 | 2022-01-24 (`v9.18.0`) | 9.18.50 | KB: "will be EOL in June, 2026" |
| 9.16 | 2020-02-12 (`v9.16.0`) | 9.16.50 | KB: "declared End of Life in March, 2024" |

Two points worth a maintainer's eye:

1. **`eol: 2028-07-08` for 9.20 is derived, not published.** ISC states a four-year total support
   window and 9.20.0 was released 2024-07-08; the release-plan table in the KB runs 9.20 through
   at least 2028 Q1. If you would rather not carry a computed date, I am happy to drop it and
   leave 9.20 without an `eol`.
2. **9.21 has no end date.** The 24-month rule would put it around mid-2026, but ISC has delayed
   9.22 to at least Q4 2026, so 9.21 is still the current development branch. I used `eol: false`
   rather than guess.

The 9.18 date looks right in practice: 9.18.50 shipped 2026-06-08, which reads as the final
release of that branch.

## Checks

- Frontmatter validates against `product-schema.json`.
- `auto` uses the git method against ISC's GitLab; the tag format is `v9.20.27`, hence
  `^v(?<major>\d+)\.(?<minor>\d+)\.(?<patch>\d+)$`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)