### PR TITLE
[New Products] - Atlassian Crowd, FishEye, Crucible and Bitbucket Mesh

### DIFF
--- a/products/bitbucket-mesh.md
+++ b/products/bitbucket-mesh.md
@@ -1,0 +1,168 @@
+---
+title: Bitbucket Mesh
+addedAt: 2026-09-10
+category: server-app
+tags: atlassian java-runtime
+iconSlug: bitbucket
+permalink: /bitbucket-mesh
+alternate_urls:
+  - /mesh
+releasePolicyLink: https://confluence.atlassian.com/bitbucketserver/bitbucket-mesh-compatibility-matrix-1127254859.html
+eolColumn: Support
+
+# Release dates from Atlassian's download feed for Mesh.
+# Mesh ships alongside Bitbucket Data Center: since 3.0 every release has landed on the same day as the matching
+# Bitbucket release, 3.0 with Bitbucket 9.0 through 4.4 with Bitbucket 10.4, so it follows the same two year
+# support window as https://endoflife.date/bitbucket .
+releases:
+  - releaseCycle: "4.4"
+    releaseDate: 2026-07-20
+    eol: 2028-07-20
+    latest: "4.4.2"
+    latestReleaseDate: 2026-09-06
+
+  - releaseCycle: "4.3"
+    releaseDate: 2026-05-11
+    eol: 2028-05-11
+    latest: "4.3.3"
+    latestReleaseDate: 2026-07-14
+
+  - releaseCycle: "4.2"
+    releaseDate: 2026-03-02
+    eol: 2028-03-02
+    latest: "4.2.5"
+    latestReleaseDate: 2026-09-06
+
+  - releaseCycle: "4.1"
+    releaseDate: 2025-11-20
+    eol: 2027-11-20
+    latest: "4.1.3"
+    latestReleaseDate: 2026-01-12
+
+  - releaseCycle: "4.0"
+    releaseDate: 2025-09-07
+    eol: 2027-09-07
+    latest: "4.0.3"
+    latestReleaseDate: 2025-11-11
+
+  - releaseCycle: "3.6"
+    releaseDate: 2025-03-17
+    eol: 2027-03-17
+    latest: "3.6.6"
+    latestReleaseDate: 2025-08-12
+
+  - releaseCycle: "3.5"
+    releaseDate: 2025-01-06
+    eol: 2027-01-06
+    latest: "3.5.2"
+    latestReleaseDate: 2025-03-06
+
+  - releaseCycle: "3.4"
+    releaseDate: 2024-12-02
+    eol: 2026-12-02
+    latest: "3.4.20"
+    latestReleaseDate: 2026-09-06
+
+  - releaseCycle: "3.3"
+    releaseDate: 2024-10-28
+    eol: 2026-10-28
+    latest: "3.3.1"
+    latestReleaseDate: 2024-11-07
+
+  - releaseCycle: "3.2"
+    releaseDate: 2024-09-23
+    eol: 2026-09-23
+    latest: "3.2.1"
+    latestReleaseDate: 2024-10-08
+
+  - releaseCycle: "3.1"
+    releaseDate: 2024-08-26
+    eol: 2026-08-26
+    latest: "3.1.1"
+    latestReleaseDate: 2024-09-08
+
+  - releaseCycle: "3.0"
+    releaseDate: 2024-07-22
+    eol: 2026-07-22
+    latest: "3.0.1"
+    latestReleaseDate: 2024-08-11
+
+  - releaseCycle: "2.5"
+    releaseDate: 2024-03-12
+    eol: 2026-03-12
+    latest: "2.5.21"
+    latestReleaseDate: 2025-12-04
+
+  - releaseCycle: "2.4"
+    releaseDate: 2024-02-05
+    eol: 2026-02-05
+    latest: "2.4.1"
+    latestReleaseDate: 2024-03-08
+
+  - releaseCycle: "2.3"
+    releaseDate: 2024-01-09
+    eol: 2026-01-09
+    latest: "2.3.1"
+    latestReleaseDate: 2024-03-08
+
+  - releaseCycle: "2.2"
+    releaseDate: 2023-10-23
+    eol: 2025-10-23
+    latest: "2.2.3"
+    latestReleaseDate: 2024-03-08
+
+  - releaseCycle: "2.1"
+    releaseDate: 2023-08-14
+    eol: 2025-08-14
+    latest: "2.1.15"
+    latestReleaseDate: 2024-03-08
+
+  - releaseCycle: "2.0"
+    releaseDate: 2023-04-11
+    eol: 2025-04-11
+    latest: "2.0.38"
+    latestReleaseDate: 2025-04-08
+
+  - releaseCycle: "1.5"
+    releaseDate: 2023-02-06
+    eol: 2025-02-06
+    latest: "1.5.6"
+    latestReleaseDate: 2023-08-08
+
+  - releaseCycle: "1.4"
+    releaseDate: 2022-11-10
+    eol: 2024-11-10
+    latest: "1.4.2"
+    latestReleaseDate: 2023-06-28
+
+  - releaseCycle: "1.3"
+    releaseDate: 2022-08-01
+    eol: 2024-08-01
+    latest: "1.3.4"
+    latestReleaseDate: 2022-10-04
+
+  - releaseCycle: "1.2"
+    releaseDate: 2022-06-28
+    eol: 2024-06-28
+    latest: "1.2.3"
+    latestReleaseDate: 2022-10-04
+
+  - releaseCycle: "1.1"
+    releaseDate: 2022-05-23
+    eol: 2024-05-23
+    latest: "1.1.6"
+    latestReleaseDate: 2022-10-04
+
+  - releaseCycle: "1.0"
+    releaseDate: 2022-05-11
+    eol: 2024-05-11
+    latest: "1.0.6"
+    latestReleaseDate: 2022-10-04
+---
+
+> [Bitbucket Mesh](https://confluence.atlassian.com/bitbucketserver/bitbucket-mesh-1101772130.html) is the
+> distributed, replicated Git repository storage service for Bitbucket Data Center, developed by Atlassian.
+
+Mesh is not installed on its own. It ships alongside Bitbucket Data Center, and since Mesh 3.0 every release has
+landed on the same day as the matching Bitbucket release, 3.0 with Bitbucket 9.0 through 4.4 with Bitbucket 10.4.
+It follows the same two year support window as [Bitbucket](/bitbucket).

--- a/products/bitbucket-mesh.md
+++ b/products/bitbucket-mesh.md
@@ -10,10 +10,15 @@ alternate_urls:
 releasePolicyLink: https://confluence.atlassian.com/bitbucketserver/bitbucket-mesh-compatibility-matrix-1127254859.html
 eolColumn: Support
 
-# Release dates from Atlassian's download feed for Mesh.
+# Release dates from Atlassian's download feed for Mesh. There is no download page of its own to read:
+# Mesh ships with Bitbucket, whose page lists Bitbucket versions.
 # Mesh ships alongside Bitbucket Data Center: since 3.0 every release has landed on the same day as the matching
 # Bitbucket release, 3.0 with Bitbucket 9.0 through 4.4 with Bitbucket 10.4, so it follows the same two year
 # support window as https://endoflife.date/bitbucket .
+auto:
+  methods:
+    - atlassian_feed: https://my.atlassian.com/download/feeds/current/mesh.json
+
 releases:
   - releaseCycle: "4.4"
     releaseDate: 2026-07-20

--- a/products/crowd.md
+++ b/products/crowd.md
@@ -1,0 +1,312 @@
+---
+title: Crowd
+addedAt: 2026-09-10
+category: server-app
+tags: atlassian java-runtime
+iconSlug: atlassian
+permalink: /crowd
+alternate_urls:
+  - /atlassian-crowd
+releasePolicyLink: https://confluence.atlassian.com/support/atlassian-support-end-of-life-policy-201851003.html
+eolColumn: Support
+
+identifiers:
+  - cpe: cpe:/a:atlassian:crowd
+  - cpe: cpe:2.3:a:atlassian:crowd
+
+auto:
+  methods:
+    - atlassian_versions: https://www.atlassian.com/software/crowd/download-archive
+    - atlassian_eol: https://confluence.atlassian.com/support/atlassian-support-end-of-life-policy-201851003.html
+      selector: AtlassianEndofSupportPolicy-Crowd
+      regex: '(?P<release>\d+(\.\d+)+) \(EO[SL] date: (?P<date>.+)\).*$'
+
+# Release dates from https://www.atlassian.com/software/crowd/download-archive.
+# EOL dates are published on
+# https://confluence.atlassian.com/support/atlassian-support-end-of-life-policy-201851003.html for 5.3 and later.
+# Earlier cycles use the two year window every dated entry there follows.
+releases:
+  - releaseCycle: "7.2"
+    releaseDate: 2026-05-18
+    eol: 2028-05-17
+    latest: "7.2.3"
+    latestReleaseDate: 2026-08-18
+
+  - releaseCycle: "7.1"
+    releaseDate: 2025-10-02
+    eol: 2027-10-02
+    latest: "7.1.5"
+    latestReleaseDate: 2026-02-24
+
+  - releaseCycle: "7.0"
+    releaseDate: 2025-08-21
+    eol: 2027-08-21
+    latest: "7.0.2"
+    latestReleaseDate: 2025-11-27
+
+  - releaseCycle: "6.3"
+    releaseDate: 2025-04-10
+    eol: 2027-04-10
+    latest: "6.3.6"
+    latestReleaseDate: 2026-04-29
+
+  - releaseCycle: "6.2"
+    releaseDate: 2024-12-18
+    eol: 2026-12-18
+    latest: "6.2.6"
+    latestReleaseDate: 2025-11-26
+
+  - releaseCycle: "6.1"
+    releaseDate: 2024-09-27
+    eol: 2026-09-27
+    latest: "6.1.7"
+    latestReleaseDate: 2025-11-26
+
+  - releaseCycle: "6.0"
+    releaseDate: 2024-07-04
+    eol: 2026-07-04
+    latest: "6.0.10"
+    latestReleaseDate: 2025-08-07
+
+  - releaseCycle: "5.3"
+    releaseDate: 2024-04-12
+    eol: 2026-04-19
+    latest: "5.3.8"
+    latestReleaseDate: 2025-08-07
+
+  - releaseCycle: "5.2"
+    releaseDate: 2023-09-28
+    eol: 2025-09-28
+    latest: "5.2.11"
+    latestReleaseDate: 2025-06-03
+
+  - releaseCycle: "5.1"
+    releaseDate: 2022-11-17
+    eol: 2024-11-17
+    latest: "5.1.13"
+    latestReleaseDate: 2024-10-09
+
+  - releaseCycle: "5.0"
+    releaseDate: 2022-05-16
+    eol: 2024-05-16
+    latest: "5.0.11"
+    latestReleaseDate: 2024-04-08
+
+  - releaseCycle: "4.4"
+    releaseDate: 2021-10-13
+    eol: 2023-10-13
+    latest: "4.4.6"
+    latestReleaseDate: 2024-03-20
+
+  - releaseCycle: "4.3"
+    releaseDate: 2021-04-21
+    eol: 2023-04-21
+    latest: "4.3.11"
+    latestReleaseDate: 2023-02-13
+
+  - releaseCycle: "4.2"
+    releaseDate: 2020-10-14
+    eol: 2022-10-14
+    latest: "4.2.5"
+    latestReleaseDate: 2021-11-04
+
+  - releaseCycle: "4.1"
+    releaseDate: 2020-06-21
+    eol: 2022-06-21
+    latest: "4.1.10"
+    latestReleaseDate: 2021-07-01
+
+  - releaseCycle: "4.0"
+    releaseDate: 2020-02-25
+    eol: 2022-02-25
+    latest: "4.0.5"
+    latestReleaseDate: 2020-11-02
+
+  - releaseCycle: "3.7"
+    releaseDate: 2019-10-03
+    eol: 2021-10-03
+    latest: "3.7.2"
+    latestReleaseDate: 2020-05-18
+
+  - releaseCycle: "3.6"
+    releaseDate: 2019-09-02
+    eol: 2021-09-02
+    latest: "3.6.2"
+    latestReleaseDate: 2019-12-30
+
+  - releaseCycle: "3.5"
+    releaseDate: 2019-07-04
+    eol: 2021-07-04
+    latest: "3.5.1"
+    latestReleaseDate: 2019-08-23
+
+  - releaseCycle: "3.4"
+    releaseDate: 2019-03-13
+    eol: 2021-03-13
+    latest: "3.4.6"
+    latestReleaseDate: 2019-08-23
+
+  - releaseCycle: "3.3"
+    releaseDate: 2018-09-26
+    eol: 2020-09-26
+    latest: "3.3.7"
+    latestReleaseDate: 2019-08-23
+
+  - releaseCycle: "3.2"
+    releaseDate: 2018-04-24
+    eol: 2020-04-24
+    latest: "3.2.11"
+    latestReleaseDate: 2020-04-20
+
+  - releaseCycle: "3.1"
+    releaseDate: 2017-11-27
+    eol: 2019-11-27
+    latest: "3.1.6"
+    latestReleaseDate: 2019-05-02
+
+  - releaseCycle: "3.0"
+    releaseDate: 2017-08-14
+    eol: 2019-08-14
+    latest: "3.0.5"
+    latestReleaseDate: 2019-05-02
+
+  - releaseCycle: "2.12"
+    releaseDate: 2017-04-26
+    eol: 2019-04-26
+    latest: "2.12.0"
+    latestReleaseDate: 2017-04-26
+
+  - releaseCycle: "2.11"
+    releaseDate: 2017-01-12
+    eol: 2019-01-12
+    latest: "2.11.2"
+    latestReleaseDate: 2017-03-31
+
+  - releaseCycle: "2.10"
+    releaseDate: 2016-09-13
+    eol: 2018-09-13
+    latest: "2.10.3"
+    latestReleaseDate: 2017-03-10
+
+  - releaseCycle: "2.9"
+    releaseDate: 2016-05-10
+    eol: 2018-05-10
+    latest: "2.9.7"
+    latestReleaseDate: 2017-03-10
+
+  - releaseCycle: "2.8"
+    releaseDate: 2014-11-06
+    eol: 2016-11-06
+    latest: "2.8.8"
+    latestReleaseDate: 2016-10-12
+
+  - releaseCycle: "2.7"
+    releaseDate: 2013-09-23
+    eol: 2015-09-23
+    latest: "2.7.2"
+    latestReleaseDate: 2014-05-13
+
+  - releaseCycle: "2.6"
+    releaseDate: 2013-02-11
+    eol: 2015-02-11
+    latest: "2.6.7"
+    latestReleaseDate: 2014-05-21
+
+  - releaseCycle: "2.5"
+    releaseDate: 2012-08-06
+    eol: 2014-08-06
+    latest: "2.5.7"
+    latestReleaseDate: 2014-05-21
+
+  - releaseCycle: "2.4"
+    releaseDate: 2012-01-11
+    eol: 2014-01-11
+    latest: "2.4.10"
+    latestReleaseDate: 2013-07-16
+
+  - releaseCycle: "2.3"
+    releaseDate: 2011-07-20
+    eol: 2013-07-20
+    latest: "2.3.9"
+    latestReleaseDate: 2013-07-16
+
+  - releaseCycle: "2.2"
+    releaseDate: 2011-03-10
+    eol: 2013-03-10
+    latest: "2.2.9"
+    latestReleaseDate: 2012-05-17
+
+  - releaseCycle: "2.1"
+    releaseDate: 2010-12-01
+    eol: 2012-12-01
+    latest: "2.1.2"
+    latestReleaseDate: 2012-05-17
+
+  - releaseCycle: "2.0"
+    releaseDate: 2009-07-30
+    eol: 2011-07-30
+    latest: "2.0.9"
+    latestReleaseDate: 2012-05-17
+
+  - releaseCycle: "1.6"
+    releaseDate: 2008-12-18
+    eol: 2010-12-18
+    latest: "1.6.3"
+    latestReleaseDate: 2010-05-04
+
+  - releaseCycle: "1.5"
+    releaseDate: 2008-09-04
+    eol: 2010-09-04
+    latest: "1.5.3"
+    latestReleaseDate: 2010-05-04
+
+  - releaseCycle: "1.4"
+    releaseDate: 2008-05-08
+    eol: 2010-05-08
+    latest: "1.4.8"
+    latestReleaseDate: 2010-05-04
+
+  - releaseCycle: "1.3"
+    releaseDate: 2008-03-03
+    eol: 2010-03-03
+    latest: "1.3.3"
+    latestReleaseDate: 2008-10-13
+
+  - releaseCycle: "1.2"
+    releaseDate: 2007-11-27
+    eol: 2009-11-27
+    latest: "1.2.4"
+    latestReleaseDate: 2008-10-13
+
+  - releaseCycle: "1.1"
+    releaseDate: 2007-06-20
+    eol: 2009-06-20
+    latest: "1.1.2"
+    latestReleaseDate: 2007-09-03
+
+  - releaseCycle: "1.0"
+    releaseDate: 2007-03-05
+    eol: 2009-03-05
+    latest: "1.0.7"
+    latestReleaseDate: 2007-05-10
+
+  - releaseCycle: "0.4"
+    releaseDate: 2007-01-15
+    eol: 2009-01-15
+    latest: "0.4.5"
+    latestReleaseDate: 2007-02-20
+
+  - releaseCycle: "0.3"
+    releaseDate: 2006-12-08
+    eol: 2008-12-08
+    latest: "0.3.3"
+    latestReleaseDate: 2006-12-20
+---
+
+> [Crowd](https://www.atlassian.com/software/crowd) is a proprietary single sign-on and user identity management
+> application developed by Atlassian, used to centralise directories across Atlassian and other applications.
+
+This page is about the self-hosted Data Center edition.
+
+A release is supported for two years from its release date. Atlassian publishes the exact end-of-life dates for 5.3
+and later; the dates shown for earlier releases follow that same two year window.

--- a/products/crucible.md
+++ b/products/crucible.md
@@ -1,0 +1,260 @@
+---
+title: Crucible
+addedAt: 2026-09-10
+category: server-app
+tags: atlassian discontinued java-runtime
+iconSlug: atlassian
+permalink: /crucible
+alternate_urls:
+  - /atlassian-crucible
+releasePolicyLink: https://confluence.atlassian.com/support/atlassian-support-end-of-life-policy-201851003.html
+eolColumn: Support
+
+identifiers:
+  - cpe: cpe:/a:atlassian:crucible
+  - cpe: cpe:2.3:a:atlassian:crucible
+
+auto:
+  methods:
+    - atlassian_versions: https://www.atlassian.com/software/crucible/download-archives
+
+# Release dates from https://www.atlassian.com/software/crucible/download-archives.
+# Atlassian discontinued new sales of FishEye and Crucible on 2025-05-13 and ends support for both on 2028-05-15,
+# which is the eol shown for the final release. No per-version EOL dates are published for these two products, so
+# earlier cycles use the two year window Atlassian applies to its other server products.
+releases:
+  - releaseCycle: "4.9"
+    releaseDate: 2024-12-20
+    eol: 2028-05-15
+    latest: "4.9.14"
+    latestReleaseDate: 2026-08-31
+
+  - releaseCycle: "4.8"
+    releaseDate: 2019-12-04
+    eol: 2021-12-04
+    latest: "4.8.16"
+    latestReleaseDate: 2024-09-27
+
+  - releaseCycle: "4.7"
+    releaseDate: 2019-02-13
+    eol: 2021-02-13
+    latest: "4.7.3"
+    latestReleaseDate: 2019-12-04
+
+  - releaseCycle: "4.6"
+    releaseDate: 2018-07-25
+    eol: 2020-07-25
+    latest: "4.6.1"
+    latestReleaseDate: 2018-10-07
+
+  - releaseCycle: "4.5"
+    releaseDate: 2017-09-11
+    eol: 2019-09-11
+    latest: "4.5.4"
+    latestReleaseDate: 2018-07-12
+
+  - releaseCycle: "4.4"
+    releaseDate: 2017-04-11
+    eol: 2019-04-11
+    latest: "4.4.7"
+    latestReleaseDate: 2018-08-30
+
+  - releaseCycle: "4.3"
+    releaseDate: 2017-01-18
+    eol: 2019-01-18
+    latest: "4.3.3"
+    latestReleaseDate: 2018-08-30
+
+  - releaseCycle: "4.2"
+    releaseDate: 2016-09-27
+    eol: 2018-09-27
+    latest: "4.2.3"
+    latestReleaseDate: 2018-08-30
+
+  - releaseCycle: "4.1"
+    releaseDate: 2016-06-28
+    eol: 2018-06-28
+    latest: "4.1.3"
+    latestReleaseDate: 2018-03-19
+
+  - releaseCycle: "4.0"
+    releaseDate: 2016-03-18
+    eol: 2018-03-18
+    latest: "4.0.4"
+    latestReleaseDate: 2016-05-06
+
+  - releaseCycle: "3.10"
+    releaseDate: 2015-10-28
+    eol: 2017-10-28
+    latest: "3.10.4"
+    latestReleaseDate: 2016-05-06
+
+  - releaseCycle: "3.9"
+    releaseDate: 2015-08-04
+    eol: 2017-08-04
+    latest: "3.9.2"
+    latestReleaseDate: 2015-10-26
+
+  - releaseCycle: "3.8"
+    releaseDate: 2015-04-27
+    eol: 2017-04-27
+    latest: "3.8.1"
+    latestReleaseDate: 2015-06-19
+
+  - releaseCycle: "3.7"
+    releaseDate: 2015-01-27
+    eol: 2017-01-27
+    latest: "3.7.1"
+    latestReleaseDate: 2015-04-07
+
+  - releaseCycle: "3.6"
+    releaseDate: 2014-10-28
+    eol: 2016-10-28
+    latest: "3.6.4"
+    latestReleaseDate: 2015-01-23
+
+  - releaseCycle: "3.5"
+    releaseDate: 2014-07-22
+    eol: 2016-07-22
+    latest: "3.5.5"
+    latestReleaseDate: 2015-01-21
+
+  - releaseCycle: "3.4"
+    releaseDate: 2014-04-14
+    eol: 2016-04-14
+    latest: "3.4.7"
+    latestReleaseDate: 2014-09-16
+
+  - releaseCycle: "3.3"
+    releaseDate: 2014-02-10
+    eol: 2016-02-10
+    latest: "3.3.4"
+    latestReleaseDate: 2014-05-16
+
+  - releaseCycle: "3.2"
+    releaseDate: 2013-11-27
+    eol: 2015-11-27
+    latest: "3.2.5"
+    latestReleaseDate: 2014-05-16
+
+  - releaseCycle: "3.1"
+    releaseDate: 2013-08-27
+    eol: 2015-08-27
+    latest: "3.1.7"
+    latestReleaseDate: 2014-05-16
+
+  - releaseCycle: "3.0"
+    releaseDate: 2013-05-30
+    eol: 2015-05-30
+    latest: "3.0.4"
+    latestReleaseDate: 2014-05-16
+
+  - releaseCycle: "2.10"
+    releaseDate: 2013-01-15
+    eol: 2015-01-15
+    latest: "2.10.8"
+    latestReleaseDate: 2013-12-03
+
+  - releaseCycle: "2.9"
+    releaseDate: 2012-11-12
+    eol: 2014-11-12
+    latest: "2.9.2"
+    latestReleaseDate: 2012-12-11
+
+  - releaseCycle: "2.8"
+    releaseDate: 2012-08-15
+    eol: 2014-08-15
+    latest: "2.8.2"
+    latestReleaseDate: 2012-10-05
+
+  - releaseCycle: "2.7"
+    releaseDate: 2011-09-07
+    eol: 2013-09-07
+    latest: "2.7.15"
+    latestReleaseDate: 2012-07-10
+
+  - releaseCycle: "2.6"
+    releaseDate: 2011-06-07
+    eol: 2013-06-07
+    latest: "2.6.9"
+    latestReleaseDate: 2012-08-22
+
+  - releaseCycle: "2.5"
+    releaseDate: 2011-02-08
+    eol: 2013-02-08
+    latest: "2.5.9"
+    latestReleaseDate: 2012-08-22
+
+  - releaseCycle: "2.4"
+    releaseDate: 2010-10-20
+    eol: 2012-10-20
+    latest: "2.4.6"
+    latestReleaseDate: 2011-04-11
+
+  - releaseCycle: "2.3"
+    releaseDate: 2010-05-26
+    eol: 2012-05-26
+    latest: "2.3.8"
+    latestReleaseDate: 2011-01-11
+
+  - releaseCycle: "2.2"
+    releaseDate: 2010-02-18
+    eol: 2012-02-18
+    latest: "2.2.3"
+    latestReleaseDate: 2010-05-02
+
+  - releaseCycle: "2.1"
+    releaseDate: 2009-11-12
+    eol: 2011-11-12
+    latest: "2.1.4"
+    latestReleaseDate: 2010-01-27
+
+  - releaseCycle: "2.0"
+    releaseDate: 2009-06-30
+    eol: 2011-06-30
+    latest: "2.0.6"
+    latestReleaseDate: 2009-10-08
+
+  - releaseCycle: "1.6"
+    releaseDate: 2008-09-03
+    eol: 2010-09-03
+    latest: "1.6.6"
+    latestReleaseDate: 2009-02-10
+
+  - releaseCycle: "1.5"
+    releaseDate: 2008-04-15
+    eol: 2010-04-15
+    latest: "1.5.4"
+    latestReleaseDate: 2008-07-31
+
+  - releaseCycle: "1.2"
+    releaseDate: 2007-12-05
+    eol: 2009-12-05
+    latest: "1.2.3"
+    latestReleaseDate: 2008-02-07
+
+  - releaseCycle: "1.1"
+    releaseDate: 2007-09-18
+    eol: 2009-09-18
+    latest: "1.1.4"
+    latestReleaseDate: 2007-11-09
+
+  - releaseCycle: "1.0"
+    releaseDate: 2007-05-21
+    eol: 2009-05-21
+    latest: "1.0.4"
+    latestReleaseDate: 2007-08-14
+---
+
+> [Crucible](https://www.atlassian.com/software/crucible) is a proprietary code review application developed by Atlassian.
+
+{: .warning }
+
+> Atlassian discontinued new sales of FishEye and Crucible on 13 May 2025, and support for both ends on 15 May 2028.
+
+This page is about the self-hosted edition. FishEye and Crucible ship together and share version numbers, so their
+release histories are nearly identical.
+
+Atlassian publishes no per-version end-of-life dates for these two products, only the single support end date above.
+The dates shown for earlier releases therefore follow the two year window Atlassian applies to its other server
+products.

--- a/products/crucible.md
+++ b/products/crucible.md
@@ -14,11 +14,9 @@ identifiers:
   - cpe: cpe:/a:atlassian:crucible
   - cpe: cpe:2.3:a:atlassian:crucible
 
-auto:
-  methods:
-    - atlassian_versions: https://www.atlassian.com/software/crucible/download-archives
-
 # Release dates from https://www.atlassian.com/software/crucible/download-archives.
+# No auto configuration: since the product was discontinued that page no longer carries a version
+# list, so atlassian_versions finds nothing there. Crowd's equivalent page still lists 260 versions.
 # Atlassian discontinued new sales of FishEye and Crucible on 2025-05-13 and ends support for both on 2028-05-15,
 # which is the eol shown for the final release. No per-version EOL dates are published for these two products, so
 # earlier cycles use the two year window Atlassian applies to its other server products.

--- a/products/crucible.md
+++ b/products/crucible.md
@@ -15,11 +15,15 @@ identifiers:
   - cpe: cpe:2.3:a:atlassian:crucible
 
 # Release dates from https://www.atlassian.com/software/crucible/download-archives.
-# No auto configuration: since the product was discontinued that page no longer carries a version
-# list, so atlassian_versions finds nothing there. Crowd's equivalent page still lists 260 versions.
+# Versions come from Atlassian's download feed rather than the download page: since the product was
+# discontinued that page no longer carries a version list, so atlassian_versions finds nothing there.
 # Atlassian discontinued new sales of FishEye and Crucible on 2025-05-13 and ends support for both on 2028-05-15,
 # which is the eol shown for the final release. No per-version EOL dates are published for these two products, so
 # earlier cycles use the two year window Atlassian applies to its other server products.
+auto:
+  methods:
+    - atlassian_feed: https://my.atlassian.com/download/feeds/current/crucible.json
+
 releases:
   - releaseCycle: "4.9"
     releaseDate: 2024-12-20

--- a/products/fisheye.md
+++ b/products/fisheye.md
@@ -1,0 +1,272 @@
+---
+title: FishEye
+addedAt: 2026-09-10
+category: server-app
+tags: atlassian discontinued java-runtime
+iconSlug: atlassian
+permalink: /fisheye
+alternate_urls:
+  - /atlassian-fisheye
+releasePolicyLink: https://confluence.atlassian.com/support/atlassian-support-end-of-life-policy-201851003.html
+eolColumn: Support
+
+identifiers:
+  - cpe: cpe:/a:atlassian:fisheye
+  - cpe: cpe:2.3:a:atlassian:fisheye
+
+auto:
+  methods:
+    - atlassian_versions: https://www.atlassian.com/software/fisheye/download-archives
+
+# Release dates from https://www.atlassian.com/software/fisheye/download-archives.
+# Atlassian discontinued new sales of FishEye and Crucible on 2025-05-13 and ends support for both on 2028-05-15,
+# which is the eol shown for the final release. No per-version EOL dates are published for these two products, so
+# earlier cycles use the two year window Atlassian applies to its other server products.
+releases:
+  - releaseCycle: "4.9"
+    releaseDate: 2024-12-20
+    eol: 2028-05-15
+    latest: "4.9.14"
+    latestReleaseDate: 2026-08-31
+
+  - releaseCycle: "4.8"
+    releaseDate: 2019-12-04
+    eol: 2021-12-04
+    latest: "4.8.16"
+    latestReleaseDate: 2024-09-27
+
+  - releaseCycle: "4.7"
+    releaseDate: 2019-02-13
+    eol: 2021-02-13
+    latest: "4.7.3"
+    latestReleaseDate: 2019-12-04
+
+  - releaseCycle: "4.6"
+    releaseDate: 2018-07-25
+    eol: 2020-07-25
+    latest: "4.6.1"
+    latestReleaseDate: 2018-10-07
+
+  - releaseCycle: "4.5"
+    releaseDate: 2017-09-11
+    eol: 2019-09-11
+    latest: "4.5.4"
+    latestReleaseDate: 2018-07-12
+
+  - releaseCycle: "4.4"
+    releaseDate: 2017-04-11
+    eol: 2019-04-11
+    latest: "4.4.7"
+    latestReleaseDate: 2018-08-30
+
+  - releaseCycle: "4.3"
+    releaseDate: 2017-01-18
+    eol: 2019-01-18
+    latest: "4.3.3"
+    latestReleaseDate: 2018-08-30
+
+  - releaseCycle: "4.2"
+    releaseDate: 2016-09-27
+    eol: 2018-09-27
+    latest: "4.2.3"
+    latestReleaseDate: 2018-08-30
+
+  - releaseCycle: "4.1"
+    releaseDate: 2016-06-28
+    eol: 2018-06-28
+    latest: "4.1.3"
+    latestReleaseDate: 2018-03-19
+
+  - releaseCycle: "4.0"
+    releaseDate: 2016-03-18
+    eol: 2018-03-18
+    latest: "4.0.4"
+    latestReleaseDate: 2016-05-06
+
+  - releaseCycle: "3.10"
+    releaseDate: 2015-10-28
+    eol: 2017-10-28
+    latest: "3.10.4"
+    latestReleaseDate: 2016-05-06
+
+  - releaseCycle: "3.9"
+    releaseDate: 2015-08-04
+    eol: 2017-08-04
+    latest: "3.9.2"
+    latestReleaseDate: 2015-10-26
+
+  - releaseCycle: "3.8"
+    releaseDate: 2015-04-27
+    eol: 2017-04-27
+    latest: "3.8.1"
+    latestReleaseDate: 2015-06-19
+
+  - releaseCycle: "3.7"
+    releaseDate: 2015-01-27
+    eol: 2017-01-27
+    latest: "3.7.1"
+    latestReleaseDate: 2015-04-07
+
+  - releaseCycle: "3.6"
+    releaseDate: 2014-10-28
+    eol: 2016-10-28
+    latest: "3.6.4"
+    latestReleaseDate: 2015-01-23
+
+  - releaseCycle: "3.5"
+    releaseDate: 2014-07-22
+    eol: 2016-07-22
+    latest: "3.5.5"
+    latestReleaseDate: 2015-01-21
+
+  - releaseCycle: "3.4"
+    releaseDate: 2014-04-14
+    eol: 2016-04-14
+    latest: "3.4.7"
+    latestReleaseDate: 2014-09-16
+
+  - releaseCycle: "3.3"
+    releaseDate: 2014-02-10
+    eol: 2016-02-10
+    latest: "3.3.4"
+    latestReleaseDate: 2014-05-16
+
+  - releaseCycle: "3.2"
+    releaseDate: 2013-11-27
+    eol: 2015-11-27
+    latest: "3.2.5"
+    latestReleaseDate: 2014-05-16
+
+  - releaseCycle: "3.1"
+    releaseDate: 2013-08-27
+    eol: 2015-08-27
+    latest: "3.1.7"
+    latestReleaseDate: 2014-05-16
+
+  - releaseCycle: "3.0"
+    releaseDate: 2013-05-30
+    eol: 2015-05-30
+    latest: "3.0.4"
+    latestReleaseDate: 2014-05-16
+
+  - releaseCycle: "2.10"
+    releaseDate: 2013-01-15
+    eol: 2015-01-15
+    latest: "2.10.8"
+    latestReleaseDate: 2013-12-03
+
+  - releaseCycle: "2.9"
+    releaseDate: 2012-11-12
+    eol: 2014-11-12
+    latest: "2.9.2"
+    latestReleaseDate: 2012-12-11
+
+  - releaseCycle: "2.8"
+    releaseDate: 2012-08-15
+    eol: 2014-08-15
+    latest: "2.8.2"
+    latestReleaseDate: 2012-10-05
+
+  - releaseCycle: "2.7"
+    releaseDate: 2011-09-07
+    eol: 2013-09-07
+    latest: "2.7.15"
+    latestReleaseDate: 2012-07-10
+
+  - releaseCycle: "2.6"
+    releaseDate: 2011-06-07
+    eol: 2013-06-07
+    latest: "2.6.9"
+    latestReleaseDate: 2012-08-22
+
+  - releaseCycle: "2.5"
+    releaseDate: 2011-02-08
+    eol: 2013-02-08
+    latest: "2.5.9"
+    latestReleaseDate: 2012-08-22
+
+  - releaseCycle: "2.4"
+    releaseDate: 2010-10-20
+    eol: 2012-10-20
+    latest: "2.4.6"
+    latestReleaseDate: 2011-04-11
+
+  - releaseCycle: "2.3"
+    releaseDate: 2010-05-26
+    eol: 2012-05-26
+    latest: "2.3.8"
+    latestReleaseDate: 2011-01-11
+
+  - releaseCycle: "2.2"
+    releaseDate: 2010-02-18
+    eol: 2012-02-18
+    latest: "2.2.3"
+    latestReleaseDate: 2010-05-02
+
+  - releaseCycle: "2.1"
+    releaseDate: 2009-11-12
+    eol: 2011-11-12
+    latest: "2.1.4"
+    latestReleaseDate: 2010-01-27
+
+  - releaseCycle: "2.0"
+    releaseDate: 2009-06-30
+    eol: 2011-06-30
+    latest: "2.0.6"
+    latestReleaseDate: 2009-10-08
+
+  - releaseCycle: "1.6"
+    releaseDate: 2008-09-03
+    eol: 2010-09-03
+    latest: "1.6.6"
+    latestReleaseDate: 2009-02-10
+
+  - releaseCycle: "1.5"
+    releaseDate: 2008-04-15
+    eol: 2010-04-15
+    latest: "1.5.4"
+    latestReleaseDate: 2008-07-31
+
+  - releaseCycle: "1.4"
+    releaseDate: 2007-12-05
+    eol: 2009-12-05
+    latest: "1.4.3"
+    latestReleaseDate: 2008-02-07
+
+  - releaseCycle: "1.3"
+    releaseDate: 2007-08-01
+    eol: 2009-08-01
+    latest: "1.3.8"
+    latestReleaseDate: 2007-11-09
+
+  - releaseCycle: "1.2"
+    releaseDate: 2007-01-21
+    eol: 2009-01-21
+    latest: "1.2.5"
+    latestReleaseDate: 2007-01-21
+
+  - releaseCycle: "1.1"
+    releaseDate: 2006-08-29
+    eol: 2008-08-29
+    latest: "1.1.3"
+    latestReleaseDate: 2006-08-29
+
+  - releaseCycle: "1.0"
+    releaseDate: 2005-11-02
+    eol: 2007-11-02
+    latest: "1.0.1a"
+    latestReleaseDate: 2005-11-02
+---
+
+> [FishEye](https://www.atlassian.com/software/fisheye) is a proprietary source code repository browser developed by Atlassian.
+
+{: .warning }
+
+> Atlassian discontinued new sales of FishEye and Crucible on 13 May 2025, and support for both ends on 15 May 2028.
+
+This page is about the self-hosted edition. FishEye and Crucible ship together and share version numbers, so their
+release histories are nearly identical.
+
+Atlassian publishes no per-version end-of-life dates for these two products, only the single support end date above.
+The dates shown for earlier releases therefore follow the two year window Atlassian applies to its other server
+products.

--- a/products/fisheye.md
+++ b/products/fisheye.md
@@ -14,11 +14,9 @@ identifiers:
   - cpe: cpe:/a:atlassian:fisheye
   - cpe: cpe:2.3:a:atlassian:fisheye
 
-auto:
-  methods:
-    - atlassian_versions: https://www.atlassian.com/software/fisheye/download-archives
-
 # Release dates from https://www.atlassian.com/software/fisheye/download-archives.
+# No auto configuration: since the product was discontinued that page no longer carries a version
+# list, so atlassian_versions finds nothing there. Crowd's equivalent page still lists 260 versions.
 # Atlassian discontinued new sales of FishEye and Crucible on 2025-05-13 and ends support for both on 2028-05-15,
 # which is the eol shown for the final release. No per-version EOL dates are published for these two products, so
 # earlier cycles use the two year window Atlassian applies to its other server products.

--- a/products/fisheye.md
+++ b/products/fisheye.md
@@ -15,11 +15,15 @@ identifiers:
   - cpe: cpe:2.3:a:atlassian:fisheye
 
 # Release dates from https://www.atlassian.com/software/fisheye/download-archives.
-# No auto configuration: since the product was discontinued that page no longer carries a version
-# list, so atlassian_versions finds nothing there. Crowd's equivalent page still lists 260 versions.
+# Versions come from Atlassian's download feed rather than the download page: since the product was
+# discontinued that page no longer carries a version list, so atlassian_versions finds nothing there.
 # Atlassian discontinued new sales of FishEye and Crucible on 2025-05-13 and ends support for both on 2028-05-15,
 # which is the eol shown for the final release. No per-version EOL dates are published for these two products, so
 # earlier cycles use the two year window Atlassian applies to its other server products.
+auto:
+  methods:
+    - atlassian_feed: https://my.atlassian.com/download/feeds/current/fisheye.json
+
 releases:
   - releaseCycle: "4.9"
     releaseDate: 2024-12-20


### PR DESCRIPTION
## Summary

The four self-hosted Atlassian products still without a page.

| Page | Cycles | Range |
| --- | --- | --- |
| `/crowd` | 46 | 0.3 (2006-12-08) → 7.2 |
| `/fisheye` | 39 | 1.0 (2005-11-02) → 4.9 |
| `/crucible` | 37 | 1.0 (2007-05-21) → 4.9 |
| `/bitbucket-mesh` | 24 | 1.0 (2022-05-11) → 4.4 |

Release dates come from Atlassian's download feeds, the source behind the `atlassian_versions` method. Pre-release builds are excluded; the feeds publish an EAP channel alongside the current and archived ones.

## Crowd

End-of-life dates are published on the [support policy page](https://confluence.atlassian.com/support/atlassian-support-end-of-life-policy-201851003.html) for 5.3 and later, so `atlassian_eol` is configured with the `AtlassianEndofSupportPolicy-Crowd` selector and will keep them current. The cycles older than that use the two year window every dated entry in that section follows.

Note that Crowd's download archive is at `/software/crowd/download-archive`, singular, unlike the other products.

## FishEye and Crucible are discontinued

Atlassian discontinued new sales of both on **13 May 2025** and ends support on **15 May 2028**. The policy page carries that as a single statement for the pair rather than per-version dates:

> As of May 13, 2025, we have discontinued new sales of Fisheye and Crucible. Support and maintenance for Fisheye and Crucible will end on May 15, 2028.

So both pages carry the `discontinued` tag and show 2028-05-15 as the eol of their final release, 4.9. Earlier cycles use the two year window Atlassian applies to its other server products, since nothing per-version is published for these two. `atlassian_eol` is deliberately not configured for them, as there is nothing for it to read.

They ship together and share version numbers, which is why the two histories are nearly identical — 37 cycles in common, with 1.3 and 1.4 existing for FishEye only.

## Bitbucket Mesh

Mesh is not installed on its own; it is the distributed repository storage service for Bitbucket Data Center. It ships alongside Bitbucket, and since Mesh 3.0 every release has landed on the same day as the matching Bitbucket release — 3.0 with Bitbucket 9.0, 3.1 with 9.1, through 4.4 with 10.4. It therefore follows the same two year window as `/bitbucket`.

No `auto` configuration: the Bitbucket download archive page lists Bitbucket versions, not Mesh ones, so pointing `atlassian_versions` at it would be wrong. No `identifiers` either, as NVD has no CPE for Mesh.

## Auto configuration

All three are driven by `atlassian_feed`, the method added in endoflife-date/release-data#649, which reads Atlassian's download feeds. **This PR depends on that one.**

`atlassian_versions` cannot cover any of them. Mesh has no download page of its own, and the pages for FishEye and Crucible stopped listing versions when Atlassian discontinued them — checked against the real script, zero `.versions-list` blocks on the FishEye page against 260 on Crowd's. The feeds still carry all three in full: 132, 222 and 224 versions.

Verified end to end: after running both stages, `update-product-data.py` changes nothing on these three pages, so the feed agrees with the data curated here.

Docker Hub was considered for Mesh and rejected on measurement — none of its tag dates match the feed, and 4.4.0 is off by seven weeks.

## Icons

`atlassian` for Crowd, FishEye and Crucible, none of which have their own Simple Icons mark; `bitbucket` for Mesh.

## Test plan

- [x] `bundle exec jekyll build` passes, including `product-data-validator.rb`
- [x] All four frontmatters validate against `product-schema.json`
- [x] `markdownlint-cli2` and `prettier --check` pass
- [x] Releases ordered by descending release date; `latestReleaseDate` and `eol` never precede `releaseDate`
- [x] Icons resolve and the discontinued tag renders on FishEye and Crucible
- [x] Netlify deploy preview renders the four pages correctly
