### PR TITLE
[forgejo] Add link to security announcements

### DIFF
--- a/products/forgejo.md
+++ b/products/forgejo.md
@@ -98,3 +98,6 @@ releases:
 Stable releases are released every quarter and receive support for three months.
 Long-term support releases are published in the first quarter of every year
 and receive critical bugfixes and security support for one year and three months.
+
+The Forgejo security team publishes advance notice of upcoming security
+releases on the [security-announcements issue tracker](https://codeberg.org/forgejo/security-announcements/issues).


### PR DESCRIPTION
This adds a link to the Forgejo security-announcements tracker, following the pattern used by NetBSD, Squid and similar products.

[Forgejo's security policy](https://codeberg.org/forgejo/governance/src/branch/main/SECURITY-POLICY.md) designates this tracker as the primary channel for advance warning of security releases and explicitly recommends admins watch/subscribe to it to be informed about upcoming security releases.