### PR TITLE
[Updated products] atlassian -- Backfill the missing release cycles for Bamboo, Confluence and Bitbucket

### DIFF
--- a/products/bamboo.md
+++ b/products/bamboo.md
@@ -125,6 +125,317 @@ releases:
     latest: "8.0.13"
     latestReleaseDate: 2023-03-28
 
+  - releaseCycle: "7.2"
+    releaseDate: 2020-11-24
+    eol: true
+    latest: "7.2.10"
+    latestReleaseDate: 2022-07-22
+
+  - releaseCycle: "7.1"
+    releaseDate: 2020-07-22
+    eol: true
+    latest: "7.1.4"
+    latestReleaseDate: 2020-11-02
+
+  - releaseCycle: "7.0"
+    releaseDate: 2020-03-10
+    eol: true
+    latest: "7.0.6"
+    latestReleaseDate: 2020-09-22
+
+  - releaseCycle: "6.10"
+    releaseDate: 2019-09-15
+    eol: true
+    latest: "6.10.6"
+    latestReleaseDate: 2020-04-19
+
+  - releaseCycle: "6.9"
+    releaseDate: 2019-05-21
+    eol: true
+    latest: "6.9.2"
+    latestReleaseDate: 2019-07-03
+
+  - releaseCycle: "6.8"
+    releaseDate: 2019-01-30
+    eol: true
+    latest: "6.8.3"
+    latestReleaseDate: 2019-06-03
+
+  - releaseCycle: "6.7"
+    releaseDate: 2018-10-17
+    eol: true
+    latest: "6.7.3"
+    latestReleaseDate: 2019-03-21
+
+  - releaseCycle: "6.6"
+    releaseDate: 2018-06-24
+    eol: true
+    latest: "6.6.3"
+    latestReleaseDate: 2018-09-24
+
+  - releaseCycle: "6.5"
+    releaseDate: 2018-04-19
+    eol: true
+    latest: "6.5.1"
+    latestReleaseDate: 2018-06-21
+
+  - releaseCycle: "6.4"
+    releaseDate: 2018-02-16
+    eol: true
+    latest: "6.4.2"
+    latestReleaseDate: 2018-06-18
+
+  - releaseCycle: "6.3"
+    releaseDate: 2017-12-20
+    eol: true
+    latest: "6.3.4"
+    latestReleaseDate: 2018-05-23
+
+  - releaseCycle: "6.2"
+    releaseDate: 2017-09-28
+    eol: true
+    latest: "6.2.9"
+    latestReleaseDate: 2018-01-11
+
+  - releaseCycle: "6.1"
+    releaseDate: 2017-07-20
+    eol: true
+    latest: "6.1.6"
+    latestReleaseDate: 2017-12-12
+
+  - releaseCycle: "6.0"
+    releaseDate: 2017-04-26
+    eol: true
+    latest: "6.0.5"
+    latestReleaseDate: 2017-10-10
+
+  - releaseCycle: "5.15"
+    releaseDate: 2017-02-14
+    eol: true
+    latest: "5.15.7"
+    latestReleaseDate: 2017-05-22
+
+  - releaseCycle: "5.14"
+    releaseDate: 2016-10-25
+    eol: true
+    latest: "5.14.5"
+    latestReleaseDate: 2017-03-10
+
+  - releaseCycle: "5.13"
+    releaseDate: 2016-08-23
+    eol: true
+    latest: "5.13.2"
+    latestReleaseDate: 2016-09-28
+
+  - releaseCycle: "5.12"
+    releaseDate: 2016-05-24
+    eol: true
+    latest: "5.12.5"
+    latestReleaseDate: 2016-09-20
+
+  - releaseCycle: "5.11"
+    releaseDate: 2016-04-26
+    eol: true
+    latest: "5.11.4.1"
+    latestReleaseDate: 2016-07-07
+
+  - releaseCycle: "5.10"
+    releaseDate: 2016-01-18
+    eol: true
+    latest: "5.10.3"
+    latestReleaseDate: 2016-03-14
+
+  - releaseCycle: "5.9"
+    releaseDate: 2015-06-09
+    eol: true
+    latest: "5.9.10"
+    latestReleaseDate: 2016-01-22
+
+  - releaseCycle: "5.8"
+    releaseDate: 2015-03-12
+    eol: true
+    latest: "5.8.5"
+    latestReleaseDate: 2015-10-14
+
+  - releaseCycle: "5.7"
+    releaseDate: 2014-11-06
+    eol: true
+    latest: "5.7.2"
+    latestReleaseDate: 2014-12-10
+
+  - releaseCycle: "5.6"
+    releaseDate: 2014-07-22
+    eol: true
+    latest: "5.6.3"
+    latestReleaseDate: 2015-01-21
+
+  - releaseCycle: "5.5"
+    releaseDate: 2014-04-24
+    eol: true
+    latest: "5.5.1"
+    latestReleaseDate: 2014-05-21
+
+  - releaseCycle: "5.4"
+    releaseDate: 2014-02-11
+    eol: true
+    latest: "5.4.3"
+    latestReleaseDate: 2014-05-21
+
+  - releaseCycle: "5.3"
+    releaseDate: 2013-12-10
+    eol: true
+    latest: "5.3"
+    latestReleaseDate: 2013-12-10
+
+  - releaseCycle: "5.2"
+    releaseDate: 2013-10-17
+    eol: true
+    latest: "5.2.2"
+    latestReleaseDate: 2013-11-19
+
+  - releaseCycle: "5.1"
+    releaseDate: 2013-08-29
+    eol: true
+    latest: "5.1.1"
+    latestReleaseDate: 2013-09-13
+
+  - releaseCycle: "5.0"
+    releaseDate: 2013-07-15
+    eol: true
+    latest: "5.0.1"
+    latestReleaseDate: 2013-07-29
+
+  - releaseCycle: "4.4"
+    releaseDate: 2013-01-29
+    eol: true
+    latest: "4.4.8"
+    latestReleaseDate: 2013-07-15
+
+  - releaseCycle: "4.3"
+    releaseDate: 2012-10-25
+    eol: true
+    latest: "4.3.4"
+    latestReleaseDate: 2013-07-09
+
+  - releaseCycle: "4.2"
+    releaseDate: 2012-08-13
+    eol: true
+    latest: "4.2.2"
+    latestReleaseDate: 2012-11-09
+
+  - releaseCycle: "4.1"
+    releaseDate: 2012-05-29
+    eol: true
+    latest: "4.1.2"
+    latestReleaseDate: 2012-06-25
+
+  - releaseCycle: "4.0"
+    releaseDate: 2012-03-28
+    eol: true
+    latest: "4.0.1"
+    latestReleaseDate: 2012-04-13
+
+  - releaseCycle: "3.4"
+    releaseDate: 2011-12-14
+    eol: true
+    latest: "3.4.5"
+    latestReleaseDate: 2012-05-14
+
+  - releaseCycle: "3.3"
+    releaseDate: 2011-10-11
+    eol: true
+    latest: "3.3.4"
+    latestReleaseDate: 2012-05-15
+
+  - releaseCycle: "3.2"
+    releaseDate: 2011-07-26
+    eol: true
+    latest: "3.2.2"
+    latestReleaseDate: 2011-08-23
+
+  - releaseCycle: "3.1"
+    releaseDate: 2011-05-10
+    eol: true
+    latest: "3.1.4"
+    latestReleaseDate: 2011-06-30
+
+  - releaseCycle: "3.0"
+    releaseDate: 2011-02-16
+    eol: true
+    latest: "3.0.5"
+    latestReleaseDate: 2011-05-05
+
+  - releaseCycle: "2.7"
+    releaseDate: 2010-11-10
+    eol: true
+    latest: "2.7.4"
+    latestReleaseDate: 2011-02-18
+
+  - releaseCycle: "2.6"
+    releaseDate: 2010-06-01
+    eol: true
+    latest: "2.6.3"
+    latestReleaseDate: 2010-10-06
+
+  - releaseCycle: "2.5"
+    releaseDate: 2009-12-29
+    eol: true
+    latest: "2.5.5"
+    latestReleaseDate: 2010-05-04
+
+  - releaseCycle: "2.4"
+    releaseDate: 2009-10-06
+    eol: true
+    latest: "2.4.3"
+    latestReleaseDate: 2009-12-09
+
+  - releaseCycle: "2.3"
+    releaseDate: 2009-08-11
+    eol: true
+    latest: "2.3.1"
+    latestReleaseDate: 2009-08-11
+
+  - releaseCycle: "2.2"
+    releaseDate: 2009-03-09
+    eol: true
+    latest: "2.2.4"
+    latestReleaseDate: 2009-07-02
+
+  - releaseCycle: "2.1"
+    releaseDate: 2008-08-05
+    eol: true
+    latest: "2.1.5"
+    latestReleaseDate: 2008-12-02
+
+  - releaseCycle: "2.0"
+    releaseDate: 2008-04-14
+    eol: true
+    latest: "2.0.6"
+    latestReleaseDate: 2008-07-08
+
+  - releaseCycle: "1.2"
+    releaseDate: 2007-07-09
+    eol: true
+    latest: "1.2.4"
+    latestReleaseDate: 2007-10-17
+
+  - releaseCycle: "1.1"
+    releaseDate: 2007-05-07
+    eol: true
+    latest: "1.1.2"
+    latestReleaseDate: 2007-05-31
+
+  - releaseCycle: "1.0"
+    releaseDate: 2007-02-20
+    eol: true
+    latest: "1.0.5"
+    latestReleaseDate: 2007-04-19
+
+  - releaseCycle: "0.9"
+    releaseDate: 2006-12-21
+    eol: true
+    latest: "0.9.1"
+    latestReleaseDate: 2006-12-21
 ---
 
 > [Bamboo](https://www.atlassian.com/software/bamboo) is a continuous delivery pipeline developed by Atlassian. It is

--- a/products/bitbucket.md
+++ b/products/bitbucket.md
@@ -187,6 +187,48 @@ releases:
     latestReleaseDate: 2023-07-04
     link: https://confluence.atlassian.com/display/BitbucketServer/Bitbucket+Data+Center+and+Server+8.7+release+notes
 
+  - releaseCycle: "8.6"
+    releaseDate: 2022-11-13
+    eol: 2024-11-13
+    latest: "8.6.4"
+    latestReleaseDate: 2023-04-11
+
+  - releaseCycle: "8.5"
+    releaseDate: 2022-10-09
+    eol: 2024-10-09
+    latest: "8.5.4"
+    latestReleaseDate: 2023-04-11
+
+  - releaseCycle: "8.4"
+    releaseDate: 2022-09-05
+    eol: 2024-09-05
+    latest: "8.4.4"
+    latestReleaseDate: 2023-02-13
+
+  - releaseCycle: "8.3"
+    releaseDate: 2022-08-01
+    eol: 2024-08-01
+    latest: "8.3.4"
+    latestReleaseDate: 2023-01-23
+
+  - releaseCycle: "8.2"
+    releaseDate: 2022-06-26
+    eol: 2024-06-26
+    latest: "8.2.4"
+    latestReleaseDate: 2022-10-26
+
+  - releaseCycle: "8.1"
+    releaseDate: 2022-05-23
+    eol: 2024-05-23
+    latest: "8.1.5"
+    latestReleaseDate: 2022-10-26
+
+  - releaseCycle: "8.0"
+    releaseDate: 2022-05-11
+    eol: 2024-05-11
+    latest: "8.0.5"
+    latestReleaseDate: 2022-10-26
+
   - releaseCycle: "7.21"
     lts: true
     releaseDate: 2022-02-28
@@ -195,6 +237,566 @@ releases:
     latestReleaseDate: 2024-03-08
     link: https://confluence.atlassian.com/display/BitbucketServer/Bitbucket+Data+Center+and+Server+7.21+release+notes
 
+  - releaseCycle: "7.20"
+    releaseDate: 2022-01-24
+    eol: 2024-01-24
+    latest: "7.20.3"
+    latestReleaseDate: 2022-07-17
+
+  - releaseCycle: "7.19"
+    releaseDate: 2021-12-21
+    eol: 2023-12-21
+    latest: "7.19.5"
+    latestReleaseDate: 2022-06-08
+
+  - releaseCycle: "7.18"
+    releaseDate: 2021-11-08
+    eol: 2023-11-08
+    latest: "7.18.4"
+    latestReleaseDate: 2022-03-17
+
+  - releaseCycle: "7.17"
+    lts: true
+    releaseDate: 2021-10-03
+    eol: 2023-10-03
+    latest: "7.17.21"
+    latestReleaseDate: 2023-10-08
+
+  - releaseCycle: "7.16"
+    releaseDate: 2021-08-30
+    eol: 2023-08-30
+    latest: "7.16.3"
+    latestReleaseDate: 2021-12-15
+
+  - releaseCycle: "7.15"
+    releaseDate: 2021-07-26
+    eol: 2023-07-26
+    latest: "7.15.3"
+    latestReleaseDate: 2021-12-15
+
+  - releaseCycle: "7.14"
+    releaseDate: 2021-06-21
+    eol: 2023-06-21
+    latest: "7.14.2"
+    latestReleaseDate: 2021-12-15
+
+  - releaseCycle: "7.13"
+    releaseDate: 2021-05-17
+    eol: 2023-05-17
+    latest: "7.13.1"
+    latestReleaseDate: 2021-07-08
+
+  - releaseCycle: "7.12"
+    releaseDate: 2021-04-12
+    eol: 2023-04-12
+    latest: "7.12.1"
+    latestReleaseDate: 2021-04-26
+
+  - releaseCycle: "7.11"
+    releaseDate: 2021-03-08
+    eol: 2023-03-08
+    latest: "7.11.2"
+    latestReleaseDate: 2021-03-22
+
+  - releaseCycle: "7.10"
+    releaseDate: 2021-02-01
+    eol: 2023-02-01
+    latest: "7.10.1"
+    latestReleaseDate: 2021-02-15
+
+  - releaseCycle: "7.9"
+    releaseDate: 2021-01-04
+    eol: 2023-01-04
+    latest: "7.9.1"
+    latestReleaseDate: 2021-01-13
+
+  - releaseCycle: "7.8"
+    releaseDate: 2020-11-22
+    eol: 2022-11-22
+    latest: "7.8.1"
+    latestReleaseDate: 2020-12-10
+
+  - releaseCycle: "7.7"
+    releaseDate: 2020-10-21
+    eol: 2022-10-21
+    latest: "7.7.1"
+    latestReleaseDate: 2020-11-04
+
+  - releaseCycle: "7.6"
+    lts: true
+    releaseDate: 2020-09-14
+    eol: 2022-09-14
+    latest: "7.6.23"
+    latestReleaseDate: 2023-04-10
+
+  - releaseCycle: "7.5"
+    releaseDate: 2020-08-10
+    eol: 2022-08-10
+    latest: "7.5.2"
+    latestReleaseDate: 2020-09-09
+
+  - releaseCycle: "7.4"
+    releaseDate: 2020-07-08
+    eol: 2022-07-08
+    latest: "7.4.2"
+    latestReleaseDate: 2020-09-08
+
+  - releaseCycle: "7.3"
+    releaseDate: 2020-06-01
+    eol: 2022-06-01
+    latest: "7.3.2"
+    latestReleaseDate: 2020-07-28
+
+  - releaseCycle: "7.2"
+    releaseDate: 2020-04-27
+    eol: 2022-04-27
+    latest: "7.2.6"
+    latestReleaseDate: 2020-09-06
+
+  - releaseCycle: "7.1"
+    releaseDate: 2020-04-07
+    eol: 2022-04-07
+    latest: "7.1.4"
+    latestReleaseDate: 2020-06-17
+
+  - releaseCycle: "7.0"
+    releaseDate: 2020-03-08
+    eol: 2022-03-08
+    latest: "7.0.5"
+    latestReleaseDate: 2020-06-10
+
+  - releaseCycle: "6.10"
+    lts: true
+    releaseDate: 2020-01-12
+    eol: 2022-01-12
+    latest: "6.10.17"
+    latestReleaseDate: 2022-01-10
+
+  - releaseCycle: "6.9"
+    releaseDate: 2019-12-09
+    eol: 2021-12-09
+    latest: "6.9.3"
+    latestReleaseDate: 2020-03-11
+
+  - releaseCycle: "6.8"
+    releaseDate: 2019-11-04
+    eol: 2021-11-04
+    latest: "6.8.4"
+    latestReleaseDate: 2020-03-30
+
+  - releaseCycle: "6.7"
+    releaseDate: 2019-09-29
+    eol: 2021-09-29
+    latest: "6.7.5"
+    latestReleaseDate: 2020-03-30
+
+  - releaseCycle: "6.6"
+    releaseDate: 2019-08-26
+    eol: 2021-08-26
+    latest: "6.6.4"
+    latestReleaseDate: 2020-02-06
+
+  - releaseCycle: "6.5"
+    releaseDate: 2019-07-28
+    eol: 2021-07-28
+    latest: "6.5.3"
+    latestReleaseDate: 2019-12-22
+
+  - releaseCycle: "6.4"
+    releaseDate: 2019-06-17
+    eol: 2021-06-17
+    latest: "6.4.4"
+    latestReleaseDate: 2019-12-22
+
+  - releaseCycle: "6.3"
+    releaseDate: 2019-05-13
+    eol: 2021-05-13
+    latest: "6.3.6"
+    latestReleaseDate: 2019-12-22
+
+  - releaseCycle: "6.2"
+    releaseDate: 2019-04-08
+    eol: 2021-04-08
+    latest: "6.2.7"
+    latestReleaseDate: 2019-12-22
+
+  - releaseCycle: "6.1"
+    releaseDate: 2019-03-04
+    eol: 2021-03-04
+    latest: "6.1.9"
+    latestReleaseDate: 2019-12-22
+
+  - releaseCycle: "6.0"
+    releaseDate: 2019-02-10
+    eol: 2021-02-10
+    latest: "6.0.11"
+    latestReleaseDate: 2019-12-22
+
+  - releaseCycle: "5.16"
+    releaseDate: 2018-11-18
+    eol: 2020-11-18
+    latest: "5.16.11"
+    latestReleaseDate: 2019-12-22
+
+  - releaseCycle: "5.15"
+    releaseDate: 2018-10-16
+    eol: 2020-10-16
+    latest: "5.15.3"
+    latestReleaseDate: 2019-03-17
+
+  - releaseCycle: "5.14"
+    releaseDate: 2018-09-09
+    eol: 2020-09-09
+    latest: "5.14.4"
+    latestReleaseDate: 2019-03-16
+
+  - releaseCycle: "5.13"
+    releaseDate: 2018-08-06
+    eol: 2020-08-06
+    latest: "5.13.6"
+    latestReleaseDate: 2019-03-14
+
+  - releaseCycle: "5.12"
+    releaseDate: 2018-07-09
+    eol: 2020-07-09
+    latest: "5.12.4"
+    latestReleaseDate: 2019-02-17
+
+  - releaseCycle: "5.11"
+    releaseDate: 2018-05-25
+    eol: 2020-05-25
+    latest: "5.11.4"
+    latestReleaseDate: 2019-02-17
+
+  - releaseCycle: "5.10"
+    releaseDate: 2018-04-23
+    eol: 2020-04-23
+    latest: "5.10.4"
+    latestReleaseDate: 2019-02-17
+
+  - releaseCycle: "5.9"
+    releaseDate: 2018-03-19
+    eol: 2020-03-19
+    latest: "5.9.2"
+    latestReleaseDate: 2018-07-30
+
+  - releaseCycle: "5.8"
+    releaseDate: 2018-02-13
+    eol: 2020-02-13
+    latest: "5.8.4"
+    latestReleaseDate: 2018-07-30
+
+  - releaseCycle: "5.7"
+    releaseDate: 2018-01-10
+    eol: 2020-01-10
+    latest: "5.7.4"
+    latestReleaseDate: 2018-04-29
+
+  - releaseCycle: "5.6"
+    releaseDate: 2017-12-05
+    eol: 2019-12-05
+    latest: "5.6.6"
+    latestReleaseDate: 2018-04-29
+
+  - releaseCycle: "5.5"
+    releaseDate: 2017-10-23
+    eol: 2019-10-23
+    latest: "5.5.9"
+    latestReleaseDate: 2018-04-29
+
+  - releaseCycle: "5.4"
+    releaseDate: 2017-09-18
+    eol: 2019-09-18
+    latest: "5.4.9"
+    latestReleaseDate: 2018-04-29
+
+  - releaseCycle: "5.3"
+    releaseDate: 2017-08-13
+    eol: 2019-08-13
+    latest: "5.3.7"
+    latestReleaseDate: 2018-02-03
+
+  - releaseCycle: "5.2"
+    releaseDate: 2017-07-10
+    eol: 2019-07-10
+    latest: "5.2.8"
+    latestReleaseDate: 2018-02-03
+
+  - releaseCycle: "5.1"
+    releaseDate: 2017-06-22
+    eol: 2019-06-22
+    latest: "5.1.9"
+    latestReleaseDate: 2018-02-03
+
+  - releaseCycle: "5.0"
+    releaseDate: 2017-05-30
+    eol: 2019-05-30
+    latest: "5.0.10"
+    latestReleaseDate: 2018-02-03
+
+  - releaseCycle: "4.14"
+    releaseDate: 2017-02-19
+    eol: 2019-02-19
+    latest: "4.14.12"
+    latestReleaseDate: 2018-02-03
+
+  - releaseCycle: "4.13"
+    releaseDate: 2017-01-19
+    eol: 2019-01-19
+    latest: "4.13.1"
+    latestReleaseDate: 2017-02-26
+
+  - releaseCycle: "4.12"
+    releaseDate: 2016-12-11
+    eol: 2018-12-11
+    latest: "4.12.1"
+    latestReleaseDate: 2017-01-03
+
+  - releaseCycle: "4.11"
+    releaseDate: 2016-11-16
+    eol: 2018-11-16
+    latest: "4.11.2"
+    latestReleaseDate: 2016-11-29
+
+  - releaseCycle: "4.10"
+    releaseDate: 2016-10-04
+    eol: 2018-10-04
+    latest: "4.10.2"
+    latestReleaseDate: 2016-11-08
+
+  - releaseCycle: "4.9"
+    releaseDate: 2016-08-28
+    eol: 2018-08-28
+    latest: "4.9.1"
+    latestReleaseDate: 2016-08-31
+
+  - releaseCycle: "4.8"
+    releaseDate: 2016-07-17
+    eol: 2018-07-17
+    latest: "4.8.6"
+    latestReleaseDate: 2016-08-31
+
+  - releaseCycle: "4.7"
+    releaseDate: 2016-06-13
+    eol: 2018-06-13
+    latest: "4.7.2"
+    latestReleaseDate: 2016-08-17
+
+  - releaseCycle: "4.6"
+    releaseDate: 2016-05-08
+    eol: 2018-05-08
+    latest: "4.6.4"
+    latestReleaseDate: 2016-08-18
+
+  - releaseCycle: "4.5"
+    releaseDate: 2016-04-05
+    eol: 2018-04-05
+    latest: "4.5.3"
+    latestReleaseDate: 2016-08-18
+
+  - releaseCycle: "4.4"
+    releaseDate: 2016-02-29
+    eol: 2018-02-28
+    latest: "4.4.4"
+    latestReleaseDate: 2016-08-16
+
+  - releaseCycle: "4.3"
+    releaseDate: 2016-01-12
+    eol: 2018-01-12
+    latest: "4.3.3"
+    latestReleaseDate: 2016-04-01
+
+  - releaseCycle: "4.2"
+    releaseDate: 2015-12-07
+    eol: 2017-12-07
+    latest: "4.2.3"
+    latestReleaseDate: 2016-01-28
+
+  - releaseCycle: "4.1"
+    releaseDate: 2015-11-02
+    eol: 2017-11-02
+    latest: "4.1.6"
+    latestReleaseDate: 2016-01-28
+
+  - releaseCycle: "4.0"
+    releaseDate: 2015-09-24
+    eol: 2017-09-24
+    latest: "4.0.8"
+    latestReleaseDate: 2016-01-28
+
+  - releaseCycle: "3.11"
+    releaseDate: 2015-07-14
+    eol: 2017-07-14
+    latest: "3.11.6"
+    latestReleaseDate: 2015-12-22
+
+  - releaseCycle: "3.10"
+    releaseDate: 2015-06-08
+    eol: 2017-06-08
+    latest: "3.10.4"
+    latestReleaseDate: 2015-07-21
+
+  - releaseCycle: "3.9"
+    releaseDate: 2015-05-13
+    eol: 2017-05-13
+    latest: "3.9.2"
+    latestReleaseDate: 2015-05-21
+
+  - releaseCycle: "3.8"
+    releaseDate: 2015-03-31
+    eol: 2017-03-31
+    latest: "3.8.1"
+    latestReleaseDate: 2015-05-05
+
+  - releaseCycle: "3.7"
+    releaseDate: 2015-02-24
+    eol: 2017-02-24
+    latest: "3.7.4"
+    latestReleaseDate: 2015-05-05
+
+  - releaseCycle: "3.6"
+    releaseDate: 2015-01-12
+    eol: 2017-01-12
+    latest: "3.6.1"
+    latestReleaseDate: 2015-01-27
+
+  - releaseCycle: "3.5"
+    releaseDate: 2014-11-25
+    eol: 2016-11-25
+    latest: "3.5.1"
+    latestReleaseDate: 2014-12-16
+
+  - releaseCycle: "3.4"
+    releaseDate: 2014-10-21
+    eol: 2016-10-21
+    latest: "3.4.5"
+    latestReleaseDate: 2014-12-21
+
+  - releaseCycle: "3.3"
+    releaseDate: 2014-09-10
+    eol: 2016-09-10
+    latest: "3.3.5"
+    latestReleaseDate: 2014-12-21
+
+  - releaseCycle: "3.2"
+    releaseDate: 2014-07-30
+    eol: 2016-07-30
+    latest: "3.2.7"
+    latestReleaseDate: 2014-11-05
+
+  - releaseCycle: "3.1"
+    releaseDate: 2014-06-24
+    eol: 2016-06-24
+    latest: "3.1.7"
+    latestReleaseDate: 2014-11-05
+
+  - releaseCycle: "3.0"
+    releaseDate: 2014-05-20
+    eol: 2016-05-20
+    latest: "3.0.8"
+    latestReleaseDate: 2014-10-03
+
+  - releaseCycle: "2.12"
+    releaseDate: 2014-03-25
+    eol: 2016-03-25
+    latest: "2.12.6"
+    latestReleaseDate: 2014-08-04
+
+  - releaseCycle: "2.11"
+    releaseDate: 2014-03-04
+    eol: 2016-03-04
+    latest: "2.11.9"
+    latestReleaseDate: 2014-08-04
+
+  - releaseCycle: "2.10"
+    releaseDate: 2013-12-17
+    eol: 2015-12-17
+    latest: "2.10.5"
+    latestReleaseDate: 2014-05-22
+
+  - releaseCycle: "2.9"
+    releaseDate: 2013-11-19
+    eol: 2015-11-19
+    latest: "2.9.5"
+    latestReleaseDate: 2014-02-14
+
+  - releaseCycle: "2.8"
+    releaseDate: 2013-11-11
+    eol: 2015-11-11
+    latest: "2.8.5"
+    latestReleaseDate: 2014-03-09
+
+  - releaseCycle: "2.7"
+    releaseDate: 2013-11-11
+    eol: 2015-11-11
+    latest: "2.7.6"
+    latestReleaseDate: 2013-11-11
+
+  - releaseCycle: "2.6"
+    releaseDate: 2013-11-11
+    eol: 2015-11-11
+    latest: "2.6.5"
+    latestReleaseDate: 2013-11-11
+
+  - releaseCycle: "2.5"
+    releaseDate: 2013-11-11
+    eol: 2015-11-11
+    latest: "2.5.4"
+    latestReleaseDate: 2013-11-11
+
+  - releaseCycle: "2.4"
+    releaseDate: 2013-05-21
+    eol: 2015-05-21
+    latest: "2.4.2"
+    latestReleaseDate: 2013-05-21
+
+  - releaseCycle: "2.3"
+    releaseDate: 2013-04-03
+    eol: 2015-04-03
+    latest: "2.3.1"
+    latestReleaseDate: 2013-04-03
+
+  - releaseCycle: "2.2"
+    releaseDate: 2013-02-27
+    eol: 2015-02-27
+    latest: "2.2.0"
+    latestReleaseDate: 2013-02-27
+
+  - releaseCycle: "2.1"
+    releaseDate: 2013-02-11
+    eol: 2015-02-11
+    latest: "2.1.2"
+    latestReleaseDate: 2013-02-11
+
+  - releaseCycle: "2.0"
+    releaseDate: 2013-01-18
+    eol: 2015-01-18
+    latest: "2.0.3"
+    latestReleaseDate: 2013-01-18
+
+  - releaseCycle: "1.3"
+    releaseDate: 2012-11-07
+    eol: 2014-11-07
+    latest: "1.3.1"
+    latestReleaseDate: 2012-11-07
+
+  - releaseCycle: "1.2"
+    releaseDate: 2012-08-17
+    eol: 2014-08-17
+    latest: "1.2.4"
+    latestReleaseDate: 2012-09-20
+
+  - releaseCycle: "1.1"
+    releaseDate: 2012-07-13
+    eol: 2014-07-13
+    latest: "1.1.2"
+    latestReleaseDate: 2012-07-13
+
+  - releaseCycle: "1.0"
+    releaseDate: 2012-05-17
+    eol: 2014-05-17
+    latest: "1.0.3"
+    latestReleaseDate: 2012-05-17
 ---
 
 > [Bitbucket](https://www.atlassian.com/software/bitbucket) is a proprietary source control and CI/CD platform developed

--- a/products/confluence.md
+++ b/products/confluence.md
@@ -194,12 +194,96 @@ releases:
     latest: "7.13.20"
     latestReleaseDate: 2023-08-02
 
+  - releaseCycle: "7.12"
+    releaseDate: 2021-04-11
+    eol: 2023-04-11
+    latest: "7.12.5"
+    latestReleaseDate: 2021-08-22
+
+  - releaseCycle: "7.11"
+    releaseDate: 2021-02-01
+    eol: 2023-02-01
+    latest: "7.11.6"
+    latestReleaseDate: 2021-08-22
+
+  - releaseCycle: "7.10"
+    releaseDate: 2020-12-14
+    eol: 2022-12-14
+    latest: "7.10.2"
+    latestReleaseDate: 2021-01-18
+
+  - releaseCycle: "7.9"
+    releaseDate: 2020-11-08
+    eol: 2022-11-08
+    latest: "7.9.3"
+    latestReleaseDate: 2020-12-08
+
+  - releaseCycle: "7.8"
+    releaseDate: 2020-09-28
+    eol: 2022-09-28
+    latest: "7.8.3"
+    latestReleaseDate: 2020-11-02
+
+  - releaseCycle: "7.7"
+    releaseDate: 2020-08-17
+    eol: 2022-08-17
+    latest: "7.7.4"
+    latestReleaseDate: 2020-09-21
+
+  - releaseCycle: "7.6"
+    releaseDate: 2020-06-29
+    eol: 2022-06-29
+    latest: "7.6.3"
+    latestReleaseDate: 2021-02-03
+
+  - releaseCycle: "7.5"
+    releaseDate: 2020-05-19
+    eol: 2022-05-19
+    latest: "7.5.2"
+    latestReleaseDate: 2020-06-20
+
   - releaseCycle: "7.4"
     lts: true
     releaseDate: 2020-04-18
     eol: 2022-04-21
     latest: "7.4.18"
     latestReleaseDate: 2022-07-04
+
+  - releaseCycle: "7.3"
+    releaseDate: 2020-02-04
+    eol: 2022-02-04
+    latest: "7.3.5"
+    latestReleaseDate: 2020-04-08
+
+  - releaseCycle: "7.2"
+    releaseDate: 2019-12-10
+    eol: 2021-12-10
+    latest: "7.2.2"
+    latestReleaseDate: 2020-02-02
+
+  - releaseCycle: "7.1"
+    releaseDate: 2019-11-01
+    eol: 2021-11-01
+    latest: "7.1.2"
+    latestReleaseDate: 2019-12-11
+
+  - releaseCycle: "7.0"
+    releaseDate: 2019-09-04
+    eol: 2021-09-04
+    latest: "7.0.5"
+    latestReleaseDate: 2019-12-11
+
+  - releaseCycle: "6.15"
+    releaseDate: 2019-03-13
+    eol: 2021-03-13
+    latest: "6.15.10"
+    latestReleaseDate: 2019-12-10
+
+  - releaseCycle: "6.14"
+    releaseDate: 2019-01-20
+    eol: 2021-01-20
+    latest: "6.14.3"
+    latestReleaseDate: 2019-04-03
 
   - releaseCycle: "6.13"
     lts: true
@@ -208,6 +292,42 @@ releases:
     latest: "6.13.23"
     latestReleaseDate: 2021-08-23
 
+  - releaseCycle: "6.12"
+    releaseDate: 2018-09-27
+    eol: 2020-09-27
+    latest: "6.12.4"
+    latestReleaseDate: 2019-04-03
+
+  - releaseCycle: "6.11"
+    releaseDate: 2018-08-12
+    eol: 2020-08-12
+    latest: "6.11.2"
+    latestReleaseDate: 2018-09-16
+
+  - releaseCycle: "6.10"
+    releaseDate: 2018-06-24
+    eol: 2020-06-24
+    latest: "6.10.3"
+    latestReleaseDate: 2019-06-04
+
+  - releaseCycle: "6.9"
+    releaseDate: 2018-05-06
+    eol: 2020-05-06
+    latest: "6.9.3"
+    latestReleaseDate: 2018-07-10
+
+  - releaseCycle: "6.8"
+    releaseDate: 2018-03-18
+    eol: 2020-03-18
+    latest: "6.8.5"
+    latestReleaseDate: 2018-07-10
+
+  - releaseCycle: "6.7"
+    releaseDate: 2018-01-28
+    eol: 2020-01-28
+    latest: "6.7.3"
+    latestReleaseDate: 2018-04-30
+
   - releaseCycle: "6.6"
     lts: true
     releaseDate: 2017-12-10
@@ -215,6 +335,245 @@ releases:
     latest: "6.6.17"
     latestReleaseDate: 2019-11-07
 
+  - releaseCycle: "6.5"
+    releaseDate: 2017-10-31
+    eol: 2019-10-31
+    latest: "6.5.3"
+    latestReleaseDate: 2018-04-30
+
+  - releaseCycle: "6.4"
+    releaseDate: 2017-09-04
+    eol: 2019-09-04
+    latest: "6.4.3"
+    latestReleaseDate: 2017-10-22
+
+  - releaseCycle: "6.3"
+    releaseDate: 2017-07-11
+    eol: 2019-07-11
+    latest: "6.3.4"
+    latestReleaseDate: 2017-09-04
+
+  - releaseCycle: "6.2"
+    releaseDate: 2017-05-11
+    eol: 2019-05-11
+    latest: "6.2.4"
+    latestReleaseDate: 2017-07-10
+
+  - releaseCycle: "6.1"
+    releaseDate: 2017-03-15
+    eol: 2019-03-15
+    latest: "6.1.4"
+    latestReleaseDate: 2017-05-21
+
+  - releaseCycle: "6.0"
+    releaseDate: 2016-10-30
+    eol: 2018-10-30
+    latest: "6.0.7"
+    latestReleaseDate: 2017-03-16
+
+  - releaseCycle: "5.10"
+    releaseDate: 2016-06-06
+    eol: 2018-06-06
+    latest: "5.10.9"
+    latestReleaseDate: 2017-11-21
+
+  - releaseCycle: "5.9"
+    releaseDate: 2015-11-24
+    eol: 2017-11-24
+    latest: "5.9.14"
+    latestReleaseDate: 2016-09-18
+
+  - releaseCycle: "5.8"
+    releaseDate: 2015-06-02
+    eol: 2017-06-02
+    latest: "5.8.18"
+    latestReleaseDate: 2015-12-07
+
+  - releaseCycle: "5.7"
+    releaseDate: 2015-01-27
+    eol: 2017-01-27
+    latest: "5.7.6"
+    latestReleaseDate: 2016-01-12
+
+  - releaseCycle: "5.6"
+    releaseDate: 2014-09-03
+    eol: 2016-09-03
+    latest: "5.6.6"
+    latestReleaseDate: 2014-12-01
+
+  - releaseCycle: "5.5"
+    releaseDate: 2014-04-29
+    eol: 2016-04-29
+    latest: "5.5.7"
+    latestReleaseDate: 2014-12-04
+
+  - releaseCycle: "5.4"
+    releaseDate: 2013-11-28
+    eol: 2015-11-28
+    latest: "5.4.4"
+    latestReleaseDate: 2014-03-13
+
+  - releaseCycle: "5.3"
+    releaseDate: 2013-09-26
+    eol: 2015-09-26
+    latest: "5.3.4"
+    latestReleaseDate: 2013-11-15
+
+  - releaseCycle: "5.2"
+    releaseDate: 2013-08-13
+    eol: 2015-08-13
+    latest: "5.2.5"
+    latestReleaseDate: 2013-09-16
+
+  - releaseCycle: "5.1"
+    releaseDate: 2013-03-24
+    eol: 2015-03-24
+    latest: "5.1.5"
+    latestReleaseDate: 2013-08-03
+
+  - releaseCycle: "5.0"
+    releaseDate: 2013-02-19
+    eol: 2015-02-19
+    latest: "5.0.3"
+    latestReleaseDate: 2013-03-18
+
+  - releaseCycle: "4.3"
+    releaseDate: 2012-09-04
+    eol: 2014-09-04
+    latest: "4.3.7"
+    latestReleaseDate: 2013-01-28
+
+  - releaseCycle: "4.2"
+    releaseDate: 2012-04-05
+    eol: 2014-04-05
+    latest: "4.2.13"
+    latestReleaseDate: 2012-08-17
+
+  - releaseCycle: "4.1"
+    releaseDate: 2011-12-13
+    eol: 2013-12-13
+    latest: "4.1.10"
+    latestReleaseDate: 2012-05-14
+
+  - releaseCycle: "4.0"
+    releaseDate: 2011-09-15
+    eol: 2013-09-15
+    latest: "4.0.7"
+    latestReleaseDate: 2012-05-14
+
+  - releaseCycle: "3.5"
+    releaseDate: 2011-03-15
+    eol: 2013-03-15
+    latest: "3.5.17"
+    latestReleaseDate: 2012-06-25
+
+  - releaseCycle: "3.4"
+    releaseDate: 2010-10-12
+    eol: 2012-10-12
+    latest: "3.4.9"
+    latestReleaseDate: 2011-02-16
+
+  - releaseCycle: "3.3"
+    releaseDate: 2010-07-06
+    eol: 2012-07-06
+    latest: "3.3.3"
+    latestReleaseDate: 2010-09-21
+
+  - releaseCycle: "3.2"
+    releaseDate: 2010-03-18
+    eol: 2012-03-18
+    latest: "3.2.1_01"
+    latestReleaseDate: 2010-05-04
+
+  - releaseCycle: "3.1"
+    releaseDate: 2009-12-08
+    eol: 2011-12-08
+    latest: "3.1.2"
+    latestReleaseDate: 2010-03-03
+
+  - releaseCycle: "3.0"
+    releaseDate: 2009-08-20
+    eol: 2011-08-20
+    latest: "3.0.2"
+    latestReleaseDate: 2009-10-06
+
+  - releaseCycle: "2.10"
+    releaseDate: 2009-08-19
+    eol: 2011-08-19
+    latest: "2.10.4"
+    latestReleaseDate: 2009-08-19
+
+  - releaseCycle: "2.9"
+    releaseDate: 2009-08-19
+    eol: 2011-08-19
+    latest: "2.9.3"
+    latestReleaseDate: 2009-08-19
+
+  - releaseCycle: "2.8"
+    releaseDate: 2009-08-19
+    eol: 2011-08-19
+    latest: "2.8.3"
+    latestReleaseDate: 2009-08-19
+
+  - releaseCycle: "2.7"
+    releaseDate: 2009-08-19
+    eol: 2011-08-19
+    latest: "2.7.4"
+    latestReleaseDate: 2009-08-19
+
+  - releaseCycle: "2.6"
+    releaseDate: 2007-12-01
+    eol: 2009-12-01
+    latest: "2.6.3"
+    latestReleaseDate: 2007-12-01
+
+  - releaseCycle: "2.2"
+    releaseDate: 2006-04-27
+    eol: 2008-04-27
+    latest: "2.2.10"
+    latestReleaseDate: 2006-11-30
+
+  - releaseCycle: "2.1"
+    releaseDate: 2005-12-20
+    eol: 2007-12-20
+    latest: "2.1.5a"
+    latestReleaseDate: 2006-03-17
+
+  - releaseCycle: "2.0"
+    releaseDate: 2005-11-17
+    eol: 2007-11-17
+    latest: "2.0.3"
+    latestReleaseDate: 2005-12-12
+
+  - releaseCycle: "1.4"
+    releaseDate: 2005-05-23
+    eol: 2007-05-23
+    latest: "1.4.4"
+    latestReleaseDate: 2005-10-04
+
+  - releaseCycle: "1.3"
+    releaseDate: 2005-03-02
+    eol: 2007-03-02
+    latest: "1.3.6"
+    latestReleaseDate: 2005-06-02
+
+  - releaseCycle: "1.2"
+    releaseDate: 2005-02-24
+    eol: 2007-02-24
+    latest: "1.2.3"
+    latestReleaseDate: 2005-02-24
+
+  - releaseCycle: "1.1"
+    releaseDate: 2004-06-21
+    eol: 2006-06-21
+    latest: "1.1.2"
+    latestReleaseDate: 2004-06-21
+
+  - releaseCycle: "1.0"
+    releaseDate: 2004-05-05
+    eol: 2006-05-05
+    latest: "1.0.3a"
+    latestReleaseDate: 2004-05-05
 ---
 
 > [Confluence](https://www.atlassian.com/software/confluence) is a web-based corporate wiki developed by Atlassian.


### PR DESCRIPTION
## Summary

Three Atlassian pages were missing most of their release history, and two of them had gaps in the middle of the range they appeared to cover.

| Page | Cycles before | After | Added |
| --- | --- | --- | --- |
| `/bamboo` | 16 | 68 | 52, back to 0.9 (2006-12-21) |
| `/confluence` | 30 | 90 | 60, back to 1.0 (2004-05-05) |
| `/bitbucket` | 26 | 126 | 100, back to 1.0 (2012-05-17) |

The interior gaps are the part worth fixing first. Confluence listed 6.6, then jumped to 6.13 and then to 7.4 before picking up again at 7.13, so someone running 6.9 or 7.9 found nothing at all. Bitbucket had the same shape across 8.0 to 8.6. In Confluence's case the missing cycles are exactly the non-Enterprise releases of that era, which suggests the page deliberately tracked only Enterprise releases until 7.13 and then switched to listing everything; it now lists everything throughout.

The diffs are additions only, with no existing line changed.

## Source

Atlassian's own download feeds, the ones behind the `atlassian_versions` method these pages already use:

```
https://my.atlassian.com/download/feeds/current/<product>.json
https://my.atlassian.com/download/feeds/archived/<product>.json
```

Each entry carries the version, the release date and the edition.

**The feed was checked against the pages before being trusted.** Of the 139 cycles present on both sides across the three products, 135 agree within three days. The four that differ are explained by which build the feed retained: Bamboo 12.0 keeps an earlier EAP build, while Bitbucket 10.4 and Jira 9.15 and 10.7 keep only a later one.

**Pre-release builds are excluded.** The feeds publish an EAP channel alongside the current and archived ones, and it currently carries `13.0.0-rc2` for Bamboo and `11.0.0-beta3` for Confluence. Those are not releases and are not listed here.

## How eol was set

- **Confluence and Bitbucket:** release date plus two years. Every existing row on both pages already follows that rule, including the older ones, so the added cycles follow it too.
- **Bamboo:** `eol: true`. The rows already on the page for 8.0 through 9.6 show batch cutoffs rather than a fixed window, with 8.0 and 8.1 both ending on 2023-03-28, so a computed date would be wrong. Atlassian's support policy page lists end-of-life dates for Bamboo 10.0 and later only.

For reference, that policy page covers Bitbucket from 9.0, Bamboo from 10.0, and has no Confluence section at all, which is why `confluence.md` keeps its `atlassian_eol` method commented out.

## Enterprise releases

The feed's `edition` field marks Enterprise builds, and it reproduces the `lts: true` cycles already on the three pages exactly: four on Bamboo, eight on Confluence, five on Bitbucket. It also identifies three Enterprise cycles among the additions, Bitbucket 6.10, 7.6 and 7.17, which are marked accordingly. None of the added Bamboo or Confluence cycles are Enterprise.

## Test plan

- [x] `bundle exec jekyll build` passes, including `product-data-validator.rb`
- [x] `markdownlint-cli2` and `prettier --check` pass on all three files
- [x] Releases stay ordered by descending release date; `latestReleaseDate` never precedes `releaseDate`; `eol` never precedes `releaseDate`
- [x] The diff adds lines only; no existing row was modified
- [x] Netlify deploy preview renders the three pages correctly