### PR TITLE
[gitlab] Add release information for GitLab version 19.4

### DIFF
--- a/products/gitlab-runner.md
+++ b/products/gitlab-runner.md
@@ -24,6 +24,13 @@ auto:
 # eoas(x) = releaseDate(x+1)
 # eol(x) = releaseDate(x+3)
 releases:
+  - releaseCycle: "19.4"
+    releaseDate: 2026-09-17
+    eoas: 2026-10-15 # releaseDate(19.5)
+    eol: 2026-12-17 # releaseDate(19.7)
+    latest: "19.4.0"
+    latestReleaseDate: 2026-09-17
+
   - releaseCycle: "19.3"
     releaseDate: 2026-08-20
     eoas: 2026-09-17 # releaseDate(19.4)

--- a/products/gitlab.md
+++ b/products/gitlab.md
@@ -25,6 +25,13 @@ auto:
 # eol(x) = releaseDate(x+3)
 # Upcoming release dates are available on https://handbook.gitlab.com/handbook/engineering/releases/monthly-releases/#monthly-release-schedule
 releases:
+  - releaseCycle: "19.4"
+    releaseDate: 2026-09-17
+    eoas: 2026-10-15 # releaseDate(19.5)
+    eol: 2026-12-17 # releaseDate(19.7)
+    latest: "19.4.0"
+    latestReleaseDate: 2026-09-17
+
   - releaseCycle: "19.3"
     releaseDate: 2026-08-20
     eoas: 2026-09-17 # releaseDate(19.4)


### PR DESCRIPTION
Scheduled for 2026-09-17