### PR TITLE
[amazon-documentdb] Update column headers to match positive polarity

### DIFF
--- a/products/amazon-documentdb.md
+++ b/products/amazon-documentdb.md
@@ -6,8 +6,8 @@ tags: amazon database
 iconSlug: amazondocumentdb
 permalink: /amazon-documentdb
 latestColumn: false
-eolColumn: End of Standard Support
-eoesColumn: End of Extended Support
+eolColumn: Standard Support
+eoesColumn: Extended Support
 staleReleaseThresholdDays: 2200
 
 auto:


### PR DESCRIPTION
The current headers I assume were just taken from [the AWS docs](https://docs.aws.amazon.com/documentdb/latest/devguide/docdb-version-support-dates.html), but they give a weird impression since "yes" is used when a production is in support and has no confirmed end-of-life date: it ends up reading "End of Standard Support? Yes"